### PR TITLE
[Enhancement] The logic of the output column is split into two stages.

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -190,7 +190,6 @@ Status HashJoinNode::prepare(RuntimeState* state) {
 void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
     param->join_type = _join_type;
-    param->row_desc = &_row_descriptor;
     param->build_row_desc = &child(1)->row_desc();
     param->probe_row_desc = &child(0)->row_desc();
     param->search_ht_timer = _search_ht_timer;
@@ -198,6 +197,7 @@ void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     param->output_probe_column_timer = _output_probe_column_timer;
     param->build_output_slots = _output_slots;
     param->probe_output_slots = _output_slots;
+    param->enable_lazy_materialize = _enable_lazy_materialize;
 
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {
@@ -464,10 +464,10 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     }
 
     auto* pool = context->fragment_context()->runtime_state()->obj_pool();
-    HashJoinerParam param(pool, _hash_join_node, _id, _type, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
+    HashJoinerParam param(pool, _hash_join_node, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
-                          _row_descriptor, child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(),
-                          _build_runtime_filters, _output_slots, _output_slots, _distribution_mode, false);
+                          child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(), _build_runtime_filters,
+                          _output_slots, _output_slots, _distribution_mode, false, _enable_lazy_materialize);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param);
 
     // Create a shared RefCountedRuntimeFilterCollector

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -115,6 +115,7 @@ private:
     std::set<SlotId> _output_slots;
 
     bool _is_push_down = false;
+    bool _enable_lazy_materialize = false;
 
     JoinHashTable _ht;
 

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -63,7 +63,6 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _conjunct_ctxs(param._conjunct_ctxs),
           _build_row_descriptor(param._build_row_descriptor),
           _probe_row_descriptor(param._probe_row_descriptor),
-          _row_descriptor(param._row_descriptor),
           _build_node_type(param._build_node_type),
           _probe_node_type(param._probe_node_type),
           _build_conjunct_ctxs_is_empty(param._build_conjunct_ctxs_is_empty),
@@ -137,7 +136,6 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
 void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
     param->join_type = _join_type;
-    param->row_desc = &_row_descriptor;
     param->build_row_desc = &_build_row_descriptor;
     param->probe_row_desc = &_probe_row_descriptor;
     param->build_output_slots = _build_output_slots;

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -64,20 +64,17 @@ enum HashJoinPhase {
     EOS = 4,
 };
 struct HashJoinerParam {
-    HashJoinerParam(ObjectPool* pool, const THashJoinNode& hash_join_node, TPlanNodeId node_id,
-                    TPlanNodeType::type node_type, std::vector<bool> is_null_safes,
+    HashJoinerParam(ObjectPool* pool, const THashJoinNode& hash_join_node, std::vector<bool> is_null_safes,
                     std::vector<ExprContext*> build_expr_ctxs, std::vector<ExprContext*> probe_expr_ctxs,
                     std::vector<ExprContext*> other_join_conjunct_ctxs, std::vector<ExprContext*> conjunct_ctxs,
                     const RowDescriptor& build_row_descriptor, const RowDescriptor& probe_row_descriptor,
-                    const RowDescriptor& row_descriptor, TPlanNodeType::type build_node_type,
-                    TPlanNodeType::type probe_node_type, bool build_conjunct_ctxs_is_empty,
-                    std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters, std::set<SlotId> build_output_slots,
-                    std::set<SlotId> probe_output_slots, const TJoinDistributionMode::type distribution_mode,
-                    bool mor_reader_mode)
+                    TPlanNodeType::type build_node_type, TPlanNodeType::type probe_node_type,
+                    bool build_conjunct_ctxs_is_empty, std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters,
+                    std::set<SlotId> build_output_slots, std::set<SlotId> probe_output_slots,
+                    const TJoinDistributionMode::type distribution_mode, bool mor_reader_mode,
+                    bool enable_lazy_materialize)
             : _pool(pool),
               _hash_join_node(hash_join_node),
-              _node_id(node_id),
-              _node_type(node_type),
               _is_null_safes(std::move(is_null_safes)),
               _build_expr_ctxs(std::move(build_expr_ctxs)),
               _probe_expr_ctxs(std::move(probe_expr_ctxs)),
@@ -85,7 +82,6 @@ struct HashJoinerParam {
               _conjunct_ctxs(std::move(conjunct_ctxs)),
               _build_row_descriptor(build_row_descriptor),
               _probe_row_descriptor(probe_row_descriptor),
-              _row_descriptor(row_descriptor),
               _build_node_type(build_node_type),
               _probe_node_type(probe_node_type),
               _build_conjunct_ctxs_is_empty(build_conjunct_ctxs_is_empty),
@@ -93,7 +89,8 @@ struct HashJoinerParam {
               _build_output_slots(std::move(build_output_slots)),
               _probe_output_slots(std::move(probe_output_slots)),
               _distribution_mode(distribution_mode),
-              _mor_reader_mode(mor_reader_mode) {}
+              _mor_reader_mode(mor_reader_mode),
+              _enable_lazy_materialize(enable_lazy_materialize) {}
 
     HashJoinerParam(HashJoinerParam&&) = default;
     HashJoinerParam(HashJoinerParam&) = default;
@@ -101,8 +98,6 @@ struct HashJoinerParam {
 
     ObjectPool* _pool;
     const THashJoinNode& _hash_join_node;
-    TPlanNodeId _node_id;
-    TPlanNodeType::type _node_type;
     const std::vector<bool> _is_null_safes;
     const std::vector<ExprContext*> _build_expr_ctxs;
     const std::vector<ExprContext*> _probe_expr_ctxs;
@@ -110,7 +105,6 @@ struct HashJoinerParam {
     const std::vector<ExprContext*> _conjunct_ctxs;
     const RowDescriptor _build_row_descriptor;
     const RowDescriptor _probe_row_descriptor;
-    const RowDescriptor _row_descriptor;
     TPlanNodeType::type _build_node_type;
     TPlanNodeType::type _probe_node_type;
     bool _build_conjunct_ctxs_is_empty;
@@ -120,6 +114,7 @@ struct HashJoinerParam {
 
     const TJoinDistributionMode::type _distribution_mode;
     const bool _mor_reader_mode;
+    const bool _enable_lazy_materialize;
 };
 
 inline bool could_short_circuit(TJoinOp::type join_type) {
@@ -404,7 +399,6 @@ private:
     const std::vector<ExprContext*>& _conjunct_ctxs;
     const RowDescriptor& _build_row_descriptor;
     const RowDescriptor& _probe_row_descriptor;
-    const RowDescriptor& _row_descriptor;
     const TPlanNodeType::type _build_node_type;
     const TPlanNodeType::type _probe_node_type;
     const bool _build_conjunct_ctxs_is_empty;

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -323,6 +323,7 @@ void JoinHashTable::create(const HashTableParam& param) {
     _table_items->with_other_conjunct = param.with_other_conjunct;
     _table_items->join_type = param.join_type;
     _table_items->mor_reader_mode = param.mor_reader_mode;
+    _table_items->enable_lazy_materialize = param.enable_lazy_materialize;
 
     if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN || _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN ||
         _table_items->join_type == TJoinOp::RIGHT_OUTER_JOIN) {
@@ -338,77 +339,153 @@ void JoinHashTable::create(const HashTableParam& param) {
     }
     _table_items->join_keys = param.join_keys;
 
+    _init_probe_column(param);
+    _init_build_column(param);
+
+    if (param.mor_reader_mode) {
+        _init_mor_reader();
+    }
+
+    _init_join_keys();
+}
+
+void JoinHashTable::_init_probe_column(const HashTableParam& param) {
     const auto& probe_desc = *param.probe_row_desc;
     for (const auto& tuple_desc : probe_desc.tuple_descriptors()) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (param.probe_output_slots.empty() ||
-                std::find(param.probe_output_slots.begin(), param.probe_output_slots.end(), slot->id()) !=
-                        param.probe_output_slots.end() ||
-                std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
-                        param.predicate_slots.end()) {
-                hash_table_slot.need_output = true;
-                _table_items->output_probe_column_count++;
+
+            if (param.enable_lazy_materialize) {
+                if (param.probe_output_slots.empty()) {
+                    // Empty means need output all
+                    hash_table_slot.need_output = true;
+                    hash_table_slot.need_lazy_materialize = false;
+                    _table_items->output_probe_column_count++;
+                } else if (std::find(param.probe_output_slots.begin(), param.probe_output_slots.end(), slot->id()) !=
+                           param.probe_output_slots.end()) {
+                    if (param.predicate_slots.empty() ||
+                        // Empty means no other predicate, so need output all
+                        std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                                param.predicate_slots.end()) {
+                        hash_table_slot.need_output = true;
+                        hash_table_slot.need_lazy_materialize = false;
+                        _table_items->output_probe_column_count++;
+                    } else {
+                        hash_table_slot.need_output = false;
+                        hash_table_slot.need_lazy_materialize = true;
+                        _table_items->lazy_output_probe_column_count++;
+                    }
+                } else {
+                    if (param.predicate_slots.empty() ||
+                        std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                                param.predicate_slots.end()) {
+                        hash_table_slot.need_output = true;
+                        hash_table_slot.need_lazy_materialize = false;
+                        _table_items->output_probe_column_count++;
+                    } else {
+                        hash_table_slot.need_output = false;
+                        hash_table_slot.need_lazy_materialize = false;
+                    }
+                }
             } else {
-                hash_table_slot.need_output = false;
+                if (param.probe_output_slots.empty() ||
+                    std::find(param.probe_output_slots.begin(), param.probe_output_slots.end(), slot->id()) !=
+                            param.probe_output_slots.end() ||
+                    std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                            param.predicate_slots.end()) {
+                    hash_table_slot.need_output = true;
+                    _table_items->output_probe_column_count++;
+                } else {
+                    hash_table_slot.need_output = false;
+                }
             }
 
             _table_items->probe_slots.emplace_back(hash_table_slot);
             _table_items->probe_column_count++;
         }
     }
+}
 
+void JoinHashTable::_init_build_column(const HashTableParam& param) {
     const auto& build_desc = *param.build_row_desc;
     for (const auto& tuple_desc : build_desc.tuple_descriptors()) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (!param.mor_reader_mode && (param.build_output_slots.empty() ||
-                                           std::find(param.build_output_slots.begin(), param.build_output_slots.end(),
-                                                     slot->id()) != param.build_output_slots.end() ||
-                                           std::find(param.predicate_slots.begin(), param.predicate_slots.end(),
-                                                     slot->id()) != param.predicate_slots.end())) {
-                hash_table_slot.need_output = true;
-                _table_items->output_build_column_count++;
-            } else {
-                hash_table_slot.need_output = false;
-            }
 
-            _table_items->build_slots.emplace_back(hash_table_slot);
-            ColumnPtr column = ColumnHelper::create_column(slot->type(), slot->is_nullable());
-            if (slot->is_nullable()) {
-                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(column);
-                nullable_column->append_default_not_null_value();
+            if (!param.mor_reader_mode && param.enable_lazy_materialize) {
+                if (param.build_output_slots.empty()) {
+                    hash_table_slot.need_output = true;
+                    hash_table_slot.need_lazy_materialize = false;
+                    _table_items->output_build_column_count++;
+                } else if (std::find(param.build_output_slots.begin(), param.build_output_slots.end(), slot->id()) !=
+                           param.build_output_slots.end()) {
+                    if (param.predicate_slots.empty() ||
+                        std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                                param.predicate_slots.end()) {
+                        hash_table_slot.need_output = true;
+                        hash_table_slot.need_lazy_materialize = false;
+                        _table_items->output_build_column_count++;
+                    } else {
+                        hash_table_slot.need_output = false;
+                        hash_table_slot.need_lazy_materialize = true;
+                        _table_items->lazy_output_build_column_count++;
+                    }
+                } else {
+                    if (param.predicate_slots.empty() ||
+                        std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                                param.predicate_slots.end()) {
+                        hash_table_slot.need_output = true;
+                        hash_table_slot.need_lazy_materialize = false;
+                        _table_items->output_build_column_count++;
+                    } else {
+                        hash_table_slot.need_output = false;
+                        hash_table_slot.need_lazy_materialize = false;
+                    }
+                }
             } else {
-                column->append_default();
-            }
-            _table_items->build_chunk->append_column(std::move(column), slot->id());
-            _table_items->build_column_count++;
-        }
-    }
-
-    if (param.mor_reader_mode) {
-        for (const auto& build_slot : _table_items->build_slots) {
-            bool found_build_slot = false;
-            for (auto probe_slot : _table_items->probe_slots) {
-                if (probe_slot.slot->id() == build_slot.slot->id()) {
-                    found_build_slot = true;
-                    break;
+                if (!param.mor_reader_mode &&
+                    (param.build_output_slots.empty() ||
+                     std::find(param.build_output_slots.begin(), param.build_output_slots.end(), slot->id()) !=
+                             param.build_output_slots.end() ||
+                     std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                             param.predicate_slots.end())) {
+                    hash_table_slot.need_output = true;
+                    _table_items->output_build_column_count++;
+                } else {
+                    hash_table_slot.need_output = false;
                 }
             }
 
-            if (!found_build_slot) {
-                HashTableSlotDescriptor hash_table_slot;
-                hash_table_slot.slot = build_slot.slot;
-                hash_table_slot.need_output = true;
-
-                _table_items->probe_slots.emplace_back(hash_table_slot);
-                _table_items->probe_column_count++;
-            }
+            _table_items->build_slots.emplace_back(hash_table_slot);
+            _table_items->build_column_count++;
         }
     }
+}
 
+void JoinHashTable::_init_mor_reader() {
+    for (const auto& build_slot : _table_items->build_slots) {
+        bool found_build_slot = false;
+        for (auto probe_slot : _table_items->probe_slots) {
+            if (probe_slot.slot->id() == build_slot.slot->id()) {
+                found_build_slot = true;
+                break;
+            }
+        }
+
+        if (!found_build_slot) {
+            HashTableSlotDescriptor hash_table_slot;
+            hash_table_slot.slot = build_slot.slot;
+            hash_table_slot.need_output = true;
+
+            _table_items->probe_slots.emplace_back(hash_table_slot);
+            _table_items->probe_column_count++;
+        }
+    }
+}
+
+void JoinHashTable::_init_join_keys() {
     for (const auto& key_desc : _table_items->join_keys) {
         if (key_desc.col_ref) {
             _table_items->key_columns.emplace_back(nullptr);

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -459,6 +459,14 @@ void JoinHashTable::_init_build_column(const HashTableParam& param) {
             }
 
             _table_items->build_slots.emplace_back(hash_table_slot);
+            ColumnPtr column = ColumnHelper::create_column(slot->type(), slot->is_nullable());
+            if (slot->is_nullable()) {
+                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(column);
+                nullable_column->append_default_not_null_value();
+            } else {
+                column->append_default();
+            }
+            _table_items->build_chunk->append_column(std::move(column), slot->id());
             _table_items->build_column_count++;
         }
     }

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -94,6 +94,7 @@ struct JoinKeyDesc {
 struct HashTableSlotDescriptor {
     SlotDescriptor* slot;
     bool need_output;
+    bool need_lazy_materialize = false;
 };
 
 struct JoinHashTableItems {
@@ -117,8 +118,10 @@ struct JoinHashTableItems {
     uint32_t row_count = 0; // real row count
     size_t build_column_count = 0;
     size_t output_build_column_count = 0;
+    size_t lazy_output_build_column_count = 0;
     size_t probe_column_count = 0;
     size_t output_probe_column_count = 0;
+    size_t lazy_output_probe_column_count = 0;
     bool with_other_conjunct = false;
     bool left_to_nullable = false;
     bool right_to_nullable = false;
@@ -127,6 +130,7 @@ struct JoinHashTableItems {
     size_t used_buckets = 0;
     bool cache_miss_serious = false;
     bool mor_reader_mode = false;
+    bool enable_lazy_materialize = false;
 
     float get_keys_per_bucket() const { return keys_per_bucket; }
     bool ht_cache_miss_serious() const { return cache_miss_serious; }
@@ -260,8 +264,8 @@ struct HashTableProbeState {
 
 struct HashTableParam {
     bool with_other_conjunct = false;
+    bool enable_lazy_materialize = false;
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
-    const RowDescriptor* row_desc = nullptr;
     const RowDescriptor* build_row_desc = nullptr;
     const RowDescriptor* probe_row_desc = nullptr;
     std::set<SlotId> build_output_slots;
@@ -767,10 +771,16 @@ public:
     size_t get_bucket_size() const { return _table_items->bucket_size; }
     float get_keys_per_bucket() const;
     void remove_duplicate_index(Filter* filter);
+    JoinHashTableItems* table_items() const { return _table_items.get(); }
 
     int64_t mem_usage() const;
 
 private:
+    void _init_probe_column(const HashTableParam& param);
+    void _init_build_column(const HashTableParam& param);
+    void _init_mor_reader();
+    void _init_join_keys();
+
     JoinHashMapType _choose_join_hash_map();
     static size_t _get_size_of_fixed_and_contiguous_type(LogicalType data_type);
 

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -41,13 +41,12 @@ Status IcebergMORProcessor::init(RuntimeState* runtime_state, const MORParams& p
             std::make_unique<RowDescriptor>(runtime_state->desc_tbl().get_tuple_descriptor(params.mor_tuple_id));
     _probe_row_desc = std::make_unique<RowDescriptor>(params.tuple_desc);
 
-    const auto param = _pool.add(
-            new HashJoinerParam(&_pool, _hash_join_node, 1, TPlanNodeType::HASH_JOIN_NODE,
-                                std::vector<bool>(params.equality_slots.size(), false), _join_exprs, _join_exprs,
-                                std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc,
-                                *_probe_row_desc, *_probe_row_desc, TPlanNodeType::HDFS_SCAN_NODE,
-                                TPlanNodeType::HDFS_SCAN_NODE, true, std::list<RuntimeFilterBuildDescriptor*>(),
-                                std::set<SlotId>(), probe_output_slot_ids, TJoinDistributionMode::PARTITIONED, true));
+    const auto param = _pool.add(new HashJoinerParam(
+            &_pool, _hash_join_node, std::vector<bool>(params.equality_slots.size(), false), _join_exprs, _join_exprs,
+            std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc, *_probe_row_desc,
+            TPlanNodeType::HDFS_SCAN_NODE, TPlanNodeType::HDFS_SCAN_NODE, true,
+            std::list<RuntimeFilterBuildDescriptor*>(), std::set<SlotId>(), probe_output_slot_ids,
+            TJoinDistributionMode::PARTITIONED, true, false));
 
     _hash_joiner = _pool.add(new HashJoiner(*param));
     RETURN_IF_ERROR(_hash_joiner->prepare_builder(runtime_state, _runtime_profile));


### PR DESCRIPTION
## Why I'm doing:

This is the second pr of lazy materialize join.

In the past, there was only one stage of join output column, but now it is split into two stages, output predicate columns and lazy output of other columns.

## What I'm doing:

* The logic of the output column is split into two stages.
* Remove `row_desc`, it's useless.
* Add param enable_lazy_materialize for join hash table.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
