### PR TITLE
[Enhancement] avoid load image failed when create connector with exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -118,7 +118,7 @@ public class CatalogMgr {
             Preconditions.checkState(!catalogs.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
             CatalogConnector connector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, properties));
             if (null == connector) {
-                LOG.error("connector create failed. catalog [{}] encounter unknown catalog type [{}]", catalogName, type);
+                LOG.error("{} connector [{}] create failed", type, catalogName);
                 throw new DdlException("connector create failed");
             }
             long id = isResourceMappingCatalog(catalogName) ?
@@ -265,7 +265,7 @@ public class CatalogMgr {
         try {
             CatalogConnector catalogConnector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, config));
             if (catalogConnector == null) {
-                LOG.error("connector create failed. catalog [{}] encounter unknown catalog type [{}]", catalogName, type);
+                LOG.error("{} connector [{}] create failed.", type, catalogName);
                 throw new DdlException("connector create failed");
             }
         } catch (StarRocksConnectorException e) {
@@ -525,15 +525,15 @@ public class CatalogMgr {
     }
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
-        try {
-            int serializedCatalogsSize = reader.readInt();
-            for (int i = 0; i < serializedCatalogsSize; ++i) {
-                Catalog catalog = reader.readJson(Catalog.class);
+        int serializedCatalogsSize = reader.readInt();
+        for (int i = 0; i < serializedCatalogsSize; ++i) {
+            Catalog catalog = reader.readJson(Catalog.class);
+            try {
                 replayCreateCatalog(catalog);
+            } catch (Exception e) {
+                LOG.error("Failed to load catalog {}, ignore the error, continue load", catalog.getName(), e);
             }
-            loadResourceMappingCatalog();
-        } catch (DdlException e) {
-            throw new IOException(e);
         }
+        loadResourceMappingCatalog();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
@@ -18,11 +18,16 @@ package com.starrocks.server;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.ExternalCatalog;
 import com.starrocks.common.DdlException;
+import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.persist.DropCatalogLog;
+import com.starrocks.persist.metablock.SRMetaBlockEOFException;
+import com.starrocks.persist.metablock.SRMetaBlockException;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.MockUp;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -120,4 +125,36 @@ public class CatalogMgrTest {
         Assert.assertTrue(catalogMgr.catalogExists("hive_catalog"));
     }
 
+    @Test
+    public void testLoadCatalogWithException() throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
+        CatalogMgr catalogMgr = GlobalStateMgr.getCurrentState().getCatalogMgr();
+        Assert.assertTrue(catalogMgr.catalogExists("hive_catalog"));
+
+        UtFrameUtils.PseudoImage.setUpImageVersion();
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        catalogMgr.save(image.getDataOutputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+
+        CatalogMgr loadCatalogMgr = new CatalogMgr(new ConnectorMgr());
+        loadCatalogMgr.load(reader);
+        Assert.assertTrue(loadCatalogMgr.catalogExists("hive_catalog"));
+
+        // test load with ddl exception
+        loadCatalogMgr = new CatalogMgr(new ConnectorMgr());
+        reader = new SRMetaBlockReader(image.getDataInputStream());
+        new MockUp<CatalogMgr>() {
+            @mockit.Mock
+            public void replayCreateCatalog(Catalog catalog) throws DdlException {
+                throw new DdlException("create catalog failed");
+            }
+        };
+
+        try {
+            loadCatalogMgr.load(reader);
+        } catch (Exception e) {
+            // should not throw exception
+            Assert.fail();
+        }
+        Assert.assertFalse(loadCatalogMgr.catalogExists("hive_catalog"));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
when load image for catalogMgr, it may throw exception, and it will result in load image failed.
## What I'm doing:
catch the exception when replayCreateCatalog  throws exception, ignore the excption, and continue to load other catalog 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
