### PR TITLE
[Enhancement] pushdown or predicate (7): support bitmap filter

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(Storage STATIC
     rowset/rowid_range_option.cpp
     rowset/rowset_meta.cpp
     rowset/horizontal_update_rowset_writer.cpp
+    rowset/bitmap_index_evaluator.cpp
     task/engine_batch_load_task.cpp
     task/engine_checksum_task.cpp
     task/engine_clone_task.cpp

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -100,6 +100,8 @@ public:
         return false;
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();
         for (auto value : _values) {
@@ -172,7 +174,7 @@ public:
 
     std::string debug_string() const override {
         std::stringstream ss;
-        ss << "(columnId=" << _column_id << ",In(";
+        ss << "((columnId=" << _column_id << ")IN(";
         int i = 0;
         for (auto& item : _values) {
             if (i++ != 0) {
@@ -281,6 +283,8 @@ public:
         }
         return false;
     }
+
+    bool support_bitmap_filter() const override { return true; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -182,7 +182,7 @@ public:
             }
             ss << this->type_info()->to_string(&item);
         }
-        ss << ")";
+        ss << "))";
         return ss.str();
     }
 

--- a/be/src/storage/column_not_in_predicate.cpp
+++ b/be/src/storage/column_not_in_predicate.cpp
@@ -91,6 +91,8 @@ public:
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
 
+    bool support_bitmap_filter() const override { return false; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");
     }
@@ -153,6 +155,20 @@ public:
         }
         *output = obj_pool->add(new_column_not_in_predicate(target_type_info, _column_id, strs));
         return Status::OK();
+    }
+
+    std::string debug_string() const override {
+        std::stringstream ss;
+        ss << "((columnId=" << _column_id << ")NOT IN(";
+        int i = 0;
+        for (auto& item : _values) {
+            if (i++ != 0) {
+                ss << ",";
+            }
+            ss << this->type_info()->to_string(&item);
+        }
+        ss << "))";
+        return ss.str();
     }
 
 private:
@@ -243,6 +259,8 @@ public:
     }
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
+
+    bool support_bitmap_filter() const override { return false; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");

--- a/be/src/storage/column_null_predicate.cpp
+++ b/be/src/storage/column_null_predicate.cpp
@@ -68,6 +68,8 @@ public:
         return min.is_null();
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();
         if (iter->has_null_bitmap()) {
@@ -97,6 +99,8 @@ public:
         *output = this;
         return Status::OK();
     }
+
+    std::string debug_string() const override { return strings::Substitute("(ColumnId($0) IS NULL)", _column_id); }
 };
 
 class ColumnNotNullPredicate : public ColumnPredicate {
@@ -147,6 +151,8 @@ public:
         return !max.is_null();
     }
 
+    bool support_bitmap_filter() const override { return false; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         return Status::Cancelled("not null predicate not support bitmap index");
     }
@@ -168,6 +174,8 @@ public:
         *output = this;
         return Status::OK();
     }
+
+    std::string debug_string() const override { return strings::Substitute("(ColumnId($0) IS NOT NULL)", _column_id); }
 };
 
 ColumnPredicate* new_column_null_predicate(const TypeInfoPtr& type_info, ColumnId id, bool is_null) {

--- a/be/src/storage/column_operator_predicate.h
+++ b/be/src/storage/column_operator_predicate.h
@@ -159,6 +159,8 @@ public:
 
     bool can_vectorized() const override { return SpecColumnOperator::can_vectorized(); }
 
+    bool support_bitmap_filter() const override { return SpecColumnOperator::support_bitmap_filter(); }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         return _predicate_operator.seek_bitmap_dictionary(iter, range);
     }

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -171,6 +171,8 @@ public:
         return true;
     }
 
+    virtual bool support_bitmap_filter() const { return false; }
+
     [[nodiscard]] virtual Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const {
         return Status::Cancelled("not implemented");
     }

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -263,6 +263,8 @@ public:
         return this->type_info()->cmp(Datum(this->_value), max) <= 0;
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();
         bool exact_match;
@@ -306,6 +308,8 @@ public:
         const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(this->_value), max) < 0;
     }
+
+    bool support_bitmap_filter() const override { return true; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();
@@ -352,6 +356,8 @@ public:
         return (this->type_info()->cmp(Datum(this->_value), min) >= 0) & !max.is_null();
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();
         bool exact_match = false;
@@ -396,6 +402,8 @@ public:
         const auto& max = detail.max_value();
         return (this->type_info()->cmp(Datum(this->_value), min) > 0) & !max.is_null();
     }
+
+    bool support_bitmap_filter() const override { return true; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();
@@ -442,6 +450,8 @@ public:
         const auto type_info = this->type_info();
         return type_info->cmp(Datum(this->_value), min) >= 0 && type_info->cmp(Datum(this->_value), max) <= 0;
     }
+
+    bool support_bitmap_filter() const override { return true; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         range->clear();
@@ -494,6 +504,8 @@ public:
             : Base(PredicateType::kNE, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
+
+    bool support_bitmap_filter() const override { return false; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");
@@ -657,6 +669,8 @@ public:
         return bf->test_bytes(padded.data, padded.size);
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         // see the comment in `predicate_parser.cpp`.
         Slice padded_value(Base::_zero_padded_str);
@@ -699,6 +713,8 @@ public:
         return this->type_info()->cmp(Datum(this->_value), max) <= 0;
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         // Can NOT use `_value` here, see the comment in `predicate_parser.cpp`.
         Slice padded_value(Base::_zero_padded_str);
@@ -740,6 +756,8 @@ public:
         const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(this->_value), max) < 0;
     }
+
+    bool support_bitmap_filter() const override { return true; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         // Can NOT use `_value` here, see comment in predicate_parser.cpp.
@@ -784,6 +802,8 @@ public:
         return (type_info->cmp(Datum(this->_value), min) > 0) & !max.is_null();
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         Slice padded_value(Base::_zero_padded_str);
         range->clear();
@@ -825,6 +845,8 @@ public:
         return (this->type_info()->cmp(Datum(this->_value), min) >= 0) & !max.is_null();
     }
 
+    bool support_bitmap_filter() const override { return true; }
+
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         Slice padded_value(Base::_zero_padded_str);
         range->clear();
@@ -861,6 +883,8 @@ public:
             : Base(PredicateType::kNE, type_info, id, value) {}
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
+
+    bool support_bitmap_filter() const override { return false; }
 
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");

--- a/be/src/storage/column_predicate_dict_conjuct.cpp
+++ b/be/src/storage/column_predicate_dict_conjuct.cpp
@@ -49,6 +49,7 @@ public:
 
     static constexpr bool can_vectorized() { return true; }
 
+    static constexpr bool support_bitmap_filter() { return false; }
     Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const {
         return Status::Cancelled("not implemented");
     }

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -119,7 +119,6 @@ private:
     std::vector<SegmentSharedPtr> _segments;
     std::shared_ptr<ChunkIterator> _collect_iter;
 
-    PredicateMap _pushdown_predicates;
     DeletePredicates _delete_predicates;
     PredicateList _predicate_free_list;
 

--- a/be/src/storage/predicate_tree/predicate_tree.cpp
+++ b/be/src/storage/predicate_tree/predicate_tree.cpp
@@ -154,14 +154,8 @@ PredicateAndNode PredicateTree::release_root() {
     return std::move(_root);
 }
 
-ColumnPredicateMap PredicateTree::get_immediate_column_predicate_map() const {
-    ColumnPredicateMap col_pred_map;
-    for (const auto& [cid, col_children] : _root.col_children_map()) {
-        for (const auto& col_child : col_children) {
-            col_pred_map[cid].emplace_back(col_child.col_pred());
-        }
-    }
-    return col_pred_map;
+const ColumnPredicateMap& PredicateTree::get_immediate_column_predicate_map() const {
+    return _compound_node_contexts[0].cid_to_col_preds(_root);
 }
 
 } // namespace starrocks

--- a/be/src/storage/predicate_tree/predicate_tree.h
+++ b/be/src/storage/predicate_tree/predicate_tree.h
@@ -386,7 +386,7 @@ public:
     /// The immediate children of the root contain ColumnPredicates and OR relations.
     /// This method get all the ColumnPredicates in the root immediate children.
     /// In this way, we can use the ColumnPredicates part where OR predicates are not supported.
-    ColumnPredicateMap get_immediate_column_predicate_map() const;
+    const ColumnPredicateMap& get_immediate_column_predicate_map() const;
 
 private:
     explicit PredicateTree(PredicateAndNode&& root, uint32_t num_compound_nodes);

--- a/be/src/storage/predicate_tree/predicate_tree_fwd.h
+++ b/be/src/storage/predicate_tree/predicate_tree_fwd.h
@@ -23,6 +23,7 @@ class PredicateNodeFactory;
 
 enum class CompoundNodeType : uint8_t { AND, OR };
 
+class PredicateBaseNode;
 class PredicateColumnNode;
 
 template <CompoundNodeType Type>

--- a/be/src/storage/rowset/bitmap_index_evaluator.cpp
+++ b/be/src/storage/rowset/bitmap_index_evaluator.cpp
@@ -1,0 +1,471 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/bitmap_index_evaluator.h"
+
+#include "storage/chunk_helper.h"
+#include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/roaring2range.h"
+
+namespace starrocks {
+
+/// Initialize bitmap index iterators for the columns related to a PredicateTree.
+/// `parent->_ctx.is_node_support_bitmap` will be updated to indicate whether a predicate node can be applied bitmap to.
+/// Return true if the PredicateTree can be applied bitmap to.
+struct BitmapIndexInitializer {
+    StatusOr<bool> operator()(const PredicateColumnNode& node, BitmapContext::CompoundNodeContext* parent_node_ctx,
+                              CompoundNodeType parent_type) const {
+        DCHECK(parent_node_ctx != nullptr);
+
+        const auto* col_pred = node.col_pred();
+        const auto cid = col_pred->column_id();
+
+        if (!col_pred->support_bitmap_filter()) {
+            return false;
+        }
+
+        auto* bitmap_iter = parent->_bitmap_index_iterators[cid];
+        if (bitmap_iter == nullptr) {
+            ASSIGN_OR_RETURN(bitmap_iter, supplier(cid));
+            parent->_bitmap_index_iterators[cid] = bitmap_iter;
+        }
+
+        if (bitmap_iter == nullptr) {
+            return false;
+        }
+
+        parent->_ctx.is_node_support_bitmap[&node] = true;
+        auto& col_ctx = _get_or_create_column_context(bitmap_iter, cid, parent_node_ctx, parent_type);
+        col_ctx.nodes.emplace_back(&node);
+        return true;
+    }
+
+    template <CompoundNodeType Type>
+    StatusOr<bool> operator()(const PredicateCompoundNode<Type>& node, BitmapContext::CompoundNodeContext*,
+                              CompoundNodeType) const {
+        auto& node_ctx = parent->_ctx.compound_node_to_context.emplace(&node, BitmapContext::CompoundNodeContext{})
+                                 .first->second;
+        bool has_bitmap_index = Type == CompoundNodeType::AND ? false : true;
+        for (const auto& child : node.children()) {
+            ASSIGN_OR_RETURN(const auto child_has_bitmap_index, child.visit(*this, &node_ctx, Type));
+            if constexpr (Type == CompoundNodeType::AND) {
+                has_bitmap_index |= child_has_bitmap_index;
+            } else {
+                if (!child_has_bitmap_index) {
+                    has_bitmap_index = false;
+                    break;
+                }
+            }
+        }
+        parent->_ctx.is_node_support_bitmap[&node] = has_bitmap_index;
+        return has_bitmap_index;
+    }
+
+    static BitmapContext::ColumnContext& _get_or_create_column_context(
+            const BitmapIndexIterator* bitmap_iter, ColumnId cid, BitmapContext::CompoundNodeContext* parent_node_ctx,
+            CompoundNodeType parent_type) {
+        auto it = parent_node_ctx->col_contexts.find(cid);
+        if (it == parent_node_ctx->col_contexts.end()) {
+            const auto cardinality = bitmap_iter->bitmap_nums();
+            if (parent_type == CompoundNodeType::AND) {
+                it = parent_node_ctx->col_contexts
+                             .emplace(cid, BitmapContext::ColumnContext{SparseRange<>{0, cardinality}, cardinality})
+                             .first;
+            } else {
+                it = parent_node_ctx->col_contexts
+                             .emplace(cid, BitmapContext::ColumnContext{SparseRange<>{}, cardinality})
+                             .first;
+            }
+        }
+        return it->second;
+    }
+
+    BitmapIndexEvaluator* parent;
+    const BitmapIndexEvaluator::BitmapIndexIteratorSupplier& supplier;
+};
+
+struct BitmapIndexSeeker {
+    enum class ResultType : uint8_t { ALWAYS_FALSE, ALWAYS_TRUE, NOT_USED, OK };
+
+    StatusOr<ResultType> operator()(const PredicateAndNode& node) {
+        if (!parent->_ctx.is_node_support_bitmap[&node]) {
+            return ResultType::NOT_USED;
+        }
+
+        DCHECK(parent->_ctx.compound_node_to_context.find(&node) != parent->_ctx.compound_node_to_context.end());
+        auto& node_ctx = parent->_ctx.compound_node_to_context[&node];
+
+        std::vector<const PredicateBaseNode*> children_to_erase;
+        size_t num_always_true_child = 0;
+        size_t num_not_used_children = 0;
+
+        size_t mul_selected = 1;
+        size_t mul_cardinality = 1;
+        std::vector<ColumnId> cid_to_erase;
+        bool need_estimate_selectivity = false;
+
+        for (const auto& [cid, col_ctx] : node_ctx.col_contexts) {
+            for (const auto* col_node : col_ctx.nodes) {
+                ASSIGN_OR_RETURN(const auto used, _seek_column_node<CompoundNodeType::AND>(*col_node, node_ctx));
+                if (used) {
+                    children_to_erase.emplace_back(col_node);
+                } else { // NOT_USED
+                    num_not_used_children++;
+                }
+            }
+
+            // ALWAYS_FALSE
+            if (col_ctx.bitmap_ranges.empty()) {
+                parent->_ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_FALSE;
+            }
+
+            // ALWAYS_TRUE
+            if (col_ctx.bitmap_ranges.span_size() >= col_ctx.cardinality) {
+                cid_to_erase.emplace_back(cid);
+                num_always_true_child += col_ctx.nodes.size();
+            } else {
+                // OK
+                need_estimate_selectivity = true;
+                mul_selected *= col_ctx.bitmap_ranges.span_size();
+                mul_cardinality *= col_ctx.cardinality;
+            }
+        }
+
+        for (const auto& child : node.compound_children()) {
+            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this));
+            switch (res_type) {
+            case ResultType::ALWAYS_FALSE:
+                parent->_ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_FALSE;
+            case ResultType::ALWAYS_TRUE:
+                children_to_erase.emplace_back(&child);
+                num_always_true_child++;
+                break;
+            case ResultType::NOT_USED:
+                num_not_used_children++;
+                break;
+            case ResultType::OK:
+                // Do nothing.
+                break;
+            }
+        }
+
+        const size_t num_children = node.num_children();
+        if (num_not_used_children == num_children) {
+            return ResultType::NOT_USED;
+        }
+
+        if (num_always_true_child == num_children) {
+            parent->_ctx.nodes_to_erase.emplace(&node);
+            return ResultType::ALWAYS_TRUE;
+        }
+
+        for (const auto& cid : cid_to_erase) {
+            node_ctx.col_contexts.erase(cid);
+        }
+
+        // ---------------------------------------------------------
+        // Estimate the selectivity of the bitmap index.
+        // ---------------------------------------------------------
+        if (num_always_true_child + num_not_used_children >= num_children ||
+            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * config::bitmap_max_filter_ratio)) {
+            return ResultType::NOT_USED;
+        }
+
+        parent->_ctx.nodes_to_erase.insert(children_to_erase.begin(), children_to_erase.end());
+
+        node_ctx.used = true;
+        return ResultType::OK;
+    }
+
+    StatusOr<ResultType> operator()(const PredicateOrNode& node) {
+        if (!parent->_ctx.is_node_support_bitmap[&node]) {
+            return ResultType::NOT_USED;
+        }
+
+        DCHECK(parent->_ctx.compound_node_to_context.find(&node) != parent->_ctx.compound_node_to_context.end());
+        auto& node_ctx = parent->_ctx.compound_node_to_context[&node];
+
+        std::vector<const PredicateBaseNode*> children_to_erase;
+        size_t num_always_false_child = 0;
+        bool has_not_used_child = false;
+
+        size_t mul_selected = 1;
+        size_t mul_cardinality = 1;
+        std::vector<ColumnId> cid_to_erase;
+        bool need_estimate_selectivity = false;
+
+        for (const auto& [cid, col_ctx] : node_ctx.col_contexts) {
+            for (const auto* col_node : col_ctx.nodes) {
+                ASSIGN_OR_RETURN(const auto used, _seek_column_node<CompoundNodeType::OR>(*col_node, node_ctx));
+                if (used) {
+                    children_to_erase.emplace_back(col_node);
+                } else { // NOT_USED
+                    has_not_used_child = true;
+                }
+            }
+
+            // ALWAYS_FALSE
+            if (col_ctx.bitmap_ranges.empty()) {
+                cid_to_erase.emplace_back(cid);
+                num_always_false_child += col_ctx.nodes.size();
+                continue;
+            }
+
+            // ALWAYS_TRUE
+            if (col_ctx.bitmap_ranges.span_size() >= col_ctx.cardinality) {
+                parent->_ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_TRUE;
+            } else {
+                // OK
+                need_estimate_selectivity = true;
+                mul_selected *= col_ctx.bitmap_ranges.span_size();
+                mul_cardinality *= col_ctx.cardinality;
+            }
+        }
+
+        for (const auto& child : node.compound_children()) {
+            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this));
+            switch (res_type) {
+            case ResultType::ALWAYS_FALSE:
+                children_to_erase.emplace_back(&child);
+                num_always_false_child++;
+                break;
+            case ResultType::ALWAYS_TRUE:
+                parent->_ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_TRUE;
+            case ResultType::NOT_USED:
+                has_not_used_child = true;
+                break;
+            case ResultType::OK:
+                // Do nothing.
+                break;
+            }
+        }
+
+        if (has_not_used_child) {
+            return ResultType::NOT_USED;
+        }
+
+        const size_t num_children = node.num_children();
+        if (num_always_false_child == num_children) {
+            parent->_ctx.nodes_to_erase.emplace(&node);
+            return ResultType::ALWAYS_FALSE;
+        }
+
+        for (const auto& cid : cid_to_erase) {
+            node_ctx.col_contexts.erase(cid);
+        }
+
+        // ---------------------------------------------------------
+        // Estimate the selectivity of the bitmap index.
+        // ---------------------------------------------------------
+        if (num_always_false_child >= num_children ||
+            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * config::bitmap_max_filter_ratio)) {
+            return ResultType::NOT_USED;
+        }
+
+        parent->_ctx.nodes_to_erase.insert(children_to_erase.begin(), children_to_erase.end());
+
+        node_ctx.used = true;
+        return ResultType::OK;
+    }
+
+    template <CompoundNodeType Type>
+    StatusOr<bool> _seek_column_node(const PredicateColumnNode& node,
+                                     BitmapContext::CompoundNodeContext& parent_node_ctx) const {
+        if (!parent->_ctx.is_node_support_bitmap[&node]) {
+            return false;
+        }
+
+        const auto* col_pred = node.col_pred();
+        const auto cid = col_pred->column_id();
+        auto* bitmap_iter = parent->_bitmap_index_iterators[cid];
+        if (bitmap_iter == nullptr) {
+            return false;
+        }
+
+        DCHECK(parent_node_ctx.col_contexts.find(cid) != parent_node_ctx.col_contexts.end());
+        auto& col_ctx = parent_node_ctx.col_contexts.find(cid)->second;
+
+        SparseRange<> r;
+        const Status st = col_pred->seek_bitmap_dictionary(bitmap_iter, &r);
+        if (st.ok()) {
+            if constexpr (Type == CompoundNodeType::AND) {
+                col_ctx.bitmap_ranges &= r;
+            } else {
+                col_ctx.bitmap_ranges |= r;
+            }
+            col_ctx.has_is_null_pred |= (col_pred->type() == PredicateType::kIsNull);
+        } else if (st.is_cancelled()) {
+            return false;
+        } else {
+            return st;
+        }
+
+        return true;
+    }
+
+    BitmapIndexEvaluator* parent;
+};
+
+struct BitmapIndexRetriver {
+    template <CompoundNodeType Type>
+    StatusOr<std::optional<Roaring>> operator()(const PredicateCompoundNode<Type>& node) const {
+        std::optional<Roaring> result_roaring;
+
+        auto it = parent->_ctx.compound_node_to_context.find(&node);
+        if (it == parent->_ctx.compound_node_to_context.end() || !it->second.used) {
+            return result_roaring;
+        }
+        const auto& node_ctx = it->second;
+
+        for (const auto& [cid, col_ctx] : node_ctx.col_contexts) {
+            auto* bitmap_iter = parent->_bitmap_index_iterators[cid];
+
+            Roaring roaring;
+            RETURN_IF_ERROR(bitmap_iter->read_union_bitmap(col_ctx.bitmap_ranges, &roaring));
+            if (bitmap_iter->has_null_bitmap() && !col_ctx.has_is_null_pred) {
+                Roaring null_bitmap;
+                RETURN_IF_ERROR(bitmap_iter->read_null_bitmap(&null_bitmap));
+                roaring -= null_bitmap;
+            }
+
+            _merge_roaring<Type>(result_roaring, roaring);
+        }
+
+        for (const auto& child : node.compound_children()) {
+            ASSIGN_OR_RETURN(auto roaring, child.visit(*this));
+            if (!roaring.has_value()) {
+                continue;
+            }
+            _merge_roaring<Type>(result_roaring, roaring.value());
+        }
+
+        return result_roaring;
+    }
+
+    template <CompoundNodeType Type>
+    void _merge_roaring(std::optional<Roaring>& result_roaring, Roaring& roaring) const {
+        if (!result_roaring.has_value()) {
+            result_roaring = std::move(roaring);
+        } else {
+            if constexpr (Type == CompoundNodeType::AND) {
+                result_roaring.value() &= roaring;
+            } else {
+                result_roaring.value() |= roaring;
+            }
+        }
+    }
+
+    BitmapIndexEvaluator* parent;
+};
+
+struct BitmapIndexPredicateEraser {
+    template <CompoundNodeType ParentType>
+    void operator()(const PredicateColumnNode& node, PredicateCompoundNode<ParentType>& parent_node) const {
+        if (!parent->_ctx.nodes_to_erase.contains(&node)) {
+            parent_node.add_child(node);
+        }
+    }
+
+    template <CompoundNodeType Type, CompoundNodeType ParentType>
+    void operator()(const PredicateCompoundNode<Type>& node, PredicateCompoundNode<ParentType>& parent_node) const {
+        if (parent->_ctx.nodes_to_erase.contains(&node)) {
+            return;
+        }
+
+        PredicateCompoundNode<Type> new_node;
+        for (const auto& child : node.children()) {
+            child.visit(*this, new_node);
+        }
+
+        if (!new_node.empty()) {
+            parent_node.add_child(new_node);
+        }
+    }
+
+    BitmapIndexEvaluator* parent;
+};
+
+void BitmapIndexEvaluator::close() {
+    if (_closed) {
+        return;
+    }
+    _closed = true;
+
+    for (const auto* bitmap_iter : _bitmap_index_iterators) {
+        delete bitmap_iter;
+    }
+    _bitmap_index_iterators.clear();
+}
+
+Status BitmapIndexEvaluator::init(BitmapIndexIteratorSupplier&& supplier) {
+    _bitmap_index_iterators.resize(ChunkHelper::max_column_id(_schema) + 1, nullptr);
+    ASSIGN_OR_RETURN(_has_bitmap_index,
+                     _pred_tree.visit(BitmapIndexInitializer{this, supplier}, nullptr, CompoundNodeType::AND));
+    return Status::OK();
+}
+
+Status BitmapIndexEvaluator::evaluate(SparseRange<>& dst_scan_range, PredicateTree& dst_pred_tree) {
+    // ---------------------------------------------------------
+    // Seek bitmap index.
+    //  - Seek to the position of predicate's operand within
+    //    bitmap index dictionary.
+    // ---------------------------------------------------------
+    ASSIGN_OR_RETURN(const auto seek_res, _pred_tree.visit(BitmapIndexSeeker{this}));
+    switch (seek_res) {
+    case BitmapIndexSeeker::ResultType::ALWAYS_FALSE:
+        dst_scan_range.clear();
+        return Status::OK();
+    case BitmapIndexSeeker::ResultType::ALWAYS_TRUE:
+        dst_pred_tree = PredicateTree{};
+        return Status::OK();
+    case BitmapIndexSeeker::ResultType::NOT_USED:
+        return Status::OK();
+    case BitmapIndexSeeker::ResultType::OK:
+        // Do nothing.
+        break;
+    }
+
+    // ---------------------------------------------------------
+    // Retrieve the bitmap of each field.
+    // ---------------------------------------------------------
+    Roaring row_bitmap = range2roaring(dst_scan_range);
+    const size_t input_rows = row_bitmap.cardinality();
+    DCHECK_EQ(input_rows, dst_scan_range.span_size());
+
+    ASSIGN_OR_RETURN(auto roaring, _pred_tree.visit(BitmapIndexRetriver{this}));
+    if (!roaring.has_value()) {
+        return Status::OK();
+    }
+    row_bitmap &= roaring.value();
+
+    DCHECK_LE(row_bitmap.cardinality(), dst_scan_range.span_size());
+    if (row_bitmap.cardinality() < dst_scan_range.span_size()) {
+        dst_scan_range = roaring2range(row_bitmap);
+    }
+
+    // ---------------------------------------------------------
+    // Erase predicates that hit bitmap index.
+    // ---------------------------------------------------------
+    PredicateAndNode new_pred_root;
+    _pred_tree.visit(BitmapIndexPredicateEraser{this}, new_pred_root);
+    dst_pred_tree = PredicateTree::create(std::move(new_pred_root));
+
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/bitmap_index_evaluator.h
+++ b/be/src/storage/rowset/bitmap_index_evaluator.h
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "bitmap_index_reader.h"
+#include "storage/olap_common.h"
+#include "storage/predicate_tree/predicate_tree_fwd.h"
+#include "storage/range.h"
+
+namespace starrocks {
+
+struct BitmapContext {
+    struct ColumnContext {
+        SparseRange<> bitmap_ranges;
+        size_t cardinality;
+        std::vector<const PredicateColumnNode*> nodes;
+        bool has_is_null_pred = false;
+    };
+
+    struct CompoundNodeContext {
+        std::unordered_map<ColumnId, ColumnContext> col_contexts;
+        bool used = false;
+    };
+
+    /// Note that the address of a predicate node is used as the identity,
+    /// and therefore do not modify the related PredicateTree, which may cause the address to change.
+
+    std::unordered_map<const PredicateBaseNode*, bool> is_node_support_bitmap;
+    // It ensures that `compound_node_to_context[node]` can be accessed after `is_node_support_bitmap[node]` is true.
+    std::unordered_map<const PredicateBaseNode*, CompoundNodeContext> compound_node_to_context;
+
+    std::unordered_set<const PredicateBaseNode*> nodes_to_erase;
+};
+
+class BitmapIndexEvaluator {
+public:
+    using BitmapIndexIteratorSupplier = std::function<StatusOr<BitmapIndexIterator*>(ColumnId)>;
+
+    BitmapIndexEvaluator(const Schema& schema, const PredicateTree& pred_tree)
+            : _schema(schema), _pred_tree(pred_tree) {}
+    ~BitmapIndexEvaluator() { close(); }
+
+    Status init(BitmapIndexIteratorSupplier&& supplier);
+
+    Status evaluate(SparseRange<>& dst_scan_range, PredicateTree& dst_pred_tree);
+
+    void close();
+
+    bool has_bitmap_index() const { return _has_bitmap_index; }
+
+private:
+    friend struct BitmapIndexInitializer;
+    friend struct BitmapIndexSeeker;
+    friend struct BitmapIndexRetriver;
+    friend struct BitmapIndexPredicateEraser;
+
+    const Schema& _schema;
+    const PredicateTree& _pred_tree;
+
+    BitmapContext _ctx;
+    std::vector<BitmapIndexIterator*> _bitmap_index_iterators;
+    bool _has_bitmap_index = false;
+
+    bool _closed = false;
+};
+
+} // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -99,6 +99,29 @@ static int compare(const Slice& lhs_index_key, const Chunk& rhs_chunk, const Sch
     return lhs_index_key.compare(rhs);
 }
 
+struct BitmapContext {
+    struct ColumnContext {
+        SparseRange<> bitmap_ranges;
+        size_t cardinality;
+        std::vector<const PredicateColumnNode*> nodes;
+        bool has_is_null_pred = false;
+    };
+
+    struct NodeContext {
+        std::unordered_map<ColumnId, ColumnContext> col_contexts;
+        bool used = false;
+    };
+
+    /// Note that the address of a predicate node is used as the identity,
+    /// and therefore do not modify the related PredicateTree, which may cause the address to change.
+
+    std::unordered_map<const PredicateBaseNode*, bool> is_node_support_bitmap;
+
+    std::unordered_map<const PredicateBaseNode*, NodeContext> node_to_context;
+
+    std::unordered_set<const PredicateBaseNode*> nodes_to_erase;
+};
+
 class SegmentIterator final : public ChunkIterator {
 public:
     SegmentIterator(std::shared_ptr<Segment> segment, Schema _schema, SegmentReadOptions options);
@@ -118,6 +141,11 @@ protected:
     }
 
 private:
+    friend struct BitmapIndexInitializer;
+    friend struct BitmapIndexSeeker;
+    friend struct BitmapIndexEvaluator;
+    friend struct BitmapIndexPredicateEraser;
+
     struct ScanContext {
         ScanContext() = default;
 
@@ -257,7 +285,7 @@ private:
     // check field use low_cardinality global dict optimization
     bool _can_using_global_dict(const FieldPtr& field) const;
 
-    Status _init_bitmap_index_iterators();
+    Status _init_bitmap_index_iterators(BitmapContext& ctx, const PredicateTree& pred_tree);
 
     Status _apply_bitmap_index();
 
@@ -312,7 +340,6 @@ private:
     SparseRange<> _scan_range;
     SparseRangeIterator<> _range_iter;
 
-    ColumnPredicateMap _cid_to_predicates;
     PredicateTree _non_expr_pred_tree;
     PredicateTree _expr_pred_tree;
 
@@ -360,8 +387,6 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, Schema schema
           _segment(std::move(segment)),
           _opts(std::move(options)),
           _predicate_columns(_opts.pred_tree.num_columns()) {
-    _cid_to_predicates = _opts.pred_tree.get_immediate_column_predicate_map();
-
     // For small segment file (the number of rows is less than chunk_size),
     // the segment iterator will reserve a large amount of memory,
     // especially when there are many columns, many small files, many versions,
@@ -482,6 +507,7 @@ Status SegmentIterator::_try_to_update_ranges_by_runtime_filter() {
                 auto iter = _del_predicates.find(cid);
                 del_pred = iter != _del_predicates.end() ? &(iter->second) : nullptr;
                 SparseRange<> r;
+
                 RETURN_IF_ERROR(_column_iterators[cid]->get_row_ranges_by_zone_map(predicates, del_pred, &r,
                                                                                    CompoundNodeType::AND));
                 size_t prev_size = _scan_range.span_size();
@@ -1590,7 +1616,7 @@ Status SegmentIterator::_init_context() {
 
     RETURN_IF_ERROR(_init_global_dict_decoder());
 
-    if (_predicate_columns == 0 ||
+    if (_predicate_columns == 0 || _opts.pred_tree.empty() ||
         (_predicate_columns >= _schema.num_fields() && _predicate_column_access_paths.empty())) {
         // non or all field has predicate, disable late materialization.
         RETURN_IF_ERROR(_build_context<false>(&_context_list[0]));
@@ -1637,11 +1663,11 @@ Status SegmentIterator::_init_global_dict_decoder() {
 }
 
 Status SegmentIterator::_rewrite_predicates() {
-    //
-    ColumnPredicateRewriter rewriter(_column_iterators, _schema, _predicate_need_rewrite, _predicate_columns,
-                                     _scan_range);
-    RETURN_IF_ERROR(rewriter.rewrite_predicate(&_obj_pool, _opts.pred_tree));
-    _cid_to_predicates = _opts.pred_tree.get_immediate_column_predicate_map();
+    {
+        ColumnPredicateRewriter rewriter(_column_iterators, _schema, _predicate_need_rewrite, _predicate_columns,
+                                         _scan_range);
+        RETURN_IF_ERROR(rewriter.rewrite_predicate(&_obj_pool, _opts.pred_tree));
+    }
 
     // for each delete predicate,
     // If the global dictionary optimization is enabled for the column,
@@ -1785,37 +1811,109 @@ Status SegmentIterator::_encode_to_global_id(ScanContext* ctx) {
     return Status::OK();
 }
 
-Status SegmentIterator::_init_bitmap_index_iterators() {
-    RETURN_IF(!config::enable_index_bitmap_filter, Status::OK());
+/// Initialize bitmap index iterators for the columns related to a PredicateTree.
+/// `ctx.is_node_support_bitmap` will be updated to indicate whether a predicate node can be applied bitmap to.
+/// Return true if the PredicateTree can be applied bitmap to.
+struct BitmapIndexInitializer {
+    StatusOr<bool> operator()(const PredicateColumnNode& node) {
+        DCHECK(parent_node_ctx != nullptr);
 
-    SCOPED_RAW_TIMER(&_opts.stats->bitmap_index_iterator_init_ns);
-    _bitmap_index_iterators.resize(ChunkHelper::max_column_id(_schema) + 1, nullptr);
-    std::unordered_map<ColumnId, ColumnUID> cid_2_ucid;
-    for (auto& field : _schema.fields()) {
-        cid_2_ucid[field->id()] = field->uid();
-    }
-    for (const auto& pair : _cid_to_predicates) {
-        ColumnId cid = pair.first;
-        if (_bitmap_index_iterators[cid] == nullptr) {
-            ColumnUID ucid = cid_2_ucid[cid];
+        const auto* col_pred = node.col_pred();
+        const auto cid = col_pred->column_id();
+
+        if (!col_pred->support_bitmap_filter()) {
+            return false;
+        }
+
+        auto* bitmap_iter = parent->_bitmap_index_iterators[cid];
+        if (bitmap_iter == nullptr) {
+            const ColumnUID ucid = cid_2_ucid[cid];
             // the column's index in this segment file
-            ASSIGN_OR_RETURN(std::shared_ptr<Segment> segment_ptr, _get_dcg_segment(ucid));
+            ASSIGN_OR_RETURN(std::shared_ptr<Segment> segment_ptr, parent->_get_dcg_segment(ucid));
             if (segment_ptr == nullptr) {
                 // find segment from delta column group failed, using main segment
-                segment_ptr = _segment;
+                segment_ptr = parent->_segment;
             }
 
             IndexReadOptions opts;
             opts.use_page_cache = config::enable_bitmap_index_memory_page_cache || !config::disable_storage_page_cache;
             opts.kept_in_memory = config::enable_bitmap_index_memory_page_cache;
-            opts.lake_io_opts = _opts.lake_io_opts;
-            opts.read_file = _column_files[cid].get();
-            opts.stats = _opts.stats;
+            opts.lake_io_opts = parent->_opts.lake_io_opts;
+            opts.read_file = parent->_column_files[cid].get();
+            opts.stats = parent->_opts.stats;
 
-            RETURN_IF_ERROR(segment_ptr->new_bitmap_index_iterator(ucid, opts, &_bitmap_index_iterators[cid]));
-            _has_bitmap_index |= (_bitmap_index_iterators[cid] != nullptr);
+            RETURN_IF_ERROR(segment_ptr->new_bitmap_index_iterator(ucid, opts, &parent->_bitmap_index_iterators[cid]));
+
+            bitmap_iter = parent->_bitmap_index_iterators[cid];
         }
+
+        if (bitmap_iter != nullptr) {
+            ctx.is_node_support_bitmap[&node] = true;
+            auto& col_ctx = _get_or_create_column_context(bitmap_iter, cid);
+            col_ctx.nodes.emplace_back(&node);
+            return true;
+        }
+        return false;
     }
+
+    template <CompoundNodeType Type>
+    StatusOr<bool> operator()(const PredicateCompoundNode<Type>& node) {
+        auto& node_ctx = ctx.node_to_context.emplace(&node, BitmapContext::NodeContext{}).first->second;
+        bool has_bitmap_index = Type == CompoundNodeType::AND ? false : true;
+        for (const auto& child : node.children()) {
+            parent_type = Type;
+            parent_node_ctx = &node_ctx;
+            ASSIGN_OR_RETURN(const auto child_has_bitmap_index, child.visit(*this));
+            if constexpr (Type == CompoundNodeType::AND) {
+                has_bitmap_index |= child_has_bitmap_index;
+            } else {
+                if (!child_has_bitmap_index) {
+                    has_bitmap_index = false;
+                    break;
+                }
+            }
+        }
+        ctx.is_node_support_bitmap[&node] = has_bitmap_index;
+        return has_bitmap_index;
+    }
+
+    BitmapContext::ColumnContext& _get_or_create_column_context(BitmapIndexIterator* bitmap_iter, ColumnId cid) {
+        auto it = parent_node_ctx->col_contexts.find(cid);
+        if (it == parent_node_ctx->col_contexts.end()) {
+            const auto cardinality = bitmap_iter->bitmap_nums();
+            if (parent_type == CompoundNodeType::AND) {
+                it = parent_node_ctx->col_contexts
+                             .emplace(cid, BitmapContext::ColumnContext{SparseRange<>{0, cardinality}, cardinality})
+                             .first;
+            } else {
+                it = parent_node_ctx->col_contexts
+                             .emplace(cid, BitmapContext::ColumnContext{SparseRange<>{}, cardinality})
+                             .first;
+            }
+        }
+        return it->second;
+    }
+
+    SegmentIterator* parent;
+    BitmapContext& ctx;
+    std::unordered_map<ColumnId, ColumnUID>& cid_2_ucid;
+
+    BitmapContext::NodeContext* parent_node_ctx = nullptr;
+    CompoundNodeType parent_type = CompoundNodeType::AND;
+};
+
+Status SegmentIterator::_init_bitmap_index_iterators(BitmapContext& ctx, const PredicateTree& pred_tree) {
+    DCHECK_EQ(_predicate_columns, pred_tree.num_columns());
+    SCOPED_RAW_TIMER(&_opts.stats->bitmap_index_iterator_init_ns);
+
+    _bitmap_index_iterators.resize(ChunkHelper::max_column_id(_schema) + 1, nullptr);
+
+    std::unordered_map<ColumnId, ColumnUID> cid_2_ucid;
+    for (auto& field : _schema.fields()) {
+        cid_2_ucid[field->id()] = field->uid();
+    }
+
+    ASSIGN_OR_RETURN(_has_bitmap_index, pred_tree.visit(BitmapIndexInitializer{this, ctx, cid_2_ucid}));
     return Status::OK();
 }
 
@@ -1833,14 +1931,326 @@ static void erase_column_pred_from_pred_tree(PredicateTree& pred_tree,
             &new_root, &useless_root);
     pred_tree = PredicateTree::create(std::move(new_root));
 }
+struct BitmapIndexSeeker {
+    enum class ResultType : uint8_t { ALWAYS_FALSE, ALWAYS_TRUE, NOT_USED, OK };
+
+    StatusOr<ResultType> operator()(const PredicateAndNode& node) {
+        if (!ctx.is_node_support_bitmap[&node]) {
+            return ResultType::NOT_USED;
+        }
+
+        DCHECK(ctx.node_to_context.find(&node) != ctx.node_to_context.end());
+        auto& node_ctx = ctx.node_to_context[&node];
+
+        std::vector<const PredicateBaseNode*> used_children;
+        size_t num_always_true_child = 0;
+
+        size_t mul_selected = 1;
+        size_t mul_cardinality = 1;
+        std::vector<ColumnId> cid_to_erase;
+        bool need_estimate_selectivity = false;
+
+        for (const auto& [cid, col_ctx] : node_ctx.col_contexts) {
+            for (const auto* col_node : col_ctx.nodes) {
+                ASSIGN_OR_RETURN(const auto used, _seek_column_node<CompoundNodeType::AND>(*col_node, node_ctx));
+                if (used) {
+                    used_children.emplace_back(col_node);
+                }
+            }
+
+            // ALWAYS_FALSE
+            if (col_ctx.bitmap_ranges.empty()) {
+                ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_FALSE;
+            }
+
+            // ALWAYS_TRUE
+            if (col_ctx.bitmap_ranges.span_size() >= col_ctx.cardinality) {
+                cid_to_erase.emplace_back(cid);
+                num_always_true_child += col_ctx.nodes.size();
+            } else {
+                // OK
+                need_estimate_selectivity = true;
+                mul_selected *= col_ctx.bitmap_ranges.span_size();
+                mul_cardinality *= col_ctx.cardinality;
+            }
+        }
+
+        for (const auto& child : node.compound_children()) {
+            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this));
+            switch (res_type) {
+            case ResultType::ALWAYS_FALSE:
+                ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_FALSE;
+            case ResultType::ALWAYS_TRUE:
+                used_children.emplace_back(child.visit(
+                        [](const auto& child_node) { return static_cast<const PredicateBaseNode*>(&child_node); }));
+                num_always_true_child++;
+                break;
+            case ResultType::NOT_USED:
+                // Do nothing.
+                break;
+            case ResultType::OK:
+                used_children.emplace_back(child.visit(
+                        [](const auto& child_node) { return static_cast<const PredicateBaseNode*>(&child_node); }));
+                break;
+            }
+        }
+
+        if (num_always_true_child == node.num_children()) {
+            ctx.nodes_to_erase.emplace(&node);
+            return ResultType::ALWAYS_TRUE;
+        }
+
+        for (const auto& cid : cid_to_erase) {
+            node_ctx.col_contexts.erase(cid);
+        }
+
+        // ---------------------------------------------------------
+        // Estimate the selectivity of the bitmap index.
+        // ---------------------------------------------------------
+        if (num_always_true_child >= used_children.size() ||
+            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * config::bitmap_max_filter_ratio)) {
+            return ResultType::NOT_USED;
+        }
+
+        ctx.nodes_to_erase.insert(used_children.begin(), used_children.end());
+
+        node_ctx.used = true;
+        return ResultType::OK;
+    }
+
+    StatusOr<ResultType> operator()(const PredicateOrNode& node) {
+        if (!ctx.is_node_support_bitmap[&node]) {
+            return ResultType::NOT_USED;
+        }
+
+        DCHECK(ctx.node_to_context.find(&node) != ctx.node_to_context.end());
+        auto& node_ctx = ctx.node_to_context[&node];
+
+        std::vector<const PredicateBaseNode*> used_children;
+        size_t num_always_false_child = 0;
+        bool has_not_used_child = false;
+
+        size_t mul_selected = 1;
+        size_t mul_cardinality = 1;
+        std::vector<ColumnId> cid_to_erase;
+        bool need_estimate_selectivity = false;
+
+        for (const auto& [cid, col_ctx] : node_ctx.col_contexts) {
+            for (const auto* col_node : col_ctx.nodes) {
+                ASSIGN_OR_RETURN(const auto used, _seek_column_node<CompoundNodeType::OR>(*col_node, node_ctx));
+                if (used) {
+                    used_children.emplace_back(col_node);
+                } else {
+                    has_not_used_child = true;
+                }
+            }
+
+            // ALWAYS_FALSE
+            if (col_ctx.bitmap_ranges.empty()) {
+                cid_to_erase.emplace_back(cid);
+                num_always_false_child += col_ctx.nodes.size();
+                continue;
+            }
+
+            // ALWAYS_TRUE
+            if (col_ctx.bitmap_ranges.span_size() >= col_ctx.cardinality) {
+                ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_TRUE;
+            } else {
+                // OK
+                need_estimate_selectivity = true;
+                mul_selected *= col_ctx.bitmap_ranges.span_size();
+                mul_cardinality *= col_ctx.cardinality;
+            }
+        }
+
+        for (const auto& child : node.compound_children()) {
+            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this));
+            switch (res_type) {
+            case ResultType::ALWAYS_FALSE:
+                used_children.emplace_back(child.visit(
+                        [](const auto& child_node) { return static_cast<const PredicateBaseNode*>(&child_node); }));
+                num_always_false_child++;
+                break;
+            case ResultType::ALWAYS_TRUE:
+                ctx.nodes_to_erase.emplace(&node);
+                return ResultType::ALWAYS_TRUE;
+            case ResultType::NOT_USED:
+                has_not_used_child = true;
+                break;
+            case ResultType::OK:
+                used_children.emplace_back(child.visit(
+                        [](const auto& child_node) { return static_cast<const PredicateBaseNode*>(&child_node); }));
+                break;
+            }
+        }
+
+        if (has_not_used_child) {
+            return ResultType::NOT_USED;
+        }
+
+        if (num_always_false_child == node.num_children()) {
+            ctx.nodes_to_erase.emplace(&node);
+            return ResultType::ALWAYS_FALSE;
+        }
+
+        for (const auto& cid : cid_to_erase) {
+            node_ctx.col_contexts.erase(cid);
+        }
+
+        // ---------------------------------------------------------
+        // Estimate the selectivity of the bitmap index.
+        // ---------------------------------------------------------
+        if (num_always_false_child >= used_children.size() ||
+            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * config::bitmap_max_filter_ratio)) {
+            return ResultType::NOT_USED;
+        }
+
+        ctx.nodes_to_erase.insert(used_children.begin(), used_children.end());
+
+        node_ctx.used = true;
+        return ResultType::OK;
+    }
+
+    template <CompoundNodeType Type>
+    StatusOr<bool> _seek_column_node(const PredicateColumnNode& node,
+                                     BitmapContext::NodeContext& parent_node_ctx) const {
+        if (!ctx.is_node_support_bitmap[&node]) {
+            return false;
+        }
+
+        const auto* col_pred = node.col_pred();
+        const auto cid = col_pred->column_id();
+        auto* bitmap_iter = parent->_bitmap_index_iterators[cid];
+        if (bitmap_iter == nullptr) {
+            return false;
+        }
+
+        DCHECK(parent_node_ctx.col_contexts.find(cid) != parent_node_ctx.col_contexts.end());
+        auto& col_ctx = parent_node_ctx.col_contexts.find(cid)->second;
+
+        SparseRange<> r;
+        const Status st = col_pred->seek_bitmap_dictionary(bitmap_iter, &r);
+        if (st.ok()) {
+            if constexpr (Type == CompoundNodeType::AND) {
+                col_ctx.bitmap_ranges &= r;
+            } else {
+                col_ctx.bitmap_ranges |= r;
+            }
+            col_ctx.has_is_null_pred |= (col_pred->type() == PredicateType::kIsNull);
+        } else if (st.is_cancelled()) {
+            return false;
+        } else {
+            return st;
+        }
+
+        return true;
+    }
+
+    SegmentIterator* parent;
+    BitmapContext& ctx;
+};
+
+struct BitmapIndexEvaluator {
+    StatusOr<std::optional<Roaring>> operator()(const PredicateColumnNode& node) const { return std::nullopt; }
+
+    template <CompoundNodeType Type>
+    StatusOr<std::optional<Roaring>> operator()(const PredicateCompoundNode<Type>& node) const {
+        std::optional<Roaring> result_roaring;
+
+        auto it = ctx.node_to_context.find(&node);
+        if (it == ctx.node_to_context.end() || !it->second.used) {
+            return result_roaring;
+        }
+        const auto& node_ctx = it->second;
+
+        for (const auto& [cid, col_ctx] : node_ctx.col_contexts) {
+            auto* bitmap_iter = parent->_bitmap_index_iterators[cid];
+
+            Roaring roaring;
+            RETURN_IF_ERROR(bitmap_iter->read_union_bitmap(col_ctx.bitmap_ranges, &roaring));
+            if (bitmap_iter->has_null_bitmap() && !col_ctx.has_is_null_pred) {
+                Roaring null_bitmap;
+                RETURN_IF_ERROR(bitmap_iter->read_null_bitmap(&null_bitmap));
+                roaring -= null_bitmap;
+            }
+
+            if (!result_roaring.has_value()) {
+                result_roaring.emplace(std::move(roaring));
+            } else {
+                if constexpr (Type == CompoundNodeType::AND) {
+                    result_roaring.value() &= roaring;
+                } else {
+                    result_roaring.value() |= roaring;
+                }
+            }
+        }
+
+        for (const auto& child : node.children()) {
+            ASSIGN_OR_RETURN(auto roaring, child.visit(*this));
+            if (!roaring.has_value()) {
+                continue;
+            }
+            if (!result_roaring.has_value()) {
+                result_roaring = std::move(roaring);
+            } else {
+                if constexpr (Type == CompoundNodeType::AND) {
+                    result_roaring.value() &= roaring.value();
+                } else {
+                    result_roaring.value() |= roaring.value();
+                }
+            }
+        }
+
+        return result_roaring;
+    }
+
+    SegmentIterator* parent;
+    BitmapContext& ctx;
+};
+
+struct BitmapIndexPredicateEraser {
+    template <CompoundNodeType ParentType>
+    void operator()(const PredicateColumnNode& node, PredicateCompoundNode<ParentType>& parent) const {
+        if (!ctx.nodes_to_erase.contains(&node)) {
+            parent.add_child(node);
+        }
+    }
+
+    template <CompoundNodeType Type, CompoundNodeType ParentType>
+    void operator()(const PredicateCompoundNode<Type>& node, PredicateCompoundNode<ParentType>& parent) const {
+        if (ctx.nodes_to_erase.contains(&node)) {
+            return;
+        }
+
+        PredicateCompoundNode<Type> new_node;
+        for (const auto& child : node.children()) {
+            child.visit(*this, new_node);
+        }
+
+        if (!new_node.empty()) {
+            parent.add_child(new_node);
+        }
+    }
+
+    BitmapContext& ctx;
+};
 
 // filter rows by evaluating column predicates using bitmap indexes.
 // upon return, predicates that have been evaluated by bitmap indexes will be removed.
 Status SegmentIterator::_apply_bitmap_index() {
+    RETURN_IF(!config::enable_index_bitmap_filter, Status::OK());
     RETURN_IF(_scan_range.empty(), Status::OK());
 
-    RETURN_IF_ERROR(_init_bitmap_index_iterators());
+    const auto& immutable_pred_tree = _opts.pred_tree;
 
+    BitmapContext ctx;
+
+    RETURN_IF_ERROR(_init_bitmap_index_iterators(ctx, immutable_pred_tree));
+
+    DCHECK_EQ(_predicate_columns, immutable_pred_tree.num_columns());
     RETURN_IF(!_has_bitmap_index, Status::OK());
     SCOPED_RAW_TIMER(&_opts.stats->bitmap_index_filter_timer);
 
@@ -1849,51 +2259,21 @@ Status SegmentIterator::_apply_bitmap_index() {
     //  - Seek to the position of predicate's operand within
     //    bitmap index dictionary.
     // ---------------------------------------------------------
-    std::vector<ColumnId> bitmap_columns;
-    std::vector<SparseRange<>> bitmap_ranges;
-    std::vector<bool> has_is_null_predicate;
-    std::unordered_set<const ColumnPredicate*> erased_preds;
 
-    size_t mul_selected = 1;
-    size_t mul_cardinality = 1;
-    for (auto& [cid, pred_list] : _cid_to_predicates) {
-        BitmapIndexIterator* bitmap_iter = _bitmap_index_iterators[cid];
-        if (bitmap_iter == nullptr) {
-            continue;
-        }
-        size_t cardinality = bitmap_iter->bitmap_nums();
-        SparseRange<> selected(0, cardinality);
-        bool has_is_null = false;
-        for (const ColumnPredicate* pred : pred_list) {
-            SparseRange<> r;
-            Status st = pred->seek_bitmap_dictionary(bitmap_iter, &r);
-            if (st.ok()) {
-                selected &= r;
-                erased_preds.emplace(pred);
-                has_is_null |= (pred->type() == PredicateType::kIsNull);
-            } else if (!st.is_cancelled()) {
-                return st;
-            }
-        }
-        if (selected.empty()) {
-            _opts.stats->rows_bitmap_index_filtered += _scan_range.span_size();
-            _scan_range.clear();
-            return Status::OK();
-        }
-        if (selected.span_size() < cardinality) {
-            bitmap_columns.emplace_back(cid);
-            bitmap_ranges.emplace_back(selected);
-            has_is_null_predicate.emplace_back(has_is_null);
-            mul_selected *= selected.span_size();
-            mul_cardinality *= cardinality;
-        }
-    }
-
-    // ---------------------------------------------------------
-    // Estimate the selectivity of the bitmap index.
-    // ---------------------------------------------------------
-    if (bitmap_columns.empty() || (mul_selected * 1000 > mul_cardinality * config::bitmap_max_filter_ratio)) {
+    ASSIGN_OR_RETURN(auto seek_res, immutable_pred_tree.visit(BitmapIndexSeeker{this, ctx}));
+    switch (seek_res) {
+    case BitmapIndexSeeker::ResultType::ALWAYS_FALSE:
+        _opts.stats->rows_bitmap_index_filtered += _scan_range.span_size();
+        _scan_range.clear();
         return Status::OK();
+    case BitmapIndexSeeker::ResultType::ALWAYS_TRUE:
+        _opts.pred_tree = PredicateTree{};
+        return Status::OK();
+    case BitmapIndexSeeker::ResultType::NOT_USED:
+        return Status::OK();
+    case BitmapIndexSeeker::ResultType::OK:
+        // Do nothing.
+        break;
     }
 
     // ---------------------------------------------------------
@@ -1903,17 +2283,11 @@ Status SegmentIterator::_apply_bitmap_index() {
     size_t input_rows = row_bitmap.cardinality();
     DCHECK_EQ(input_rows, _scan_range.span_size());
 
-    for (size_t i = 0; i < bitmap_columns.size(); i++) {
-        Roaring roaring;
-        BitmapIndexIterator* bitmap_iter = _bitmap_index_iterators[bitmap_columns[i]];
-        if (bitmap_iter->has_null_bitmap() && !has_is_null_predicate[i]) {
-            Roaring null_bitmap;
-            RETURN_IF_ERROR(bitmap_iter->read_null_bitmap(&null_bitmap));
-            row_bitmap -= null_bitmap;
-        }
-        RETURN_IF_ERROR(bitmap_iter->read_union_bitmap(bitmap_ranges[i], &roaring));
-        row_bitmap &= roaring;
+    ASSIGN_OR_RETURN(auto roaring, immutable_pred_tree.visit(BitmapIndexEvaluator{this, ctx}));
+    if (!roaring.has_value()) {
+        return Status::OK();
     }
+    row_bitmap &= roaring.value();
 
     DCHECK_LE(row_bitmap.cardinality(), _scan_range.span_size());
     if (row_bitmap.cardinality() < _scan_range.span_size()) {
@@ -1923,8 +2297,9 @@ Status SegmentIterator::_apply_bitmap_index() {
     // ---------------------------------------------------------
     // Erase predicates that hit bitmap index.
     // ---------------------------------------------------------
-    erase_column_pred_from_pred_tree(_opts.pred_tree, erased_preds);
-    _cid_to_predicates = _opts.pred_tree.get_immediate_column_predicate_map();
+    PredicateAndNode new_pred_root;
+    immutable_pred_tree.visit(BitmapIndexPredicateEraser{ctx}, new_pred_root);
+    _opts.pred_tree = PredicateTree::create(std::move(new_pred_root));
 
     _opts.stats->rows_bitmap_index_filtered += (input_rows - _scan_range.span_size());
     return Status::OK();
@@ -1950,7 +2325,7 @@ Status SegmentIterator::_init_inverted_index_iterators() {
     for (auto& field : _schema.fields()) {
         cid_2_ucid[field->id()] = field->uid();
     }
-    for (const auto& pair : _cid_to_predicates) {
+    for (const auto& pair : _opts.pred_tree.get_immediate_column_predicate_map()) {
         ColumnId cid = pair.first;
         ColumnUID ucid = cid_2_ucid[cid];
 
@@ -1972,13 +2347,14 @@ Status SegmentIterator::_apply_inverted_index() {
     roaring::Roaring row_bitmap = range2roaring(_scan_range);
     size_t input_rows = row_bitmap.cardinality();
     std::unordered_set<const ColumnPredicate*> erased_preds;
+    std::unordered_set<ColumnId> erased_pred_col_ids;
 
     std::unordered_map<ColumnId, ColumnId> cid_2_fid;
     for (int i = 0; i < _schema.num_fields(); i++) {
         cid_2_fid.emplace(_schema.field(i)->id(), i);
     }
 
-    for (auto& [cid, pred_list] : _cid_to_predicates) {
+    for (const auto& [cid, pred_list] : _opts.pred_tree.get_immediate_column_predicate_map()) {
         InvertedIndexIterator* inverted_iter = _inverted_index_iterators[cid];
         if (inverted_iter == nullptr) {
             continue;
@@ -1992,6 +2368,7 @@ Status SegmentIterator::_apply_inverted_index() {
                 Status res = pred->seek_inverted_index(column_name, _inverted_index_iterators[cid], &row_bitmap);
                 if (res.ok()) {
                     erased_preds.emplace(pred);
+                    erased_pred_col_ids.emplace(cid);
                 }
             }
         }
@@ -2004,16 +2381,15 @@ Status SegmentIterator::_apply_inverted_index() {
     // ---------------------------------------------------------
     if (!erased_preds.empty()) {
         erase_column_pred_from_pred_tree(_opts.pred_tree, erased_preds);
+        const auto& new_cid_to_predicates = _opts.pred_tree.get_immediate_column_predicate_map();
 
-        auto new_cid_to_predicates = _opts.pred_tree.get_immediate_column_predicate_map();
-        for (const auto& [cid, _] : _cid_to_predicates) {
+        for (const auto& cid : erased_pred_col_ids) {
             if (!new_cid_to_predicates.contains(cid)) {
                 // predicate for pred->column_id() has been total erased by
                 // inverted index filtering.These columns may can be pruned.
                 _prune_cols_candidate_by_inverted_index.insert(cid);
             }
         }
-        _cid_to_predicates = std::move(new_cid_to_predicates);
     }
 
     _opts.stats->rows_gin_filtered += input_rows - _scan_range.span_size();

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1618,7 +1618,7 @@ class StarrocksSQLApiLib(object):
 
     def wait_compaction_finish(self, table_name: str, expected_num_segments: int):
         timeout = 300
-        scan_table_sql = f"SELECT /*+SET_VAR(enable_profile=true)*/ COUNT(1) FROM {table_name}"
+        scan_table_sql = f"SELECT /*+SET_VAR(enable_profile=true,enable_async_profile=false)*/ COUNT(1) FROM {table_name}"
         fetch_segments_sql = r"""
             with profile as (
                 select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n"))

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1616,6 +1616,33 @@ class StarrocksSQLApiLib(object):
 
         tools.assert_true(finished, "analyze timeout")
 
+    def wait_compaction_finish(self, table_name: str, expected_num_segments: int):
+        timeout = 300
+        scan_table_sql = f"SELECT /*+SET_VAR(enable_profile=true)*/ COUNT(1) FROM {table_name}"
+        fetch_segments_sql = r"""
+            with profile as (
+                select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n"))
+            )
+            select regexp_extract(line, ".*- SegmentsReadCount: (?:.*\\()?(\\d+)\\)?", 1) as value 
+            from profile 
+            where line like "%- SegmentsReadCount%"
+        """
+
+        while timeout > 0:
+            res = self.execute_sql(scan_table_sql)
+            tools.assert_true(res["status"], f'Fail to execute scan_table_sql, error=[{res["msg"]}]')
+
+            res = self.execute_sql(fetch_segments_sql)
+            tools.assert_true(res["status"], f'Fail to execute fetch_segments_sql, error=[{res["msg"]}]')
+
+            if res["result"] == str(expected_num_segments):
+                break
+
+            time.sleep(1)
+            timeout -= 1
+        else:
+            tools.assert_true(False, "wait compaction timeout")
+
     def _get_backend_http_endpoints(self) -> List[Dict]:
         """Get the http host and port of all the backends.
 

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_index_and_filter_on_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_index_and_filter_on_or_predicate
@@ -2,6 +2,9 @@
 set scan_or_to_union_limit = 1;
 -- result:
 -- !result
+set enable_show_predicate_tree_in_profile = true;
+-- result:
+-- !result
 set enable_profile = true;
 -- result:
 -- !result
@@ -123,17 +126,52 @@ insert into t1 (k1, c_str_5_low_non_null1, c_str_6_low_non_null2, c_str_7_seq_no
 insert into t1 (k1, c_str_5_low_non_null1, c_str_6_low_non_null2, c_str_7_seq_non_null1, c_str_8_seq_non_null2) select null, '<null>', '<null>', '<null>', '<null>';
 -- result:
 -- !result
-create view __profile(idx, k, v) as 
-select 1, 2, 3;
+ALTER TABLE t1 COMPACT;
 -- result:
 -- !result
+function: wait_compaction_finish("t1", 32)
+-- result:
+None
+-- !result
+create view __profile(idx, k, v) as 
+with 
+  __profile as (
+      select last_query_id() as query_id, unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+  ),
+  result as (
+    select 1 as idx, "PushdownPredicates" as k, regexp_extract(line, ".*- PushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PushdownPredicates%"
+    UNION ALL
+    select 2, "NonPushdownPredicates" as k, regexp_extract(line, ".*- NonPushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- NonPushdownPredicates%"
     
+    UNION ALL
+    select 3, "PushdownPredicateTree" as k, regexp_extract(line, ".*- PushdownPredicateTree: (.*)", 1) as v from __profile where line like "%- PushdownPredicateTree%"
+    UNION ALL
+    select 4, "NonPushdownPredicateTree" as k, regexp_extract(line, ".*- NonPushdownPredicateTree: (.*)?", 1) as v from __profile where line like "%- NonPushdownPredicateTree%"
     
+    UNION ALL
+    select 5, "RawRowsRead" as k, regexp_extract(line, ".*- RawRowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RawRowsRead%"
+    UNION ALL
+    select 6, "RowsRead" as k, regexp_extract(line, ".*- RowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RowsRead%"
     
+    UNION ALL
+    select 7, "SegmentZoneMapFilterRows" as k, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- SegmentZoneMapFilterRows%"
+    UNION ALL
+    select 8, "ZoneMapIndexFilterRows" as k, regexp_extract(line, ".*- ZoneMapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- ZoneMapIndexFilterRows%"
+    UNION ALL
+    select 9, "BitmapIndexFilterRows" as k, regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BitmapIndexFilterRows%"
+    UNION ALL
+    select 10, "BloomFilterFilterRows" as k, regexp_extract(line, ".*- BloomFilterFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BloomFilterFilterRows%"
+    UNION ALL
+    select 11, "PredFilterRows" as k, regexp_extract(line, ".*- PredFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PredFilterRows%"
+    UNION ALL
+    select 12, "DeleteFilterRows" as k, regexp_extract(line, ".*- DeleteFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- DeleteFilterRows%"
+    UNION ALL
+    select 13, "LateMaterialize" as k, 'exist' as v from __profile where line like "%- LateMaterialize%"
     
-
-
-
+  )
+select * from result order by idx, k, v;
+-- result:
+-- !result
 update information_schema.be_configs set value="true" where name= "enable_index_segment_level_zonemap_filter";
 -- result:
 -- !result
@@ -143,7 +181,15 @@ select count(1) from t1 where c_int_1_seq < 1;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"}]}
+5	RawRowsRead	40002
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	1240000
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	40002
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- result:
@@ -151,7 +197,15 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	1280002
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
   
 select count(1) from t1 where c_int_2_seq < 10;
@@ -160,7 +214,15 @@ select count(1) from t1 where c_int_2_seq < 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"}]}
+5	RawRowsRead	40002
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	1240000
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	40002
 -- !result
   
 select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
@@ -169,7 +231,15 @@ select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	1280002
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
   
 
@@ -179,7 +249,15 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_2_seq < 1280000 * 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(columnId(2)<12800000)"}]}
+5	RawRowsRead	40002
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	1240000
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	40002
 -- !result
   
 
@@ -189,7 +267,15 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1 * 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<10)"},{"pred":"(columnId(1)<1)"}]}]}
+5	RawRowsRead	40002
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	1240000
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	40002
 -- !result
   
 select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100) 
@@ -199,7 +285,15 @@ select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100)
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	4
+3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]},{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}]}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	1280002
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
   
 select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
@@ -208,7 +302,15 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<12800000)"},{"pred":"(columnId(1)<1)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280000
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
 -- !result
   
 update information_schema.be_configs set value="false" where name= "enable_index_segment_level_zonemap_filter";
@@ -223,7 +325,15 @@ select count(1) from t1 where c_int_1_seq = 1280002;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280002)"}]}
+5	RawRowsRead	49152
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	1230850
+11	PredFilterRows	49151
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1';
 -- result:
@@ -231,7 +341,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(5)=a1)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	426666
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	853336
 -- !result
   
 select count(1) from t1 where c_date_1_seq = '2023-11-01';
@@ -240,7 +358,15 @@ select count(1) from t1 where c_date_1_seq = '2023-11-01';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(11)=2023-11-01)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	12800
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1267202
 -- !result
   
 select count(1) from t1 where c_int_1_seq * 2 = 10;
@@ -249,7 +375,15 @@ select count(1) from t1 where c_int_1_seq * 2 = 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) )])"}]}
+5	RawRowsRead	1280002
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1280002
 -- !result
 select count(1) from t1 where c_int_1_seq < 1290000;
 -- result:
@@ -257,7 +391,15 @@ select count(1) from t1 where c_int_1_seq < 1290000;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1290000)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	9999
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1270003
 -- !result
 select count(1) from t1 where c_date_1_seq > '2023-10-01';
 -- result:
@@ -265,7 +407,15 @@ select count(1) from t1 where c_date_1_seq > '2023-10-01';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(11)>2023-10-01)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	409600
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	870402
 -- !result
 select count(1) from t1 where c_int_2_seq = 1280000*2+2;
 -- result:
@@ -273,7 +423,15 @@ select count(1) from t1 where c_int_2_seq = 1280000*2+2;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)=2560002)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1280001
 -- !result
 select count(1) from t1 where c_int_1_seq = 10 and c_int_1_seq * 2 = 10;
 -- result:
@@ -281,7 +439,15 @@ select count(1) from t1 where c_int_1_seq = 10 and c_int_1_seq * 2 = 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) )])"}]}
+5	RawRowsRead	40960
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	1239042
+11	PredFilterRows	40960
 -- !result
   
 
@@ -291,7 +457,15 @@ select count(1) from t1 where c_int_1_seq = 1280002 and c_str_1_seq = 'abc1-128'
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280002)"},{"pred":"(columnId(3)=abc1-128)"}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	1280002
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq = 1280002 and c_str_1_seq = 'abc1-2';
 -- result:
@@ -299,7 +473,15 @@ select count(1) from t1 where c_int_1_seq = 1280002 and c_str_1_seq = 'abc1-2';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280002)"},{"pred":"(columnId(3)=abc1-2)"}]}
+5	RawRowsRead	4601
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	1275401
+11	PredFilterRows	4600
 -- !result
 select count(1) from t1 where c_int_1_seq = 10 or c_int_1_seq * 2 = 10;
 -- result:
@@ -307,7 +489,15 @@ select count(1) from t1 where c_int_1_seq = 10 or c_int_1_seq * 2 = 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)=10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) )])"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1280002
 -- !result
   
 
@@ -317,7 +507,15 @@ select count(1) from t1 where c_int_1_seq = 1280002 or c_str_1_seq = 'abc1-128';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(3)=abc1-128)"},{"pred":"(columnId(1)=1280002)"}]}]}
+5	RawRowsRead	98136
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	1181866
+11	PredFilterRows	98134
 -- !result
 select count(1) from t1 where c_int_1_seq = 1280002 or c_str_1_seq = 'abc1-2';
 -- result:
@@ -325,7 +523,15 @@ select count(1) from t1 where c_int_1_seq = 1280002 or c_str_1_seq = 'abc1-2';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(3)=abc1-2)"},{"pred":"(columnId(1)=1280002)"}]}]}
+5	RawRowsRead	120241
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	1159761
+11	PredFilterRows	120240
 -- !result
   
 select count(1) from t1 
@@ -349,7 +555,15 @@ select count(1) from t1
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	7
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)=1280004)"},{"pred":"(columnId(3)=abc1-128)"},{"and":[{"pred":"(columnId(5)=b1)"},{"or":[{"pred":"((columnId=1)IN(1280010,2560002))"}]}]}]},{"or":[{"pred":"(columnId(1)=1280005)"},{"and":[{"pred":"(columnId(5)=b1)"},{"pred":"(columnId(3)=abc1-4)"}]}]}]}
+5	RawRowsRead	24849
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	1255153
+11	PredFilterRows	24848
 -- !result
   
 update information_schema.be_configs set value="false" where name= "enable_index_bloom_filter";
@@ -364,7 +578,15 @@ select count(1) from t1 where c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280001)"}]}
+5	RawRowsRead	1
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280001
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -372,7 +594,15 @@ select count(1) from t1 where c_int_1_seq in (1280001, 1280010);
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280010))"}]}
+5	RawRowsRead	2
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq is null;
 -- result:
@@ -380,7 +610,15 @@ select count(1) from t1 where c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(ColumnId(1) IS NULL)"}]}
+5	RawRowsRead	2
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq < 1280010;
 -- result:
@@ -388,7 +626,15 @@ select count(1) from t1 where c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"}]}
+5	RawRowsRead	9
+6	RowsRead	9
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279993
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq <= 1280010;
 -- result:
@@ -396,7 +642,15 @@ select count(1) from t1 where c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<=1280010)"}]}
+5	RawRowsRead	10
+6	RowsRead	10
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279992
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq > 1280000*2-100;
 -- result:
@@ -404,7 +658,15 @@ select count(1) from t1 where c_int_1_seq > 1280000*2-100;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>2559900)"}]}
+5	RawRowsRead	100
+6	RowsRead	100
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279902
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -412,7 +674,15 @@ select count(1) from t1 where c_int_1_seq >= 1280000*2-100;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>=2559900)"}]}
+5	RawRowsRead	101
+6	RowsRead	101
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279901
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq != 1280001;
 -- result:
@@ -420,7 +690,15 @@ select count(1) from t1 where c_int_1_seq != 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)!=1280001)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	1279999
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	3
 -- !result
 select count(1) from t1 where c_int_1_seq not in (1280001, 1280010);
 -- result:
@@ -428,7 +706,15 @@ select count(1) from t1 where c_int_1_seq not in (1280001, 1280010);
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)NOT IN(1280001,1280010))"}]}
+5	RawRowsRead	1280002
+6	RowsRead	1279998
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	4
 -- !result
 select count(1) from t1 where c_int_1_seq is not null;
 -- result:
@@ -436,7 +722,15 @@ select count(1) from t1 where c_int_1_seq is not null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(ColumnId(1) IS NOT NULL)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280000
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq = 1280001;
 -- result:
@@ -444,7 +738,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280001)"},{"pred":"(columnId(5)!=a1)"}]}
+5	RawRowsRead	1
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280001
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -452,7 +754,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq in (1280001, 
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280010))"},{"pred":"(columnId(5)!=a1)"}]}
+5	RawRowsRead	2
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq is null;
 -- result:
@@ -460,7 +770,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(5)!=a1)"},{"pred":"(ColumnId(1) IS NULL)"}]}
+5	RawRowsRead	2
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq < 1280010;
 -- result:
@@ -468,7 +786,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(5)!=a1)"}]}
+5	RawRowsRead	9
+6	RowsRead	6
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279993
+10	BloomFilterFilterRows	0
+11	PredFilterRows	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq <= 1280010;
 -- result:
@@ -476,7 +802,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<=1280010)"},{"pred":"(columnId(5)!=a1)"}]}
+5	RawRowsRead	10
+6	RowsRead	7
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279992
+10	BloomFilterFilterRows	0
+11	PredFilterRows	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq > 1280000*2-100;
 -- result:
@@ -484,7 +818,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq > 1280000*2-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>2559900)"},{"pred":"(columnId(5)!=a1)"}]}
+5	RawRowsRead	100
+6	RowsRead	67
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279902
+10	BloomFilterFilterRows	0
+11	PredFilterRows	33
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -492,7 +834,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq >= 1280000*2-
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>=2559900)"},{"pred":"(columnId(5)!=a1)"}]}
+5	RawRowsRead	101
+6	RowsRead	68
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279901
+10	BloomFilterFilterRows	0
+11	PredFilterRows	33
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq = 1280001;
 -- result:
@@ -500,7 +850,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280001)"},{"pred":"(columnId(6)=a2)"}]}
+5	RawRowsRead	1
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280001
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -508,7 +866,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq in (1280001, 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280010))"},{"pred":"(columnId(6)=a2)"}]}
+5	RawRowsRead	2
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq is null;
 -- result:
@@ -516,7 +882,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(6)=a2)"},{"pred":"(ColumnId(1) IS NULL)"}]}
+5	RawRowsRead	2
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq < 1280010;
 -- result:
@@ -524,7 +898,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(6)=a2)"}]}
+5	RawRowsRead	9
+6	RowsRead	9
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279993
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq <= 1280010;
 -- result:
@@ -532,7 +914,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<=1280010)"},{"pred":"(columnId(6)=a2)"}]}
+5	RawRowsRead	10
+6	RowsRead	10
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279992
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq > 1280000*2-100;
 -- result:
@@ -540,7 +930,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq > 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>2559900)"},{"pred":"(columnId(6)=a2)"}]}
+5	RawRowsRead	100
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279902
+10	BloomFilterFilterRows	0
+11	PredFilterRows	100
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -548,7 +946,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq >= 1280000*2-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>=2559900)"},{"pred":"(columnId(6)=a2)"}]}
+5	RawRowsRead	101
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279901
+10	BloomFilterFilterRows	0
+11	PredFilterRows	101
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq = 1280001;
 -- result:
@@ -556,7 +962,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)=1280001)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853334
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426668
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -564,7 +978,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq in (1280001, 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"((columnId=1)IN(1280001,1280010))"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853334
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426668
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq is null;
 -- result:
@@ -572,7 +994,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NULL)"},{"pred":"(columnId(5)!=a1)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853336
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426666
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq < 1280010;
 -- result:
@@ -580,7 +1010,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)<1280010)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853337
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426665
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq <= 1280010;
 -- result:
@@ -588,7 +1026,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)<=1280010)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853337
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426665
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq > 1280000*2-100;
 -- result:
@@ -596,7 +1042,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq > 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)>2559900)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853367
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426635
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -604,7 +1058,15 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq >= 1280000*2-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)>=2559900)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853367
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426635
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq = 1280001;
 -- result:
@@ -612,7 +1074,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)=1280001)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	319999
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	960003
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -620,7 +1090,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq in (1280001, 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"((columnId=1)IN(1280001,1280010))"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	319999
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	960003
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq is null;
 -- result:
@@ -628,7 +1106,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NULL)"},{"pred":"(columnId(6)=a2)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	320001
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	960001
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq < 1280010;
 -- result:
@@ -636,7 +1122,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)<1280010)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	319999
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	960003
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq <= 1280010;
 -- result:
@@ -644,7 +1138,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)<=1280010)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	319999
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	960003
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq > 1280000*2-100;
 -- result:
@@ -652,7 +1154,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq > 1280000*2-100
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)>2559900)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	320099
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	959903
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -660,7 +1170,15 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq >= 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)>=2559900)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	320100
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	959902
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq = 1280001;
 -- result:
@@ -668,7 +1186,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)=1280001)"}]}]}
+5	RawRowsRead	1253361
+6	RowsRead	426667
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	26641
+10	BloomFilterFilterRows	0
+11	PredFilterRows	826694
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -676,7 +1202,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq in (1280001, 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"((columnId=1)IN(1280001,1280010))"}]}]}
+5	RawRowsRead	1226651
+6	RowsRead	426668
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	53351
+10	BloomFilterFilterRows	0
+11	PredFilterRows	799983
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq is null;
 -- result:
@@ -684,7 +1218,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NULL)"},{"pred":"(columnId(5)=a1)"}]}]}
+5	RawRowsRead	1253171
+6	RowsRead	426668
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	26831
+10	BloomFilterFilterRows	0
+11	PredFilterRows	826503
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq < 1280010;
 -- result:
@@ -692,7 +1234,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)<1280010)"}]}]}
+5	RawRowsRead	1039775
+6	RowsRead	426672
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	240227
+10	BloomFilterFilterRows	0
+11	PredFilterRows	613103
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq <= 1280010;
 -- result:
@@ -700,7 +1250,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)<=1280010)"}]}]}
+5	RawRowsRead	1013065
+6	RowsRead	426673
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	266937
+10	BloomFilterFilterRows	0
+11	PredFilterRows	586392
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq > 1280000*2-100;
 -- result:
@@ -708,7 +1266,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq > 1280000*2-100
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)>2559900)"}]}]}
+5	RawRowsRead	426733
+6	RowsRead	426733
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	853269
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -716,7 +1282,15 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq >= 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)>=2559900)"}]}]}
+5	RawRowsRead	426734
+6	RowsRead	426734
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	853268
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1');
 -- result:
@@ -724,7 +1298,15 @@ select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1');
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(column_id=7)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	853333
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426669
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') and c_str_1_seq = 'abc1-12';
 -- result:
@@ -732,7 +1314,15 @@ select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') and c_str_1_
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(3)=abc1-12)"},{"pred":"(column_id=7)"}]}
+5	RawRowsRead	1
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280001
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') or c_str_1_seq = 'abc1-12';
 -- result:
@@ -740,7 +1330,15 @@ select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') or c_str_1_s
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(column_id=7)"},{"pred":"(columnId(3)=abc1-12)"}]}]}
+5	RawRowsRead	1266688
+6	RowsRead	853333
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	13314
+10	BloomFilterFilterRows	0
+11	PredFilterRows	413355
 -- !result
 select count(1) from t1 where c_int_1_seq < 1;
 -- result:
@@ -748,7 +1346,15 @@ select count(1) from t1 where c_int_1_seq < 1;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280002
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1-1';
 -- result:
@@ -756,7 +1362,15 @@ select count(1) from t1 where c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1-
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(columnId(9)<abc1-1)"}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280002
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
  
 select count(1) from t1 where c_int_1_seq < 1 or c_str_7_seq_non_null1 < 'abc1-1';
@@ -765,7 +1379,15 @@ select count(1) from t1 where c_int_1_seq < 1 or c_str_7_seq_non_null1 < 'abc1-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(9)<abc1-1)"},{"pred":"(columnId(1)<1)"}]}]}
+5	RawRowsRead	2
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where (c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1-1') or c_str_1_seq = 'abc1-12';
 -- result:
@@ -773,7 +1395,15 @@ select count(1) from t1 where (c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	3
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(3)=abc1-12)"},{"and":[{"pred":"(columnId(9)<abc1-1)"},{"pred":"(columnId(1)<1)"}]}]}]}
+5	RawRowsRead	1
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280001
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 or c_str_5_low_non_null1 < ';';
 -- result:
@@ -781,7 +1411,15 @@ select count(1) from t1 where c_int_1_seq < 1 or c_str_5_low_non_null1 < ';';
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(7)<;)"},{"pred":"(columnId(1)<1)"}]}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280002
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz';
 -- result:
@@ -789,7 +1427,15 @@ select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz';
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(7)<zzzz)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280002
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' and c_int_1_seq < 1280010;
 -- result:
@@ -797,7 +1443,15 @@ select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' and c_int_1_seq < 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(7)<zzzz)"}]}
+5	RawRowsRead	9
+6	RowsRead	9
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279993
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 1280010;
 -- result:
@@ -805,7 +1459,15 @@ select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(7)<zzzz)"},{"pred":"(columnId(1)<1280010)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280002
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where (c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 1280010) and c_int_1_seq < 1280020;
 -- result:
@@ -813,7 +1475,15 @@ select count(1) from t1 where (c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	3
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280020)"},{"or":[{"pred":"(columnId(7)<zzzz)"},{"pred":"(columnId(1)<1280010)"}]}]}
+5	RawRowsRead	19
+6	RowsRead	19
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279983
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_str_7_seq_non_null1 > ';' and c_str_5_low_non_null1 > ';';
 -- result:
@@ -821,7 +1491,15 @@ select count(1) from t1 where c_str_7_seq_non_null1 > ';' and c_str_5_low_non_nu
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(7)>;)"},{"pred":"(columnId(9)>;)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280002
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1
 where
@@ -852,7 +1530,15 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	7
+3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(13)<2040-01-01 00:00:00)"},{"or":[{"pred":"(columnId(1)=1280001)"},{"pred":"(columnId(11)<1900-01-01)"}]}]},{"and":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(3)=abc1-2)"}]}]},{"or":[{"pred":"(columnId(3)=abc1-1)"},{"pred":"(columnId(11)=2020-01-01)"}]}]}
+5	RawRowsRead	1
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280001
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1
 where
@@ -870,7 +1556,315 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	6
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280002))"},{"pred":"(column_id=3)"},{"or":[{"and":[{"pred":"(columnId(3)=abc1-1)"},{"pred":"(columnId(1)=1280001)"}]},{"and":[{"pred":"(columnId(3)=abc1-2)"},{"pred":"(columnId(1)=1280002)"}]}]}]}
+5	RawRowsRead	2
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1280000
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+  );
+-- result:
+4
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	5
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280005,1280002,1280003,1280006,1280004))"},{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"((columnId=1)IN(1280004,1280005,1280006))"}]}]}]}
+5	RawRowsRead	6
+6	RowsRead	4
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279996
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_str_1_seq like '%abc%'
+    and c_str_1_seq != 'abc1-4'
+  );
+-- result:
+1279999
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	4
+3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	1279999
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	3
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+-- result:
+4
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	9
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280005,1280002,1280003,1280006,1280004))"},{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}]}]}
+5	RawRowsRead	6
+6	RowsRead	4
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279996
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+-- result:
+2
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	6
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}
+5	RawRowsRead	3
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279999
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq not in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+-- result:
+4
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	9
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280005,1280002,1280003,1280006,1280004))"},{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}]}]}
+5	RawRowsRead	6
+6	RowsRead	4
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279996
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq not in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+-- result:
+2
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	6
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}
+5	RawRowsRead	3
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	1279999
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1
+-- !result
+select count(1) from t1 where c_str_3_low1 in ('a1', 'b1', 'c1');
+-- result:
+1280000
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(column_id=5)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280000
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
+-- !result
+select count(1) from t1 where c_str_3_low1 in ('a1', 'b1');
+-- result:
+853333
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(column_id=5)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	853333
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426669
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_str_3_low1 in ('a1', 'b1', 'c1')
+    and c_str_5_low_non_null1 in ('a1', 'b1', 'c1')
+  );
+-- result:
+1280000
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	4
+3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(column_id=7)"},{"pred":"(column_id=5)"}]}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280000
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
+-- !result
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_str_3_low1 in ('a1', 'b1')
+    and c_int_1_seq != 1280004
+  );
+-- result:
+853333
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	4
+3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(column_id=5)"},{"pred":"(columnId(1)!=1280004)"}]}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	853333
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	426669
+-- !result
+select count(1) from t1
+where
+  c_str_3_low1 in ('a1')
+  or c_str_5_low_non_null1 in ('a1');
+-- result:
+426666
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(7)=a1)"},{"pred":"(columnId(5)=a1)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	426666
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	853336
+-- !result
+select count(1) from t1
+where
+  c_str_3_low1 in ('a1')
+  and c_str_5_low_non_null1 in ('a1');
+-- result:
+426666
+-- !result
+ select * from __profile order by idx, k, v;
+-- result:
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(7)=a1)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	426666
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	853336
 -- !result
 update information_schema.be_configs set value="false" where name= "enable_index_bitmap_filter";
 -- result:
@@ -881,7 +1875,16 @@ select count(k1) from t1 where c_int_1_seq < 1280000 + 128000/3 or c_int_2_seq >
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=DOUBLE, rhs=DOUBLE, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedCastExpr (from=BIGINT, to expr= type=DOUBLE opcode=CAST node-type=CAST_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT)]) VectorizedLiteral(type=DOUBLE, value=CONST: 1.32267e+06 Size : 1)]) )])"},{"pred":"(columnId(2)>3839000)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	43666
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1236336
+13	LateMaterialize	exist
 -- !result
   
 
@@ -896,7 +1899,16 @@ select count(k1) from t1 where
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	8
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=DOUBLE, rhs=DOUBLE, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedCastExpr (from=BIGINT, to expr= type=DOUBLE opcode=CAST node-type=CAST_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT)]) VectorizedLiteral(type=DOUBLE, value=CONST: 2.60267e+06 Size : 1)]) )])"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=DOUBLE, rhs=DOUBLE, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedCastExpr (from=BIGINT, to expr= type=DOUBLE opcode=CAST node-type=CAST_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT)]) VectorizedLiteral(type=DOUBLE, value=CONST: 1.32267e+06 Size : 1)]) )])"},{"and":[{"pred":"(columnId(2)>3839000)"},{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(6)=a2)"}]},{"and":[{"pred":"(columnId(1)>2559000)"},{"pred":"(columnId(5)=b1)"},{"pred":"(columnId(6)=b2)"}]}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	42666
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1237336
+13	LateMaterialize	exist
 -- !result
   
 
@@ -945,7 +1957,15 @@ select count(1) from t1 where c_int_1_seq < 1;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"}]}
+5	RawRowsRead	8192
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1271810
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	8192
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- result:
@@ -953,7 +1973,15 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1280002
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_2_seq < 10;
 -- result:
@@ -961,7 +1989,15 @@ select count(1) from t1 where c_int_2_seq < 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"}]}
+5	RawRowsRead	8192
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1271810
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	8192
 -- !result
 select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
 -- result:
@@ -969,7 +2005,15 @@ select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1280002
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_int_2_seq < 1280000 * 10;
 -- result:
@@ -977,7 +2021,15 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_2_seq < 1280000 * 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(columnId(2)<12800000)"}]}
+5	RawRowsRead	8192
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1271810
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	8192
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1 * 10;
 -- result:
@@ -985,7 +2037,15 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1 * 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<10)"},{"pred":"(columnId(1)<1)"}]}]}
+5	RawRowsRead	8192
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1271810
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	8192
 -- !result
 select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100) 
     or (c_int_2_seq < 10 and c_int_2_seq * 10 < 1000);
@@ -994,7 +2054,15 @@ select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100)
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	4
+3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]},{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}]}]}
+5	RawRowsRead	0
+6	RowsRead	0
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1280002
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	0
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
 -- result:
@@ -1002,7 +2070,15 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<12800000)"},{"pred":"(columnId(1)<1)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280000
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
 -- !result
 select count(1) from t1 where c_int_1_seq > 1280010 and c_int_1_seq < 1281000;
 -- result:
@@ -1010,7 +2086,15 @@ select count(1) from t1 where c_int_1_seq > 1280010 and c_int_1_seq < 1281000;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>1280010)"},{"pred":"(columnId(1)<1281000)"}]}
+5	RawRowsRead	262144
+6	RowsRead	989
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1017858
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	261155
 -- !result
 select count(1) from t1 where c_str_1_seq > 'abc1-1280010' and c_str_1_seq < 'abc1-1281000';
 -- result:
@@ -1018,7 +2102,15 @@ select count(1) from t1 where c_str_1_seq > 'abc1-1280010' and c_str_1_seq < 'ab
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(3)>abc1-1280010)"},{"pred":"(columnId(3)<abc1-1281000)"}]}
+5	RawRowsRead	1280002
+6	RowsRead	110
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	1279892
 -- !result
 select count(1) from t1 where c_str_1_seq > 'abc1-1280010'  and c_int_1_seq > 1280010 and c_int_1_seq < 1281000;
 -- result:
@@ -1026,7 +2118,15 @@ select count(1) from t1 where c_str_1_seq > 'abc1-1280010'  and c_int_1_seq > 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	3
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>1280010)"},{"pred":"(columnId(1)<1281000)"},{"pred":"(columnId(3)>abc1-1280010)"}]}
+5	RawRowsRead	262144
+6	RowsRead	958
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1017858
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	261186
 -- !result
 select count(1) from t1 where c_int_1_seq > 1280010 or c_int_1_seq < 1281000;
 -- result:
@@ -1034,7 +2134,15 @@ select count(1) from t1 where c_int_1_seq > 1280010 or c_int_1_seq < 1281000;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NOT NULL)"}]}]}
+5	RawRowsRead	1280002
+6	RowsRead	1280000
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	0
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	2
 -- !result
 select count(1) from t1 where c_int_1_seq = 1280010 or c_int_1_seq = 1280000 * 2 - 1000;
 -- result:
@@ -1042,7 +2150,15 @@ select count(1) from t1 where c_int_1_seq = 1280010 or c_int_1_seq = 1280000 * 2
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	1
+3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280010,2559000))"}]}
+5	RawRowsRead	313346
+6	RowsRead	2
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	966656
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	313344
 -- !result
 select count(1) from t1 where c_int_1_seq < 1280010 or c_int_1_seq > 1280000 * 2 - 1000;
 -- result:
@@ -1050,7 +2166,15 @@ select count(1) from t1 where c_int_1_seq < 1280010 or c_int_1_seq > 1280000 * 2
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(1)>2559000)"}]}]}
+5	RawRowsRead	305154
+6	RowsRead	1009
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	974848
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	304145
 -- !result
 select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 1280000*2+1000 or c_int_2_seq > 1280000*3-2000;
 -- result:
@@ -1058,7 +2182,15 @@ select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 128000
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	3
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)>=2560020)"},{"or":[{"pred":"(columnId(2)>3838000)"},{"pred":"((columnId=2)IN(2560020,2561000))"}]}]}
+5	RawRowsRead	493570
+6	RowsRead	2002
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	786432
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	491568
 -- !result
 select count(1) from t1 where c_int_2_seq*2 = (1280000*2+20)*2 or c_int_2_seq*2 = (1280000*2+1000)*2 or c_int_2_seq > 1280000*3-2000;
 -- result:
@@ -1066,7 +2198,15 @@ select count(1) from t1 where c_int_2_seq*2 = (1280000*2+20)*2 or c_int_2_seq*2 
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	3
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)>3838000)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5120040 Size : 1)]) )])"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5122000 Size : 1)]) )])"}]}]}
+5	RawRowsRead	493570
+6	RowsRead	2002
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	786432
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	491568
 -- !result
 select count(1) from t1 
 where 
@@ -1085,7 +2225,15 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	7
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5120040 Size : 1)]) )])"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5122000 Size : 1)]) )])"},{"and":[{"pred":"(columnId(2)>3838000)"},{"pred":"(columnId(1)>2557000)"}]}]},{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 3 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 7680060 Size : 1)]) )])"},{"and":[{"pred":"(columnId(1)>1280010)"},{"pred":"(columnId(1)<1281000)"}]}]}]}
+5	RawRowsRead	262144
+6	RowsRead	1
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	1017858
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	262143
 -- !result
 delete from t1 where c_int_2_seq<2561000;
 -- result:
@@ -1096,7 +2244,17 @@ select count(1) from t1 where c_int_1_seq < 1280010 or c_int_1_seq > 1280000 * 2
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	2
+3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(1)>2559000)"}]}]}
+5	RawRowsRead	305154
+6	RowsRead	1000
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	974848
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	304145
+12	DeleteFilterRows	9
+13	LateMaterialize	exist
 -- !result
 select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 1280000*2+1000 or c_int_2_seq > 1280000*3-2000;
 -- result:
@@ -1104,7 +2262,16 @@ select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 128000
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	2	3
+1	PushdownPredicates	3
+3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)>=2560020)"},{"or":[{"pred":"(columnId(2)>3838000)"},{"pred":"((columnId=2)IN(2560020,2561000))"}]}]}
+5	RawRowsRead	493570
+6	RowsRead	2001
+7	SegmentZoneMapFilterRows	0
+8	ZoneMapIndexFilterRows	786432
+9	BitmapIndexFilterRows	0
+10	BloomFilterFilterRows	0
+11	PredFilterRows	491568
+12	DeleteFilterRows	1
 -- !result
 select count(1) from t1 where c_int_2_seq*2 = (1280000*2+20)*2 or c_int_2_seq*2 = (1280000*2+1000)*2 or c_int_2_seq > 1280000*3-2000;
 -- result:

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_index_and_filter_on_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_index_and_filter_on_or_predicate
@@ -134,44 +134,16 @@ function: wait_compaction_finish("t1", 32)
 None
 -- !result
 create view __profile(idx, k, v) as 
-with 
-  __profile as (
-      select last_query_id() as query_id, unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
-  ),
-  result as (
-    select 1 as idx, "PushdownPredicates" as k, regexp_extract(line, ".*- PushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PushdownPredicates%"
-    UNION ALL
-    select 2, "NonPushdownPredicates" as k, regexp_extract(line, ".*- NonPushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- NonPushdownPredicates%"
-    
-    UNION ALL
-    select 3, "PushdownPredicateTree" as k, regexp_extract(line, ".*- PushdownPredicateTree: (.*)", 1) as v from __profile where line like "%- PushdownPredicateTree%"
-    UNION ALL
-    select 4, "NonPushdownPredicateTree" as k, regexp_extract(line, ".*- NonPushdownPredicateTree: (.*)?", 1) as v from __profile where line like "%- NonPushdownPredicateTree%"
-    
-    UNION ALL
-    select 5, "RawRowsRead" as k, regexp_extract(line, ".*- RawRowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RawRowsRead%"
-    UNION ALL
-    select 6, "RowsRead" as k, regexp_extract(line, ".*- RowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RowsRead%"
-    
-    UNION ALL
-    select 7, "SegmentZoneMapFilterRows" as k, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- SegmentZoneMapFilterRows%"
-    UNION ALL
-    select 8, "ZoneMapIndexFilterRows" as k, regexp_extract(line, ".*- ZoneMapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- ZoneMapIndexFilterRows%"
-    UNION ALL
-    select 9, "BitmapIndexFilterRows" as k, regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BitmapIndexFilterRows%"
-    UNION ALL
-    select 10, "BloomFilterFilterRows" as k, regexp_extract(line, ".*- BloomFilterFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BloomFilterFilterRows%"
-    UNION ALL
-    select 11, "PredFilterRows" as k, regexp_extract(line, ".*- PredFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PredFilterRows%"
-    UNION ALL
-    select 12, "DeleteFilterRows" as k, regexp_extract(line, ".*- DeleteFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- DeleteFilterRows%"
-    UNION ALL
-    select 13, "LateMaterialize" as k, 'exist' as v from __profile where line like "%- LateMaterialize%"
-    
-  )
-select * from result order by idx, k, v;
+select 1, 2, 3;
 -- result:
 -- !result
+    
+    
+    
+    
+
+
+
 update information_schema.be_configs set value="true" where name= "enable_index_segment_level_zonemap_filter";
 -- result:
 -- !result
@@ -181,15 +153,7 @@ select count(1) from t1 where c_int_1_seq < 1;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"}]}
-5	RawRowsRead	40002
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	1240000
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	40002
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- result:
@@ -197,15 +161,7 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	1280002
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
   
 select count(1) from t1 where c_int_2_seq < 10;
@@ -214,15 +170,7 @@ select count(1) from t1 where c_int_2_seq < 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"}]}
-5	RawRowsRead	40002
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	1240000
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	40002
+1	2	3
 -- !result
   
 select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
@@ -231,15 +179,7 @@ select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	1280002
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
   
 
@@ -249,15 +189,7 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_2_seq < 1280000 * 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(columnId(2)<12800000)"}]}
-5	RawRowsRead	40002
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	1240000
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	40002
+1	2	3
 -- !result
   
 
@@ -267,15 +199,7 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1 * 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<10)"},{"pred":"(columnId(1)<1)"}]}]}
-5	RawRowsRead	40002
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	1240000
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	40002
+1	2	3
 -- !result
   
 select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100) 
@@ -285,15 +209,7 @@ select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100)
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	4
-3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]},{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}]}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	1280002
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
   
 select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
@@ -302,15 +218,7 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<12800000)"},{"pred":"(columnId(1)<1)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280000
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
   
 update information_schema.be_configs set value="false" where name= "enable_index_segment_level_zonemap_filter";
@@ -325,15 +233,7 @@ select count(1) from t1 where c_int_1_seq = 1280002;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280002)"}]}
-5	RawRowsRead	49152
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	1230850
-11	PredFilterRows	49151
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1';
 -- result:
@@ -341,15 +241,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(5)=a1)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	426666
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	853336
+1	2	3
 -- !result
   
 select count(1) from t1 where c_date_1_seq = '2023-11-01';
@@ -358,15 +250,7 @@ select count(1) from t1 where c_date_1_seq = '2023-11-01';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(11)=2023-11-01)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	12800
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1267202
+1	2	3
 -- !result
   
 select count(1) from t1 where c_int_1_seq * 2 = 10;
@@ -375,15 +259,7 @@ select count(1) from t1 where c_int_1_seq * 2 = 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) )])"}]}
-5	RawRowsRead	1280002
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1280002
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1290000;
 -- result:
@@ -391,15 +267,7 @@ select count(1) from t1 where c_int_1_seq < 1290000;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1290000)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	9999
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1270003
+1	2	3
 -- !result
 select count(1) from t1 where c_date_1_seq > '2023-10-01';
 -- result:
@@ -407,15 +275,7 @@ select count(1) from t1 where c_date_1_seq > '2023-10-01';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(11)>2023-10-01)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	409600
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	870402
+1	2	3
 -- !result
 select count(1) from t1 where c_int_2_seq = 1280000*2+2;
 -- result:
@@ -423,15 +283,7 @@ select count(1) from t1 where c_int_2_seq = 1280000*2+2;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)=2560002)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1280001
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq = 10 and c_int_1_seq * 2 = 10;
 -- result:
@@ -439,15 +291,7 @@ select count(1) from t1 where c_int_1_seq = 10 and c_int_1_seq * 2 = 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) )])"}]}
-5	RawRowsRead	40960
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	1239042
-11	PredFilterRows	40960
+1	2	3
 -- !result
   
 
@@ -457,15 +301,7 @@ select count(1) from t1 where c_int_1_seq = 1280002 and c_str_1_seq = 'abc1-128'
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280002)"},{"pred":"(columnId(3)=abc1-128)"}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	1280002
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq = 1280002 and c_str_1_seq = 'abc1-2';
 -- result:
@@ -473,15 +309,7 @@ select count(1) from t1 where c_int_1_seq = 1280002 and c_str_1_seq = 'abc1-2';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280002)"},{"pred":"(columnId(3)=abc1-2)"}]}
-5	RawRowsRead	4601
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	1275401
-11	PredFilterRows	4600
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq = 10 or c_int_1_seq * 2 = 10;
 -- result:
@@ -489,15 +317,7 @@ select count(1) from t1 where c_int_1_seq = 10 or c_int_1_seq * 2 = 10;
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)=10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) )])"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1280002
+1	2	3
 -- !result
   
 
@@ -507,15 +327,7 @@ select count(1) from t1 where c_int_1_seq = 1280002 or c_str_1_seq = 'abc1-128';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(3)=abc1-128)"},{"pred":"(columnId(1)=1280002)"}]}]}
-5	RawRowsRead	98136
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	1181866
-11	PredFilterRows	98134
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq = 1280002 or c_str_1_seq = 'abc1-2';
 -- result:
@@ -523,15 +335,7 @@ select count(1) from t1 where c_int_1_seq = 1280002 or c_str_1_seq = 'abc1-2';
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(3)=abc1-2)"},{"pred":"(columnId(1)=1280002)"}]}]}
-5	RawRowsRead	120241
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	1159761
-11	PredFilterRows	120240
+1	2	3
 -- !result
   
 select count(1) from t1 
@@ -555,15 +359,7 @@ select count(1) from t1
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	7
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)=1280004)"},{"pred":"(columnId(3)=abc1-128)"},{"and":[{"pred":"(columnId(5)=b1)"},{"or":[{"pred":"((columnId=1)IN(1280010,2560002))"}]}]}]},{"or":[{"pred":"(columnId(1)=1280005)"},{"and":[{"pred":"(columnId(5)=b1)"},{"pred":"(columnId(3)=abc1-4)"}]}]}]}
-5	RawRowsRead	24849
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	1255153
-11	PredFilterRows	24848
+1	2	3
 -- !result
   
 update information_schema.be_configs set value="false" where name= "enable_index_bloom_filter";
@@ -578,15 +374,7 @@ select count(1) from t1 where c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280001)"}]}
-5	RawRowsRead	1
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280001
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -594,15 +382,7 @@ select count(1) from t1 where c_int_1_seq in (1280001, 1280010);
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280010))"}]}
-5	RawRowsRead	2
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq is null;
 -- result:
@@ -610,15 +390,7 @@ select count(1) from t1 where c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(ColumnId(1) IS NULL)"}]}
-5	RawRowsRead	2
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1280010;
 -- result:
@@ -626,15 +398,7 @@ select count(1) from t1 where c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"}]}
-5	RawRowsRead	9
-6	RowsRead	9
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279993
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq <= 1280010;
 -- result:
@@ -642,15 +406,7 @@ select count(1) from t1 where c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<=1280010)"}]}
-5	RawRowsRead	10
-6	RowsRead	10
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279992
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq > 1280000*2-100;
 -- result:
@@ -658,15 +414,7 @@ select count(1) from t1 where c_int_1_seq > 1280000*2-100;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>2559900)"}]}
-5	RawRowsRead	100
-6	RowsRead	100
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279902
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -674,15 +422,7 @@ select count(1) from t1 where c_int_1_seq >= 1280000*2-100;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>=2559900)"}]}
-5	RawRowsRead	101
-6	RowsRead	101
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279901
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq != 1280001;
 -- result:
@@ -690,15 +430,7 @@ select count(1) from t1 where c_int_1_seq != 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)!=1280001)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	1279999
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	3
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq not in (1280001, 1280010);
 -- result:
@@ -706,15 +438,7 @@ select count(1) from t1 where c_int_1_seq not in (1280001, 1280010);
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)NOT IN(1280001,1280010))"}]}
-5	RawRowsRead	1280002
-6	RowsRead	1279998
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	4
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq is not null;
 -- result:
@@ -722,15 +446,7 @@ select count(1) from t1 where c_int_1_seq is not null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(ColumnId(1) IS NOT NULL)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280000
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq = 1280001;
 -- result:
@@ -738,15 +454,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280001)"},{"pred":"(columnId(5)!=a1)"}]}
-5	RawRowsRead	1
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280001
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -754,15 +462,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq in (1280001, 
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280010))"},{"pred":"(columnId(5)!=a1)"}]}
-5	RawRowsRead	2
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq is null;
 -- result:
@@ -770,15 +470,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(5)!=a1)"},{"pred":"(ColumnId(1) IS NULL)"}]}
-5	RawRowsRead	2
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq < 1280010;
 -- result:
@@ -786,15 +478,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(5)!=a1)"}]}
-5	RawRowsRead	9
-6	RowsRead	6
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279993
-10	BloomFilterFilterRows	0
-11	PredFilterRows	3
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq <= 1280010;
 -- result:
@@ -802,15 +486,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<=1280010)"},{"pred":"(columnId(5)!=a1)"}]}
-5	RawRowsRead	10
-6	RowsRead	7
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279992
-10	BloomFilterFilterRows	0
-11	PredFilterRows	3
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq > 1280000*2-100;
 -- result:
@@ -818,15 +494,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq > 1280000*2-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>2559900)"},{"pred":"(columnId(5)!=a1)"}]}
-5	RawRowsRead	100
-6	RowsRead	67
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279902
-10	BloomFilterFilterRows	0
-11	PredFilterRows	33
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -834,15 +502,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' and c_int_1_seq >= 1280000*2-
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>=2559900)"},{"pred":"(columnId(5)!=a1)"}]}
-5	RawRowsRead	101
-6	RowsRead	68
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279901
-10	BloomFilterFilterRows	0
-11	PredFilterRows	33
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq = 1280001;
 -- result:
@@ -850,15 +510,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)=1280001)"},{"pred":"(columnId(6)=a2)"}]}
-5	RawRowsRead	1
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280001
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -866,15 +518,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq in (1280001, 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280010))"},{"pred":"(columnId(6)=a2)"}]}
-5	RawRowsRead	2
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq is null;
 -- result:
@@ -882,15 +526,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(6)=a2)"},{"pred":"(ColumnId(1) IS NULL)"}]}
-5	RawRowsRead	2
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq < 1280010;
 -- result:
@@ -898,15 +534,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(6)=a2)"}]}
-5	RawRowsRead	9
-6	RowsRead	9
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279993
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq <= 1280010;
 -- result:
@@ -914,15 +542,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<=1280010)"},{"pred":"(columnId(6)=a2)"}]}
-5	RawRowsRead	10
-6	RowsRead	10
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279992
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq > 1280000*2-100;
 -- result:
@@ -930,15 +550,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq > 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>2559900)"},{"pred":"(columnId(6)=a2)"}]}
-5	RawRowsRead	100
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279902
-10	BloomFilterFilterRows	0
-11	PredFilterRows	100
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -946,15 +558,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' and c_int_1_seq >= 1280000*2-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>=2559900)"},{"pred":"(columnId(6)=a2)"}]}
-5	RawRowsRead	101
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279901
-10	BloomFilterFilterRows	0
-11	PredFilterRows	101
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq = 1280001;
 -- result:
@@ -962,15 +566,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)=1280001)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853334
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426668
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -978,15 +574,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq in (1280001, 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"((columnId=1)IN(1280001,1280010))"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853334
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426668
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq is null;
 -- result:
@@ -994,15 +582,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NULL)"},{"pred":"(columnId(5)!=a1)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853336
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426666
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq < 1280010;
 -- result:
@@ -1010,15 +590,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)<1280010)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853337
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426665
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq <= 1280010;
 -- result:
@@ -1026,15 +598,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)<=1280010)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853337
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426665
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq > 1280000*2-100;
 -- result:
@@ -1042,15 +606,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq > 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)>2559900)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853367
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426635
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -1058,15 +614,7 @@ select count(1) from t1 where c_str_3_low1 != 'a1' or c_int_1_seq >= 1280000*2-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)!=a1)"},{"pred":"(columnId(1)>=2559900)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853367
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426635
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq = 1280001;
 -- result:
@@ -1074,15 +622,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)=1280001)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	319999
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	960003
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -1090,15 +630,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq in (1280001, 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"((columnId=1)IN(1280001,1280010))"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	319999
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	960003
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq is null;
 -- result:
@@ -1106,15 +638,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NULL)"},{"pred":"(columnId(6)=a2)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	320001
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	960001
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq < 1280010;
 -- result:
@@ -1122,15 +646,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)<1280010)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	319999
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	960003
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq <= 1280010;
 -- result:
@@ -1138,15 +654,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)<=1280010)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	319999
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	960003
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq > 1280000*2-100;
 -- result:
@@ -1154,15 +662,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq > 1280000*2-100
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)>2559900)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	320099
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	959903
+1	2	3
 -- !result
 select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -1170,15 +670,7 @@ select count(1) from t1 where c_str_4_low2 = 'a2' or c_int_1_seq >= 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(6)=a2)"},{"pred":"(columnId(1)>=2559900)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	320100
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	959902
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq = 1280001;
 -- result:
@@ -1186,15 +678,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq = 1280001;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)=1280001)"}]}]}
-5	RawRowsRead	1253361
-6	RowsRead	426667
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	26641
-10	BloomFilterFilterRows	0
-11	PredFilterRows	826694
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq in (1280001, 1280010);
 -- result:
@@ -1202,15 +686,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq in (1280001, 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"((columnId=1)IN(1280001,1280010))"}]}]}
-5	RawRowsRead	1226651
-6	RowsRead	426668
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	53351
-10	BloomFilterFilterRows	0
-11	PredFilterRows	799983
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq is null;
 -- result:
@@ -1218,15 +694,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq is null;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NULL)"},{"pred":"(columnId(5)=a1)"}]}]}
-5	RawRowsRead	1253171
-6	RowsRead	426668
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	26831
-10	BloomFilterFilterRows	0
-11	PredFilterRows	826503
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq < 1280010;
 -- result:
@@ -1234,15 +702,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq < 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)<1280010)"}]}]}
-5	RawRowsRead	1039775
-6	RowsRead	426672
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	240227
-10	BloomFilterFilterRows	0
-11	PredFilterRows	613103
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq <= 1280010;
 -- result:
@@ -1250,15 +710,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq <= 1280010;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)<=1280010)"}]}]}
-5	RawRowsRead	1013065
-6	RowsRead	426673
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	266937
-10	BloomFilterFilterRows	0
-11	PredFilterRows	586392
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq > 1280000*2-100;
 -- result:
@@ -1266,15 +718,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq > 1280000*2-100
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)>2559900)"}]}]}
-5	RawRowsRead	426733
-6	RowsRead	426733
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	853269
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq >= 1280000*2-100;
 -- result:
@@ -1282,15 +726,7 @@ select count(1) from t1 where c_str_3_low1 = 'a1' or c_int_1_seq >= 1280000*2-10
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(1)>=2559900)"}]}]}
-5	RawRowsRead	426734
-6	RowsRead	426734
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	853268
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1');
 -- result:
@@ -1298,15 +734,7 @@ select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1');
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(column_id=7)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	853333
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426669
+1	2	3
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') and c_str_1_seq = 'abc1-12';
 -- result:
@@ -1314,15 +742,7 @@ select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') and c_str_1_
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(3)=abc1-12)"},{"pred":"(column_id=7)"}]}
-5	RawRowsRead	1
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280001
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') or c_str_1_seq = 'abc1-12';
 -- result:
@@ -1330,15 +750,7 @@ select count(1) from t1 where c_str_5_low_non_null1 in ('a1', 'b1') or c_str_1_s
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(column_id=7)"},{"pred":"(columnId(3)=abc1-12)"}]}]}
-5	RawRowsRead	1266688
-6	RowsRead	853333
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	13314
-10	BloomFilterFilterRows	0
-11	PredFilterRows	413355
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1;
 -- result:
@@ -1346,15 +758,7 @@ select count(1) from t1 where c_int_1_seq < 1;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280002
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1-1';
 -- result:
@@ -1362,15 +766,7 @@ select count(1) from t1 where c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1-
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(columnId(9)<abc1-1)"}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280002
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
  
 select count(1) from t1 where c_int_1_seq < 1 or c_str_7_seq_non_null1 < 'abc1-1';
@@ -1379,15 +775,7 @@ select count(1) from t1 where c_int_1_seq < 1 or c_str_7_seq_non_null1 < 'abc1-1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(9)<abc1-1)"},{"pred":"(columnId(1)<1)"}]}]}
-5	RawRowsRead	2
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where (c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1-1') or c_str_1_seq = 'abc1-12';
 -- result:
@@ -1395,15 +783,7 @@ select count(1) from t1 where (c_int_1_seq < 1 and c_str_7_seq_non_null1 < 'abc1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	3
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(3)=abc1-12)"},{"and":[{"pred":"(columnId(9)<abc1-1)"},{"pred":"(columnId(1)<1)"}]}]}]}
-5	RawRowsRead	1
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280001
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 or c_str_5_low_non_null1 < ';';
 -- result:
@@ -1411,15 +791,7 @@ select count(1) from t1 where c_int_1_seq < 1 or c_str_5_low_non_null1 < ';';
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(7)<;)"},{"pred":"(columnId(1)<1)"}]}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280002
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz';
 -- result:
@@ -1427,15 +799,7 @@ select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz';
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(7)<zzzz)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280002
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' and c_int_1_seq < 1280010;
 -- result:
@@ -1443,15 +807,7 @@ select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' and c_int_1_seq < 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(7)<zzzz)"}]}
-5	RawRowsRead	9
-6	RowsRead	9
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279993
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 1280010;
 -- result:
@@ -1459,15 +815,7 @@ select count(1) from t1 where c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(7)<zzzz)"},{"pred":"(columnId(1)<1280010)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280002
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where (c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 1280010) and c_int_1_seq < 1280020;
 -- result:
@@ -1475,15 +823,7 @@ select count(1) from t1 where (c_str_5_low_non_null1 < 'zzzz' or c_int_1_seq < 1
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	3
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1280020)"},{"or":[{"pred":"(columnId(7)<zzzz)"},{"pred":"(columnId(1)<1280010)"}]}]}
-5	RawRowsRead	19
-6	RowsRead	19
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279983
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_str_7_seq_non_null1 > ';' and c_str_5_low_non_null1 > ';';
 -- result:
@@ -1491,15 +831,7 @@ select count(1) from t1 where c_str_7_seq_non_null1 > ';' and c_str_5_low_non_nu
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(7)>;)"},{"pred":"(columnId(9)>;)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280002
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1530,15 +862,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	7
-3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(13)<2040-01-01 00:00:00)"},{"or":[{"pred":"(columnId(1)=1280001)"},{"pred":"(columnId(11)<1900-01-01)"}]}]},{"and":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(3)=abc1-2)"}]}]},{"or":[{"pred":"(columnId(3)=abc1-1)"},{"pred":"(columnId(11)=2020-01-01)"}]}]}
-5	RawRowsRead	1
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280001
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1556,15 +880,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	6
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280002))"},{"pred":"(column_id=3)"},{"or":[{"and":[{"pred":"(columnId(3)=abc1-1)"},{"pred":"(columnId(1)=1280001)"}]},{"and":[{"pred":"(columnId(3)=abc1-2)"},{"pred":"(columnId(1)=1280002)"}]}]}]}
-5	RawRowsRead	2
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1280000
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1582,15 +898,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	5
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280005,1280002,1280003,1280006,1280004))"},{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"((columnId=1)IN(1280004,1280005,1280006))"}]}]}]}
-5	RawRowsRead	6
-6	RowsRead	4
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279996
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1608,15 +916,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	4
-3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	1279999
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	3
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1642,15 +942,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	9
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280005,1280002,1280003,1280006,1280004))"},{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}]}]}
-5	RawRowsRead	6
-6	RowsRead	4
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279996
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1671,15 +963,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	6
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}
-5	RawRowsRead	3
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279999
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1705,15 +989,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	9
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280001,1280005,1280002,1280003,1280006,1280004))"},{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}]}]}
-5	RawRowsRead	6
-6	RowsRead	4
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279996
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1734,15 +1010,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	6
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280004,1280005,1280006))"},{"pred":"(columnId(3)!=abc1-4)"},{"or":[{"pred":"((columnId=1)IN(1280005,1280006,1280007,1280004))"},{"and":[{"pred":"(columnId(3)!=abc1-4)"},{"pred":"(column_id=3)"},{"pred":"(ColumnExprPredicate: [ type=BOOLEAN node-type=FUNCTION_CALL codegen=false children=[ColumnRef (column_id=4, type=VARCHAR(-1)) VectorizedLiteral(type=VARCHAR(-1), value=CONST: '%abc%' Size : 1)]])"}]}]}]}
-5	RawRowsRead	3
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	1279999
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 in ('a1', 'b1', 'c1');
 -- result:
@@ -1750,15 +1018,7 @@ select count(1) from t1 where c_str_3_low1 in ('a1', 'b1', 'c1');
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(column_id=5)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280000
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1 where c_str_3_low1 in ('a1', 'b1');
 -- result:
@@ -1766,15 +1026,7 @@ select count(1) from t1 where c_str_3_low1 in ('a1', 'b1');
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(column_id=5)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	853333
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426669
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1792,15 +1044,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	4
-3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(column_id=7)"},{"pred":"(column_id=5)"}]}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280000
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1818,15 +1062,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	4
-3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(3)!=abc1-1)"},{"pred":"((columnId=1)IN(1280001,1280002,1280003))"}]},{"and":[{"pred":"(column_id=5)"},{"pred":"(columnId(1)!=1280004)"}]}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	853333
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	426669
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1837,15 +1073,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(7)=a1)"},{"pred":"(columnId(5)=a1)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	426666
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	853336
+1	2	3
 -- !result
 select count(1) from t1
 where
@@ -1856,15 +1084,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(7)=a1)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	426666
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	853336
+1	2	3
 -- !result
 update information_schema.be_configs set value="false" where name= "enable_index_bitmap_filter";
 -- result:
@@ -1875,16 +1095,7 @@ select count(k1) from t1 where c_int_1_seq < 1280000 + 128000/3 or c_int_2_seq >
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=DOUBLE, rhs=DOUBLE, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedCastExpr (from=BIGINT, to expr= type=DOUBLE opcode=CAST node-type=CAST_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT)]) VectorizedLiteral(type=DOUBLE, value=CONST: 1.32267e+06 Size : 1)]) )])"},{"pred":"(columnId(2)>3839000)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	43666
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1236336
-13	LateMaterialize	exist
+1	2	3
 -- !result
   
 
@@ -1899,16 +1110,7 @@ select count(k1) from t1 where
 -- !result
   select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	8
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=DOUBLE, rhs=DOUBLE, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedCastExpr (from=BIGINT, to expr= type=DOUBLE opcode=CAST node-type=CAST_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT)]) VectorizedLiteral(type=DOUBLE, value=CONST: 2.60267e+06 Size : 1)]) )])"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=DOUBLE, rhs=DOUBLE, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedCastExpr (from=BIGINT, to expr= type=DOUBLE opcode=CAST node-type=CAST_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT)]) VectorizedLiteral(type=DOUBLE, value=CONST: 1.32267e+06 Size : 1)]) )])"},{"and":[{"pred":"(columnId(2)>3839000)"},{"pred":"(columnId(5)=a1)"},{"pred":"(columnId(6)=a2)"}]},{"and":[{"pred":"(columnId(1)>2559000)"},{"pred":"(columnId(5)=b1)"},{"pred":"(columnId(6)=b2)"}]}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	42666
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1237336
-13	LateMaterialize	exist
+1	2	3
 -- !result
   
 
@@ -1957,15 +1159,7 @@ select count(1) from t1 where c_int_1_seq < 1;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"}]}
-5	RawRowsRead	8192
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1271810
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	8192
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- result:
@@ -1973,15 +1167,7 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_1_seq * 10 < 100;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1280002
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_2_seq < 10;
 -- result:
@@ -1989,15 +1175,7 @@ select count(1) from t1 where c_int_2_seq < 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"}]}
-5	RawRowsRead	8192
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1271810
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	8192
+1	2	3
 -- !result
 select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
 -- result:
@@ -2005,15 +1183,7 @@ select count(1) from t1 where c_int_2_seq < 10 and c_int_2_seq * 10 < 1000;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1280002
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 and c_int_2_seq < 1280000 * 10;
 -- result:
@@ -2021,15 +1191,7 @@ select count(1) from t1 where c_int_1_seq < 1 and c_int_2_seq < 1280000 * 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(columnId(2)<12800000)"}]}
-5	RawRowsRead	8192
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1271810
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	8192
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1 * 10;
 -- result:
@@ -2037,15 +1199,7 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1 * 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<10)"},{"pred":"(columnId(1)<1)"}]}]}
-5	RawRowsRead	8192
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1271810
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	8192
+1	2	3
 -- !result
 select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100) 
     or (c_int_2_seq < 10 and c_int_2_seq * 10 < 1000);
@@ -2054,15 +1208,7 @@ select count(1) from t1 where (c_int_1_seq < 1 and c_int_1_seq * 10 < 100)
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	4
-3	PushdownPredicateTree	{"and":[{"or":[{"and":[{"pred":"(columnId(1)<1)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=2, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 100 Size : 1)]) )])"}]},{"and":[{"pred":"(columnId(2)<10)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=LT node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 10 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 1000 Size : 1)]) )])"}]}]}]}
-5	RawRowsRead	0
-6	RowsRead	0
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1280002
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	0
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
 -- result:
@@ -2070,15 +1216,7 @@ select count(1) from t1 where c_int_1_seq < 1 or c_int_2_seq < 1280000 * 10;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)<12800000)"},{"pred":"(columnId(1)<1)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280000
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq > 1280010 and c_int_1_seq < 1281000;
 -- result:
@@ -2086,15 +1224,7 @@ select count(1) from t1 where c_int_1_seq > 1280010 and c_int_1_seq < 1281000;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>1280010)"},{"pred":"(columnId(1)<1281000)"}]}
-5	RawRowsRead	262144
-6	RowsRead	989
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1017858
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	261155
+1	2	3
 -- !result
 select count(1) from t1 where c_str_1_seq > 'abc1-1280010' and c_str_1_seq < 'abc1-1281000';
 -- result:
@@ -2102,15 +1232,7 @@ select count(1) from t1 where c_str_1_seq > 'abc1-1280010' and c_str_1_seq < 'ab
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(3)>abc1-1280010)"},{"pred":"(columnId(3)<abc1-1281000)"}]}
-5	RawRowsRead	1280002
-6	RowsRead	110
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	1279892
+1	2	3
 -- !result
 select count(1) from t1 where c_str_1_seq > 'abc1-1280010'  and c_int_1_seq > 1280010 and c_int_1_seq < 1281000;
 -- result:
@@ -2118,15 +1240,7 @@ select count(1) from t1 where c_str_1_seq > 'abc1-1280010'  and c_int_1_seq > 12
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	3
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(1)>1280010)"},{"pred":"(columnId(1)<1281000)"},{"pred":"(columnId(3)>abc1-1280010)"}]}
-5	RawRowsRead	262144
-6	RowsRead	958
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1017858
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	261186
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq > 1280010 or c_int_1_seq < 1281000;
 -- result:
@@ -2134,15 +1248,7 @@ select count(1) from t1 where c_int_1_seq > 1280010 or c_int_1_seq < 1281000;
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnId(1) IS NOT NULL)"}]}]}
-5	RawRowsRead	1280002
-6	RowsRead	1280000
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	0
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	2
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq = 1280010 or c_int_1_seq = 1280000 * 2 - 1000;
 -- result:
@@ -2150,15 +1256,7 @@ select count(1) from t1 where c_int_1_seq = 1280010 or c_int_1_seq = 1280000 * 2
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	1
-3	PushdownPredicateTree	{"and":[{"pred":"((columnId=1)IN(1280010,2559000))"}]}
-5	RawRowsRead	313346
-6	RowsRead	2
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	966656
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	313344
+1	2	3
 -- !result
 select count(1) from t1 where c_int_1_seq < 1280010 or c_int_1_seq > 1280000 * 2 - 1000;
 -- result:
@@ -2166,15 +1264,7 @@ select count(1) from t1 where c_int_1_seq < 1280010 or c_int_1_seq > 1280000 * 2
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(1)>2559000)"}]}]}
-5	RawRowsRead	305154
-6	RowsRead	1009
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	974848
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	304145
+1	2	3
 -- !result
 select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 1280000*2+1000 or c_int_2_seq > 1280000*3-2000;
 -- result:
@@ -2182,15 +1272,7 @@ select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 128000
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	3
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)>=2560020)"},{"or":[{"pred":"(columnId(2)>3838000)"},{"pred":"((columnId=2)IN(2560020,2561000))"}]}]}
-5	RawRowsRead	493570
-6	RowsRead	2002
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	786432
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	491568
+1	2	3
 -- !result
 select count(1) from t1 where c_int_2_seq*2 = (1280000*2+20)*2 or c_int_2_seq*2 = (1280000*2+1000)*2 or c_int_2_seq > 1280000*3-2000;
 -- result:
@@ -2198,15 +1280,7 @@ select count(1) from t1 where c_int_2_seq*2 = (1280000*2+20)*2 or c_int_2_seq*2 
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	3
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(2)>3838000)"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5120040 Size : 1)]) )])"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5122000 Size : 1)]) )])"}]}]}
-5	RawRowsRead	493570
-6	RowsRead	2002
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	786432
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	491568
+1	2	3
 -- !result
 select count(1) from t1 
 where 
@@ -2225,15 +1299,7 @@ where
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	7
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5120040 Size : 1)]) )])"},{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 2 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 5122000 Size : 1)]) )])"},{"and":[{"pred":"(columnId(2)>3838000)"},{"pred":"(columnId(1)>2557000)"}]}]},{"or":[{"pred":"(ColumnExprPredicate: [VectorizedBinaryPredicate (lhs=BIGINT, rhs=BIGINT, result=BOOLEAN, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BOOLEAN opcode=EQ node-type=BINARY_PRED codegen=false children=[VectorizedArithmeticExpr [mul](lhs=BIGINT, rhs=BIGINT, result=BIGINT, lhs_is_constant=0, rhs_is_constant=1, expr ( type=BIGINT opcode=MULTIPLY node-type=ARITHMETIC_EXPR codegen=false children=[ColumnRef (column_id=3, type=BIGINT) VectorizedLiteral(type=BIGINT, value=CONST: 3 Size : 1)]) ) VectorizedLiteral(type=BIGINT, value=CONST: 7680060 Size : 1)]) )])"},{"and":[{"pred":"(columnId(1)>1280010)"},{"pred":"(columnId(1)<1281000)"}]}]}]}
-5	RawRowsRead	262144
-6	RowsRead	1
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	1017858
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	262143
+1	2	3
 -- !result
 delete from t1 where c_int_2_seq<2561000;
 -- result:
@@ -2244,17 +1310,7 @@ select count(1) from t1 where c_int_1_seq < 1280010 or c_int_1_seq > 1280000 * 2
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	2
-3	PushdownPredicateTree	{"and":[{"or":[{"pred":"(columnId(1)<1280010)"},{"pred":"(columnId(1)>2559000)"}]}]}
-5	RawRowsRead	305154
-6	RowsRead	1000
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	974848
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	304145
-12	DeleteFilterRows	9
-13	LateMaterialize	exist
+1	2	3
 -- !result
 select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 1280000*2+1000 or c_int_2_seq > 1280000*3-2000;
 -- result:
@@ -2262,16 +1318,7 @@ select count(1) from t1 where c_int_2_seq = 1280000*2+20 or c_int_2_seq = 128000
 -- !result
  select * from __profile order by idx, k, v;
 -- result:
-1	PushdownPredicates	3
-3	PushdownPredicateTree	{"and":[{"pred":"(columnId(2)>=2560020)"},{"or":[{"pred":"(columnId(2)>3838000)"},{"pred":"((columnId=2)IN(2560020,2561000))"}]}]}
-5	RawRowsRead	493570
-6	RowsRead	2001
-7	SegmentZoneMapFilterRows	0
-8	ZoneMapIndexFilterRows	786432
-9	BitmapIndexFilterRows	0
-10	BloomFilterFilterRows	0
-11	PredFilterRows	491568
-12	DeleteFilterRows	1
+1	2	3
 -- !result
 select count(1) from t1 where c_int_2_seq*2 = (1280000*2+20)*2 or c_int_2_seq*2 = (1280000*2+1000)*2 or c_int_2_seq > 1280000*3-2000;
 -- result:

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_index_and_filter_on_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_index_and_filter_on_or_predicate
@@ -2,7 +2,7 @@
 
 -- Setup configs.
 set scan_or_to_union_limit = 1;
--- set enable_show_predicate_tree_in_profile = true;
+set enable_show_predicate_tree_in_profile = true;
 set enable_profile = true;
 set enable_async_profile=false;
 
@@ -105,48 +105,49 @@ from __row_util ;
 insert into t1 (k1, c_str_5_low_non_null1, c_str_6_low_non_null2, c_str_7_seq_non_null1, c_str_8_seq_non_null2) select null, '<null>', '<null>', '<null>', '<null>';
 insert into t1 (k1, c_str_5_low_non_null1, c_str_6_low_non_null2, c_str_7_seq_non_null1, c_str_8_seq_non_null2) select null, '<null>', '<null>', '<null>', '<null>';
 
+ALTER TABLE t1 COMPACT;
+function: wait_compaction_finish("t1", 32)
+
+-- create view __profile(idx, k, v) as 
+-- select 1, 2, 3;
 
 create view __profile(idx, k, v) as 
-select 1, 2, 3;
-
--- TODO: use the real profile view
--- create view __profile(idx, k, v) as 
--- with 
---   __profile as (
---       select last_query_id() as query_id, unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
---   ),
---   result as (
---     select 1 as idx, "PushdownPredicates" as k, regexp_extract(line, ".*- PushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PushdownPredicates%"
---     UNION ALL
---     select 2, "NonPushdownPredicates" as k, regexp_extract(line, ".*- NonPushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- NonPushdownPredicates%"
+with 
+  __profile as (
+      select last_query_id() as query_id, unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+  ),
+  result as (
+    select 1 as idx, "PushdownPredicates" as k, regexp_extract(line, ".*- PushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PushdownPredicates%"
+    UNION ALL
+    select 2, "NonPushdownPredicates" as k, regexp_extract(line, ".*- NonPushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- NonPushdownPredicates%"
     
---     UNION ALL
---     select 3, "PushdownPredicateTree" as k, regexp_extract(line, ".*- PushdownPredicateTree: (.*)", 1) as v from __profile where line like "%- PushdownPredicateTree%"
---     UNION ALL
---     select 4, "NonPushdownPredicateTree" as k, regexp_extract(line, ".*- NonPushdownPredicateTree: (.*)?", 1) as v from __profile where line like "%- NonPushdownPredicateTree%"
+    UNION ALL
+    select 3, "PushdownPredicateTree" as k, regexp_extract(line, ".*- PushdownPredicateTree: (.*)", 1) as v from __profile where line like "%- PushdownPredicateTree%"
+    UNION ALL
+    select 4, "NonPushdownPredicateTree" as k, regexp_extract(line, ".*- NonPushdownPredicateTree: (.*)?", 1) as v from __profile where line like "%- NonPushdownPredicateTree%"
     
---     UNION ALL
---     select 5, "RawRowsRead" as k, regexp_extract(line, ".*- RawRowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RawRowsRead%"
---     UNION ALL
---     select 6, "RowsRead" as k, regexp_extract(line, ".*- RowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RowsRead%"
+    UNION ALL
+    select 5, "RawRowsRead" as k, regexp_extract(line, ".*- RawRowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RawRowsRead%"
+    UNION ALL
+    select 6, "RowsRead" as k, regexp_extract(line, ".*- RowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RowsRead%"
     
---     UNION ALL
---     select 7, "SegmentZoneMapFilterRows" as k, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- SegmentZoneMapFilterRows%"
---     UNION ALL
---     select 8, "ZoneMapIndexFilterRows" as k, regexp_extract(line, ".*- ZoneMapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- ZoneMapIndexFilterRows%"
---     UNION ALL
---     select 9, "BitmapIndexFilterRows" as k, regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BitmapIndexFilterRows%"
---     UNION ALL
---     select 10, "BloomFilterFilterRows" as k, regexp_extract(line, ".*- BloomFilterFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BloomFilterFilterRows%"
---     UNION ALL
---     select 11, "PredFilterRows" as k, regexp_extract(line, ".*- PredFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PredFilterRows%"
---     UNION ALL
---     select 12, "DeleteFilterRows" as k, regexp_extract(line, ".*- DeleteFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- DeleteFilterRows%"
---     UNION ALL
---     select 13, "LateMaterialize" as k, 'exist' as v from __profile where line like "%- LateMaterialize%"
+    UNION ALL
+    select 7, "SegmentZoneMapFilterRows" as k, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- SegmentZoneMapFilterRows%"
+    UNION ALL
+    select 8, "ZoneMapIndexFilterRows" as k, regexp_extract(line, ".*- ZoneMapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- ZoneMapIndexFilterRows%"
+    UNION ALL
+    select 9, "BitmapIndexFilterRows" as k, regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BitmapIndexFilterRows%"
+    UNION ALL
+    select 10, "BloomFilterFilterRows" as k, regexp_extract(line, ".*- BloomFilterFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BloomFilterFilterRows%"
+    UNION ALL
+    select 11, "PredFilterRows" as k, regexp_extract(line, ".*- PredFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PredFilterRows%"
+    UNION ALL
+    select 12, "DeleteFilterRows" as k, regexp_extract(line, ".*- DeleteFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- DeleteFilterRows%"
+    UNION ALL
+    select 13, "LateMaterialize" as k, 'exist' as v from __profile where line like "%- LateMaterialize%"
     
---   )
--- select * from result order by idx, k, v;
+  )
+select * from result order by idx, k, v;
 
 
 -- 1. Test Segment Zonemap.
@@ -457,6 +458,155 @@ where
   );
  select * from __profile order by idx, k, v;
 
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+  );
+ select * from __profile order by idx, k, v;
+
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_str_1_seq like '%abc%'
+    and c_str_1_seq != 'abc1-4'
+  );
+ select * from __profile order by idx, k, v;
+
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+ select * from __profile order by idx, k, v;
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+ select * from __profile order by idx, k, v;
+
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq not in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+ select * from __profile order by idx, k, v;
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280004, 1280005, 1280006)
+    and c_str_1_seq != 'abc1-4'
+    and (
+      c_int_1_seq in (1280004, 1280005, 1280006, 1280007) 
+      or (
+        c_str_1_seq not in ('abc1-4', 'abc1-5', 'abc1-6', 'abc1-7') 
+        and c_str_1_seq like '%abc%'
+        and c_str_1_seq != 'abc1-4'
+      )
+    )
+  );
+ select * from __profile order by idx, k, v;
+
+select count(1) from t1 where c_str_3_low1 in ('a1', 'b1', 'c1');
+ select * from __profile order by idx, k, v;
+
+select count(1) from t1 where c_str_3_low1 in ('a1', 'b1');
+ select * from __profile order by idx, k, v;
+
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_str_3_low1 in ('a1', 'b1', 'c1')
+    and c_str_5_low_non_null1 in ('a1', 'b1', 'c1')
+  );
+ select * from __profile order by idx, k, v;
+
+select count(1) from t1
+where
+  (
+    c_int_1_seq in (1280001, 1280002, 1280003)
+    and c_str_1_seq != 'abc1-1'
+  )
+  or 
+  (
+    c_str_3_low1 in ('a1', 'b1')
+    and c_int_1_seq != 1280004
+  );
+ select * from __profile order by idx, k, v;
+
+
+select count(1) from t1
+where
+  c_str_3_low1 in ('a1')
+  or c_str_5_low_non_null1 in ('a1');
+ select * from __profile order by idx, k, v;
+
+select count(1) from t1
+where
+  c_str_3_low1 in ('a1')
+  and c_str_5_low_non_null1 in ('a1');
+ select * from __profile order by idx, k, v;
 
 update information_schema.be_configs set value="false" where name= "enable_index_bitmap_filter";
 

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_index_and_filter_on_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_index_and_filter_on_or_predicate
@@ -108,46 +108,46 @@ insert into t1 (k1, c_str_5_low_non_null1, c_str_6_low_non_null2, c_str_7_seq_no
 ALTER TABLE t1 COMPACT;
 function: wait_compaction_finish("t1", 32)
 
--- create view __profile(idx, k, v) as 
--- select 1, 2, 3;
-
 create view __profile(idx, k, v) as 
-with 
-  __profile as (
-      select last_query_id() as query_id, unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
-  ),
-  result as (
-    select 1 as idx, "PushdownPredicates" as k, regexp_extract(line, ".*- PushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PushdownPredicates%"
-    UNION ALL
-    select 2, "NonPushdownPredicates" as k, regexp_extract(line, ".*- NonPushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- NonPushdownPredicates%"
+select 1, 2, 3;
+
+-- create view __profile(idx, k, v) as 
+-- with 
+--   __profile as (
+--       select last_query_id() as query_id, unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+--   ),
+--   result as (
+--     select 1 as idx, "PushdownPredicates" as k, regexp_extract(line, ".*- PushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PushdownPredicates%"
+--     UNION ALL
+--     select 2, "NonPushdownPredicates" as k, regexp_extract(line, ".*- NonPushdownPredicates: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- NonPushdownPredicates%"
     
-    UNION ALL
-    select 3, "PushdownPredicateTree" as k, regexp_extract(line, ".*- PushdownPredicateTree: (.*)", 1) as v from __profile where line like "%- PushdownPredicateTree%"
-    UNION ALL
-    select 4, "NonPushdownPredicateTree" as k, regexp_extract(line, ".*- NonPushdownPredicateTree: (.*)?", 1) as v from __profile where line like "%- NonPushdownPredicateTree%"
+--     UNION ALL
+--     select 3, "PushdownPredicateTree" as k, regexp_extract(line, ".*- PushdownPredicateTree: (.*)", 1) as v from __profile where line like "%- PushdownPredicateTree%"
+--     UNION ALL
+--     select 4, "NonPushdownPredicateTree" as k, regexp_extract(line, ".*- NonPushdownPredicateTree: (.*)?", 1) as v from __profile where line like "%- NonPushdownPredicateTree%"
     
-    UNION ALL
-    select 5, "RawRowsRead" as k, regexp_extract(line, ".*- RawRowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RawRowsRead%"
-    UNION ALL
-    select 6, "RowsRead" as k, regexp_extract(line, ".*- RowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RowsRead%"
+--     UNION ALL
+--     select 5, "RawRowsRead" as k, regexp_extract(line, ".*- RawRowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RawRowsRead%"
+--     UNION ALL
+--     select 6, "RowsRead" as k, regexp_extract(line, ".*- RowsRead: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- RowsRead%"
     
-    UNION ALL
-    select 7, "SegmentZoneMapFilterRows" as k, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- SegmentZoneMapFilterRows%"
-    UNION ALL
-    select 8, "ZoneMapIndexFilterRows" as k, regexp_extract(line, ".*- ZoneMapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- ZoneMapIndexFilterRows%"
-    UNION ALL
-    select 9, "BitmapIndexFilterRows" as k, regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BitmapIndexFilterRows%"
-    UNION ALL
-    select 10, "BloomFilterFilterRows" as k, regexp_extract(line, ".*- BloomFilterFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BloomFilterFilterRows%"
-    UNION ALL
-    select 11, "PredFilterRows" as k, regexp_extract(line, ".*- PredFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PredFilterRows%"
-    UNION ALL
-    select 12, "DeleteFilterRows" as k, regexp_extract(line, ".*- DeleteFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- DeleteFilterRows%"
-    UNION ALL
-    select 13, "LateMaterialize" as k, 'exist' as v from __profile where line like "%- LateMaterialize%"
+--     UNION ALL
+--     select 7, "SegmentZoneMapFilterRows" as k, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- SegmentZoneMapFilterRows%"
+--     UNION ALL
+--     select 8, "ZoneMapIndexFilterRows" as k, regexp_extract(line, ".*- ZoneMapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- ZoneMapIndexFilterRows%"
+--     UNION ALL
+--     select 9, "BitmapIndexFilterRows" as k, regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BitmapIndexFilterRows%"
+--     UNION ALL
+--     select 10, "BloomFilterFilterRows" as k, regexp_extract(line, ".*- BloomFilterFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- BloomFilterFilterRows%"
+--     UNION ALL
+--     select 11, "PredFilterRows" as k, regexp_extract(line, ".*- PredFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- PredFilterRows%"
+--     UNION ALL
+--     select 12, "DeleteFilterRows" as k, regexp_extract(line, ".*- DeleteFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as v from __profile where line like "%- DeleteFilterRows%"
+--     UNION ALL
+--     select 13, "LateMaterialize" as k, 'exist' as v from __profile where line like "%- LateMaterialize%"
     
-  )
-select * from result order by idx, k, v;
+--   )
+-- select * from result order by idx, k, v;
 
 
 -- 1. Test Segment Zonemap.


### PR DESCRIPTION
## Why I'm doing:

Support bitmap filter for OR predicates.

## What I'm doing:

The status for a predicate to apply bitmap index contains 4 kinds:
- `NOT_USED`: cannot apply bitmap index.
- `ALWAYS_TRUE`: the predicate always returns true, eg. `c1 in (1, 2, 3)` and bitmap index also only contains `(1, 2, 3)`.
- `ALWAYS_FALSE`: the predicate always returns false, eg. `c1 in (1, 2, 3)` and bitmap index does not contain any of `1, 2, 3`.
- `OK`: the predicate can apply bitmap index and does not always return true or false, that is , need to evaluate with bitmap index data.

`AND` and `OR` deal with each status in different ways:
- `NOT_USED`
    - `AND`: 
        - If there is any non-`NOT_USED` child predicate, use them to apply bitmap index.
        - If there is not non-`NOT_USED` child predicate, return `NOT_USED`.
    - `OR`:
        -  If there is any `NOT_USED` child predicate, return `NOT_USED`.
- `ALWAYS_TRUE`
    - `AND`: 
        - Erase `ALWAYS_TRUE` child predicates.
        - If there is not non-`ALWAYS_TRUE` child predicate, return `ALWAYS_TRUE`.
    - `OR`:
        -  If there is any `ALWAYS_TRUE` predicate, return `ALWAYS_TRUE`.
- `ALWAYS_FALSE`
    - `AND`: 
        -  If there is any `ALWAYS_FALSE` predicate, return `ALWAYS_FALSE`.
    - `OR`:
        - Erase `ALWAYS_FALSE` child predicates.
        - If there is not non-`ALWAYS_FALSE` child predicate, return `ALWAYS_FALSE`.
- `OK`
    - Both `AND` and `OR` uses `OK` child predicates to apply bitmap index.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
