### PR TITLE
[Feature] Unified catalog support kudu

### DIFF
--- a/docs/en/data_source/catalog/kudu_catalog.md
+++ b/docs/en/data_source/catalog/kudu_catalog.md
@@ -43,7 +43,6 @@ CREATE EXTERNAL CATALOG <catalog_name>
 PROPERTIES
 (
     "type" = "kudu",
-    "kudu.master" = "<kudu_master_addresses>",
     CatalogParams
 )
 ```
@@ -74,6 +73,7 @@ The following table describes the parameter you need to configure in `CatalogPar
 | Parameter           | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                             |
 |---------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | kudu.catalog.type   | Yes      | The type of metastore that you use for your Kudu cluster. Set this parameter to `kudu` or `hive`.                                                                                                                                                                                                                                                                                                                       |
+| kudu.master                   | No       | Specifies the Kudu Master address, which defaults to `localhost:7051`.                                                                                                                                                                                                                                                                                                                                         |
 | kudu.metastore.uris | No       | The URI of your Hive metastore. Format: `thrift://<metastore_IP_address>:<metastore_port>`. If high availability (HA) is enabled for your Hive metastore, you can specify multiple metastore URIs and separate them with commas (`,`), for example, `"thrift://<metastore_IP_address_1>:<metastore_port_1>,thrift://<metastore_IP_address_2>:<metastore_port_2>,thrift://<metastore_IP_address_3>:<metastore_port_3>"`. |
 | kudu.schema-emulation.enabled | No       | option to enable or disable the `schema` emulation. By default, it is turned off (false), which means that all tables belong to the `default` `schema`.                                                                                                                                                                                                                                                                 |
 | kudu.schema-emulation.prefix | No       | The prefix for `schema` emulation should only be set when `kudu.schema-emulation.enabled` = `true`. The default prefix used is empty string: ` `.                                                                                                                                                                                                                                                                       |
@@ -106,7 +106,7 @@ The following table describes the parameter you need to configure in `CatalogPar
   (
       "type" = "kudu",
       "kudu.master" = "localhost:7051",
-      "kudu.metastore.type" = "kudu",
+      "kudu.metastore.type" = "hive",
       "kudu.metastore.uris" = "thrift://xx.xx.xx.xx:9083",
   );
   ```

--- a/docs/en/data_source/catalog/unified_catalog.md
+++ b/docs/en/data_source/catalog/unified_catalog.md
@@ -5,10 +5,10 @@ toc_max_heading_level: 5
 
 # Unified catalog
 
-A unified catalog is a type of external catalog that is provided by StarRocks from v3.2 onwards to handle tables from Apache Hive™, Apache Iceberg, Apache Hudi, and Delta Lake data sources as a unified data source without ingestion. With unified catalogs, you can:
+A unified catalog is a type of external catalog that is provided by StarRocks from v3.2 onwards to handle tables from Apache Hive™, Apache Iceberg, Apache Hudi, Delta Lake, and Apache Kudu data sources as a unified data source without ingestion. With unified catalogs, you can:
 
-- Directly query data stored in Hive, Iceberg, Hudi, and Delta Lake without the need to manually create tables.
-- Use [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) or asynchronous materialized views (which are supported from v2.5 onwards) to process data stored in Hive, Iceberg, Hudi, and Delta Lake and load the data into StarRocks.
+- Directly query data stored in Hive, Iceberg, Hudi, Delta Lake, and Kudu without the need to manually create tables.
+- Use [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) or asynchronous materialized views (which are supported from v2.5 onwards) to process data stored in Hive, Iceberg, Hudi, Delta Lake, and Kudu and load the data into StarRocks.
 - Perform operations on StarRocks to create or drop Hive and Iceberg databases and tables.
 
 To ensure successful SQL workloads on your unified data source, your StarRocks cluster must be able to access the storage system and metastore of your unified data source. StarRocks supports the following storage systems and metastores:
@@ -27,7 +27,7 @@ One unified catalog supports integrations with only a single storage system and 
 
 ## Usage notes
 
-- See the "Usage notes" section in [Hive catalog](../../data_source/catalog/hive_catalog.md), [Iceberg catalog](../../data_source/catalog/iceberg_catalog.md), [Hudi catalog](../../data_source/catalog/hudi_catalog.md), and [Delta Lake catalog](../../data_source/catalog/deltalake_catalog.md) to understand the file formats and data types supported.
+- See the "Usage notes" section in [Hive catalog](../../data_source/catalog/hive_catalog.md), [Iceberg catalog](../../data_source/catalog/iceberg_catalog.md), [Hudi catalog](../../data_source/catalog/hudi_catalog.md), [Delta Lake catalog](../../data_source/catalog/deltalake_catalog.md), and [Kudu catalog](../../data_source/catalog/kudu_catalog.md) to understand the file formats and data types supported.
 
 - Format-specific operations are supported only for specific table formats. For example, [CREATE TABLE](../../sql-reference/sql-statements/data-definition/CREATE_TABLE.md) and [DROP TABLE](../../sql-reference/sql-statements/data-definition/DROP_TABLE.md) are supported only for Hive and Iceberg, and [REFRESH EXTERNAL TABLE](../../sql-reference/sql-statements/data-definition/REFRESH_EXTERNAL_TABLE.md) is supported only for Hive and Hudi.
 
@@ -73,7 +73,8 @@ PROPERTIES
     "type" = "unified",
     MetastoreParams,
     StorageCredentialParams,
-    MetadataUpdateParams
+    MetadataUpdateParams,
+    KuduCatalogParams
 )
 ```
 
@@ -432,6 +433,16 @@ However, if the frequency of data updates in Hive, Hudi, or Delta Lake is high, 
 | remote_file_cache_refresh_interval_sec | No       | The time interval at which StarRocks asynchronously updates the metadata of the underlying data files of Hive, Hudi, or Delta Lake tables or partitions cached in itself. Unit: seconds. Default value: `60`. |
 | metastore_cache_ttl_sec                | No       | The time interval at which StarRocks automatically discards the metadata of Hive, Hudi, or Delta Lake tables or partitions cached in itself. Unit: seconds. Default value: `86400`, which is 24 hours. |
 | remote_file_cache_ttl_sec              | No       | The time interval at which StarRocks automatically discards the metadata of the underlying data files of Hive, Hudi, or Delta Lake tables or partitions cached in itself. Unit: seconds. Default value: `129600`, which is 36 hours. |
+
+#### KuduCatalogParams
+
+A set of parameters about how to connect Kudu Catalog. This parameter set is optional.
+
+| Parameter                              | Required | Description                                                  |
+| -------------------------------------- | -------- | ------------------------------------------------------------ |
+| kudu.master                 | No       | Specifies the Kudu Master address, which defaults to `localhost:7051`. |
+| kudu.schema-emulation.enabled               | No       | option to enable or disable the `schema` emulation. By default, it is turned off (false), which means that all tables belong to the `default` `schema`. |
+| kudu.schema-emulation.prefix   | No       | The prefix for `schema` emulation should only be set when `kudu.schema-emulation.enabled` = `true`. The default prefix used is empty string: ` `. |
 
 ### Examples
 
@@ -822,9 +833,9 @@ To query data from a unified catalog, follow these steps:
    SELECT count(*) FROM <table_name> LIMIT 10
    ```
 
-## Load data from Hive, Iceberg, Hudi, or Delta Lake
+## Load data from Hive, Iceberg, Hudi, Delta Lake, or Kudu
 
-You can use [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) to load the data of a Hive, Iceberg, Hudi, or Delta Lake table into a StarRocks table created within a unified catalog.
+You can use [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) to load the data of a Hive, Iceberg, Hudi, Delta Lake, or Kudu table into a StarRocks table created within a unified catalog.
 
 The following example loads the data of the Hive table `hive_table` into the StarRocks table `test_tbl` created in the database `test_database` that belongs to the unified catalog `unified_catalog`:
 

--- a/docs/zh/data_source/catalog/kudu_catalog.md
+++ b/docs/zh/data_source/catalog/kudu_catalog.md
@@ -43,7 +43,6 @@ CREATE EXTERNAL CATALOG <catalog_name>
 PROPERTIES
 (
     "type" = "kudu",
-    "kudu.master" = "<kudu_master_addresses>",
     CatalogParams,
 )
 ```
@@ -75,6 +74,7 @@ StarRocks 访问 Kudu 集群元数据的相关参数配置。
 | 参数                            | 是否必须 | 说明                                                                                                                                                                                                                                                |
 |-------------------------------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | kudu.catalog.type             | 是    | Kudu 使用的元数据类型。设置为 `kudu`、`hive`。                                                                                                                                                                                                                  |
+| kudu.master                   | 否    | 指定 `Kudu Master` 连接地址，默认为：`localhost:7051`。                                                                                                                                                                                                                  |
 | kudu.metastore.uris           | 否    | HMS 的 URI， 格式：`thrift://<HMS IP 地址>:<HMS 端口号>`。仅在 `kudu.catalog.type` = `hive` 时设置。<br />如果您的 HMS 开启了高可用模式，此处可以填写多个 HMS 地址并用逗号分隔，例如：`"thrift://<HMS IP 地址 1>:<HMS 端口号 1>,thrift://<HMS IP 地址 2>:<HMS 端口号 2>,thrift://<HMS IP 地址 3>:<HMS 端口号 3>"`。 |
 | kudu.schema-emulation.enabled | 否    | 是否启用模拟 `schema` 功能，默认处于关闭状态（`false`），即所有表都属于 `default` `schema`。                                                                                                                                                                                  |
 | kudu.schema-emulation.prefix  | 否    | 仅在 `kudu.schema-emulation.enabled` = `true` 即启用模拟 `schema` 功能时，需设置匹配前缀，默认采用前缀空字符串：` `。                                                                                                                                                            |
@@ -107,7 +107,7 @@ StarRocks 访问 Kudu 集群元数据的相关参数配置。
   (
       "type" = "kudu",
       "kudu.master" = "localhost:7051",
-      "kudu.metastore.type" = "kudu",
+      "kudu.metastore.type" = "hive",
       "kudu.metastore.uris" = "thrift://xx.xx.xx.xx:9083",
   );
   ```

--- a/docs/zh/data_source/catalog/unified_catalog.md
+++ b/docs/zh/data_source/catalog/unified_catalog.md
@@ -5,10 +5,10 @@ toc_max_heading_level: 5
 
 # Unified catalog
 
-Unified Catalog 是一种 External Catalog，自 3.2 版本起支持。通过 Unified Catalog，您可以把 Apache Hive™、Apache Iceberg、Apache Hudi 和 Delta Lake 数据源作为一个融合的数据源，不需要执行导入就可以直接操作其中的表数据，包括：
+Unified Catalog 是一种 External Catalog，自 3.2 版本起支持。通过 Unified Catalog，您可以把 Apache Hive™、Apache Iceberg、Apache Hudi、 Delta Lake 和 Apache Kudu 数据源作为一个融合的数据源，不需要执行导入就可以直接操作其中的表数据，包括：
 
-- 无需手动建表，通过 Unified Catalog 直接查询 Hive、Iceberg、Hudi 和 Delta Lake 数据源里的数据。
-- 通过 [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) 或异步物化视图（2.5 版本及以上）将 Hive、Iceberg、Hudi 和 Delta Lake 数据源里的数据进行加工建模，并导入至 StarRocks。
+- 无需手动建表，通过 Unified Catalog 直接查询 Hive、Iceberg、Hudi、Delta Lake 和 Kudu 数据源里的数据。
+- 通过 [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) 或异步物化视图（2.5 版本及以上）将 Hive、Iceberg、Hudi、Delta Lake 和 Kudu 数据源里的数据进行加工建模，并导入至 StarRocks。
 - 在 StarRocks 侧创建或删除 Hive、Iceberg 库表。
 
 为保证正常访问融合数据源内的数据，StarRocks 集群必须能够访问融合数据源的存储系统和元数据服务。目前 StarRocks 支持以下存储系统和元数据服务：
@@ -27,7 +27,7 @@ Unified Catalog 是一种 External Catalog，自 3.2 版本起支持。通过 Un
 
 ## 使用说明
 
-- 有关 Unified Catalog 支持的文件格式和数据类型，请参见 [Hive catalog](../catalog/hive_catalog.md)、[Iceberg catalog](../catalog/iceberg_catalog.md)、[Hudi catalog](../catalog/hudi_catalog.md) 和 [Delta Lake catalog](../catalog/deltalake_catalog.md) 文档中“使用说明”部分。
+- 有关 Unified Catalog 支持的文件格式和数据类型，请参见 [Hive catalog](../catalog/hive_catalog.md)、[Iceberg catalog](../catalog/iceberg_catalog.md)、[Hudi catalog](../catalog/hudi_catalog.md)、[Delta Lake catalog](../catalog/deltalake_catalog.md) 和 [Kudu catalog](../catalog/kudu_catalog.md) 文档中“使用说明”部分。
 
 - 部分操作只能用于特定的表格式。例如，[CREATE TABLE](../../sql-reference/sql-statements/data-definition/CREATE_TABLE.md) 和 [DROP TABLE](../../sql-reference/sql-statements/data-definition/DROP_TABLE.md) 当前只支持 Hive 和 Iceberg 表，[REFRESH EXTERNAL TABLE](../../sql-reference/sql-statements/data-definition/REFRESH_EXTERNAL_TABLE.md) 只支持 Hive 和 Hudi 表。
 
@@ -73,7 +73,8 @@ PROPERTIES
     "type" = "unified",
     MetastoreParams,
     StorageCredentialParams,
-    MetadataUpdateParams
+    MetadataUpdateParams,
+    KuduCatalogParams
 )
 ```
 
@@ -449,6 +450,16 @@ StarRocks 默认采用自动异步更新策略，开箱即用。因此，一般�
 | remote_file_cache_refresh_interval_sec | 否       | StarRocks 异步更新缓存的 Hive、Hudi、或 Delta Lake 表或分区的数据文件的元数据的时间间隔。单位：秒。默认值：`60`。 |
 | metastore_cache_ttl_sec                | 否       | StarRocks 自动淘汰缓存的 Hive、Hudi、或 Delta Lake 表或分区的元数据的时间间隔。单位：秒。默认值：`86400`，即 24 小时。 |
 | remote_file_cache_ttl_sec              | 否       | StarRocks 自动淘汰缓存的 Hive、Hudi、或 Delta Lake 表或分区的数据文件的元数据的时间间隔。单位：秒。默认值：`129600`，即 36 小时。 |
+
+#### KuduCatalogParams
+
+指定 Kudu Catalog 连接的一组参数。此组参数为可选。
+
+| 参数                                   | 是否必须 | 说明                                                                                     |
+| -------------------------------------- | -------- |----------------------------------------------------------------------------------------|
+| kudu.master                 | 否       | 指定 `Kudu Master` 连接地址，默认为：`localhost:7051`。                                            |
+| kudu.schema-emulation.enabled               | 否       | 是否启用模拟 `schema` 功能，默认处于关闭状态（`false`），即所有表都属于 `default` `schema`。                       |
+| kudu.schema-emulation.prefix   | 否       | 仅在 `kudu.schema-emulation.enabled` = `true` 即启用模拟 `schema` 功能时，需设置匹配前缀，默认采用前缀空字符串：` `。 |
 
 ### 示例
 
@@ -842,9 +853,9 @@ DROP CATALOG unified_catalog_glue;
    SELECT count(*) FROM <table_name> LIMIT 10
    ```
 
-## 从 Hive、Iceberg、Hudi 或 Delta Lake 导入数据
+## 从 Hive、Iceberg、Hudi、Delta Lake 或 Kudu 导入数据
 
-您可以通过 [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) 将 Hive、Iceberg、Hudi 或 Delta Lake 表中的数据导入 StarRocks 中 Unified Catalog 下的表。
+您可以通过 [INSERT INTO](../../sql-reference/sql-statements/data-manipulation/INSERT.md) 将 Hive、Iceberg、Hudi、Delta Lake 或 Kudu 表中的数据导入 StarRocks 中 Unified Catalog 下的表。
 
 例如，通过如下命令将 Hive 表 `hive_table` 的数据导入到 StarRocks 中 Unified Catalog `unified_catalog` 下数据库`test_database` 里的表 `test_table`：
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1173,17 +1173,6 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                    <release>${maven.compiler.source}</release>
-                </configuration>
-            </plugin>
         </plugins>
 
         <pluginManagement>

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
@@ -24,7 +24,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,11 +38,16 @@ public class KuduTable extends Table {
     public static final Set<String> KUDU_INPUT_FORMATS = Sets.newHashSet(
             "org.apache.hadoop.hive.kudu.KuduInputFormat", "org.apache.kudu.mapreduce.KuduTableInputFormat");
     public static final String PARTITION_NULL_VALUE = "null";
-    private final String masterAddresses;
-    private final String catalogName;
-    private final String databaseName;
-    private final String tableName;
-    private final List<String> partColNames;
+    private String masterAddresses;
+    private String catalogName;
+    private String databaseName;
+    private String tableName;
+    private List<String> partColNames;
+    private Map<String, String> properties;
+
+    public KuduTable() {
+        super(TableType.KUDU);
+    }
 
     public KuduTable(String masterAddresses, String catalogName, String dbName, String tblName, List<Column> schema,
                      List<String> partColNames) {
@@ -82,6 +89,14 @@ public class KuduTable extends Table {
                     .collect(Collectors.toList());
         }
         return partitionColumns;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        if (properties == null) {
+            this.properties = new HashMap<>();
+        }
+        return properties;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduConnector.java
@@ -38,12 +38,14 @@ import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class KuduConnector implements Connector {
     private static final String HIVE = "hive";
+    private static final String GLUE = "glue";
     private static final String KUDU = "kudu";
-    private static final Set<String> SUPPORTED_METASTORE_TYPE = Sets.newHashSet(HIVE, KUDU);
-    private static final String KUDU_MASTER = "kudu.master";
-    private static final String KUDU_CATALOG_TYPE = "kudu.catalog.type";
-    private static final String KUDU_SCHEMA_EMULATION_ENABLED = "kudu.schema-emulation.enabled";
-    private static final String KUDU_SCHEMA_EMULATION_PREFIX = "kudu.schema-emulation.prefix";
+    private static final Set<String> SUPPORTED_METASTORE_TYPE = Sets.newHashSet(HIVE, GLUE, KUDU);
+    public static final String KUDU_MASTER = "kudu.master";
+    public static final String KUDU_CATALOG_TYPE = "kudu.catalog.type";
+    public static final String KUDU_SCHEMA_EMULATION_ENABLED = "kudu.schema-emulation.enabled";
+    public static final String KUDU_SCHEMA_EMULATION_PREFIX = "kudu.schema-emulation.prefix";
+    public static final String DEFAULT_KUDU_MASTER = "localhost:7051";
     private final String catalogName;
     private final String kuduMaster;
     private final String catalogType;
@@ -58,7 +60,7 @@ public class KuduConnector implements Connector {
         this.catalogName = context.getCatalogName();
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
-        this.kuduMaster = getPropertyOrThrow(KUDU_MASTER);
+        this.kuduMaster = properties.getOrDefault(KUDU_MASTER, DEFAULT_KUDU_MASTER);
         this.catalogType = getPropertyOrThrow(KUDU_CATALOG_TYPE).toLowerCase();
         this.metastoreUris = properties.get(HIVE_METASTORE_URIS);
         this.schemaEmulationEnabled = Boolean.parseBoolean(properties.get(KUDU_SCHEMA_EMULATION_ENABLED));
@@ -92,10 +94,11 @@ public class KuduConnector implements Connector {
     @Override
     public ConnectorMetadata getMetadata() {
         Optional<IHiveMetastore> hiveMetastore = Optional.empty();
-        if (HIVE.equals(catalogType)) {
+        if (HIVE.equals(catalogType) || GLUE.equals(catalogType)) {
             Util.validateMetastoreUris(metastoreUris);
+            MetastoreType metastoreType = MetastoreType.get(catalogType);
             HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(this.hdfsEnvironment, properties);
-            hiveMetastore = Optional.of(new HiveMetastore(metaClient, catalogName, MetastoreType.HMS));
+            hiveMetastore = Optional.of(new HiveMetastore(metaClient, catalogName, metastoreType));
             // TODO caching hiveMetastore support
         }
         return new KuduMetadata(catalogName, hdfsEnvironment, kuduMaster, schemaEmulationEnabled, schemaEmulationPrefix,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedConnector.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.delta.DeltaLakeConnector;
 import com.starrocks.connector.hive.HiveConnector;
 import com.starrocks.connector.hudi.HudiConnector;
 import com.starrocks.connector.iceberg.IcebergConnector;
+import com.starrocks.connector.kudu.KuduConnector;
 import com.starrocks.sql.analyzer.SemanticException;
 
 import java.util.HashMap;
@@ -35,8 +36,10 @@ import static com.starrocks.catalog.Table.TableType.DELTALAKE;
 import static com.starrocks.catalog.Table.TableType.HIVE;
 import static com.starrocks.catalog.Table.TableType.HUDI;
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
+import static com.starrocks.catalog.Table.TableType.KUDU;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
+import static com.starrocks.connector.kudu.KuduConnector.KUDU_CATALOG_TYPE;
 
 public class UnifiedConnector implements Connector {
     public static final String UNIFIED_METASTORE_TYPE = "unified.metastore.type";
@@ -53,6 +56,7 @@ public class UnifiedConnector implements Connector {
         derivedProperties.putAll(context.getProperties());
         derivedProperties.put(HIVE_METASTORE_TYPE, metastoreType);
         derivedProperties.put(ICEBERG_CATALOG_TYPE, metastoreType);
+        derivedProperties.put(KUDU_CATALOG_TYPE, metastoreType);
 
         ConnectorContext derivedContext = new ConnectorContext(context.getCatalogName(), context.getType(),
                 derivedProperties.build());
@@ -61,7 +65,8 @@ public class UnifiedConnector implements Connector {
                 HIVE, new HiveConnector(derivedContext),
                 ICEBERG, new IcebergConnector(derivedContext),
                 HUDI, new HudiConnector(derivedContext),
-                DELTALAKE, new DeltaLakeConnector(derivedContext)
+                DELTALAKE, new DeltaLakeConnector(derivedContext),
+                KUDU, new KuduConnector(derivedContext)
         );
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -47,6 +47,7 @@ import static com.starrocks.catalog.Table.TableType.DELTALAKE;
 import static com.starrocks.catalog.Table.TableType.HIVE;
 import static com.starrocks.catalog.Table.TableType.HUDI;
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
+import static com.starrocks.catalog.Table.TableType.KUDU;
 import static java.util.Objects.requireNonNull;
 
 public class UnifiedMetadata implements ConnectorMetadata {
@@ -92,6 +93,9 @@ public class UnifiedMetadata implements ConnectorMetadata {
         }
         if (isDeltaLakeTable(table.getProperties())) {
             return DELTALAKE;
+        }
+        if (table.isKuduTable()) {
+            return KUDU;
         }
         return HIVE;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedConnectorTest.java
@@ -35,6 +35,9 @@ public class UnifiedConnectorTest {
         properties.put("type", "unified");
         properties.put("unified.metastore.type", "hive");
         properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
+        properties.put("kudu.master", "localhost:7051");
+        properties.put("kudu.schema-emulation.enabled", "true");
+        properties.put("kudu.schema-emulation.prefix", "impala::");
         ConnectorContext context = new ConnectorContext("unified_catalog", "unified", properties);
         CatalogConnector catalogConnector = ConnectorFactory.createConnector(context);
         ConnectorMetadata metadata = catalogConnector.getMetadata();
@@ -48,6 +51,9 @@ public class UnifiedConnectorTest {
         properties.put("type", "unified");
         properties.put("unified.metastore.type", "hive");
         properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
+        properties.put("kudu.master", "localhost:7051");
+        properties.put("kudu.schema-emulation.enabled", "true");
+        properties.put("kudu.schema-emulation.prefix", "impala::");
         ConnectorContext context = new ConnectorContext("unified_catalog", "unified", properties);
         UnifiedConnector unifiedConnector = new UnifiedConnector(context);
         ConnectorMetadata metadata = unifiedConnector.getMetadata();


### PR DESCRIPTION
Make unified catalog support kudu data sources.

example: 
```
CREATE EXTERNAL CATALOG unified
PROPERTIES
(
    "type" = "unified",
    "unified.metastore.type" = "hive",
    "hive.metastore.uris" = "thrift://localhost:9083",
    "kudu.master" = "localhost:7051",
    "kudu.schema-emulation.enabled" = "true",
    "kudu.schema-emulation.prefix" = "impala::"
);
```

Fixes #45591 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
