### PR TITLE
[Enhancement] Enable shared scan for cloud native data source

### DIFF
--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -110,7 +110,7 @@ void DataSource::update_profile(const Profile& profile) {
 StatusOr<pipeline::MorselQueuePtr> DataSourceProvider::convert_scan_range_to_morsel_queue(
         const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
         bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
-        size_t num_total_scan_ranges) {
+        size_t num_total_scan_ranges, size_t scan_dop) {
     peek_scan_ranges(scan_ranges);
 
     pipeline::Morsels morsels;
@@ -143,7 +143,11 @@ StatusOr<pipeline::MorselQueuePtr> DataSourceProvider::convert_scan_range_to_mor
         });
     }
 
-    return std::make_unique<pipeline::DynamicMorselQueue>(std::move(morsels));
+    auto morsel_queue = std::make_unique<pipeline::DynamicMorselQueue>(std::move(morsels));
+    if (scan_dop > 0) {
+        morsel_queue->set_max_degree_of_parallelism(scan_dop);
+    }
+    return morsel_queue;
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -167,7 +167,7 @@ public:
     virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
-            size_t num_total_scan_ranges);
+            size_t num_total_scan_ranges, size_t scan_dop = 0);
 
     int64_t get_scan_dop() const { return scan_dop; }
 

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -636,20 +636,20 @@ DataSourceProviderPtr LakeConnector::create_data_source_provider(ConnectorScanNo
 StatusOr<pipeline::MorselQueuePtr> LakeDataSourceProvider::convert_scan_range_to_morsel_queue(
         const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
         bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
-        size_t num_total_scan_ranges) {
-    auto morsel_queue = DataSourceProvider::convert_scan_range_to_morsel_queue(
-            scan_ranges, node_id, pipeline_dop, enable_tablet_internal_parallel, tablet_internal_parallel_mode,
-            num_total_scan_ranges);
+        size_t num_total_scan_ranges, size_t scan_dop) {
+    int64_t lake_scan_dop = 0;
     if (enable_tablet_internal_parallel) {
-        int64_t scan_dop;
         ASSIGN_OR_RETURN(_could_split, _could_tablet_internal_parallel(scan_ranges, pipeline_dop, num_total_scan_ranges,
-                                                                       tablet_internal_parallel_mode, &scan_dop,
+                                                                       tablet_internal_parallel_mode, &lake_scan_dop,
                                                                        &splitted_scan_rows));
         if (_could_split) {
             ASSIGN_OR_RETURN(_could_split_physically, _could_split_tablet_physically(scan_ranges));
         }
     }
-    return morsel_queue;
+
+    return DataSourceProvider::convert_scan_range_to_morsel_queue(
+            scan_ranges, node_id, pipeline_dop, enable_tablet_internal_parallel, tablet_internal_parallel_mode,
+            num_total_scan_ranges, (size_t)lake_scan_dop);
 }
 
 StatusOr<bool> LakeDataSourceProvider::_could_tablet_internal_parallel(
@@ -659,6 +659,7 @@ StatusOr<bool> LakeDataSourceProvider::_could_tablet_internal_parallel(
     //if (_t_lake_scan_node.use_pk_index) {
     //    return false;
     //}
+
     bool force_split = tablet_internal_parallel_mode == TTabletInternalParallelMode::type::FORCE_SPLIT;
     // The enough number of tablets shouldn't use tablet internal parallel.
     if (!force_split && num_total_scan_ranges >= pipeline_dop) {

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -189,13 +189,13 @@ public:
     Status init(ObjectPool* pool, RuntimeState* state) override;
     const TupleDescriptor* tuple_descriptor(RuntimeState* state) const override;
 
-    // Make cloud native table behavior same as olap table
-    bool always_shared_scan() const override { return false; }
+    // always enable shared scan for cloud native table
+    bool always_shared_scan() const override { return true; }
 
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
-            size_t num_total_scan_ranges) override;
+            size_t num_total_scan_ranges, size_t scan_dop = 0) override;
 
     // for ut
     void set_lake_tablet_manager(lake::TabletManager* tablet_manager) { _tablet_manager = tablet_manager; }

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -558,7 +558,9 @@ public:
     explicit DynamicMorselQueue(Morsels&& morsels) {
         append_morsels(std::move(morsels));
         _size = _num_morsels = _queue.size();
+        _degree_of_parallelism = _num_morsels;
     }
+
     ~DynamicMorselQueue() override = default;
     bool empty() const override { return _size.load(std::memory_order_relaxed) == 0; }
     StatusOr<MorselPtr> try_get() override;
@@ -571,11 +573,15 @@ public:
     bool could_attch_ticket_checker() const override { return true; }
     Type type() const override { return DYNAMIC; }
 
+    void set_max_degree_of_parallelism(size_t degree_of_parallelism) { _degree_of_parallelism = degree_of_parallelism; }
+    size_t max_degree_of_parallelism() const override { return _degree_of_parallelism; }
+
 private:
     std::atomic<int64_t> _size = 0;
     std::deque<MorselPtr> _queue;
     std::mutex _mutex;
     query_cache::TicketCheckerPtr _ticket_checker;
+    size_t _degree_of_parallelism;
 };
 
 MorselQueuePtr create_empty_morsel_queue();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -232,6 +232,7 @@ set(EXEC_FILES
         ./storage/lake/starlet_location_provider_test.cpp
         ./storage/lake/rowset_test.cpp
         ./storage/lake/tablet_test.cpp
+        ./storage/lake/lake_data_source_test.cpp
         ./storage/lake/lake_scan_node_test.cpp
         ./storage/lake/schema_change_test.cpp
         ./storage/lake/alter_tablet_meta_test.cpp

--- a/be/test/exec/connector_scan_node_test.cpp
+++ b/be/test/exec/connector_scan_node_test.cpp
@@ -160,7 +160,7 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_cl
                     scan_node->convert_scan_range_to_morsel_queue_factory(
                             scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
-    ASSERT_FALSE(morsel_queue_factory->is_shared());
+    ASSERT_TRUE(morsel_queue_factory->is_shared());
 
     // dop is 2 and so much morsels
     pipeline_dop = 2;

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -1,0 +1,190 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "connector/lake_connector.h"
+#include "exec/connector_scan_node.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/metacache.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/tablet_schema.h"
+#include "test_util.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+class LakeDataSourceTest : public TestBase {
+public:
+    LakeDataSourceTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+    void create_rowsets_for_testing(TabletMetadata* tablet_metadata, int64_t version) {
+        std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22}; // 23 rows
+        std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+        std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41}; // 12 rows
+        std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int32Column::create();
+        auto c3 = Int32Column::create();
+        c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+        c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+        c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+        Chunk chunk0({c0, c1}, _schema);
+        Chunk chunk1({c2, c3}, _schema);
+
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(tablet_metadata->id()));
+
+        {
+            int64_t txn_id = next_id();
+            // write rowset 1 with 2 segments
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+            ASSERT_OK(writer->open());
+
+            // write rowset data
+            // segment #1
+            ASSERT_OK(writer->write(chunk0));
+            ASSERT_OK(writer->write(chunk1));
+            ASSERT_OK(writer->finish());
+
+            // segment #2
+            ASSERT_OK(writer->write(chunk0));
+            ASSERT_OK(writer->write(chunk1));
+            ASSERT_OK(writer->finish());
+
+            auto files = writer->files();
+            ASSERT_EQ(2, files.size());
+
+            // add rowset metadata
+            auto* rowset = tablet_metadata->add_rowsets();
+            rowset->set_overlapped(true);
+            rowset->set_id(1);
+            rowset->set_num_rows(k0.size() + k1.size());
+            auto* segs = rowset->mutable_segments();
+            for (auto& file : writer->files()) {
+                segs->Add(std::move(file.path));
+            }
+
+            writer->close();
+        }
+
+        // write tablet metadata
+        tablet_metadata->set_version(version);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
+    }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_scan_node";
+
+    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+TEST_F(LakeDataSourceTest, test_convert_scan_range_to_morsel_queue) {
+    create_rowsets_for_testing(_tablet_metadata.get(), 2);
+
+    std::shared_ptr<RuntimeState> runtime_state = create_runtime_state();
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_INT);
+    auto* descs = create_table_desc(runtime_state.get(), types);
+    auto tnode = create_tplan_node_cloud();
+    auto scan_node = std::make_shared<starrocks::ConnectorScanNode>(runtime_state->obj_pool(), *tnode, *descs);
+    ASSERT_OK(scan_node->init(*tnode, runtime_state.get()));
+
+    bool enable_tablet_internal_parallel = true;
+    auto tablet_internal_parallel_mode = TTabletInternalParallelMode::type::FORCE_SPLIT;
+    std::map<int32_t, std::vector<TScanRangeParams>> no_scan_ranges_per_driver_seq;
+
+    auto data_source_provider = dynamic_cast<connector::LakeDataSourceProvider*>(scan_node->data_source_provider());
+    data_source_provider->set_lake_tablet_manager(_tablet_mgr.get());
+
+    ASSERT_TRUE(data_source_provider->always_shared_scan());
+
+    config::tablet_internal_parallel_max_splitted_scan_bytes = 32;
+    config::tablet_internal_parallel_min_splitted_scan_rows = 4;
+
+    int pipeline_dop = 2;
+    config::tablet_internal_parallel_min_scan_dop = 4;
+
+    auto tablet_metas = std::vector<TabletMetadata*>();
+    tablet_metas.emplace_back(_tablet_metadata.get());
+    auto scan_ranges = create_scan_ranges_cloud(tablet_metas);
+
+    ASSIGN_OR_ABORT(auto morsel_queue_factory,
+                    scan_node->convert_scan_range_to_morsel_queue_factory(
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
+                            enable_tablet_internal_parallel, tablet_internal_parallel_mode));
+    ASSERT_TRUE(data_source_provider->could_split());
+    ASSERT_TRUE(data_source_provider->could_split_physically());
+
+    ASSERT_TRUE(morsel_queue_factory->is_shared());
+    auto morsel_queue = morsel_queue_factory->create(1);
+    ASSERT_TRUE(morsel_queue->max_degree_of_parallelism() > 1);
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The pr wants to address the issue where parallel scans enabled for cloud-native tables but were not effectively taking place. There are two primary reasons for this problem:

1. The scan_dop was not recorded in DynamicMorselQueue, causing the `max_degree_of_parallelism` interface to return  1.
2. LakeDataSourceProvider returns false within`always_shared_scan`, preventing the use of `SharedMorselQueueFactory` and instead enforcing the use of `IndividualMorselQueueFactory`. This IndividualMorselQueueFactory would limit the parallelism of the ScanOperator to 1. For more information on SharedMorselQueueFactory and IndividualMorselQueueFactory, please refer to the illustration below.

![image](https://github.com/StarRocks/starrocks/assets/4231537/9c544ab6-0ea5-432e-bdca-0264ea578320)

![image](https://github.com/StarRocks/starrocks/assets/4231537/821a7ac4-2437-41a4-95bc-3ed6bbee81ee)


Fixes #issue https://github.com/StarRocks/StarRocksTest/issues/7270

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
