### PR TITLE
[Enhancement] support cache select metrics for cloud table

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -583,13 +583,23 @@ void LakeDataSource::update_counter() {
     COUNTER_UPDATE(_io_count_total_counter, _reader->stats().io_count);
     COUNTER_UPDATE(_io_count_request_counter, _reader->stats().io_count_request);
 
-    COUNTER_UPDATE(_io_ns_local_disk_timer, _reader->stats().io_ns_local_disk);
+    COUNTER_UPDATE(_io_ns_local_disk_timer, _reader->stats().io_ns_read_local_disk);
     COUNTER_UPDATE(_io_ns_remote_timer, _reader->stats().io_ns_remote);
     COUNTER_UPDATE(_io_ns_total_timer, _reader->stats().io_ns);
 
     COUNTER_UPDATE(_prefetch_hit_counter, _reader->stats().prefetch_hit_count);
     COUNTER_UPDATE(_prefetch_wait_finish_timer, _reader->stats().prefetch_wait_finish_ns);
     COUNTER_UPDATE(_prefetch_pending_timer, _reader->stats().prefetch_pending_ns);
+
+    // update cache related info for CACHE SELECT
+    if (_runtime_state->query_options().__isset.query_type &&
+        _runtime_state->query_options().query_type == TQueryType::LOAD) {
+        _runtime_state->update_num_datacache_read_bytes(_reader->stats().compressed_bytes_read_local_disk);
+        _runtime_state->update_num_datacache_read_time_ns(_reader->stats().io_ns_read_local_disk);
+        _runtime_state->update_num_datacache_write_bytes(_reader->stats().compressed_bytes_write_local_disk);
+        _runtime_state->update_num_datacache_write_time_ns(_reader->stats().io_ns_write_local_disk);
+        _runtime_state->update_num_datacache_count(1);
+    }
 }
 
 // ================================

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -175,12 +175,14 @@ public:
 
         const auto& read_stats = (*stream_st)->get_io_stats();
         auto stats = std::make_unique<io::NumericStatistics>();
-        stats->reserve(9);
+        stats->reserve(11);
         stats->append(kBytesReadLocalDisk, read_stats.bytes_read_local_disk);
+        stats->append(kBytesWriteLocalDisk, read_stats.bytes_write_local_disk);
         stats->append(kBytesReadRemote, read_stats.bytes_read_remote);
         stats->append(kIOCountLocalDisk, read_stats.io_count_local_disk);
         stats->append(kIOCountRemote, read_stats.io_count_remote);
-        stats->append(kIONsLocalDisk, read_stats.io_ns_read_local_disk);
+        stats->append(kIONsReadLocalDisk, read_stats.io_ns_read_local_disk);
+        stats->append(kIONsWriteLocalDisk, read_stats.io_ns_write_local_disk);
         stats->append(kIONsRemote, read_stats.io_ns_remote);
         stats->append(kPrefetchHitCount, read_stats.prefetch_hit_count);
         stats->append(kPrefetchWaitFinishNs, read_stats.prefetch_wait_finish_ns);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -48,6 +48,9 @@
 #include "exec/pipeline/query_context.h"
 #include "exprs/jit/jit_engine.h"
 #include "fs/fs_util.h"
+#ifdef USE_STAROS
+#include "fslib/star_cache_handler.h"
+#endif
 #include "runtime/datetime_value.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -519,6 +522,40 @@ Status RuntimeState::reset_epoch() {
 bool RuntimeState::is_jit_enabled() const {
     return JITEngine::get_instance()->support_jit() && _query_options.__isset.jit_level &&
            _query_options.jit_level != 0;
+}
+
+void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_params) const {
+    if (!_query_options.__isset.catalog) {
+        return;
+    }
+
+    TLoadDataCacheMetrics metrics{};
+    metrics.__set_read_bytes(_num_datacache_read_bytes.load(std::memory_order_relaxed));
+    metrics.__set_read_time_ns(_num_datacache_read_time_ns.load(std::memory_order_relaxed));
+    metrics.__set_write_bytes(_num_datacache_write_bytes.load(std::memory_order_relaxed));
+    metrics.__set_write_time_ns(_num_datacache_write_time_ns.load(std::memory_order_relaxed));
+    metrics.__set_count(_num_datacache_count.load(std::memory_order_relaxed));
+
+    if (_query_options.catalog == "default_catalog") {
+#ifdef USE_STAROS
+        if (config::starlet_use_star_cache) {
+            TDataCacheMetrics t_metrics{};
+            starcache::CacheMetrics cache_metrics;
+            staros::starlet::fslib::star_cache_get_metrics(&cache_metrics);
+            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache_metrics);
+            metrics.__set_metrics(t_metrics);
+            load_params->__set_load_datacache_metrics(metrics);
+        }
+#endif // USE_STAROS
+    } else {
+        if (config::datacache_enable) {
+            const BlockCache* cache = BlockCache::instance();
+            TDataCacheMetrics t_metrics{};
+            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());
+            metrics.__set_metrics(t_metrics);
+            load_params->__set_load_datacache_metrics(metrics);
+        }
+    }
 }
 
 } // end namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -329,34 +329,7 @@ public:
         _num_datacache_count.fetch_add(count, std::memory_order_relaxed);
     }
 
-    void update_load_datacache_metrics(TReportExecStatusParams* load_params) const {
-        if (!_query_options.__isset.catalog) {
-            return;
-        }
-
-        TLoadDataCacheMetrics metrics{};
-        metrics.__set_read_bytes(_num_datacache_read_bytes.load(std::memory_order_relaxed));
-        metrics.__set_read_time_ns(_num_datacache_read_time_ns.load(std::memory_order_relaxed));
-        metrics.__set_write_bytes(_num_datacache_write_bytes.load(std::memory_order_relaxed));
-        metrics.__set_write_time_ns(_num_datacache_write_time_ns.load(std::memory_order_relaxed));
-        metrics.__set_count(_num_datacache_count.load(std::memory_order_relaxed));
-
-        if (_query_options.catalog == "default_catalog") {
-#ifdef USE_STAROS
-            if (config::starlet_use_star_cache) {
-                // support this later
-            }
-#endif
-        } else {
-            if (config::datacache_enable) {
-                const BlockCache* cache = BlockCache::instance();
-                TDataCacheMetrics t_metrics{};
-                DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());
-                metrics.__set_metrics(t_metrics);
-                load_params->__set_load_datacache_metrics(metrics);
-            }
-        }
-    }
+    void update_load_datacache_metrics(TReportExecStatusParams* load_params) const;
 
     std::atomic_int64_t* mutable_total_spill_bytes();
 

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -27,7 +27,7 @@ static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
 void CompactionTaskStats::accumulate(const OlapReaderStatistics& reader_stats) {
     io_ns += reader_stats.io_ns;
     io_ns_remote += reader_stats.io_ns_remote;
-    io_ns_local_disk += reader_stats.io_ns_local_disk;
+    io_ns_local_disk += reader_stats.io_ns_read_local_disk;
     segment_init_ns += reader_stats.segment_init_ns;
     column_iterator_init_ns += reader_stats.column_iterator_init_ns;
     io_count_local_disk += reader_stats.io_count_local_disk;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -280,6 +280,7 @@ struct OlapReaderStatistics {
     int64_t pages_from_local_disk = 0;
 
     int64_t compressed_bytes_read_local_disk = 0;
+    int64_t compressed_bytes_write_local_disk = 0;
     int64_t compressed_bytes_read_remote = 0;
     // bytes read requested from be, same as compressed_bytes_read for local tablet
     int64_t compressed_bytes_read_request = 0;
@@ -289,7 +290,8 @@ struct OlapReaderStatistics {
     int64_t io_count_remote = 0;
     int64_t io_count_request = 0;
 
-    int64_t io_ns_local_disk = 0;
+    int64_t io_ns_read_local_disk = 0;
+    int64_t io_ns_write_local_disk = 0;
     int64_t io_ns_remote = 0;
 
     int64_t prefetch_hit_count = 0;
@@ -310,10 +312,12 @@ struct OlapWriterStatistics {
 };
 
 const char* const kBytesReadLocalDisk = "bytes_read_local_disk";
+const char* const kBytesWriteLocalDisk = "bytes_write_local_disk";
 const char* const kBytesReadRemote = "bytes_read_remote";
 const char* const kIOCountLocalDisk = "io_count_local_disk";
 const char* const kIOCountRemote = "io_count_remote";
-const char* const kIONsLocalDisk = "io_ns_local_disk";
+const char* const kIONsReadLocalDisk = "io_ns_read_local_disk";
+const char* const kIONsWriteLocalDisk = "io_ns_write_local_disk";
 const char* const kIONsRemote = "io_ns_remote";
 const char* const kPrefetchHitCount = "prefetch_hit_count";
 const char* const kPrefetchWaitFinishNs = "prefetch_wait_finish_ns";

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2090,6 +2090,8 @@ void SegmentIterator::_update_stats(io::SeekableInputStream* rfile) {
         if (name == kBytesReadLocalDisk) {
             _opts.stats->compressed_bytes_read_local_disk += value;
             _opts.stats->compressed_bytes_read += value;
+        } else if (name == kBytesWriteLocalDisk) {
+            _opts.stats->compressed_bytes_write_local_disk += value;
         } else if (name == kBytesReadRemote) {
             _opts.stats->compressed_bytes_read_remote += value;
             _opts.stats->compressed_bytes_read += value;
@@ -2099,8 +2101,10 @@ void SegmentIterator::_update_stats(io::SeekableInputStream* rfile) {
         } else if (name == kIOCountRemote) {
             _opts.stats->io_count_remote += value;
             _opts.stats->io_count += value;
-        } else if (name == kIONsLocalDisk) {
-            _opts.stats->io_ns_local_disk += value;
+        } else if (name == kIONsReadLocalDisk) {
+            _opts.stats->io_ns_read_local_disk += value;
+        } else if (name == kIONsWriteLocalDisk) {
+            _opts.stats->io_ns_write_local_disk += value;
         } else if (name == kIONsRemote) {
             _opts.stats->io_ns_remote += value;
         } else if (name == kPrefetchHitCount) {

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -63,7 +63,7 @@ TEST_F(CompactionTaskContextTest, test_accumulate) {
     OlapReaderStatistics reader_stats;
     reader_stats.io_ns = 100;
     reader_stats.io_ns_remote = 200;
-    reader_stats.io_ns_local_disk = 300;
+    reader_stats.io_ns_read_local_disk = 300;
     reader_stats.segment_init_ns = 400;
     reader_stats.column_iterator_init_ns = 500;
     reader_stats.io_count_local_disk = 600;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```plaintext
mysql> cache select * from ssb.lineorder;
+---------+---------------------+------------------+----------------------+-------------------+
| STATUS  | ALREADY_CACHED_SIZE | WRITE_CACHE_SIZE | AVG_WRITE_CACHE_TIME | TOTAL_CACHE_USAGE |
+---------+---------------------+------------------+----------------------+-------------------+
| SUCCESS | 15.2MB              | 754.7MB          | 88.7ms               | 29.04%            |
+---------+---------------------+------------------+----------------------+-------------------+
1 row in set (36.56 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
