### PR TITLE
[BugFix] Fix ColumnId empty bug when upgrading

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -134,7 +134,6 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public Column() {
         this.name = "";
-        this.columnId = ColumnId.create(this.name);
         this.type = Type.NULL;
         this.isAggregationTypeImplicit = false;
         this.isKey = false;
@@ -788,7 +787,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                     SqlModeHelper.MODE_DEFAULT);
         }
 
-        if (columnId == null) {
+        if (columnId == null || Strings.isNullOrEmpty(columnId.getId())) {
             columnId = ColumnId.create(name);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -132,6 +132,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     private GsonUtils.ExpressionSerializedObject generatedColumnExprSerialized;
     private Expr generatedColumnExpr;
 
+    // Only for persist
     public Column() {
         this.name = "";
         this.type = Type.NULL;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -78,7 +78,7 @@ public class AccessTestUtil {
         RandomDistributionInfo distributionInfo = new RandomDistributionInfo(10);
         Partition partition = new Partition(20000L, "testTbl", baseIndex, distributionInfo);
         List<Column> baseSchema = new LinkedList<Column>();
-        Column column = new Column();
+        Column column = new Column("k1", Type.INT);
         baseSchema.add(column);
         OlapTable table = new OlapTable(30000, "testTbl", baseSchema,
                 KeysType.AGG_KEYS, new SinglePartitionInfo(), distributionInfo, null);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -358,9 +358,7 @@ public class ColumnTest {
     @Test
     public void testColumnDeserialization() {
         String str = "{\"name\": \"test\"}";
-
         Column column = GsonUtils.GSON.fromJson(str, Column.class);
-
-        System.out.println("column id is" +  column.getColumnId());
+        Assert.assertEquals("test", column.getColumnId().getId());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -39,6 +39,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnDef.DefaultValueDef;
@@ -352,5 +353,14 @@ public class ColumnTest {
 
         Assert.assertEquals(f0.getUniqueId(), 1);
 
+    }
+
+    @Test
+    public void testColumnDeserialization() {
+        String str = "{\"name\": \"test\"}";
+
+        Column column = GsonUtils.GSON.fromJson(str, Column.class);
+
+        System.out.println("column id is" +  column.getColumnId());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -30,6 +30,7 @@ import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -395,7 +396,7 @@ public class TabletSchedulerTest {
                 .setShortKeyColumnCount((short) 1)
                 .setSchemaHash(-1)
                 .setStorageType(TStorageType.COLUMN)
-                .addColumn(new Column())
+                .addColumn(new Column("k1", Type.INT))
                 .build().toTabletSchema();
 
         CreateReplicaTask createReplicaTask = CreateReplicaTask.newBuilder()

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsTableTest.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.odps;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.OdpsTable;
+import com.starrocks.catalog.Type;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public class OdpsTableTest {
     public void testDataColumnNames() {
         OdpsTable odpsTable = mock(OdpsTable.class);
         List<Column> dataColumns = new ArrayList<>();
-        Column column = new Column();
+        Column column = new Column("k1", Type.INT);
         column.setName("name");
         dataColumns.add(column);
         when(odpsTable.getDataColumnNames()).thenReturn(
@@ -75,7 +76,7 @@ public class OdpsTableTest {
     public void testPartitionColumns() {
         OdpsTable odpsTable = mock(OdpsTable.class);
         List<Column> partitionColumns = new ArrayList<>();
-        Column column = new Column();
+        Column column = new Column("k1", Type.INT);
         column.setName("name");
         partitionColumns.add(column);
         when(odpsTable.getPartitionColumns()).thenReturn(partitionColumns);
@@ -86,7 +87,7 @@ public class OdpsTableTest {
     public void testPartitionColumnNames() {
         OdpsTable odpsTable = mock(OdpsTable.class);
         List<Column> partitionColumns = new ArrayList<>();
-        Column column = new Column();
+        Column column = new Column("k1", Type.INT);
         column.setName("name");
         partitionColumns.add(column);
         when(odpsTable.getPartitionColumnNames()).thenReturn(

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonSerializationTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Table;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.io.FastByteArrayOutputStream;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -493,7 +494,7 @@ public class GsonSerializationTest {
 
     @Test
     public void testMaterializedIndexMetaGsonProcess() throws Exception {
-        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, Lists.newArrayList(new Column()), 1, 1,
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, Lists.newArrayList(new Column("k1", Type.INT)), 1, 1,
                 (short) 1, COLUMN, PRIMARY_KEYS, null);
         FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();
         try (DataOutputStream out = new DataOutputStream(byteArrayOutputStream)) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ShowExecutor;
@@ -367,7 +368,7 @@ public class MaterializedViewAnalyzerTest {
     private void checkQueryOutputIndices(List<Integer> inputs, String expect, boolean isChanged) {
         List<Pair<Column, Integer>> mvColumnPairs = Lists.newArrayList();
         for (Integer i : inputs) {
-            mvColumnPairs.add(Pair.create(new Column(), i));
+            mvColumnPairs.add(Pair.create(new Column("k1", Type.INT), i));
         }
         List<Integer> queryOutputIndices = MaterializedViewAnalyzer.getQueryOutputIndices(mvColumnPairs);
         Assert.assertTrue(queryOutputIndices.size() == mvColumnPairs.size());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
@@ -1188,7 +1188,7 @@ public class OptimizerTaskTest {
         List<ColumnRefOperator> scanColumns = Lists.newArrayList(column1);
 
         Map<ColumnRefOperator, Column> scanColumnMap = Maps.newHashMap();
-        scanColumnMap.put(column1, new Column());
+        scanColumnMap.put(column1, new Column("k1", Type.INT));
 
         Map<ColumnRefOperator, CallOperator> map = Maps.newHashMap();
         LogicalAggregationOperator aggregationOperator =
@@ -1427,7 +1427,7 @@ public class OptimizerTaskTest {
 
         List<ColumnRefOperator> scanColumns = Lists.newArrayList(column1);
         Map<ColumnRefOperator, Column> scanColumnMap = Maps.newHashMap();
-        scanColumnMap.put(column1, new Column());
+        scanColumnMap.put(column1, new Column("k1", Type.INT));
 
         Map<ColumnRefOperator, ScalarOperator> projectColumnMap = Maps.newHashMap();
         projectColumnMap.put(column1, column1);
@@ -1548,7 +1548,7 @@ public class OptimizerTaskTest {
         List<ColumnRefOperator> scanColumns = Lists.newArrayList(column1, column2);
 
         Map<ColumnRefOperator, Column> scanColumnMap = Maps.newHashMap();
-        scanColumnMap.put(column1, new Column());
+        scanColumnMap.put(column1, new Column("k1", Type.INT));
 
         Map<ColumnRefOperator, ScalarOperator> projectColumnMap1 = Maps.newHashMap();
         projectColumnMap1.put(column3, column1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
@@ -91,7 +91,7 @@ public class MaterializedViewRuleTest extends PlanTestBase {
         ColumnRefFactory tmpRefFactory = new ColumnRefFactory();
         ColumnRefOperator queryColumnRef = tmpRefFactory.create("count", Type.INT, false);
         ColumnRefOperator mvColumnRef = tmpRefFactory.create("count", Type.INT, false);
-        Column mvColumn = new Column();
+        Column mvColumn = new Column("k1", Type.INT);
         List<ScalarOperator> arguments = Lists.newArrayList();
         arguments.add(queryColumnRef);
         CallOperator aggCall = new CallOperator(FunctionSet.COUNT, Type.BIGINT, arguments);


### PR DESCRIPTION
## Why I'm doing:
Introduced by #45364

The default value of columnId is set to empty in `Column()`, which will cause the logic in `gsonPostProcess()` not to be executed during the upgrade.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
