### PR TITLE
[Enhancement] Collect routine load committed and aborted tasks number metric

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/TableMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/TableMetricsEntity.java
@@ -39,6 +39,10 @@ public final class TableMetricsEntity {
     private static final String TABLE_LOAD_UNSELECTED_COMMENT = "total unselected rows in load job of a table";
     public static final String TABLE_LOAD_FINISHED = "table_load_finished";
     private static final String TABLE_LOAD_FINISHED_COMMENT = "total loaded times of this table";
+    public static final String TABLE_LOAD_COMMITTED_TASKS = "table_load_committed_tasks";
+    private static final String TABLE_LOAD_COMMITTED_TASKS_COMMENT = "total committed tasks of this table";
+    public static final String TABLE_LOAD_ABORTED_TASKS = "table_load_aborted_tasks";
+    private static final String TABLE_LOAD_ABORTED_TASKS_COMMENT = "total aborted tasks of this table";
 
     private List<Metric> metrics;
 
@@ -55,6 +59,8 @@ public final class TableMetricsEntity {
     public LongCounterMetric counterRoutineLoadErrorRowsTotal;
     public LongCounterMetric counterRoutineLoadUnselectedRowsTotal;
     public LongCounterMetric counterRoutineLoadFinishedTotal;
+    public LongCounterMetric counterRoutineLoadCommittedTasksTotal;
+    public LongCounterMetric counterRoutineLoadAbortedTasksTotal;
 
     public LongCounterMetric counterInsertLoadBytesTotal;
     public LongCounterMetric counterInsertLoadRowsTotal;
@@ -122,6 +128,14 @@ public final class TableMetricsEntity {
                 new LongCounterMetric(TABLE_LOAD_FINISHED, MetricUnit.REQUESTS, TABLE_LOAD_FINISHED_COMMENT);
         counterRoutineLoadFinishedTotal.addLabel(new MetricLabel("type", "routine_load"));
         metrics.add(counterRoutineLoadFinishedTotal);
+        counterRoutineLoadCommittedTasksTotal = new LongCounterMetric(TABLE_LOAD_COMMITTED_TASKS, MetricUnit.REQUESTS,
+                TABLE_LOAD_COMMITTED_TASKS_COMMENT);
+        counterRoutineLoadCommittedTasksTotal.addLabel(new MetricLabel("type", "routine_load"));
+        metrics.add(counterRoutineLoadCommittedTasksTotal);
+        counterRoutineLoadAbortedTasksTotal =
+                new LongCounterMetric(TABLE_LOAD_ABORTED_TASKS, MetricUnit.REQUESTS, TABLE_LOAD_ABORTED_TASKS_COMMENT);
+        counterRoutineLoadAbortedTasksTotal.addLabel(new MetricLabel("type", "routine_load"));
+        metrics.add(counterRoutineLoadAbortedTasksTotal);
 
         counterBrokerLoadBytesTotal =
                 new LongCounterMetric(TABLE_LOAD_BYTES, MetricUnit.BYTES, TABLE_LOAD_BYTES_COMMENT);


### PR DESCRIPTION
## Why I'm doing:
collect committed and aborted tasks number metric to indicate that a routine load is running normally
## What I'm doing:
add routine_load_committed_tasks and routine_load_aborted_tasks in MetricRepo

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
