### PR TITLE
[Enhancement] Improve column not found in load files error message

### DIFF
--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -248,7 +248,7 @@ Status ParquetReaderWrap::column_indices(const std::vector<SlotDescriptor*>& tup
             }
         } else {
             std::stringstream str_error;
-            str_error << "Invalid Column Name:" << slot_desc->col_name();
+            str_error << "Column: " << slot_desc->col_name() << " is not found in file: " << _filename;
             LOG(WARNING) << str_error.str();
             return Status::InvalidArgument(str_error.str());
         }

--- a/be/src/formats/orc/orc_mapping.cpp
+++ b/be/src/formats/orc/orc_mapping.cpp
@@ -180,8 +180,7 @@ Status OrcMappingFactory::_init_orc_mapping_with_orc_column_names(std::unique_pt
                 // don't need to add mapping for none-existed column
                 continue;
             } else {
-                auto s = strings::Substitute("OrcMappingFactory::_init_orc_mapping not found column name $0, file = $1",
-                                             col_name, options.filename);
+                auto s = strings::Substitute("Column: $0 is not found in file: $1", col_name, options.filename);
                 return Status::NotFound(s);
             }
         }

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -947,10 +947,10 @@ class StarrocksSQLApiLib(object):
 
         # get records
         query_sql = """
-        select file, log_type, name, group_concat(log, ""), group_concat(hex(sequence), ",") 
+        select file, log_type, name, group_concat(log, ""), group_concat(hex(sequence), ",")
         from (
             select * from %s.%s where version=\"%s\" and log_type="R" order by sequence
-        ) a 
+        ) a
         group by file, log_type, name;
         """ % (
             T_R_DB,
@@ -1079,6 +1079,7 @@ class StarrocksSQLApiLib(object):
 
     def wait_load_finish(self, label, time_out=300):
         times = 0
+        load_state = ""
         while times < time_out:
             result = self.execute_sql('show load where label = "' + label + '"', True)
             log.info('show load where label = "' + label + '"')
@@ -1088,13 +1089,13 @@ class StarrocksSQLApiLib(object):
                 log.info(load_state)
                 if load_state == "CANCELLED":
                     log.info(result)
-                    return False
+                    break
                 elif load_state == "FINISHED":
                     log.info(result)
-                    return True
+                    break
             time.sleep(1)
             times += 1
-        tools.assert_less(times, time_out, "load failed, timeout 300s")
+        tools.assert_true(load_state in ("FINISHED", "CANCELLED"), "wait load finish error, timeout 300s")
 
     def show_routine_load(self, routine_load_task_name):
         show_sql = "show routine load for %s" % routine_load_task_name

--- a/test/sql/test_broker_load/R/test_broker_load_parquet
+++ b/test/sql/test_broker_load/R/test_broker_load_parquet
@@ -1,0 +1,44 @@
+-- name: test_broker_load_parquet_column_not_found
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (k1 int, k2 int, k3 int) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k2) BUCKETS 1 PROPERTIES("replication_num" = "3");
+-- result:
+-- !result
+insert into t1 values(1, 2, 3);
+-- result:
+-- !result
+insert into files (
+    "path" = "oss://${oss_bucket}/test_broker_load/test_parquet/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+) select k1, k2 from t1;
+-- result:
+-- !result
+LOAD LABEL label0_${uuid0} (
+    DATA INFILE("oss://${oss_bucket}/test_broker_load/test_parquet/${uuid0}/*") INTO TABLE t1 FORMAT AS "parquet" (k1, k2, k3)
+) WITH BROKER (
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+function: wait_load_finish("label0_${uuid0}")
+-- result:
+None
+-- !result
+select error_msg from information_schema.loads where label="label0_${uuid0}";
+-- result:
+[REGEX]type:LOAD_RUN_FAIL; msg:Column: k3 is not found in file:.*
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_broker_load/test_parquet/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_broker_load/T/test_broker_load_parquet
+++ b/test/sql/test_broker_load/T/test_broker_load_parquet
@@ -1,0 +1,22 @@
+-- name: test_broker_load_parquet_column_not_found
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE t1 (k1 int, k2 int, k3 int) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k2) BUCKETS 1 PROPERTIES("replication_num" = "3");
+insert into t1 values(1, 2, 3);
+insert into files (
+    "path" = "oss://${oss_bucket}/test_broker_load/test_parquet/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+) select k1, k2 from t1;
+LOAD LABEL label0_${uuid0} (
+    DATA INFILE("oss://${oss_bucket}/test_broker_load/test_parquet/${uuid0}/*") INTO TABLE t1 FORMAT AS "parquet" (k1, k2, k3)
+) WITH BROKER (
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+function: wait_load_finish("label0_${uuid0}")
+select error_msg from information_schema.loads where label="label0_${uuid0}";
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_broker_load/test_parquet/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
parquet file
```
*************************** 24. row ***************************
         JobId: 290314
         Label: label00
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:LOAD_RUN_FAIL; msg:Invalid Column Name:k3
    CreateTime: 2024-05-13 19:30:02
  EtlStartTime: 2024-05-13 19:30:49
 EtlFinishTime: 2024-05-13 19:30:49
 LoadStartTime: 2024-05-13 19:30:49
LoadFinishTime: 2024-05-13 19:30:49
   TrackingSQL:
    JobDetails: {"All backends":{"b57335d0-7cfb-435a-97cf-e4f81f8d0e46":[10004]},"FileNumber":1,"FileSize":996,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":1,"Unfinished backends":{"b57335d0-7cfb-435a-97cf-e4f81f8d0e46":[]}}
```

orc file
```
*************************** 25. row ***************************
         JobId: 290327
         Label: label00
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:LOAD_RUN_FAIL; msg:OrcMappingFactory::_init_orc_mapping not found column name k3, file = hdfs://172.26.92.212:10000/4.orc
    CreateTime: 2024-05-13 19:36:44
  EtlStartTime: 2024-05-13 19:36:49
 EtlFinishTime: 2024-05-13 19:36:49
 LoadStartTime: 2024-05-13 19:36:49
LoadFinishTime: 2024-05-13 19:36:49
   TrackingSQL:
    JobDetails: {"All backends":{"ed9cf5e0-2558-4983-a251-536f5c489bbe":[10004]},"FileNumber":1,"FileSize":336,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":1,"Unfinished backends":{"ed9cf5e0-2558-4983-a251-536f5c489bbe":[]}}
```

## What I'm doing:
parquet file
```
*************************** 26. row ***************************
         JobId: 290335
         Label: label00
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:LOAD_RUN_FAIL; msg:Column: k3 is not found in file: hdfs://172.26.92.212:10000/4.parq
    CreateTime: 2024-05-13 19:43:46
  EtlStartTime: 2024-05-13 19:43:49
 EtlFinishTime: 2024-05-13 19:43:49
 LoadStartTime: 2024-05-13 19:43:49
LoadFinishTime: 2024-05-13 19:43:51
   TrackingSQL:
    JobDetails: {"All backends":{"9677cf8a-a880-4339-ac35-d2e8004073b8":[10004]},"FileNumber":1,"FileSize":996,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":1,"Unfinished backends":{"9677cf8a-a880-4339-ac35-d2e8004073b8":[]}}
```

orc file
```
*************************** 27. row ***************************
         JobId: 290348
         Label: label00
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:LOAD_RUN_FAIL; msg:Column: k3 is not found in file: hdfs://172.26.92.212:10000/4.orc
    CreateTime: 2024-05-13 19:53:44
  EtlStartTime: 2024-05-13 19:53:49
 EtlFinishTime: 2024-05-13 19:53:49
 LoadStartTime: 2024-05-13 19:53:49
LoadFinishTime: 2024-05-13 19:53:51
   TrackingSQL:
    JobDetails: {"All backends":{"86efdf3a-9afa-4957-8e86-9c015e909125":[10004]},"FileNumber":1,"FileSize":336,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":1,"Unfinished backends":{"86efdf3a-9afa-4957-8e86-9c015e909125":[]}}
27 rows in set (0.00 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
