### PR TITLE
[BugFix] fix cache select task property not set correctly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
@@ -56,6 +56,9 @@ public class SubmitTaskStmt extends DdlStmt {
         this.taskName = taskName.getName();
         this.sqlBeginIndex = sqlBeginIndex;
         this.dataCacheSelectStmt = dataCacheSelectStatement;
+        if (this.dataCacheSelectStmt.getProperties() != null) {
+            this.properties.putAll(this.dataCacheSelectStmt.getProperties());
+        }
     }
 
     public SubmitTaskStmt(TaskName taskName, int sqlBeginIndex, InsertStmt insertStmt, NodePosition pos) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
mysql> select * from information_schema.tasks;
+-----------+---------------------+-----------------------------------------------------+-----------------+----------+---------------------------------------------------------+-------------+--------------------+
| TASK_NAME | CREATE_TIME         | SCHEDULE                                            | CATALOG         | DATABASE | DEFINITION                                              | EXPIRE_TIME | PROPERTIES         |
+-----------+---------------------+-----------------------------------------------------+-----------------+----------+---------------------------------------------------------+-------------+--------------------+
| aaa       | 2024-05-14 16:16:33 | PERIODICAL START(2024-05-14T16:10) EVERY(1 MINUTES) | default_catalog | test     | cache select * from test.t PROPERTIES("verbose"="true") | NULL        | ('verbose'='true') |
+-----------+---------------------+-----------------------------------------------------+-----------------+----------+---------------------------------------------------------+-------------+--------------------+
1 row in set (0.04 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
