### PR TITLE
[Doc] fix obs in loading from s3-compatible storage

### DIFF
--- a/docs/en/loading/BrokerLoad.md
+++ b/docs/en/loading/BrokerLoad.md
@@ -221,12 +221,12 @@ Use MinIO as an example. You can execute the following statement to load `file1.
 ```SQL
 LOAD LABEL test_db.label7
 (
-    DATA INFILE("obs://bucket_minio/input/file1.csv")
+    DATA INFILE("s3://bucket_minio/input/file1.csv")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
     ,
-    DATA INFILE("obs://bucket_minio/input/file2.csv")
+    DATA INFILE("s3://bucket_minio/input/file2.csv")
     INTO TABLE table2
     COLUMNS TERMINATED BY ","
     (id, city)

--- a/docs/en/loading/cloud_storage_load.md
+++ b/docs/en/loading/cloud_storage_load.md
@@ -605,7 +605,7 @@ Execute the following statement to load the data of `file1.csv` stored in the `i
 ```SQL
 LOAD LABEL test_db.label_brokerloadtest_401
 (
-    DATA INFILE("obs://bucket_minio/input/file1.csv")
+    DATA INFILE("s3://bucket_minio/input/file1.csv")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
@@ -652,7 +652,7 @@ Execute the following statement to load the data of all data files (`file1.csv` 
 ```SQL
 LOAD LABEL test_db.label_brokerloadtest_402
 (
-    DATA INFILE("obs://bucket_minio/input/*")
+    DATA INFILE("s3://bucket_minio/input/*")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
@@ -703,12 +703,12 @@ Execute the following statement to load the data of all data files (`file1.csv` 
 ```SQL
 LOAD LABEL test_db.label_brokerloadtest_403
 (
-    DATA INFILE("obs://bucket_minio/input/file1.csv")
+    DATA INFILE("s3://bucket_minio/input/file1.csv")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
     ,
-    DATA INFILE("obs://bucket_minio/input/file2.csv")
+    DATA INFILE("s3://bucket_minio/input/file2.csv")
     INTO TABLE table2
     COLUMNS TERMINATED BY ","
     (id, city)

--- a/docs/zh/loading/BrokerLoad.md
+++ b/docs/zh/loading/BrokerLoad.md
@@ -309,12 +309,12 @@ WITH BROKER
 ```SQL
 LOAD LABEL test_db.label7
 (
-    DATA INFILE("obs://bucket_minio/input/file1.csv")
+    DATA INFILE("s3://bucket_minio/input/file1.csv")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
     ,
-    DATA INFILE("obs://bucket_minio/input/file2.csv")
+    DATA INFILE("s3://bucket_minio/input/file2.csv")
     INTO TABLE table2
     COLUMNS TERMINATED BY ","
     (id, city)

--- a/docs/zh/loading/cloud_storage_load.md
+++ b/docs/zh/loading/cloud_storage_load.md
@@ -1100,7 +1100,7 @@ PROPERTIES
 ```SQL
 LOAD LABEL test_db.label_brokerloadtest_701
 (
-    DATA INFILE("obs://bucket_minio/input/file1.csv")
+    DATA INFILE("s3://bucket_minio/input/file1.csv")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
@@ -1147,7 +1147,7 @@ SELECT * FROM table1;
 ```SQL
 LOAD LABEL test_db.label_brokerloadtest_702
 (
-    DATA INFILE("obs://bucket_minio/input/*")
+    DATA INFILE("s3://bucket_minio/input/*")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
@@ -1198,12 +1198,12 @@ SELECT * FROM table1;
 ```SQL
 LOAD LABEL test_db.label_brokerloadtest_703
 (
-    DATA INFILE("obs://bucket_minio/input/file1.csv")
+    DATA INFILE("s3://bucket_minio/input/file1.csv")
     INTO TABLE table1
     COLUMNS TERMINATED BY ","
     (id, name, score)
     ,
-    DATA INFILE("obs://bucket_minio/input/file2.csv")
+    DATA INFILE("s3://bucket_minio/input/file2.csv")
     INTO TABLE table2
     COLUMNS TERMINATED BY ","
     (id, name, score)


### PR DESCRIPTION
Signed-off-by: evelynzhaojie <everlyn.zhaojie@gmail.com

## Why I'm doing:

`obs` is wrong, should change to `s3` for MinIO

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [x] 2.5
