### PR TITLE
[Enhancement] Support execute-only flag for performance test

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -522,6 +522,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // their ordinal position in the Hive table definition.
     public static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
 
+    public static final String ENABLE_EXECUTION_ONLY = "enable_execution_only";
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -1025,6 +1027,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
 
+    // execute sql don't return result, for performance test
+    @VarAttr(name = ENABLE_EXECUTION_ONLY, flag = VariableMgr.INVISIBLE)
+    private boolean enableExecutionOnly = false;
+
     /*
      * The maximum pipeline dop limit which only takes effect when pipeline_dop=0.
      * This limitation is to avoid the negative overhead caused by scheduling on super multi-core scenarios.
@@ -1428,6 +1434,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
+
+    public boolean isEnableExecutionOnly() {
+        return enableExecutionOnly;
+    }
 
     public boolean isCboPruneJsonSubfield() {
         return cboPruneJsonSubfield;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1093,7 +1093,7 @@ public class StmtExecutor {
                     context.updateReturnRows(batch.getBatch().getRows().size());
                 }
             } while (!batch.isEos());
-            if (!isSendFields && !isOutfileQuery && needSendResult) {
+            if (!isSendFields && !isOutfileQuery && !isExplainAnalyze) {
                 sendFields(colNames, outputExprs);
             }
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
don't send sql result to client, for test accurate performance

```
MySQL td> set enable_execution_only=false
Query OK, 0 rows affected
Time: 0.021s
MySQL td> select * from t1;
+--------+--------+-----------+
| v1     | v2     | a1        |
+--------+--------+-----------+
| <null> | <null> | ["a"]     |
| 1      | 1      | ["1","2"] |
| 1      | <null> | []        |
| 2      | 2      | ["3","4"] |
| 2      | <null> | []        |
| 3      | <null> | []        |
| 4      | <null> | []        |
| 5      | <null> | <null>    |
+--------+--------+-----------+
8 rows in set
Time: 0.099s
MySQL td> set enable_execution_only=true
Query OK, 0 rows affected
Time: 0.004s
MySQL td> select * from t1;
+----+----+----+
| v1 | v2 | a1 |
+----+----+----+
+----+----+----+
0 rows in set
Time: 0.059s
MySQL td>
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
