### PR TITLE
[Enhancement] Add storage-related profiles for load

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -200,6 +200,7 @@ void OlapTableSink::_prepare_profile(RuntimeState* state) {
     _ts_profile->server_rpc_timer = ADD_TIMER(_profile, "RpcServerSideTime");
     _ts_profile->server_wait_flush_timer = ADD_TIMER(_profile, "RpcServerWaitFlushTime");
     _ts_profile->alloc_auto_increment_timer = ADD_TIMER(_profile, "AllocAutoIncrementTime");
+    _ts_profile->update_load_channel_profile_timer = ADD_TIMER(_profile, "UpdateLoadChannelProfileTime");
 }
 
 void OlapTableSink::set_profile(RuntimeProfile* profile) {

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -833,6 +833,7 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
     }
 
     if (closure->result.has_load_channel_profile()) {
+        SCOPED_TIMER(_ts_profile->update_load_channel_profile_timer);
         const auto* buf = (const uint8_t*)(closure->result.load_channel_profile().data());
         uint32_t len = closure->result.load_channel_profile().size();
         TRuntimeProfileTree thrift_profile;

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -97,6 +97,7 @@ struct TabletSinkProfile {
     RuntimeProfile::Counter* server_rpc_timer = nullptr;
     RuntimeProfile::Counter* alloc_auto_increment_timer = nullptr;
     RuntimeProfile::Counter* server_wait_flush_timer = nullptr;
+    RuntimeProfile::Counter* update_load_channel_profile_timer = nullptr;
 };
 
 // map index_id to TabletBEMap(map tablet_id to backend id)

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -83,6 +83,11 @@ LoadChannel::LoadChannel(LoadChannelMgr* mgr, LakeTabletManager* lake_tablet_mgr
     _index_num = ADD_COUNTER(_profile, "IndexNum", TUnit::UNIT);
     ADD_COUNTER(_profile, "LoadMemoryLimit", TUnit::BYTES)->set(_mem_tracker->limit());
     _peak_memory_usage = ADD_PEAK_COUNTER(_profile, "PeakMemoryUsage", TUnit::BYTES);
+    _deserialize_chunk_count = ADD_COUNTER(_profile, "DeserializeChunkCount", TUnit::UNIT);
+    _deserialize_chunk_timer = ADD_TIMER(_profile, "DeserializeChunkTime");
+    _profile_report_count = ADD_COUNTER(_profile, "ProfileReportCount", TUnit::UNIT);
+    _profile_report_timer = ADD_TIMER(_profile, "ProfileReportTime");
+    _profile_serialized_size = ADD_COUNTER(_profile, "ProfileSerializedSize", TUnit::BYTES);
 }
 
 LoadChannel::~LoadChannel() {
@@ -164,7 +169,14 @@ void LoadChannel::_add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& r
                 fmt::format("cannot find the tablets channel associated with the key {}", key.to_string()));
         return;
     }
-    channel->add_chunk(chunk, request, response);
+    bool close_channel;
+    channel->add_chunk(chunk, request, response, &close_channel);
+    if (close_channel && _should_enable_profile()) {
+        // If close_channel is true, the channel has been removed from _tablets_channels
+        // in TabletsChannel::add_chunk, so there will be no chance to get the channel to
+        // update the profile later. So update the profile here
+        channel->update_profile();
+    }
 }
 
 void LoadChannel::add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {
@@ -306,6 +318,8 @@ Status LoadChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
 }
 
 Status LoadChannel::_deserialize_chunk(const ChunkPB& pchunk, Chunk& chunk, faststring* uncompressed_buffer) {
+    COUNTER_UPDATE(_deserialize_chunk_count, 1);
+    SCOPED_TIMER(_deserialize_chunk_timer);
     if (pchunk.compress_type() == CompressionTypePB::NO_COMPRESSION) {
         TRY_CATCH_BAD_ALLOC({
             serde::ProtobufChunkDeserializer des(_chunk_meta);
@@ -337,19 +351,39 @@ Status LoadChannel::_deserialize_chunk(const ChunkPB& pchunk, Chunk& chunk, fast
     return Status::OK();
 }
 
+std::vector<std::shared_ptr<TabletsChannel>> LoadChannel::_get_all_channels() {
+    std::vector<std::shared_ptr<TabletsChannel>> channels;
+    std::lock_guard l(_lock);
+    channels.reserve(_tablets_channels.size());
+    for (auto& it : _tablets_channels) {
+        channels.push_back(it.second);
+    }
+    return channels;
+}
+
+bool LoadChannel::_should_enable_profile() {
+    if (_enable_profile) {
+        return true;
+    }
+    if (_big_query_profile_threshold_ns <= 0) {
+        return false;
+    }
+    int64_t query_run_duration = MonotonicNanos() - _create_time_ns;
+    return query_run_duration > _big_query_profile_threshold_ns;
+}
+
 void LoadChannel::report_profile(PTabletWriterAddBatchResult* result, bool print_profile) {
-    // report profile if enable profile or the query has run for a long time
-    if (!_enable_profile) {
-        if (_big_query_profile_threshold_ns <= 0) {
-            return;
-        }
-        int64_t query_run_duration = MonotonicNanos() - _create_time_ns;
-        if (query_run_duration <= _big_query_profile_threshold_ns) {
-            return;
-        }
+    if (!_should_enable_profile()) {
+        return;
     }
 
-    int64_t last_report_tims_ns = _last_report_time_ns.load();
+    bool expect = false;
+    if (!_is_reporting_profile.compare_exchange_strong(expect, true)) {
+        // skip concurrent report
+        return;
+    }
+    DeferOp defer([this]() { _is_reporting_profile.store(false); });
+
     int64_t now = MonotonicNanos();
     bool should_report;
     if (_closed) {
@@ -357,15 +391,22 @@ void LoadChannel::report_profile(PTabletWriterAddBatchResult* result, bool print
         bool old = false;
         should_report = _final_report.compare_exchange_strong(old, true);
     } else {
-        // runtime profile report
-        bool time_to_report = now - last_report_tims_ns >= _runtime_profile_report_interval_ns;
-        should_report = time_to_report && _last_report_time_ns.compare_exchange_strong(last_report_tims_ns, now);
+        // runtime profile report periodically
+        should_report = now - _last_report_time_ns >= _runtime_profile_report_interval_ns;
     }
     if (!should_report) {
         return;
     }
 
+    _last_report_time_ns.store(now);
+    COUNTER_UPDATE(_profile_report_count, 1);
+    SCOPED_TIMER(_profile_report_timer);
+
     COUNTER_SET(_peak_memory_usage, _mem_tracker->peak_consumption());
+    auto channels = _get_all_channels();
+    for (auto& channel : channels) {
+        channel->update_profile();
+    }
     _profile->inc_version();
 
     if (print_profile) {
@@ -385,6 +426,7 @@ void LoadChannel::report_profile(PTabletWriterAddBatchResult* result, bool print
                    << ", status: " << st;
         return;
     }
+    COUNTER_UPDATE(_profile_serialized_size, len);
     result->set_load_channel_profile((char*)buf, len);
 }
 } // namespace starrocks

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -126,6 +126,8 @@ private:
     void _add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response);
     Status _build_chunk_meta(const ChunkPB& pb_chunk);
     Status _deserialize_chunk(const ChunkPB& pchunk, Chunk& chunk, faststring* uncompressed_buffer);
+    bool _should_enable_profile();
+    std::vector<std::shared_ptr<TabletsChannel>> _get_all_channels();
 
     LoadChannelMgr* _load_mgr;
     LakeTabletManager* _lake_tablet_mgr;
@@ -163,9 +165,15 @@ private:
     int64_t _runtime_profile_report_interval_ns = std::numeric_limits<int64_t>::max();
     std::atomic<int64_t> _last_report_time_ns{0};
     std::atomic<bool> _final_report{false};
+    std::atomic<bool> _is_reporting_profile{false};
 
     RuntimeProfile::Counter* _index_num = nullptr;
     RuntimeProfile::Counter* _peak_memory_usage = nullptr;
+    RuntimeProfile::Counter* _deserialize_chunk_count = nullptr;
+    RuntimeProfile::Counter* _deserialize_chunk_timer = nullptr;
+    RuntimeProfile::Counter* _profile_report_count = nullptr;
+    RuntimeProfile::Counter* _profile_report_timer = nullptr;
+    RuntimeProfile::Counter* _profile_serialized_size = nullptr;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const LoadChannel& load_channel) {

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -1099,7 +1099,7 @@ void LocalTabletsChannel::_update_primary_replica_profile(DeltaWriter* writer, R
     }
     auto& replicate_stat = replicate_token->get_stat();
     ADD_AND_UPDATE_COUNTER(profile, "ReplicatePendingTaskCount", TUnit::UNIT, replicate_stat.num_pending_tasks);
-    ADD_AND_UPDATE_COUNTER(profile, "ReplicateExecutingTaskCount", TUnit::UNIT, replicate_stat.num_executing_tasks);
+    ADD_AND_UPDATE_COUNTER(profile, "ReplicateExecutingTaskCount", TUnit::UNIT, replicate_stat.num_running_tasks);
     ADD_AND_UPDATE_COUNTER(profile, "ReplicateFinishedTaskCount", TUnit::UNIT, replicate_stat.num_finished_tasks);
     ADD_AND_UPDATE_TIMER(profile, "ReplicateTaskPendingTime", replicate_stat.pending_time_ns);
     ADD_AND_UPDATE_TIMER(profile, "ReplicateTaskExecuteTime", replicate_stat.execute_time_ns);
@@ -1123,7 +1123,7 @@ void LocalTabletsChannel::_update_secondary_replica_profile(DeltaWriter* writer,
     }
     auto& stat = segment_flush_token->get_stat();
     ADD_AND_UPDATE_COUNTER(profile, "FlushPendingTaskCount", TUnit::UNIT, stat.num_pending_tasks);
-    ADD_AND_UPDATE_COUNTER(profile, "FlushExecutingTaskCount", TUnit::UNIT, stat.num_executing_tasks);
+    ADD_AND_UPDATE_COUNTER(profile, "FlushExecutingTaskCount", TUnit::UNIT, stat.num_running_tasks);
     ADD_AND_UPDATE_COUNTER(profile, "FlushFinishedTaskCount", TUnit::UNIT, stat.num_finished_tasks);
     ADD_AND_UPDATE_TIMER(profile, "FlushTaskPendingTime", stat.pending_time_ns);
     ADD_AND_UPDATE_TIMER(profile, "FlushTaskExecuteTime", stat.execute_time_ns);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <unordered_map>
@@ -67,17 +68,18 @@ LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const Tablet
     });
 
     _profile = parent_profile->create_child(fmt::format("Index (id={})", key.index_id));
-    _primary_tablets_num = ADD_COUNTER(_profile, "PrimaryTabletsNum", TUnit::UNIT);
-    _secondary_tablets_num = ADD_COUNTER(_profile, "SecondaryTabletsNum", TUnit::UNIT);
-    _open_counter = ADD_COUNTER(_profile, "OpenCount", TUnit::UNIT);
-    _open_timer = ADD_TIMER(_profile, "OpenTime");
-    _add_chunk_counter = ADD_COUNTER(_profile, "AddChunkCount", TUnit::UNIT);
-    _add_chunk_timer = ADD_TIMER(_profile, "AddChunkTime");
+    _profile_update_counter = ADD_COUNTER(_profile, "ProfileUpdateCount", TUnit::UNIT);
+    _profile_update_timer = ADD_TIMER(_profile, "ProfileUpdateTime");
+    _open_counter = ADD_COUNTER(_profile, "OpenRpcCount", TUnit::UNIT);
+    _open_timer = ADD_TIMER(_profile, "OpenRpcTime");
+    _add_chunk_counter = ADD_COUNTER(_profile, "AddChunkRpcCount", TUnit::UNIT);
     _add_row_num = ADD_COUNTER(_profile, "AddRowNum", TUnit::UNIT);
-    _wait_flush_timer = ADD_CHILD_TIMER(_profile, "WaitFlushTime", "AddChunkTime");
-    _wait_write_timer = ADD_CHILD_TIMER(_profile, "WaitWriteTime", "AddChunkTime");
-    _wait_replica_timer = ADD_CHILD_TIMER(_profile, "WaitReplicaTime", "AddChunkTime");
-    _wait_txn_persist_timer = ADD_CHILD_TIMER(_profile, "WaitTxnPersistTime", "AddChunkTime");
+    _add_chunk_timer = ADD_TIMER(_profile, "AddChunkRpcTime");
+    _wait_flush_timer = ADD_CHILD_TIMER(_profile, "WaitFlushTime", "AddChunkRpcTime");
+    _wait_write_timer = ADD_CHILD_TIMER(_profile, "WaitWriteTime", "AddChunkRpcTime");
+    _wait_replica_timer = ADD_CHILD_TIMER(_profile, "WaitReplicaTime", "AddChunkRpcTime");
+    _wait_txn_persist_timer = ADD_CHILD_TIMER(_profile, "WaitTxnPersistTime", "AddChunkRpcTime");
+    _tablets_profile = std::make_unique<RuntimeProfile>("TabletsProfile");
 }
 
 LocalTabletsChannel::~LocalTabletsChannel() {
@@ -150,7 +152,9 @@ void LocalTabletsChannel::add_segment(brpc::Controller* cntl, const PTabletWrite
 }
 
 void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
-                                    PTabletWriterAddBatchResult* response) {
+                                    PTabletWriterAddBatchResult* response, bool* close_channel_ptr) {
+    bool& close_channel = *close_channel_ptr;
+    close_channel = false;
     MonotonicStopWatch watch;
     watch.start();
     std::shared_lock<bthreads::BThreadSharedMutex> lk(_rw_mtx);
@@ -294,8 +298,6 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
 
     // _channel_row_idx_start_points no longer used, release it to free memory.
     context->_channel_row_idx_start_points.reset();
-
-    bool close_channel = false;
 
     // NOTE: Must close sender *AFTER* the write requests submitted, otherwise a delta writer commit request may
     // be executed ahead of the write requests submitted by other senders.
@@ -652,8 +654,6 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
     std::vector<int64_t> tablet_ids;
     tablet_ids.reserve(params.tablets_size());
     std::vector<int64_t> failed_tablet_ids;
-    int32_t primary_num = 0;
-    int32_t secondary_num = 0;
     for (const PTabletWithPartition& tablet : params.tablets()) {
         DeltaWriterOptions options;
         options.tablet_id = tablet.tablet_id();
@@ -681,14 +681,11 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
             }
             if (options.replicas.size() > 0 && options.replicas[0].node_id() == options.node_id) {
                 options.replica_state = Primary;
-                primary_num += 1;
             } else {
                 options.replica_state = Secondary;
-                secondary_num += 1;
             }
         } else {
             options.replica_state = Peer;
-            primary_num += 1;
         }
         options.merge_condition = params.merge_condition();
         options.partial_update_mode = params.partial_update_mode();
@@ -734,8 +731,6 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         ss << " _num_remaining_senders: " << _num_remaining_senders;
         LOG(INFO) << ss.str();
     }
-    COUNTER_UPDATE(_primary_tablets_num, primary_num);
-    COUNTER_UPDATE(_secondary_tablets_num, secondary_num);
     return Status::OK();
 }
 
@@ -988,6 +983,150 @@ void LocalTabletsChannel::WriteCallback::run(const Status& st, const CommittedRo
         }
     }
     delete this;
+}
+
+void LocalTabletsChannel::update_profile() {
+    if (_profile == nullptr) {
+        return;
+    }
+
+    bool expect = false;
+    if (!_is_updating_profile.compare_exchange_strong(expect, true)) {
+        // skip concurrent update
+        return;
+    }
+    DeferOp defer([this]() { _is_updating_profile.store(false); });
+    _profile->inc_version();
+    COUNTER_UPDATE(_profile_update_counter, 1);
+    SCOPED_TIMER(_profile_update_timer);
+
+    std::vector<AsyncDeltaWriter*> async_writers;
+    {
+        std::shared_lock<bthreads::BThreadSharedMutex> lk(_rw_mtx);
+        async_writers.reserve(_delta_writers.size());
+        for (auto& [tablet_id, delta_writer] : _delta_writers) {
+            async_writers.push_back(delta_writer.get());
+        }
+    }
+
+    bool replicated_storage = true;
+    std::vector<RuntimeProfile*> peer_or_primary_replica_profiles;
+    std::vector<RuntimeProfile*> secondary_replica_profiles;
+    for (auto async_writer : async_writers) {
+        DeltaWriter* writer = async_writer->writer();
+        RuntimeProfile* profile = _tablets_profile->create_child(fmt::format("{}", writer->tablet()->tablet_id()));
+        auto replica_state = writer->replica_state();
+        if (replica_state == Peer) {
+            _update_peer_replica_profile(writer, profile);
+            peer_or_primary_replica_profiles.push_back(profile);
+            replicated_storage = false;
+        } else if (replica_state == Primary) {
+            _update_primary_replica_profile(writer, profile);
+            peer_or_primary_replica_profiles.push_back(profile);
+        } else if (writer->replica_state() == Secondary) {
+            _update_secondary_replica_profile(writer, profile);
+            secondary_replica_profiles.push_back(profile);
+        } else {
+            // ignore unknown replica state
+        }
+    }
+
+    ObjectPool obj_pool;
+    if (!peer_or_primary_replica_profiles.empty()) {
+        auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(&obj_pool, peer_or_primary_replica_profiles);
+        RuntimeProfile* final_profile = _profile->create_child(replicated_storage ? "PrimaryReplicas" : "PeerReplicas");
+        auto* tablets_counter = ADD_COUNTER(_profile, "TabletsNum", TUnit::UNIT);
+        COUNTER_UPDATE(tablets_counter, peer_or_primary_replica_profiles.size());
+        final_profile->copy_all_info_strings_from(merged_profile);
+        final_profile->copy_all_counters_from(merged_profile);
+    }
+
+    if (!secondary_replica_profiles.empty()) {
+        auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(&obj_pool, secondary_replica_profiles);
+        RuntimeProfile* final_profile = _profile->create_child("SecondaryReplicas");
+        auto* tablets_counter = ADD_COUNTER(_profile, "TabletsNum", TUnit::UNIT);
+        COUNTER_UPDATE(tablets_counter, peer_or_primary_replica_profiles.size());
+        final_profile->copy_all_info_strings_from(merged_profile);
+        final_profile->copy_all_counters_from(merged_profile);
+    }
+}
+
+#define ADD_AND_UPDATE_COUNTER(profile, name, type, val) (ADD_COUNTER(profile, name, type))->update(val)
+#define ADD_AND_UPDATE_TIMER(profile, name, val) (ADD_TIMER(profile, name))->update(val)
+
+void LocalTabletsChannel::_update_peer_replica_profile(DeltaWriter* writer, RuntimeProfile* profile) {
+    const DeltaWriterStat& writer_stat = writer->get_writer_stat();
+    ADD_AND_UPDATE_COUNTER(profile, "WriterTaskCount", TUnit::UNIT, writer_stat.task_count);
+    ADD_AND_UPDATE_TIMER(profile, "WriterTaskPendingTime", writer_stat.pending_time_ns);
+    ADD_AND_UPDATE_COUNTER(profile, "WriteCount", TUnit::UNIT, writer_stat.write_count);
+    ADD_AND_UPDATE_COUNTER(profile, "RowCount", TUnit::UNIT, writer_stat.row_count);
+    ADD_AND_UPDATE_TIMER(profile, "WriteTime", writer_stat.write_time_ns);
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableFullCount", TUnit::UNIT, writer_stat.memtable_full_count);
+    ADD_AND_UPDATE_COUNTER(profile, "MemoryExceedCount", TUnit::UNIT, writer_stat.memory_exceed_count);
+    ADD_AND_UPDATE_TIMER(profile, "WriteWaitFlushTime", writer_stat.write_wait_flush_tims_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CloseTime", writer_stat.write_wait_flush_tims_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitTime", writer_stat.commit_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitWaitFlushTime", writer_stat.commit_wait_flush_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitRowsetBuildTime", writer_stat.commit_rowset_build_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitFinishPkTime", writer_stat.commit_finish_pk_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitWaitReplicaTime", writer_stat.commit_wait_replica_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitTxnCommitTime", writer_stat.commit_txn_commit_time_ns);
+
+    const FlushStatistic& flush_stat = writer->get_flush_stats();
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableFlushedCount", TUnit::UNIT, flush_stat.flush_count);
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableFlushingCount", TUnit::UNIT, flush_stat.cur_flush_count);
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableQueueCount", TUnit::UNIT, flush_stat.queueing_memtable_num);
+    ADD_AND_UPDATE_COUNTER(profile, "FlushTaskPendingTime", TUnit::UNIT, flush_stat.pending_time_ns);
+    auto& memtable_stat = flush_stat.memtable_stats;
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableInsertCount", TUnit::UNIT, memtable_stat.insert_count);
+    ADD_AND_UPDATE_TIMER(profile, "MemtableInsertTime", memtable_stat.insert_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "MemtableFinalizeTime", memtable_stat.finalize_time_ns);
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableSortCount", TUnit::UNIT, memtable_stat.sort_count);
+    ADD_AND_UPDATE_TIMER(profile, "MemtableSortTime", memtable_stat.sort_time_ns);
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableAggCount", TUnit::UNIT, memtable_stat.agg_count);
+    ADD_AND_UPDATE_TIMER(profile, "MemtableAggTime", memtable_stat.agg_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "MemtableFlushTime", memtable_stat.flush_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "MemtableIOTime", memtable_stat.io_time_ns);
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableMemorySize", TUnit::BYTES, memtable_stat.flush_memory_size);
+    ADD_AND_UPDATE_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES, memtable_stat.flush_disk_size);
+}
+
+void LocalTabletsChannel::_update_primary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile) {
+    _update_peer_replica_profile(writer, profile);
+    auto* replicate_token = writer->replicate_token();
+    if (replicate_token == nullptr) {
+        return;
+    }
+    auto& replicate_stat = replicate_token->get_stat();
+    ADD_AND_UPDATE_COUNTER(profile, "ReplicatePendingTaskCount", TUnit::UNIT, replicate_stat.num_pending_tasks);
+    ADD_AND_UPDATE_COUNTER(profile, "ReplicateExecutingTaskCount", TUnit::UNIT, replicate_stat.num_executing_tasks);
+    ADD_AND_UPDATE_COUNTER(profile, "ReplicateFinishedTaskCount", TUnit::UNIT, replicate_stat.num_finished_tasks);
+    ADD_AND_UPDATE_TIMER(profile, "ReplicateTaskPendingTime", replicate_stat.pending_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "ReplicateTaskExecuteTime", replicate_stat.execute_time_ns);
+}
+
+void LocalTabletsChannel::_update_secondary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile) {
+    const DeltaWriterStat& writer_stat = writer->get_writer_stat();
+    ADD_AND_UPDATE_COUNTER(profile, "RowCount", TUnit::UNIT, writer_stat.row_count);
+    ADD_AND_UPDATE_COUNTER(profile, "DataSize", TUnit::BYTES, writer_stat.add_segment_data_size);
+    ADD_AND_UPDATE_COUNTER(profile, "AddSegmentCount", TUnit::UNIT, writer_stat.add_segment_count);
+    ADD_AND_UPDATE_TIMER(profile, "AddSegmentTime", writer_stat.add_segment_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "AddSegmentIOTime", writer_stat.add_segment_io_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitTime", writer_stat.commit_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitRowsetBuildTime", writer_stat.commit_rowset_build_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitFinishPkTime", writer_stat.commit_finish_pk_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "CommitTxnCommitTime", writer_stat.commit_txn_commit_time_ns);
+
+    auto* segment_flush_token = writer->segment_flush_token();
+    if (segment_flush_token == nullptr) {
+        return;
+    }
+    auto& stat = segment_flush_token->get_stat();
+    ADD_AND_UPDATE_COUNTER(profile, "FlushPendingTaskCount", TUnit::UNIT, stat.num_pending_tasks);
+    ADD_AND_UPDATE_COUNTER(profile, "FlushExecutingTaskCount", TUnit::UNIT, stat.num_executing_tasks);
+    ADD_AND_UPDATE_COUNTER(profile, "FlushFinishedTaskCount", TUnit::UNIT, stat.num_finished_tasks);
+    ADD_AND_UPDATE_TIMER(profile, "FlushTaskPendingTime", stat.pending_time_ns);
+    ADD_AND_UPDATE_TIMER(profile, "FlushTaskExecuteTime", stat.execute_time_ns);
 }
 
 std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -1035,7 +1035,7 @@ void LocalTabletsChannel::update_profile() {
     if (!peer_or_primary_replica_profiles.empty()) {
         auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(&obj_pool, peer_or_primary_replica_profiles);
         RuntimeProfile* final_profile = _profile->create_child(replicated_storage ? "PrimaryReplicas" : "PeerReplicas");
-        auto* tablets_counter = ADD_COUNTER(_profile, "TabletsNum", TUnit::UNIT);
+        auto* tablets_counter = ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT);
         COUNTER_UPDATE(tablets_counter, peer_or_primary_replica_profiles.size());
         final_profile->copy_all_info_strings_from(merged_profile);
         final_profile->copy_all_counters_from(merged_profile);
@@ -1044,7 +1044,7 @@ void LocalTabletsChannel::update_profile() {
     if (!secondary_replica_profiles.empty()) {
         auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(&obj_pool, secondary_replica_profiles);
         RuntimeProfile* final_profile = _profile->create_child("SecondaryReplicas");
-        auto* tablets_counter = ADD_COUNTER(_profile, "TabletsNum", TUnit::UNIT);
+        auto* tablets_counter = ADD_COUNTER(final_profile, "TabletsNum", TUnit::UNIT);
         COUNTER_UPDATE(tablets_counter, peer_or_primary_replica_profiles.size());
         final_profile->copy_all_info_strings_from(merged_profile);
         final_profile->copy_all_counters_from(merged_profile);

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -49,8 +49,8 @@ public:
     Status open(const PTabletWriterOpenRequest& params, PTabletWriterOpenResult* result,
                 std::shared_ptr<OlapTableSchemaParam> schema, bool is_incremental) override;
 
-    void add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
-                   PTabletWriterAddBatchResult* response) override;
+    void add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response,
+                   bool* close_channel_ptr) override;
 
     Status incremental_open(const PTabletWriterOpenRequest& params, PTabletWriterOpenResult* result,
                             std::shared_ptr<OlapTableSchemaParam> schema) override;
@@ -63,6 +63,8 @@ public:
     void abort() override;
 
     void abort(const std::vector<int64_t>& tablet_ids, const std::string& reason) override;
+
+    void update_profile() override;
 
     MemTracker* mem_tracker() { return _mem_tracker; }
 
@@ -179,6 +181,10 @@ private:
 
     void _flush_stale_memtables();
 
+    void _update_peer_replica_profile(DeltaWriter* writer, RuntimeProfile* profile);
+    void _update_primary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile);
+    void _update_secondary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile);
+
     LoadChannel* _load_channel;
 
     TabletsChannelKey _key;
@@ -226,12 +232,10 @@ private:
     std::map<string, string> _column_to_expr_value;
 
     // Profile counters
-    // replicated_storage=false, the number of tablets
-    // replicated_storage=true, the number of primary tablets
-    RuntimeProfile::Counter* _primary_tablets_num = nullptr;
-    // Only available for replicated_storage=true, the number of
-    // secondary tablets
-    RuntimeProfile::Counter* _secondary_tablets_num = nullptr;
+    // Number of times that update_profile() is called
+    RuntimeProfile::Counter* _profile_update_counter = nullptr;
+    // Accumulated time for update_profile()
+    RuntimeProfile::Counter* _profile_update_timer = nullptr;
     // Number of times that open() is called
     RuntimeProfile::Counter* _open_counter = nullptr;
     // Accumulated time of open()
@@ -250,6 +254,9 @@ private:
     RuntimeProfile::Counter* _wait_replica_timer = nullptr;
     // Accumulated time to wait for txn persist in add_chunk()
     RuntimeProfile::Counter* _wait_txn_persist_timer = nullptr;
+
+    std::atomic<bool> _is_updating_profile{false};
+    std::unique_ptr<RuntimeProfile> _tablets_profile;
 };
 
 std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -57,7 +57,7 @@ public:
                                     std::shared_ptr<OlapTableSchemaParam> schema) = 0;
 
     virtual void add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
-                           PTabletWriterAddBatchResult* response) = 0;
+                           PTabletWriterAddBatchResult* response, bool* close_channel_ptr) = 0;
 
     virtual void cancel() = 0;
 
@@ -67,6 +67,8 @@ public:
 
     // timeout: in microseconds
     virtual bool drain_senders(int64_t timeout, const std::string& log_msg);
+
+    virtual void update_profile() = 0;
 
 protected:
     // counter of remaining senders

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -88,6 +88,7 @@ int AsyncDeltaWriter::_execute(void* meta, bthread::TaskIterator<AsyncDeltaWrite
         LOG_IF(WARNING, !st.ok()) << "Fail to flush. txn_id: " << writer->txn_id()
                                   << " tablet_id: " << writer->tablet()->tablet_id() << ": " << st;
     }
+    writer->update_task_stat(num_tasks, pending_time_ns);
     StarRocksMetrics::instance()->async_delta_writer_execute_total.increment(1);
     StarRocksMetrics::instance()->async_delta_writer_task_total.increment(num_tasks);
     StarRocksMetrics::instance()->async_delta_writer_task_execute_duration_us.increment(watch.elapsed_time() / 1000);

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -417,6 +417,9 @@ Status DeltaWriter::_check_partial_update_with_sort_key(const Chunk& chunk) {
 Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     RETURN_IF_ERROR(_check_partial_update_with_sort_key(chunk));
+    _stats.write_count += 1;
+    _stats.row_count += size;
+    SCOPED_RAW_TIMER(&_stats.write_time_ns);
 
     // Delay the creation memtables until we write data.
     // Because for the tablet which doesn't have any written data, we will not use their memtables.
@@ -465,6 +468,7 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
     } else if (full) {
         st = flush_memtable_async();
         _reset_mem_table();
+        _stats.memtable_full_count += 1;
     }
     if (!st.ok()) {
         _set_state(kAborted, st);
@@ -497,18 +501,26 @@ Status DeltaWriter::write_segment(const SegmentPB& segment_pb, butil::IOBuf& dat
         RETURN_IF_ERROR(_rowset_writer->flush_segment(segment_pb, data));
     }
     auto io_stat = scope.current_scoped_tls_io();
+    auto io_time_ns = io_stat.write_time_ns + io_stat.sync_time_ns;
+
+    _stats.add_segment_count += 1;
+    _stats.row_count += segment_pb.num_rows();
+    _stats.add_segment_data_size += segment_pb.data_size();
+    _stats.add_segment_time_ns += duration_ns;
+    _stats.add_segment_io_time_ns += io_time_ns;
+
     StarRocksMetrics::instance()->segment_flush_total.increment(1);
     StarRocksMetrics::instance()->segment_flush_duration_us.increment(duration_ns / 1000);
-    auto io_time_us = (io_stat.write_time_ns + io_stat.sync_time_ns) / 1000;
-    StarRocksMetrics::instance()->segment_flush_io_time_us.increment(io_time_us);
+    StarRocksMetrics::instance()->segment_flush_io_time_us.increment(io_time_ns / 1000);
     StarRocksMetrics::instance()->segment_flush_bytes_total.increment(segment_pb.data_size());
     VLOG(2) << "Flush segment tablet " << _opt.tablet_id << " segment: " << segment_pb.DebugString()
-            << ", duration: " << duration_ns / 1000 << "us, io_time: " << io_time_us << "us";
+            << ", duration: " << duration_ns / 1000 << "us, io_time: " << (io_time_ns / 1000) << "us";
     return Status::OK();
 }
 
 Status DeltaWriter::close() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    SCOPED_RAW_TIMER(&_stats.close_time_ns);
     auto state = get_state();
     switch (state) {
     case kUninitialized:
@@ -625,7 +637,10 @@ Status DeltaWriter::_flush_memtable() {
     MonotonicStopWatch watch;
     watch.start();
     Status st = _flush_token->wait();
-    StarRocksMetrics::instance()->delta_writer_wait_flush_duration_us.increment(watch.elapsed_time() / 1000);
+    auto elapsed_time = watch.elapsed_time();
+    _stats.memory_exceed_count += 1;
+    _stats.write_wait_flush_tims_ns += elapsed_time;
+    StarRocksMetrics::instance()->delta_writer_wait_flush_duration_us.increment(elapsed_time / 1000);
     return st;
 }
 
@@ -721,6 +736,7 @@ Status DeltaWriter::commit() {
         _set_state(kAborted, res.status());
         return res.status();
     }
+    auto rowset_build_ts = watch.elapsed_time();
 
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
@@ -742,6 +758,7 @@ Status DeltaWriter::commit() {
 
     auto res = _storage_engine->txn_manager()->commit_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id,
                                                           _cur_rowset, false);
+    auto commit_txn_ts = watch.elapsed_time();
 
     if (!res.ok()) {
         _storage_engine->update_manager()->on_rowset_cancel(_tablet.get(), _cur_rowset.get());
@@ -761,6 +778,12 @@ Status DeltaWriter::commit() {
         }
     }
     VLOG(2) << "Closed delta writer. tablet_id: " << _tablet->tablet_id() << ", stats: " << _flush_token->get_stats();
+    _stats.commit_time_ns += watch.elapsed_time();
+    _stats.commit_wait_flush_time_ns += flush_ts;
+    _stats.commit_rowset_build_time_ns += rowset_build_ts - flush_ts;
+    _stats.commit_finish_pk_time_ns += pk_finish_ts - rowset_build_ts;
+    _stats.commit_wait_replica_time_ns += replica_ts - pk_finish_ts;
+    _stats.commit_txn_commit_time_ns += commit_txn_ts - replica_ts;
     StarRocksMetrics::instance()->delta_writer_wait_flush_duration_us.increment(flush_ts / 1000);
     StarRocksMetrics::instance()->delta_writer_wait_replica_duration_us.increment((replica_ts - pk_finish_ts) / 1000);
     return Status::OK();

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -82,6 +82,58 @@ enum State {
     kCommitted, // committed state can transfer to kAborted state
 };
 
+// Statistics for DeltaWriter
+struct DeltaWriterStat {
+    int32_t task_count = 0;
+    int64_t pending_time_ns = 0;
+
+    // ====== statistics for write()
+
+    // The number of write()
+    int32_t write_count = 0;
+    // The number of rows to write
+    int32_t row_count = 0;
+    // Accumulated time for write()
+    int64_t write_time_ns = 0;
+    // The number that memtable is full
+    int32_t memtable_full_count = 0;
+    // The number that reach memory limit, and each will
+    // trigger memtable flush, and wait for it to finish
+    int32_t memory_exceed_count = 0;
+    // Accumulated time to wait for flush because of reaching memory limit
+    int64_t write_wait_flush_tims_ns = 0;
+
+    // ====== statistics for add_segment()
+
+    // The number of add_segment()
+    int32_t add_segment_count = 0;
+    // Accumulated time for add_segment()
+    int32_t add_segment_time_ns = 0;
+    // Accumulated io time for add_segment()
+    int64_t add_segment_io_time_ns = 0;
+    int64_t add_segment_data_size = 0;
+
+    // ====== statistics for close()
+
+    // Time for close()
+    int64_t close_time_ns = 0;
+
+    // ====== statistics for commit()
+
+    // Time for commit()
+    int64_t commit_time_ns = 0;
+    // Time to wait for memtable flush in commit()
+    int64_t commit_wait_flush_time_ns = 0;
+    // Time to build rowset in commit()
+    int64_t commit_rowset_build_time_ns = 0;
+    // Time to deal with primary key in commit() which may load data from disk
+    int64_t commit_finish_pk_time_ns = 0;
+    // Time to wait for replica sync in commit()
+    int64_t commit_wait_replica_time_ns = 0;
+    // Time to commit txn in commit()
+    int64_t commit_txn_commit_time_ns = 0;
+};
+
 // Writer for a particular (load, index, tablet).
 class DeltaWriter {
 public:
@@ -170,6 +222,12 @@ public:
 
     int64_t write_buffer_size() const { return _write_buffer_size; }
 
+    void update_task_stat(int32_t num_tasks, int64_t pending_time_ns) {
+        _stats.task_count += num_tasks;
+        _stats.pending_time_ns += pending_time_ns;
+    }
+    const DeltaWriterStat& get_writer_stat() const { return _stats; }
+
     static bool is_partial_update_with_sort_key_conflict(const PartialUpdateMode& partial_update_mode,
                                                          const std::vector<int32_t>& referenced_column_ids,
                                                          const std::vector<ColumnId>& sort_key_idxes,
@@ -227,6 +285,8 @@ private:
     int64_t _last_write_ts = 0;
     // for concurrency issue, we can't get write_buffer_size from memtable directly
     int64_t _write_buffer_size = 0;
+
+    DeltaWriterStat _stats;
 };
 
 } // namespace starrocks

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -162,6 +162,8 @@ bool MemTable::check_supported_column_partial_update(const Chunk& chunk) {
 }
 
 StatusOr<bool> MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
+    SCOPED_RAW_TIMER(&_stats.insert_time_ns);
+    _stats.insert_count += 1;
     if (_chunk == nullptr) {
         _chunk = ChunkHelper::new_chunk(*_vectorized_schema, 0);
     }
@@ -316,6 +318,7 @@ Status MemTable::finalize() {
         }
     }
 
+    _stats.finalize_time_ns = duration_ns;
     StarRocksMetrics::instance()->memtable_finalize_duration_us.increment(duration_ns / 1000);
     return Status::OK();
 }
@@ -339,16 +342,19 @@ Status MemTable::flush(SegmentPB* seg_info) {
         }
     }
     auto io_stat = scope.current_scoped_tls_io();
+    _stats.flush_time_ns = duration_ns;
+    _stats.io_time_ns = io_stat.write_time_ns + io_stat.sync_time_ns;
+    _stats.flush_memory_size = memory_usage();
+    _stats.flush_disk_size = io_stat.write_bytes;
+
     StarRocksMetrics::instance()->memtable_flush_total.increment(1);
-    StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
-    auto io_time_us = (io_stat.write_time_ns + io_stat.sync_time_ns) / 1000;
-    StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_time_us);
-    auto flush_bytes = memory_usage();
-    StarRocksMetrics::instance()->memtable_flush_memory_bytes_total.increment(flush_bytes);
-    StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.increment(io_stat.write_bytes);
-    VLOG(2) << "memtable of tablet " << _tablet_id << " flush duration: " << duration_ns / 1000 << "us, "
-            << "io time: " << io_time_us << "us, memory bytes: " << flush_bytes
-            << ", disk bytes: " << io_stat.write_bytes;
+    StarRocksMetrics::instance()->memtable_flush_duration_us.increment(_stats.flush_time_ns / 1000);
+    StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(_stats.io_time_ns / 1000);
+    StarRocksMetrics::instance()->memtable_flush_memory_bytes_total.increment(_stats.flush_memory_size);
+    StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.increment(_stats.flush_disk_size);
+    VLOG(2) << "memtable of tablet " << _tablet_id << " flush duration: " << _stats.flush_time_ns / 1000 << "us, "
+            << "io time: " << _stats.io_time_ns / 1000 << "us, memory bytes: " << _stats.flush_memory_size
+            << ", disk bytes: " << _stats.flush_disk_size;
     return Status::OK();
 }
 
@@ -371,7 +377,8 @@ void MemTable::_aggregate(bool is_final) {
     if (_result_chunk == nullptr || _result_chunk->num_rows() <= 0) {
         return;
     }
-
+    SCOPED_RAW_TIMER(&_stats.agg_time_ns);
+    _stats.agg_count += 1;
     DCHECK(_result_chunk->num_rows() < INT_MAX);
     DCHECK(_aggregator->source_exhausted());
 
@@ -396,6 +403,8 @@ void MemTable::_aggregate(bool is_final) {
 }
 
 Status MemTable::_sort(bool is_final, bool by_sort_key) {
+    SCOPED_RAW_TIMER(&_stats.sort_time_ns);
+    _stats.sort_count += 1;
     SmallPermutation perm = create_small_permutation(static_cast<uint32_t>(_chunk->num_rows()));
     std::swap(perm, _permutations);
 

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -30,6 +30,46 @@ class TabletSchema;
 
 class MemTableSink;
 
+struct MemtableStats {
+    // The number of insert operation
+    int32_t insert_count = 0;
+    // Accumulated time to insert
+    int64_t insert_time_ns = 0;
+    // Time to finalize
+    int64_t finalize_time_ns = 0;
+    // The number of sort operation
+    int32_t sort_count = 0;
+    // Accumulated time to sort
+    int64_t sort_time_ns = 0;
+    // The number of agg operation
+    int32_t agg_count = 0;
+    // Accumulated time to aggregate
+    int64_t agg_time_ns = 0;
+    // Time to flush the memtable
+    int64_t flush_time_ns = 0;
+    // IO time for flush
+    int64_t io_time_ns = 0;
+    // Memory size to flush
+    int64_t flush_memory_size = 0;
+    // Disk size to flush
+    int64_t flush_disk_size = 0;
+
+    MemtableStats& operator+=(const MemtableStats& other) {
+        insert_count += other.insert_count;
+        insert_time_ns += other.insert_time_ns;
+        finalize_time_ns += other.finalize_time_ns;
+        sort_count += other.sort_count;
+        sort_time_ns += other.sort_time_ns;
+        agg_count += other.agg_count;
+        agg_time_ns += other.agg_time_ns;
+        flush_time_ns += other.flush_time_ns;
+        io_time_ns += other.io_time_ns;
+        flush_memory_size += other.flush_memory_size;
+        flush_disk_size += other.flush_disk_size;
+        return *this;
+    }
+};
+
 class MemTable {
 public:
     MemTable(int64_t tablet_id, const Schema* schema, const std::vector<SlotDescriptor*>* slot_descs,
@@ -70,6 +110,8 @@ public:
     ChunkPtr get_result_chunk() { return _result_chunk; }
 
     bool check_supported_column_partial_update(const Chunk& chunk);
+
+    const MemtableStats& get_stat() const { return _stats; }
 
 private:
     Status _merge();
@@ -123,6 +165,8 @@ private:
     size_t _chunk_bytes_usage = 0;
     size_t _aggregator_memory_usage = 0;
     size_t _aggregator_bytes_usage = 0;
+
+    MemtableStats _stats;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -92,8 +92,7 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat) {
     os << "(flush time(ms)=" << stat.memtable_stats.flush_time_ns / 1000 / 1000 << ", flush count=" << stat.flush_count
-       << ")"
-       << ", flush flush_size_bytes = " << stat.memtable_stats.flush_memory_size;
+       << "), flush flush_size_bytes=" << stat.memtable_stats.flush_memory_size;
     return os;
 }
 

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -38,7 +38,6 @@
 
 #include "gen_cpp/data.pb.h"
 #include "runtime/current_thread.h"
-#include "storage/memtable.h"
 
 namespace starrocks {
 
@@ -46,12 +45,17 @@ class MemtableFlushTask final : public Runnable {
 public:
     MemtableFlushTask(FlushToken* flush_token, std::unique_ptr<MemTable> memtable, bool eos,
                       std::function<void(std::unique_ptr<SegmentPB>, bool)> cb)
-            : _flush_token(flush_token), _memtable(std::move(memtable)), _eos(eos), _cb(std::move(cb)) {}
+            : _flush_token(flush_token),
+              _memtable(std::move(memtable)),
+              _eos(eos),
+              _cb(std::move(cb)),
+              _create_time_ns(MonotonicNanos()) {}
 
     ~MemtableFlushTask() override = default;
 
     void run() override {
         _flush_token->_stats.queueing_memtable_num--;
+        _flush_token->_stats.pending_time_ns += MonotonicNanos() - _create_time_ns;
         std::unique_ptr<SegmentPB> segment = nullptr;
         if (_memtable) {
             SCOPED_THREAD_LOCAL_MEM_SETTER(_memtable->mem_tracker(), false);
@@ -83,11 +87,13 @@ private:
     std::unique_ptr<MemTable> _memtable;
     bool _eos;
     std::function<void(std::unique_ptr<SegmentPB>, bool)> _cb;
+    int64_t _create_time_ns;
 };
 
 std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat) {
-    os << "(flush time(ms)=" << stat.flush_time_ns / 1000 / 1000 << ", flush count=" << stat.flush_count << ")"
-       << ", flush flush_size_bytes = " << stat.flush_size_bytes;
+    os << "(flush time(ms)=" << stat.memtable_stats.flush_time_ns / 1000 / 1000 << ", flush count=" << stat.flush_count
+       << ")"
+       << ", flush flush_size_bytes = " << stat.memtable_stats.flush_memory_size;
     return os;
 }
 
@@ -131,12 +137,9 @@ void FlushToken::_flush_memtable(MemTable* memtable, SegmentPB* segment) {
         return;
     }
 
-    MonotonicStopWatch timer;
-    timer.start();
     set_status(memtable->flush(segment));
-    _stats.flush_time_ns += timer.elapsed_time();
     _stats.flush_count++;
-    _stats.flush_size_bytes += memtable->memory_usage();
+    _stats.memtable_stats += memtable->get_stat();
 }
 
 Status MemTableFlushExecutor::init(const std::vector<DataDir*>& data_dirs) {

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "storage/memtable.h"
 #include "storage/olap_define.h"
 #include "util/spinlock.h"
 #include "util/threadpool.h"
@@ -53,11 +54,11 @@ class MemTable;
 // the statistic of a certain flush handler.
 // use atomic because it may be updated by multi threads
 struct FlushStatistic {
-    int64_t flush_time_ns = 0;
     int64_t flush_count = 0;
-    int64_t flush_size_bytes = 0;
     int64_t cur_flush_count = 0;
     std::atomic<int64_t> queueing_memtable_num = 0;
+    int64_t pending_time_ns = 0;
+    MemtableStats memtable_stats;
 };
 
 std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat);

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -67,10 +67,10 @@ public:
         auto& stat = _flush_token->_stat;
         stat.num_pending_tasks -= 1;
         stat.pending_time_ns += MonotonicNanos() - _create_time_ns;
-        stat.num_executing_tasks += 1;
+        stat.num_running_tasks += 1;
         int64_t duration_ns = 0;
         DeferOp defer([&stat, &duration_ns]() {
-            stat.num_executing_tasks -= 1;
+            stat.num_running_tasks -= 1;
             stat.num_finished_tasks += 1;
             stat.execute_time_ns += duration_ns;
         });

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -43,7 +43,8 @@ public:
               _cntl(cntl),
               _request(request),
               _response(response),
-              _done(done) {}
+              _done(done),
+              _create_time_ns(MonotonicNanos()) {}
 
     // Destructor which will respond to the brpc if run() or release() is not called.
     ~SegmentFlushTask() override {
@@ -63,6 +64,18 @@ public:
     // Run the task if release() is not called which will flush the segment, and respond the brpc
     // BackendInternalServiceImpl<T>::tablet_writer_add_segment.
     void run() override {
+        auto& stat = _flush_token->_stat;
+        stat.num_pending_tasks -= 1;
+        stat.pending_time_ns += MonotonicNanos() - _create_time_ns;
+        stat.num_executing_tasks += 1;
+        int64_t duration_ns = 0;
+        DeferOp defer([&stat, &duration_ns]() {
+            stat.num_executing_tasks -= 1;
+            stat.num_finished_tasks += 1;
+            stat.execute_time_ns += duration_ns;
+        });
+        SCOPED_RAW_TIMER(&duration_ns);
+
         bool expect = false;
         if (!_run_or_released.compare_exchange_strong(expect, true)) {
             return;
@@ -151,6 +164,7 @@ private:
     const PTabletWriterAddSegmentRequest* _request;
     PTabletWriterAddSegmentResult* _response;
     google::protobuf::Closure* _done;
+    int64_t _create_time_ns;
     // whether run() or release() has been called
     std::atomic<bool> _run_or_released = false;
 };
@@ -172,6 +186,7 @@ Status SegmentFlushToken::submit(DeltaWriter* writer, brpc::Controller* cntl,
     auto task = std::make_shared<SegmentFlushTask>(this, writer, cntl, request, response, done);
     auto submit_st = _flush_token->submit(task);
     if (submit_st.ok()) {
+        _stat.num_pending_tasks += 1;
         closure_guard.release();
     } else {
         task->release();

--- a/be/src/storage/segment_flush_executor.h
+++ b/be/src/storage/segment_flush_executor.h
@@ -41,6 +41,14 @@ class ThreadPoolToken;
 
 class DeltaWriter;
 
+struct SegmentFlushStat {
+    int32_t num_pending_tasks = 0;
+    int32_t num_executing_tasks = 0;
+    int32_t num_finished_tasks = 0;
+    int64_t pending_time_ns = 0;
+    int64_t execute_time_ns = 0;
+};
+
 class SegmentFlushToken {
 public:
     SegmentFlushToken(std::unique_ptr<ThreadPoolToken> flush_pool_token);
@@ -65,12 +73,17 @@ public:
 
     Status wait();
 
+    const SegmentFlushStat& get_stat() const { return _stat; }
+
 private:
+    friend class SegmentFlushTask;
+
     std::unique_ptr<ThreadPoolToken> _flush_token;
 
     mutable SpinLock _status_lock;
     // Records the current flush status of the tablet.
     Status _status;
+    SegmentFlushStat _stat;
 };
 
 class SegmentFlushExecutor {

--- a/be/src/storage/segment_flush_executor.h
+++ b/be/src/storage/segment_flush_executor.h
@@ -43,7 +43,7 @@ class DeltaWriter;
 
 struct SegmentFlushStat {
     int32_t num_pending_tasks = 0;
-    int32_t num_executing_tasks = 0;
+    int32_t num_running_tasks = 0;
     int32_t num_finished_tasks = 0;
     int64_t pending_time_ns = 0;
     int64_t execute_time_ns = 0;

--- a/be/src/storage/segment_flush_executor.h
+++ b/be/src/storage/segment_flush_executor.h
@@ -42,11 +42,11 @@ class ThreadPoolToken;
 class DeltaWriter;
 
 struct SegmentFlushStat {
-    int32_t num_pending_tasks = 0;
-    int32_t num_running_tasks = 0;
-    int32_t num_finished_tasks = 0;
-    int64_t pending_time_ns = 0;
-    int64_t execute_time_ns = 0;
+    std::atomic_int32_t num_pending_tasks = 0;
+    std::atomic_int32_t num_running_tasks = 0;
+    std::atomic_int32_t num_finished_tasks = 0;
+    std::atomic_int64_t pending_time_ns = 0;
+    std::atomic_int64_t execute_time_ns = 0;
 };
 
 class SegmentFlushToken {

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -274,7 +274,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->data_size()];
-            data.append_user_data(buf, segment->data_size(), [](void* buf) { delete[] (uint8*)buf; });
+            data.append_user_data(buf, segment->data_size(), [](void* buf) { delete[](uint8*) buf; });
             auto st = rfile->read_fully(buf, segment->data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read segment " << segment->DebugString() << " by " << debug_string()
@@ -291,7 +291,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->delete_data_size()];
-            data.append_user_data(buf, segment->delete_data_size(), [](void* buf) { delete[] (uint8*)buf; });
+            data.append_user_data(buf, segment->delete_data_size(), [](void* buf) { delete[](uint8*) buf; });
             auto st = rfile->read_fully(buf, segment->delete_data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read delete file " << segment->DebugString() << " by " << debug_string()
@@ -308,7 +308,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->update_data_size()];
-            data.append_user_data(buf, segment->update_data_size(), [](void* buf) { delete[] (uint8*)buf; });
+            data.append_user_data(buf, segment->update_data_size(), [](void* buf) { delete[](uint8*) buf; });
             auto st = rfile->read_fully(buf, segment->update_data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read delete file " << segment->DebugString() << " by " << debug_string()
@@ -342,7 +342,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
 
                     auto rfile = std::move(res.value());
                     auto buf = new uint8[file_size];
-                    data.append_user_data(buf, file_size, [](void* buf) { delete[] (uint8*)buf; });
+                    data.append_user_data(buf, file_size, [](void* buf) { delete[](uint8*) buf; });
                     auto st = rfile->read_fully(buf, file_size);
                     if (!st.ok()) {
                         LOG(WARNING) << "Failed to read index file " << segment->DebugString() << " by "

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -72,6 +72,14 @@ private:
     Status _st = Status::OK();
 };
 
+struct SegmentReplicateStat {
+    int32_t num_pending_tasks = 0;
+    int32_t num_executing_tasks = 0;
+    int32_t num_finished_tasks = 0;
+    int64_t pending_time_ns = 0;
+    int64_t execute_time_ns = 0;
+};
+
 class ReplicateToken {
 public:
     ReplicateToken(std::unique_ptr<ThreadPoolToken> sync_pool_token, const DeltaWriterOptions* opt);
@@ -109,6 +117,8 @@ public:
 
     const std::vector<int64_t> replica_node_ids() const { return _replica_node_ids; }
 
+    const SegmentReplicateStat& get_stat() const { return _stat; }
+
 private:
     friend class SegmentReplicateTask;
 
@@ -133,6 +143,8 @@ private:
 
     int64_t _max_fail_replica_num;
     std::vector<int64_t> _replica_node_ids;
+
+    SegmentReplicateStat _stat;
 };
 
 class SegmentReplicateExecutor {

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -73,11 +73,11 @@ private:
 };
 
 struct SegmentReplicateStat {
-    int32_t num_pending_tasks = 0;
-    int32_t num_executing_tasks = 0;
-    int32_t num_finished_tasks = 0;
-    int64_t pending_time_ns = 0;
-    int64_t execute_time_ns = 0;
+    atomic_int32_t num_pending_tasks{0};
+    atomic_int32_t num_running_tasks{0};
+    atomic_int32_t num_finished_tasks{0};
+    atomic_int64_t pending_time_ns{0};
+    atomic_int64_t execute_time_ns{0};
 };
 
 class ReplicateToken {

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -73,11 +73,11 @@ private:
 };
 
 struct SegmentReplicateStat {
-    atomic_int32_t num_pending_tasks{0};
-    atomic_int32_t num_running_tasks{0};
-    atomic_int32_t num_finished_tasks{0};
-    atomic_int64_t pending_time_ns{0};
-    atomic_int64_t execute_time_ns{0};
+    std::atomic_int32_t num_pending_tasks{0};
+    std::atomic_int32_t num_running_tasks{0};
+    std::atomic_int32_t num_finished_tasks{0};
+    std::atomic_int64_t pending_time_ns{0};
+    std::atomic_int64_t execute_time_ns{0};
 };
 
 class ReplicateToken {

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -288,47 +288,56 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
         add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
     }
 
+    bool close_channel;
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // Duplicated request, should be ignored.
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // Out-of-order request, should return error.
     add_chunk_request.set_packet_seq(10);
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() != TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // No packet_seq
     add_chunk_request.clear_packet_seq();
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() != TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // No sender_id
     add_chunk_request.set_packet_seq(1);
     add_chunk_request.clear_sender_id();
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() != TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // sender_id < 0
     add_chunk_request.set_sender_id(-1);
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() != TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // sender_id too large
     add_chunk_request.set_sender_id(1);
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() != TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // no chunk and no eos
     add_chunk_request.set_sender_id(0);
     add_chunk_request.clear_chunk();
-    _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response);
+    _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() != TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     PTabletWriterAddChunkRequest finish_request;
     PTabletWriterAddBatchResult finish_response;
@@ -340,10 +349,11 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
     finish_request.add_partition_ids(11);
 
     config::stale_memtable_flush_time_sec = 30;
-    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
     config::stale_memtable_flush_time_sec = 0;
     ASSERT_EQ(TStatusCode::OK, finish_response.status().status_code());
     ASSERT_EQ(4, finish_response.tablet_vec_size());
+    ASSERT_TRUE(close_channel);
 
     std::vector<int64_t> finished_tablets;
     for (auto& info : finish_response.tablet_vec()) {
@@ -364,8 +374,9 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
     }
 
     // Duplicated eos request should return error
-    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
     ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, finish_response.status().status_code());
+    ASSERT_FALSE(close_channel);
 }
 
 TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
@@ -394,8 +405,10 @@ TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    bool close_channel;
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     PTabletWriterAddChunkRequest finish_request;
     PTabletWriterAddBatchResult finish_response;
@@ -406,9 +419,10 @@ TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
     // Does not contain partition 11
     finish_request.add_partition_ids(10);
 
-    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
     ASSERT_TRUE(finish_response.status().status_code() == TStatusCode::OK);
     ASSERT_EQ(2, finish_response.tablet_vec_size());
+    ASSERT_TRUE(close_channel);
 
     std::vector<int64_t> finished_tablets;
     for (auto& info : finish_response.tablet_vec()) {
@@ -438,10 +452,12 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
     auto chunk = generate_data(kChunkSize);
 
     std::atomic<bool> started{false};
+    std::atomic<int32_t> close_channel_count{0};
 
     auto do_write = [&](int sender_id) {
         while (!started) {
         }
+        bool close_channel;
         for (int i = 0; i < kLookCount; i++) {
             PTabletWriterAddChunkRequest add_chunk_request;
             PTabletWriterAddBatchResult add_chunk_response;
@@ -459,8 +475,9 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
             ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
             add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-            _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+            _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
             ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+            ASSERT_FALSE(close_channel);
         }
 
         PTabletWriterAddChunkRequest finish_request;
@@ -472,8 +489,11 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
         finish_request.add_partition_ids(10);
         finish_request.add_partition_ids(11);
 
-        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
         ASSERT_TRUE(finish_response.status().status_code() == TStatusCode::OK);
+        if (close_channel) {
+            close_channel_count.fetch_add(1);
+        }
     };
 
     auto t0 = std::thread([&]() { do_write(0); });
@@ -489,6 +509,7 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
         auto tmp_chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
         ASSERT_EQ(kSegmentRows, tmp_chunk->num_rows());
     }
+    ASSERT_EQ(1, close_channel_count.load());
 }
 
 TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
@@ -504,6 +525,7 @@ TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
     std::atomic<bool> stopped{false};
     auto t0 = std::thread([&]() {
         int64_t packet_seq = 0;
+        bool close_channel;
         while (true) {
             PTabletWriterAddChunkRequest add_chunk_request;
             PTabletWriterAddBatchResult add_chunk_response;
@@ -521,7 +543,8 @@ TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
             ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
             add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-            _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+            _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
+            ASSERT_FALSE(close_channel);
             if (add_chunk_response.status().status_code() != TStatusCode::OK) {
                 break;
             }
@@ -535,8 +558,9 @@ TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
         finish_request.set_packet_seq(packet_seq++);
         finish_request.add_partition_ids(10);
         finish_request.add_partition_ids(11);
-        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
         ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
+        ASSERT_TRUE(close_channel);
         stopped.store(true);
     });
 
@@ -589,8 +613,10 @@ TEST_F(LakeTabletsChannelTest, test_write_failed) {
         _tablet_manager->prune_metacache();
     }
 
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    bool close_channel;
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_NE(TStatusCode::OK, add_chunk_response.status().status_code());
+    ASSERT_FALSE(close_channel);
 
     _tablets_channel->cancel();
 
@@ -624,8 +650,10 @@ TEST_F(LakeTabletsChannelTest, test_empty_tablet) {
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    bool close_channel;
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     PTabletWriterAddChunkRequest finish_request;
     PTabletWriterAddBatchResult finish_response;
@@ -636,9 +664,10 @@ TEST_F(LakeTabletsChannelTest, test_empty_tablet) {
     finish_request.add_partition_ids(10);
     finish_request.add_partition_ids(11);
 
-    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
     ASSERT_TRUE(finish_response.status().status_code() == TStatusCode::OK);
     ASSERT_EQ(4, finish_response.tablet_vec_size());
+    ASSERT_TRUE(close_channel);
 
     std::vector<int64_t> finished_tablets;
     for (auto& info : finish_response.tablet_vec()) {
@@ -689,8 +718,10 @@ TEST_F(LakeTabletsChannelTest, test_finish_failed) {
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    bool close_channel;
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_FALSE(close_channel);
 
     // Remove txn log directory before finish
     fs::remove_all(_location_provider->txn_log_root_location(10087));
@@ -704,8 +735,9 @@ TEST_F(LakeTabletsChannelTest, test_finish_failed) {
     finish_request.add_partition_ids(10);
     finish_request.add_partition_ids(11);
 
-    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
     ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
+    ASSERT_TRUE(close_channel);
 }
 
 TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
@@ -735,13 +767,16 @@ TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
         ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
         add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+        bool close_channel;
+        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
         ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+        ASSERT_FALSE(close_channel);
 
         _tablets_channel->abort();
 
-        _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response);
+        _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response, &close_channel);
         ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, add_chunk_response.status().status_code());
+        ASSERT_FALSE(close_channel);
     }
     {
         PTabletWriterAddChunkRequest finish_request;
@@ -751,15 +786,18 @@ TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
         finish_request.set_eos(true);
         finish_request.set_packet_seq(0);
 
-        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+        bool close_channel;
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
         ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
         ASSERT_GE(finish_response.status().error_msgs_size(), 1);
         const auto& message = finish_response.status().error_msgs(0);
         ASSERT_TRUE(message.find("AsyncDeltaWriter has been closed") != std::string::npos) << message;
+        ASSERT_TRUE(close_channel);
 
         PTabletWriterAddBatchResult finish_response2;
-        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response2);
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response2, &close_channel);
         ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, finish_response2.status().status_code());
+        ASSERT_FALSE(close_channel);
     }
 }
 
@@ -789,8 +827,10 @@ TEST_F(LakeTabletsChannelTest, test_profile) {
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    bool close_channel;
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_TRUE(close_channel);
 
     auto* profile = _root_profile->get_child(fmt::format("Index (id={})", kIndexId));
     ASSERT_NE(nullptr, profile);
@@ -843,7 +883,7 @@ TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
 
     ASSERT_OK(_tablets_channel->open(open_request, &open_response, _schema_param, false));
     ASSERT_EQ(0, open_response.status().status_code());
-
+    std::atomic<int> close_channel_count{0};
     auto sender_task = [&](int sender_id) {
         PTabletWriterAddChunkRequest add_chunk_request;
         PTabletWriterAddBatchResult add_chunk_response;
@@ -862,9 +902,11 @@ TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
         ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
         add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
-        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+        bool close_channel;
+        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
         ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
         ASSERT_FALSE(add_chunk_response.has_lake_tablet_data());
+        ASSERT_FALSE(close_channel);
 
         PTabletWriterAddChunkRequest finish_request;
         PTabletWriterAddBatchResult finish_response;
@@ -876,7 +918,10 @@ TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
         finish_request.add_partition_ids(11);
         finish_request.set_timeout_ms(30 * 1000);
 
-        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
+        if (close_channel) {
+            close_channel_count.fetch_add(1);
+        }
 
         LOG(INFO) << "sender_id=" << sender_id << " #finished_tablets=" << finish_response.tablet_vec_size();
 
@@ -907,6 +952,7 @@ TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
     for (auto bid : bids) {
         (void)bthread_join(bid, nullptr);
     }
+    ASSERT_EQ(1, close_channel_count.load());
 }
 // clang-format off
 INSTANTIATE_TEST_SUITE_P(LakeTabletsChannelMultiSenderTest, LakeTabletsChannelMultiSenderTest,

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -200,7 +200,6 @@ protected:
 
 TEST_F(LocalTabletsChannelTest, test_profile) {
     auto open_request = _open_request;
-
     ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
 
     PTabletWriterAddChunkRequest add_chunk_request;
@@ -230,10 +229,10 @@ TEST_F(LocalTabletsChannelTest, test_profile) {
     _tablets_channel->update_profile();
     auto* profile = _root_profile->get_child(fmt::format("Index (id={})", _index_id));
     ASSERT_NE(nullptr, profile);
-    ASSERT_EQ(1, profile->get_counter("OpenCount")->value());
-    ASSERT_TRUE(profile->get_counter("OpenTime")->value() > 0);
-    ASSERT_EQ(1, profile->get_counter("AddChunkCount")->value());
-    ASSERT_TRUE(profile->get_counter("AddChunkTime")->value() > 0);
+    ASSERT_EQ(1, profile->get_counter("OpenRpcCount")->value());
+    ASSERT_TRUE(profile->get_counter("OpenRpcTime")->value() > 0);
+    ASSERT_EQ(1, profile->get_counter("AddChunkRpcCount")->value());
+    ASSERT_TRUE(profile->get_counter("AddChunkRpcTime")->value() > 0);
     ASSERT_EQ(chunk.num_rows(), profile->get_counter("AddRowNum")->value());
     auto* primary_replicas_profile = profile->get_child("PrimaryReplicas");
     ASSERT_NE(nullptr, primary_replicas_profile);

--- a/test/sql/test_profile/T/test_load_channel_profile_analysis.sh
+++ b/test/sql/test_profile/T/test_load_channel_profile_analysis.sh
@@ -39,5 +39,5 @@ EOF
 )
 
 output=$(${mysql_cmd} -e "$sql")
-check_keywords "$output" "LoadChannel" "1"
+check_keywords "$output" "LoadChannel:" "1"
 check_keywords "$output" "Index (id=" "3"


### PR DESCRIPTION
## Why I'm doing:
Need storage metrics in the load profile to know why the load is slow if the bottleneck is at the storage

## What I'm doing:
* For primary/peer tablets, there are following metrics
   * the number/cost of methods for DeltaWriter write/close/commit
   * the statistics about memtable including the number/cost  of sort, agg, flush
   * for primary tablets, also includes the time to sync segments to secondary replica
   * the pending time of tasks in the queue such as async delta writer task, flush task, segment replica task
* For secondary tablets, there are following metrics
   * the number/cost of methods for DeltaWriter add_segment/commit
   * the statistics about segment flush

Fix #46373

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
