### PR TITLE
[BugFix] Fix schemachange failed caused by storage migration

### DIFF
--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -57,6 +57,12 @@ Status EngineStorageMigrationTask::execute() {
         return Status::NotFound(fmt::format("Not found tablet: {}", _tablet_id));
     }
 
+    if (tablet->tablet_state() == TABLET_NOTREADY) {
+        LOG(WARNING) << "storage migrate failed, tablet is in schemachange process. tablet_id=" << _tablet_id;
+        return Status::InternalError(
+                fmt::format("storage migrate failed, tablet is in schemachange process. tablet_id: {}", _tablet_id));
+    }
+
     // check tablet data dir
     if (tablet->data_dir() == _dest_store) {
         LOG(INFO) << "Already existed path. tablet_id=" << _tablet_id << ", dest_store=" << _dest_store->path();

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -573,7 +573,6 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_empty_pk_tablet) {
     ASSERT_TRUE(tablet != nullptr);
     ASSERT_EQ(tablet->tablet_id(), empty_tablet_id);
     DataDir* source_path = tablet->data_dir();
-    tablet.reset();
     DataDir* dest_path = nullptr;
     DataDir* data_dir_1 = starrocks::StorageEngine::instance()->get_stores()[0];
     DataDir* data_dir_2 = starrocks::StorageEngine::instance()->get_stores()[1];
@@ -582,6 +581,11 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_empty_pk_tablet) {
     } else {
         dest_path = data_dir_1;
     }
+    tablet->set_tablet_state(TabletState::TABLET_NOTREADY);
+    EngineStorageMigrationTask migration_task_not_ready(empty_tablet_id, empty_schema_hash, dest_path);
+    ASSERT_ERROR(migration_task_not_ready.execute());
+    tablet->set_tablet_state(TabletState::TABLET_RUNNING);
+    tablet.reset();
     EngineStorageMigrationTask migration_task(empty_tablet_id, empty_schema_hash, dest_path);
     ASSERT_OK(migration_task.execute());
 }


### PR DESCRIPTION
## Why I'm doing:

Schemachange will fail if tablet was migrated

## What I'm doing:

When doing migration, check if tablet is in schemachange process, if so abort migration.

Fixes #45384

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
