### PR TITLE
[BugFix] Support MERGED state for task run

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -38,6 +38,7 @@ import com.starrocks.persist.RenameMaterializedViewLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
@@ -330,7 +331,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
 
             // for event triggered type, run task
             if (task.getType() == Constants.TaskType.EVENT_TRIGGERED) {
-                taskManager.executeTask(task.getName());
+                taskManager.executeTask(task.getName(), ExecuteOption.makeMergeRedundantOption());
             }
 
             final MaterializedView.MvRefreshScheme refreshScheme = materializedView.getRefreshScheme();

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -452,7 +452,7 @@ public class Pipe implements GsonPostProcessable {
                 recordTaskError(taskDesc, "create task failed");
                 return;
             }
-            SubmitResult result = taskManager.executeTaskAsync(task, new ExecuteOption());
+            SubmitResult result = taskManager.executeTaskAsync(task, new ExecuteOption(task.getSource().isMergeable()));
             taskDesc.onRunning();
             taskDesc.setFuture(result.getFuture());
             if (result.getStatus() != SubmitResult.SubmitStatus.SUBMITTED) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -40,20 +40,31 @@ public class Constants {
         MV,
         INSERT,
         PIPE,
-        DATACACHE_SELECT
+        DATACACHE_SELECT;
+
+        // Whether the task source is mergeable, only MV is mergeable by default.
+        public boolean isMergeable() {
+            return this == MV;
+        }
     }
 
-    // PENDING -> RUNNING -> FAILED
-    //                    -> SUCCESS
+    //                   ------> FAILED
+    //                  |
+    //                  |
+    //     PENDING -> RUNNING -> SUCCESS
+    //        |
+    //        |
+    //         ----------------> MERGED
     public enum TaskRunState {
-        PENDING,
-        RUNNING,
-        FAILED,
-        SUCCESS,
+        PENDING,    // The task run is created and in the pending queue waiting to be scheduled
+        RUNNING,    // The task run is scheduled into running queue and is running
+        FAILED,     // The task run is failed
+        MERGED,     // The task run is merged into another task run
+        SUCCESS,    // The task run is finished successfully
     }
 
     public static boolean isFinishState(TaskRunState state) {
-        return state.equals(TaskRunState.SUCCESS) || state.equals(TaskRunState.FAILED);
+        return state.equals(TaskRunState.SUCCESS) || state.equals(TaskRunState.FAILED) || state.equals(TaskRunState.MERGED);
     }
 
     // Used to determine the scheduling order of Pending TaskRun to Running TaskRun

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.scheduler;
 
+import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.persist.gson.GsonUtils;
 
@@ -29,28 +30,30 @@ public class ExecuteOption {
     private Map<String, String> taskRunProperties;
 
     @SerializedName("isMergeRedundant")
-    private boolean isMergeRedundant = false;
-    // indicates whether the current execution is manual
+    private final boolean isMergeRedundant;
 
+    // indicates whether the current execution is manual
     @SerializedName("isManual")
     private boolean isManual = false;
+
     @SerializedName("isSync")
     private boolean isSync = false;
 
     @SerializedName("isReplay")
     private boolean isReplay = false;
 
-    public ExecuteOption() {
-    }
-
-    public ExecuteOption(int priority) {
-        this.priority = priority;
+    public ExecuteOption(boolean isMergeRedundant) {
+        this.isMergeRedundant = isMergeRedundant;
     }
 
     public ExecuteOption(int priority, boolean isMergeRedundant, Map<String, String> taskRunProperties) {
         this.priority = priority;
         this.isMergeRedundant = isMergeRedundant;
         this.taskRunProperties = taskRunProperties;
+    }
+
+    public static ExecuteOption makeMergeRedundantOption() {
+        return new ExecuteOption(Constants.TaskRunPriority.LOWEST.value(), true, Maps.newHashMap());
     }
 
     public int getPriority() {
@@ -65,10 +68,6 @@ public class ExecuteOption {
         // If old task run is a sync-mode task, skip to merge it to avoid sync-mode task
         // hanging after removing it.
         return !isSync && isMergeRedundant;
-    }
-
-    public void setMergeRedundant(boolean mergeRedundant) {
-        this.isMergeRedundant = mergeRedundant;
     }
 
     public Map<String, String> getTaskRunProperties() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -270,7 +270,7 @@ public class TaskBuilder {
 
         // for event triggered type, run task
         if (task.getType() == Constants.TaskType.EVENT_TRIGGERED) {
-            taskManager.executeTask(task.getName());
+            taskManager.executeTask(task.getName(), ExecuteOption.makeMergeRedundantOption());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -291,7 +291,11 @@ public class TaskManager implements MemoryTrackable {
     }
 
     public SubmitResult executeTask(String taskName) {
-        ExecuteOption option = new ExecuteOption();
+        Task task = getTask(taskName);
+        if (task == null) {
+            return new SubmitResult(null, SubmitResult.SubmitStatus.FAILED);
+        }
+        ExecuteOption option = new ExecuteOption(task.getSource().isMergeable());
         option.setManual(true);
         return executeTask(taskName, option);
     }
@@ -308,9 +312,8 @@ public class TaskManager implements MemoryTrackable {
         }
     }
 
-    // for test
     public SubmitResult executeTaskSync(Task task) {
-        return executeTaskSync(task, new ExecuteOption());
+        return executeTaskSync(task, new ExecuteOption(task.getSource().isMergeable()));
     }
 
     public SubmitResult executeTaskSync(Task task, ExecuteOption option) {
@@ -550,7 +553,7 @@ public class TaskManager implements MemoryTrackable {
         try {
             createTask(task, false);
             if (task.getType() == Constants.TaskType.MANUAL) {
-                submitResult = executeTask(taskName);
+                submitResult = executeTask(task.getName());
             } else {
                 submitResult = new SubmitResult(null, SUBMITTED);
             }
@@ -772,7 +775,7 @@ public class TaskManager implements MemoryTrackable {
                     LOG.warn("fail to obtain task name {} because task is null", taskName);
                     return;
                 }
-                ExecuteOption executeOption = new ExecuteOption();
+                ExecuteOption executeOption = new ExecuteOption(task.getSource().isMergeable());
                 executeOption.setReplay(true);
                 TaskRun taskRun = TaskRunBuilder
                         .newBuilder(task)
@@ -829,13 +832,13 @@ public class TaskManager implements MemoryTrackable {
                 status.setErrorCode(statusChange.getErrorCode());
                 status.setState(Constants.TaskRunState.FAILED);
                 taskRunManager.getTaskRunHistory().addHistory(status);
-            } else if (toStatus == Constants.TaskRunState.SUCCESS) {
+            } else if (toStatus == Constants.TaskRunState.MERGED) {
                 // This only happened when the task run is merged by others and no run ever.
                 LOG.info("Replay update pendingTaskRun which is merged by others, query_id:{}, taskId:{}",
                         statusChange.getQueryId(), taskId);
                 status.setErrorMessage(statusChange.getErrorMessage());
                 status.setErrorCode(statusChange.getErrorCode());
-                status.setState(Constants.TaskRunState.SUCCESS);
+                status.setState(Constants.TaskRunState.MERGED);
                 status.setProgress(100);
                 status.setFinishTime(statusChange.getFinishTime());
                 taskRunManager.getTaskRunHistory().addHistory(status);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
@@ -24,7 +24,7 @@ public class TaskRunBuilder {
     private final Task task;
     private Map<String, String> properties;
     private ConnectContext connectContext;
-    private ExecuteOption executeOption = new ExecuteOption();
+    private ExecuteOption executeOption = new ExecuteOption(false);
 
     public static TaskRunBuilder newBuilder(Task task) {
         return new TaskRunBuilder(task);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -144,11 +144,10 @@ public class TaskRunManager implements MemoryTrackable {
                 }
             }
             for (TaskRun oldTaskRun : mergedTaskRuns) {
-                // Update follower's state to SUCCESS, otherwise the merged task run will always be PENDING.
-                // TODO: 1. add a MERGED state later. 2. support batch update to reduce the number of edit logs.
+                // TODO: support batch update to reduce the number of edit logs.
                 oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
-                        oldTaskRun.getStatus().getState(), Constants.TaskRunState.SUCCESS);
+                        oldTaskRun.getStatus().getState(), Constants.TaskRunState.MERGED);
                 GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
                 taskRunScheduler.removePendingTaskRun(oldTaskRun);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -55,7 +55,7 @@ public class MVTaskRunExtraMessage implements Writable {
     private String nextPartitionEnd;
 
     @SerializedName("executeOption")
-    private ExecuteOption executeOption = new ExecuteOption();
+    private ExecuteOption executeOption = new ExecuteOption(true);
 
     public MVTaskRunExtraMessage() {
     }

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/TaskSchedulerBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/TaskSchedulerBench.java
@@ -54,8 +54,7 @@ public class TaskSchedulerBench extends MvRewriteTestBase {
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync) {
-        ExecuteOption executeOption = new ExecuteOption();
-        executeOption.setMergeRedundant(isMergeRedundant);
+        ExecuteOption executeOption = new ExecuteOption(isMergeRedundant);
         executeOption.setSync(isSync);
         return executeOption;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -139,7 +139,7 @@ public class TaskManagerTest {
         TaskRunManager taskRunManager = taskManager.getTaskRunManager();
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.setProcessor(new MockTaskRunProcessor());
-        taskRunManager.submitTaskRun(taskRun, new ExecuteOption());
+        taskRunManager.submitTaskRun(taskRun, new ExecuteOption(false));
         List<TaskRunStatus> taskRuns = null;
         Constants.TaskRunState state = null;
 
@@ -543,8 +543,7 @@ public class TaskManagerTest {
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync) {
-        ExecuteOption executeOption = new ExecuteOption();
-        executeOption.setMergeRedundant(isMergeRedundant);
+        ExecuteOption executeOption = new ExecuteOption(isMergeRedundant);
         executeOption.setSync(isSync);
         return executeOption;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunFIFOQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunFIFOQueueTest.java
@@ -67,8 +67,7 @@ public class TaskRunFIFOQueueTest {
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync, int priority) {
-        ExecuteOption executeOption = new ExecuteOption();
-        executeOption.setMergeRedundant(isMergeRedundant);
+        ExecuteOption executeOption = new ExecuteOption(isMergeRedundant);
         executeOption.setSync(isSync);
         executeOption.setPriority(priority);
         return executeOption;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -68,8 +68,7 @@ public class TaskRunSchedulerTest {
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync, int priority) {
-        ExecuteOption executeOption = new ExecuteOption();
-        executeOption.setMergeRedundant(isMergeRedundant);
+        ExecuteOption executeOption = new ExecuteOption(isMergeRedundant);
         executeOption.setSync(isSync);
         executeOption.setPriority(priority);
         return executeOption;

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger
@@ -1,0 +1,147 @@
+-- name: test_mv_refresh_with_event_trigger
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23")), 
+PARTITION p20201023 VALUES [("2020-10-23"), ("2020-10-24")), 
+PARTITION p20201024 VALUES [("2020-10-24"), ("2020-10-25"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 ;
+-- result:
+-- !result
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201010 VALUES [("2020-10-10"), ("2020-10-11")), 
+PARTITION p20201011 VALUES [("2020-10-11"), ("2020-10-12")), 
+PARTITION p20201012 VALUES [("2020-10-12"), ("2020-10-13")), 
+PARTITION p20201021 VALUES [("2020-10-21"), ("2020-10-22")), 
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t2
+union all
+select * from t1;
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("test_mv1")
+-- result:
+None
+-- !result
+select count(1) from test_mv1;
+-- result:
+16
+-- !result
+function: wait_async_materialized_view_finish("test_mv2")
+-- result:
+None
+-- !result
+select count(1) from test_mv2;
+-- result:
+16
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger
@@ -1,0 +1,98 @@
+-- name: test_mv_refresh_with_event_trigger
+
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23")), 
+PARTITION p20201023 VALUES [("2020-10-23"), ("2020-10-24")), 
+PARTITION p20201024 VALUES [("2020-10-24"), ("2020-10-25"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 ;
+
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201010 VALUES [("2020-10-10"), ("2020-10-11")), 
+PARTITION p20201011 VALUES [("2020-10-11"), ("2020-10-12")), 
+PARTITION p20201012 VALUES [("2020-10-12"), ("2020-10-13")), 
+PARTITION p20201021 VALUES [("2020-10-21"), ("2020-10-22")), 
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+
+INSERT INTO t1 VALUES ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t1 VALUES ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t1 VALUES ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+
+INSERT INTO t2 VALUES ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t2
+union all
+select * from t1;
+
+INSERT INTO t1 VALUES ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t1 VALUES ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t1 VALUES ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+
+INSERT INTO t2 VALUES ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889);
+INSERT INTO t2 VALUES ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+
+function: wait_async_materialized_view_finish("test_mv1")
+select count(1) from test_mv1;
+
+function: wait_async_materialized_view_finish("test_mv2")
+select count(1) from test_mv2;
+
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop table t1;
+drop table t2;


### PR DESCRIPTION
## Why I'm doing:
- Problem1: When a task run is merged, we cannot distinguish it between task runs from RUNNING to SUCCESS.
- Problem2: Task run may not be merged if it's triggered by mv's event-trigger refresh mode.

## What I'm doing:
- Add `MERGED` State for TaskRun
- Change `isMergeRedudant` as true for mv's task run which means it can be merged in the pending queue.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
