### PR TITLE
[BugFix] get identifier field ids from equality delete file for adaptation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -16,6 +16,7 @@ package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -300,6 +301,10 @@ public class IcebergScanNode extends ScanNode {
             scanRangeLocations.addToLocations(scanRangeLocation);
 
             result.add(scanRangeLocations);
+        }
+
+        if (!currentEqualityIds.isEmpty()) {
+            icebergTable.setIdentifierFieldIds(ImmutableSet.copyOf(currentEqualityIds));
         }
 
         scanNodePredicates.setSelectedPartitionIds(partitionKeyToId.values());


### PR DESCRIPTION
## Why I'm doing:

iceberg equality delete file schema with parquet is from identifier_field_ids of iceberg . currently, identifier_ids obtained from iceberg metadata file of json. but if user create table by spark engine, it won't record the identifier in the metadata file. so if the iceberg table metadata doesn't identifier_filed_ids, we need to get it from the equality delete file.

## What I'm doing:

Fixes #issue
https://github.com/StarRocks/starrocks/issues/44753

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
