### PR TITLE
[Refactor] Add cur_probe_index to join hashtable

### DIFF
--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -187,6 +187,7 @@ struct HashTableProbeState {
     // When one-to-many, one probe may not be able to probe all the data,
     // cur_probe_index records the position of the last probe
     uint32_t cur_probe_index = 0;
+    uint32_t cur_build_index = 0;
     uint32_t cur_row_match_count = 0;
 
     std::unique_ptr<MemPool> probe_pool = nullptr;
@@ -241,6 +242,7 @@ struct HashTableProbeState {
               match_flag(rhs.match_flag),
               has_remain(rhs.has_remain),
               cur_probe_index(rhs.cur_probe_index),
+              cur_build_index(rhs.cur_build_index),
               cur_row_match_count(rhs.cur_row_match_count),
               probe_pool(rhs.probe_pool == nullptr ? nullptr : std::make_unique<MemPool>()),
               search_ht_timer(rhs.search_ht_timer),
@@ -511,9 +513,9 @@ public:
     explicit JoinHashMapForEmpty(JoinHashTableItems* table_items, HashTableProbeState* probe_state)
             : _table_items(table_items), _probe_state(probe_state) {}
 
-    void build_prepare(RuntimeState* state) { return; }
-    void probe_prepare(RuntimeState* state) { return; }
-    void build(RuntimeState* state) { return; }
+    void build_prepare(RuntimeState* state) {}
+    void probe_prepare(RuntimeState* state) {}
+    void build(RuntimeState* state) {}
     void probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
                bool* has_remain) {
         DCHECK_EQ(0, _table_items->row_count);
@@ -610,7 +612,6 @@ private:
     void _probe_null_output(ChunkPtr* chunk, size_t count);
 
     void _build_output(ChunkPtr* chunk);
-    void _build_default_output(ChunkPtr* chunk, size_t count);
 
     void _copy_probe_column(ColumnPtr* src_column, ChunkPtr* chunk, const SlotDescriptor* slot, bool to_nullable);
 

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -612,6 +612,7 @@ private:
     void _probe_null_output(ChunkPtr* chunk, size_t count);
 
     void _build_output(ChunkPtr* chunk);
+    void _build_default_output(ChunkPtr* chunk, size_t count);
 
     void _copy_probe_column(ColumnPtr* src_column, ChunkPtr* chunk, const SlotDescriptor* slot, bool to_nullable);
 

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -978,40 +978,6 @@ TEST_F(JoinHashMapTest, ProbeNullOutput) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, BuildDefaultOutput) {
-    JoinHashTableItems table_items;
-    HashTableProbeState probe_state;
-    table_items.build_column_count = 3;
-
-    TDescriptorTableBuilder row_desc_builder;
-    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
-    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
-    auto row_desc = create_row_desc(&row_desc_builder);
-
-    vector<HashTableSlotDescriptor> hash_table_slot_vec;
-    for (auto& slot : row_desc->tuple_descriptors()[0]->slots()) {
-        HashTableSlotDescriptor hash_table_slot{};
-        hash_table_slot.slot = slot;
-        hash_table_slot.need_output = true;
-        hash_table_slot_vec.emplace_back(hash_table_slot);
-    }
-    table_items.build_slots = hash_table_slot_vec;
-
-    auto chunk = std::make_shared<Chunk>();
-    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_build_default_output(&chunk, 2);
-
-    ASSERT_EQ(chunk->num_columns(), 3);
-
-    for (size_t i = 0; i < chunk->num_columns(); i++) {
-        auto null_column = ColumnHelper::as_raw_column<NullableColumn>(chunk->columns()[i])->null_column();
-        for (size_t j = 0; j < 2; j++) {
-            ASSERT_EQ(null_column->get_data()[j], 1);
-        }
-    }
-}
-
-// NOLINTNEXTLINE
 TEST_F(JoinHashMapTest, JoinBuildProbeFunc) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -978,6 +978,40 @@ TEST_F(JoinHashMapTest, ProbeNullOutput) {
 }
 
 // NOLINTNEXTLINE
+TEST_F(JoinHashMapTest, BuildDefaultOutput) {
+    JoinHashTableItems table_items;
+    HashTableProbeState probe_state;
+    table_items.build_column_count = 3;
+
+    TDescriptorTableBuilder row_desc_builder;
+    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
+    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
+
+    vector<HashTableSlotDescriptor> hash_table_slot_vec;
+    for (auto& slot : row_desc->tuple_descriptors()[0]->slots()) {
+        HashTableSlotDescriptor hash_table_slot{};
+        hash_table_slot.slot = slot;
+        hash_table_slot.need_output = true;
+        hash_table_slot_vec.emplace_back(hash_table_slot);
+    }
+    table_items.build_slots = hash_table_slot_vec;
+
+    auto chunk = std::make_shared<Chunk>();
+    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
+    join_hash_map->_build_default_output(&chunk, 2);
+
+    ASSERT_EQ(chunk->num_columns(), 3);
+
+    for (size_t i = 0; i < chunk->num_columns(); i++) {
+        auto null_column = ColumnHelper::as_raw_column<NullableColumn>(chunk->columns()[i])->null_column();
+        for (size_t j = 0; j < 2; j++) {
+            ASSERT_EQ(null_column->get_data()[j], 1);
+        }
+    }
+}
+
+// NOLINTNEXTLINE
 TEST_F(JoinHashMapTest, JoinBuildProbeFunc) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;


### PR DESCRIPTION
## Why I'm doing:

This is the third pr for lazy materialize join.

When join appears 1-to-many, for hash-join one key may produce multiple rows according to the equivalent conditions, so we need to record the position of the last join (probe_index, build_index). 

Currently, only probe index is recorded, and the build index is obtained through the build index array, but after supporting lazy materialize join later, this array will be changed when doing non-equivalent join conjunctions. 

So add current build index here to record the location of the last probe.

## What I'm doing:

* Add cur_probe_index to join hashtable.
* For left-semi-join/left-anti-join/right-semi-join/right-anti-join with no other conjunct, no need to output the place-hold column now.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
