### PR TITLE
[BugFix] Report correct errors when there is no alive workers

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -28,7 +28,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
-import com.starrocks.lake.Utils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TStorageMedium;
@@ -118,7 +117,7 @@ public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
         WarehouseManager warehouseManager =  GlobalStateMgr.getCurrentState().getWarehouseMgr();
         return GlobalStateMgr.getCurrentState().getStarOSAgent()
                 .createShards(shardCount, pathInfo, cacheInfo, groupId, matchShardIds, properties,
-                        Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouseId)
+                        warehouseManager.selectWorkerGroupByWarehouseId(warehouseId)
                                 .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -118,7 +118,7 @@ public class LakeTableHelper {
                     throw new RuntimeException("Cannot call getShardInfo in checkpoint thread");
                 }
                 WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-                long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouseId)
+                long workerGroupId = warehouseManager.selectWorkerGroupByWarehouseId(warehouseId)
                         .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
                 ShardInfo shardInfo = GlobalStateMgr.getCurrentState().getStarOSAgent().getShardInfo(tablet.getShardId(),
                         workerGroupId);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -99,7 +99,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             try {
                 WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
                 Warehouse warehouse = manager.getBackgroundWarehouse();
-                long workerGroupId = Utils.selectWorkerGroupByWarehouseId(manager, warehouse.getId())
+                long workerGroupId = manager.selectWorkerGroupByWarehouseId(warehouse.getId())
                         .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
                 long backendId = starOSAgent.getPrimaryComputeNodeIdByShard(shardId, workerGroupId);
                 shardIdsByBeMap.computeIfAbsent(backendId, k -> Sets.newHashSet()).add(shardId);
@@ -214,7 +214,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         try {
             WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
-            long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouse.getId())
+            long workerGroupId = warehouseManager.selectWorkerGroupByWarehouseId(warehouse.getId())
                     .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
             List<String> workerAddresses = GlobalStateMgr.getCurrentState().getStarOSAgent().listWorkerGroupIpPort(workerGroupId);
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -33,8 +33,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.warehouse.Warehouse;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -208,22 +206,6 @@ public class Utils {
                 throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
             }
         }
-    }
-
-    public static Optional<Long> selectWorkerGroupByWarehouseId(WarehouseManager manager, long warehouseId) {
-        Warehouse warehouse = manager.getWarehouse(warehouseId);
-        if (warehouse == null)  {
-            LOG.warn("failed to get warehouse by id {}", warehouseId);
-            return Optional.empty();
-        }
-
-        List<Long> ids = warehouse.getWorkerGroupIds();
-        if (CollectionUtils.isEmpty(ids)) {
-            LOG.warn("failed to get worker group id from warehouse {}", warehouse);
-            return Optional.empty();
-        }
-
-        return Optional.of(ids.get(0));
     }
 
     public static Optional<Long> getWarehouseIdByNodeId(SystemInfoService systemInfo, long nodeId) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -20,13 +20,17 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -65,16 +69,23 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
                                                                        boolean preferComputeNode,
                                                                        int numUsedComputeNodes, long warehouseId) {
 
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
-            List<Long> computeNodeIds =
-                    GlobalStateMgr.getCurrentState().getWarehouseMgr().getAllComputeNodeIds(warehouseId);
+            List<Long> computeNodeIds = warehouseManager.getAllComputeNodeIds(warehouseId);
             computeNodeIds.forEach(nodeId -> builder.put(nodeId,
                     GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeId)));
             ImmutableMap<Long, ComputeNode> idToComputeNode = builder.build();
             if (LOG.isDebugEnabled()) {
                 LOG.debug("idToComputeNode: {}", idToComputeNode);
             }
-            return new DefaultSharedDataWorkerProvider(idToComputeNode, filterAvailableWorkers(idToComputeNode));
+
+            ImmutableMap<Long, ComputeNode> availableComputeNodes = filterAvailableWorkers(idToComputeNode);
+            if (availableComputeNodes.isEmpty()) {
+                Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
+                ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
+            }
+
+            return new DefaultSharedDataWorkerProvider(idToComputeNode, availableComputeNodes);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -71,6 +71,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
@@ -79,6 +80,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.rowstore.RowStoreUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -97,6 +99,7 @@ import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -523,9 +526,10 @@ public class OlapScanNode extends ScanNode {
             List<Replica> allQueryableReplicas = Lists.newArrayList();
             List<Replica> localReplicas = Lists.newArrayList();
             if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
-                List<Long> computeNodeIds = GlobalStateMgr.getCurrentState().getWarehouseMgr().getAllComputeNodeIds(warehouseId);
-                if (computeNodeIds.isEmpty()) {
-                    throw new UserException(" no backend or compute node in warehouse " + warehouseId);
+                WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+                if (CollectionUtils.isEmpty(warehouseManager.getAliveComputeNodes(warehouseId))) {
+                    Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
+                    ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
                 }
 
                 tablet.getQueryableReplicas(allQueryableReplicas, localReplicas,

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -138,7 +138,6 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeMaterializedView;
 import com.starrocks.lake.LakeTablet;
-import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.load.pipe.PipeManager;
 import com.starrocks.persist.AddPartitionsInfoV2;
@@ -286,6 +285,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -2497,11 +2497,14 @@ public class LocalMetastore implements ConnectorMetadata {
         properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(index.getId()));
         int bucketNum = distributionInfo.getBucketNum();
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        Optional<Long> workerGroupId = warehouseManager.selectWorkerGroupByWarehouseId(warehouseId);
+        if (workerGroupId.isEmpty()) {
+            Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
+            ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
+        }
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(partitionId), table.getPartitionFileCacheInfo(partitionId), shardGroupId,
-                null, properties,
-                com.starrocks.lake.Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouseId)
-                        .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID));
+                null, properties, workerGroupId.get());
         for (long shardId : shardIds) {
             Tablet tablet = new LakeTablet(shardId);
             index.addTablet(tablet, tabletMeta);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.lake;
 
-import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.UserException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
@@ -29,18 +28,10 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Optional;
-
 public class UtilsTest {
 
     @Mocked
-    GlobalStateMgr globalStateMgr;
-
-    @Mocked
     NodeMgr nodeMgr;
-
-    @Mocked
-    NodeSelector nodeSelector;
 
     @Test
     public void testChooseBackend() {
@@ -73,25 +64,6 @@ public class UtilsTest {
                 throw new UserException("No backend or compute node alive.");
             }
         };
-    }
-
-    @Test
-    public void testGetWarehouse() {
-        WarehouseManager manager = new WarehouseManager();
-        manager.initDefaultWarehouse();
-
-        Optional<Long> workerGroupId = Utils.selectWorkerGroupByWarehouseId(manager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
-        Assert.assertFalse(workerGroupId.isEmpty());
-        Assert.assertEquals(StarOSAgent.DEFAULT_WORKER_GROUP_ID, workerGroupId.get().longValue());
-
-        try {
-            workerGroupId = Optional.ofNullable(null);
-            workerGroupId = Utils.selectWorkerGroupByWarehouseId(manager, 1111L);
-            Assert.assertEquals(1, 2);   // can not be here
-        } catch (ErrorReportException e) {
-            Assert.assertTrue(workerGroupId.isEmpty());
-            Assert.assertEquals(workerGroupId.orElse(1000L).longValue(), 1000L);
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -46,6 +46,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class PseudoClusterTest {
@@ -245,6 +247,12 @@ public class PseudoClusterTest {
             @Mock
             public FilePathInfo allocateFilePath(String storageVolumeId, long dbId, long tableId) throws DdlException {
                 return pathInfo;
+            }
+
+            @Mock
+            public List<Long> getWorkersByWorkerGroup(long workerGroupId) throws UserException {
+                // the worker id is a random number
+                return new ArrayList<>(Arrays.asList(10001L));
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -14,11 +14,41 @@
 
 package com.starrocks.server;
 
+import com.google.common.collect.Lists;
+import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.UserException;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.warehouse.DefaultWarehouse;
+import com.starrocks.warehouse.Warehouse;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
 public class WarehouseManagerTest {
+    @Mocked
+    GlobalStateMgr globalStateMgr;
+
+    @Mocked
+    NodeMgr nodeMgr;
+
+    @Mocked
+    SystemInfoService systemInfo;
+
+    @Mocked
+    StarOSAgent starOSAgent;
 
     @Test
     public void testWarehouseNotExist() {
@@ -35,5 +65,198 @@ public class WarehouseManagerTest {
                 () -> mgr.getComputeNodeId("a", null));
         ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
                 () -> mgr.getComputeNodeId(1L, null));
+    }
+
+    @Test
+    public void testGetAliveComputeNodes() throws UserException {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public NodeMgr getNodeMgr() {
+                return nodeMgr;
+            }
+        };
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public SystemInfoService getClusterInfo() {
+                return systemInfo;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                if (nodeId == 10003L) {
+                    ComputeNode node = new ComputeNode();
+                    node.setAlive(false);
+                    return node;
+                }
+                ComputeNode node = new ComputeNode();
+                node.setAlive(true);
+                return node;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkersByWorkerGroup(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                minTimes = 0;
+                result = Lists.newArrayList(10003L, 10004L);
+            }
+        };
+
+        WarehouseManager mgr = new WarehouseManager();
+        mgr.initDefaultWarehouse();
+
+        List<Long> nodeIds = mgr.getAllComputeNodeIds(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        Assert.assertEquals(2, nodeIds.size());
+
+        List<ComputeNode> nodes = mgr.getAliveComputeNodes(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        Assert.assertEquals(1, nodes.size());
+    }
+
+    @Test
+    public void testSelectWorkerGroupByWarehouseId_hasAliveNodes() throws UserException {
+        Backend b1 = new Backend(10001L, "192.168.0.1", 9050);
+        b1.setBePort(9060);
+        b1.setAlive(true);
+        b1.setWarehouseId(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public NodeMgr getNodeMgr() {
+                return nodeMgr;
+            }
+
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public SystemInfoService getClusterInfo() {
+                return systemInfo;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                return b1;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> getWorkersByWorkerGroup(long workerGroupId) throws UserException {
+                if (workerGroupId == StarOSAgent.DEFAULT_WORKER_GROUP_ID) {
+                    return Lists.newArrayList(b1.getId());
+                }
+                return Lists.newArrayList();
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<ComputeNode> getAliveComputeNodes(long warehouseId) {
+                if (warehouseId == WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+                    return new ArrayList<>(Arrays.asList(b1));
+                }
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                if (warehouseId != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+                    ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("id: %d", warehouseId));
+                }
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+        };
+
+        WarehouseManager warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
+        Optional<Long> workerGroupId = warehouseManager.selectWorkerGroupByWarehouseId(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        Assert.assertFalse(workerGroupId.isEmpty());
+        Assert.assertEquals(StarOSAgent.DEFAULT_WORKER_GROUP_ID, workerGroupId.get().longValue());
+
+        try {
+            workerGroupId = Optional.ofNullable(null);
+            workerGroupId = warehouseManager.selectWorkerGroupByWarehouseId(1111L);
+            Assert.assertEquals(1, 2);   // can not be here
+        } catch (ErrorReportException e) {
+            Assert.assertTrue(workerGroupId.isEmpty());
+            Assert.assertEquals(workerGroupId.orElse(1000L).longValue(), 1000L);
+        }
+    }
+
+    @Test
+    public void testSelectWorkerGroupByWarehouseId_hasNoAliveNodes() throws UserException {
+        Backend b1 = new Backend(10001L, "192.168.0.1", 9050);
+        b1.setBePort(9060);
+        b1.setAlive(false);
+        b1.setWarehouseId(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public NodeMgr getNodeMgr() {
+                return nodeMgr;
+            }
+
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public SystemInfoService getClusterInfo() {
+                return systemInfo;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                return b1;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> getWorkersByWorkerGroup(long workerGroupId) throws UserException {
+                if (workerGroupId == StarOSAgent.DEFAULT_WORKER_GROUP_ID) {
+                    return Lists.newArrayList(b1.getId());
+                }
+                return Lists.newArrayList();
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<ComputeNode> getAliveComputeNodes(long warehouseId) {
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                if (warehouseId != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+                    ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("id: %d", warehouseId));
+                }
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+        };
+
+        try {
+            WarehouseManager warehouseManager = new WarehouseManager();
+            warehouseManager.initDefaultWarehouse();
+            Optional<Long> workerGroupId = warehouseManager.selectWorkerGroupByWarehouseId(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+            Assert.assertTrue(workerGroupId.isEmpty());
+        } catch (ErrorReportException e) {
+            Assert.assertEquals(1, 2);   // can not be here
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Report correct errors when there is no alive workers.

```
[sr@iZ8vbbr5n5arc0z8b22vabZ be]$ ./bin/stop_be.sh

mysql> create table t3(a int);
ERROR 1064 (HY000): Unexpected exception: Failed to get primary backend. shard id: 10117

mysql> select * from t12;
ERROR 1064 (HY000): Backend node not found. Check if any backend node is down.backend: [172.26.80.30 alive: false inBlacklist: false]

mysql> create table t9(a int);
ERROR 1064 (HY000): Unexpected exception: Failed to create shards. error: INVALID_ARGUMENT:shard info can not be empty.
```

When a warehouse has no alive workers, SR will report errors, but not quit correct.

## What I'm doing:

In the logic of "create table" and "DefaultSharedDataWorkerProvider," check for the existence of an "alive worker."

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
