### PR TITLE
[Feature] add backends table for information_schema(#45600)

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -131,6 +131,7 @@ set(EXEC_FILES
     schema_scanner/schema_partitions_meta_scanner.cpp
     schema_scanner/schema_user_privileges_scanner.cpp
     schema_scanner/schema_schema_privileges_scanner.cpp
+    schema_scanner/schema_servers_scanner.cpp
     schema_scanner/schema_table_privileges_scanner.cpp
     schema_scanner/schema_tables_config_scanner.cpp
     schema_scanner/schema_be_metrics_scanner.cpp

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -44,6 +44,7 @@
 #include "exec/schema_scanner/schema_routine_load_jobs_scanner.h"
 #include "exec/schema_scanner/schema_schema_privileges_scanner.h"
 #include "exec/schema_scanner/schema_schemata_scanner.h"
+#include "exec/schema_scanner/schema_servers_scanner.h"
 #include "exec/schema_scanner/schema_stream_loads_scanner.h"
 #include "exec/schema_scanner/schema_table_privileges_scanner.h"
 #include "exec/schema_scanner/schema_tables_config_scanner.h"
@@ -213,6 +214,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SysFeMemoryUsage>();
     case TSchemaTableType::SCH_TEMP_TABLES:
         return std::make_unique<SchemaTempTablesScanner>();
+    case TSchemaTableType::SCH_BACKENDS:
+        return std::make_unique<SchemaServersScanner>(TServerType::BACKEND);
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner/schema_helper.cpp
+++ b/be/src/exec/schema_scanner/schema_helper.cpp
@@ -184,6 +184,13 @@ Status SchemaHelper::get_stream_loads(const SchemaScannerState& state, const TGe
     });
 }
 
+Status SchemaHelper::get_servers(const SchemaScannerState& state, const TGetServersParams& var_params,
+                                          TGetServersResult* var_result) {
+    return _call_rpc(state, [&var_params, &var_result](FrontendServiceConnection& client) {
+        client->getServers(*var_result, var_params);
+    });
+}
+
 Status SchemaHelper::get_tablet_schedules(const SchemaScannerState& state, const TGetTabletScheduleRequest& request,
                                           TGetTabletScheduleResponse* response) {
     return _call_rpc(state, [&request, &response](FrontendServiceConnection& client) {

--- a/be/src/exec/schema_scanner/schema_helper.h
+++ b/be/src/exec/schema_scanner/schema_helper.h
@@ -92,6 +92,9 @@ public:
     static Status get_stream_loads(const SchemaScannerState& state, const TGetLoadsParams& var_params,
                                    TGetStreamLoadsResult* var_result);
 
+    static Status get_servers(const SchemaScannerState& state, const TGetServersParams& var_params,
+                                   TGetServersResult* var_result);
+
     static Status get_task_runs(const SchemaScannerState& state, const TGetTasksParams& var_params,
                                 TGetTaskRunInfoResult* var_result);
 

--- a/be/src/exec/schema_scanner/schema_servers_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_servers_scanner.cpp
@@ -1,0 +1,172 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_servers_scanner.h"
+
+#include "exec/schema_scanner/schema_helper.h"
+#include "runtime/runtime_state.h"
+#include "runtime/string_value.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaServersScanner::_s_tbls_columns[] = {
+    //   name,       type,          size,     is_null
+    {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+    {"VERSION", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"IP", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"HEARTBEAT_PORT", TYPE_INT, sizeof(int32_t), false},
+    {"BE_PORT", TYPE_INT, sizeof(int32_t), false},
+    {"HTTP_PORT", TYPE_INT, sizeof(int32_t), false},
+    {"BRPC_PORT", TYPE_INT, sizeof(int32_t), false},
+    {"ALIVE", TYPE_BOOLEAN, sizeof(bool), false},
+    {"DECOMMISSIONED", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"DATA_USED_CAPACITY", TYPE_BIGINT, sizeof(int64_t), false},
+    {"AVAIL_CAPACITY", TYPE_BIGINT, sizeof(int64_t), false},
+    {"TOTAL_CAPACITY", TYPE_BIGINT, sizeof(int64_t), false},
+    {"DATA_TOTAL_CAPACITY", TYPE_BIGINT, sizeof(int64_t), false},
+    {"CPU_CORES", TYPE_INT, sizeof(int32_t), false}};
+
+SchemaServersScanner::SchemaServersScanner(TServerType::type type)
+    : SchemaScanner(_s_tbls_columns, sizeof(_s_tbls_columns) / sizeof(SchemaScanner::ColumnDesc)),
+    _type(type){}
+
+SchemaServersScanner::~SchemaServersScanner() = default;
+
+Status SchemaServersScanner::start(RuntimeState* state) {
+    RETURN_IF_ERROR(SchemaScanner::start(state));
+    TGetServersParams params;
+
+    params.__set_type(_type);
+    int32_t timeout = static_cast<int32_t>(std::min(state->query_options().query_timeout * 1000 / 2, INT_MAX));
+    if (nullptr != _param->ip && 0 != _param->port) {
+        RETURN_IF_ERROR(SchemaHelper::get_servers(*(_param->ip), _param->port, params, &_result, timeout));
+    } else {
+        return Status::InternalError("IP or port doesn't exists");
+    }
+
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+Status SchemaServersScanner::fill_be_chunk(ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _result.backends.size(); _cur_idx++) {
+        auto& info = _result.backends[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 23) {
+                return Status::InternalError(fmt::format("invalid slot id:{}", slot_id));
+            }
+
+            ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+                case 1: {
+                    // be_id
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), &info.id);
+                    break;
+                }
+                case 2: {
+                    // Version
+                    Slice version = Slice(info.version);
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), &version);
+                    break;
+                }
+                case 3: {
+                    // IP
+                    Slice ip = Slice(info.ip);
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), &ip);
+                    break;
+                }
+                case 4: {
+                    // heartbeat_port
+                    fill_column_with_slot<TYPE_INT>(column.get(), &info.heartbeat_port);
+                    break;
+                }
+                case 5: {
+                    // be_port
+                    fill_column_with_slot<TYPE_INT>(column.get(), &info.be_port);
+                    break;
+                }
+                case 6: {
+                    // http_port
+                    fill_column_with_slot<TYPE_INT>(column.get(), &info.http_port);
+                    break;
+                }
+                case 7: {
+                    // brpc_port
+                    fill_column_with_slot<TYPE_INT>(column.get(), &info.brpc_port);
+                    break;
+                }
+                case 8: {
+                    // alive
+                    fill_column_with_slot<TYPE_BOOLEAN>(column.get(), &info.alive);
+                    break;
+                }
+                case 9: {
+                    // decommissioned
+                    Slice decommissioned = Slice(info.decommissioned);
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), &decommissioned);
+                    break;
+                }
+                case 10: {
+                    // data_used_capacity
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), &info.data_used_capacity);
+                    break;
+                }
+                case 11: {
+                    // avail_capacity
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), &info.avail_capacity);
+                    break;
+                }
+                case 12: {
+                    // total_capacity
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), &info.total_capacity);
+                    break;
+                }
+                case 13: {
+                    // data_total_capacity
+                    fill_column_with_slot<TYPE_BIGINT>(column.get(), &info.data_total_capacity);
+                    break;
+                }
+                case 14: {
+                    // cpu_cores
+                    fill_column_with_slot<TYPE_INT>(column.get(), &info.cpu_cores);
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaServersScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    if (_type == TServerType::BACKEND) {
+        if (_cur_idx >= _result.backends.size()) {
+            *eos = true;
+            return Status::OK();
+        }
+        *eos = false;
+        return fill_be_chunk(chunk);
+    }
+    return Status::InternalError("invalid parameter.");
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_servers_scanner.h
+++ b/be/src/exec/schema_scanner/schema_servers_scanner.h
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+class SchemaServersScanner : public SchemaScanner {
+public:
+    SchemaServersScanner(TServerType::type type);
+    ~SchemaServersScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_be_chunk(ChunkPtr* chunk);
+
+    TServerType::type _type;
+    int _cur_idx = 0;
+    TGetServersResult _result;
+    static SchemaScanner::ColumnDesc _s_tbls_columns[];
+};
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
@@ -104,6 +104,8 @@ public class SystemId {
 
     public static final long TEMP_TABLES_ID = 43L;
 
+    public static final long BACKENDS_ID = 44L;
+
     public static final long SYS_DB_ID = 100L;
 
     public static final long ROLE_EDGES_ID = 101L;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BackendSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BackendSystemTable.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.catalog.system.information;
+
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemId;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.thrift.TSchemaTableType;
+
+import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
+import static com.starrocks.catalog.system.SystemTable.builder;
+
+public class BackendSystemTable {
+    public static SystemTable create() {
+        return new SystemTable(SystemId.BACKENDS_ID,
+                "backends",
+                Table.TableType.SCHEMA,
+                builder()
+                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("VERSION", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("IP", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("HEARTBEAT_PORT", ScalarType.createType(PrimitiveType.INT))
+                        .column("BE_PORT", ScalarType.createType(PrimitiveType.INT))
+                        .column("HTTP_PORT", ScalarType.createType(PrimitiveType.INT))
+                        .column("BRPC_PORT", ScalarType.createType(PrimitiveType.INT))
+                        .column("ALIVE", ScalarType.createType(PrimitiveType.BOOLEAN))
+                        .column("DECOMMISSIONED", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("DATA_USED_CAPACITY", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("AVAIL_CAPACITY", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("TOTAL_CAPACITY", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("DATA_TOTAL_CAPACITY", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("CPU_CORES", ScalarType.createType(PrimitiveType.INT))
+                        .build(), TSchemaTableType.SCH_BACKENDS);
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
@@ -88,6 +88,7 @@ public class InfoSchemaDb extends Database {
             super.registerTableUnlocked(BeDataCacheMetricsTable.create());
             super.registerTableUnlocked(PartitionsMetaSystemTable.create());
             super.registerTableUnlocked(TemporaryTablesTable.create());
+            super.registerTableUnlocked(BackendSystemTable.create());
         }
     }
 

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -169,6 +169,7 @@ enum TSchemaTableType {
     SCH_PARTITIONS_META,
     SYS_FE_MEMORY_USAGE,
     SCH_TEMP_TABLES,
+    SCH_BACKENDS,
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -631,7 +631,38 @@ struct TStreamLoadInfo {
     23: string channel_state,
     24: string type
     25: string tracking_sql,
+}
 
+enum TServerType {
+  FRONTEND,
+  BACKEND,
+  BROCKER,
+  COMPUTE_NODE
+}
+
+struct TGetServersParams {
+    1: required TServerType type
+}
+
+struct TGetServersResult {
+    1: optional list<TBackendResult> backends
+}
+
+struct TBackendResult {
+    1: optional i64 id
+    2: optional string version
+    3: optional string ip
+    4: optional i32 heartbeat_port
+    5: optional i32 be_port
+    6: optional i32 http_port
+    7: optional i32 brpc_port
+    8: optional bool alive
+    9: optional string decommissioned
+    10: optional i64 data_used_capacity
+    11: optional i64 avail_capacity
+    12: optional i64 total_capacity
+    13: optional i64 data_total_capacity
+    14: optional i32 cpu_cores
 }
 
 // getTableNames returns a list of unqualified table names
@@ -1796,6 +1827,8 @@ service FrontendService {
     TGetLoadsResult getLoads(1:TGetLoadsParams params)
     TGetTrackingLoadsResult getTrackingLoads(1:TGetLoadsParams params)
     TGetRoutineLoadJobsResult getRoutineLoadJobs(1:TGetLoadsParams params)
+    TGetStreamLoadsResult getStreamLoads(1:TGetLoadsParams params)
+
     TGetStreamLoadsResult getStreamLoads(1:TGetLoadsParams params)
 
     TGetProfileResponse getQueryProfile(1:TGetProfileRequest request)


### PR DESCRIPTION
## Why I'm doing:
Currently, we could get some summary info from information_schema database.

![image](https://github.com/StarRocks/starrocks/assets/130516674/7b09dc8e-04c2-42de-bdd2-d43060c84866)

But, it's realy poor readable.

## What I'm doing:

Add a new table, so we can aggregate, filter with ip, version and so on.

![image](https://github.com/StarRocks/starrocks/assets/130516674/fa7ed4d0-49dd-43f8-a32c-6dafa61a9537)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
