### PR TITLE
[Enhancement] to_json return null when unsupported

### DIFF
--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -193,7 +193,7 @@ struct CastToString {
     }
 };
 
-StatusOr<ColumnPtr> cast_nested_to_json(const ColumnPtr& column);
+StatusOr<ColumnPtr> cast_nested_to_json(const ColumnPtr& column, bool allow_throw_exception);
 
 // cast column[idx] to coresponding json type.
 StatusOr<std::string> cast_type_to_json_str(const ColumnPtr& column, int idx);

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -169,6 +169,10 @@ bool FunctionContext::error_if_overflow() const {
     return _state != nullptr && _state->error_if_overflow();
 }
 
+bool FunctionContext::allow_throw_exception() const {
+    return _state != nullptr && _state->query_options().allow_throw_exception;
+}
+
 void FunctionContext::set_function_state(FunctionStateScope scope, void* ptr) {
     switch (scope) {
     case THREAD_LOCAL:

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -174,6 +174,8 @@ public:
 
     bool error_if_overflow() const;
 
+    bool allow_throw_exception() const;
+
     std::unique_ptr<NgramBloomFilterState>& get_ngram_state() { return _ngramState; }
 
 private:

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -1085,7 +1085,7 @@ StatusOr<ColumnPtr> JsonFunctions::_json_keys_without_path(FunctionContext* cont
 
 StatusOr<ColumnPtr> JsonFunctions::to_json(FunctionContext* context, const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
-    return cast_nested_to_json(columns[0]);
+    return cast_nested_to_json(columns[0], context->allow_throw_exception());
 }
 
 } // namespace starrocks

--- a/test/sql/test_json/R/to_json
+++ b/test/sql/test_json/R/to_json
@@ -34,3 +34,11 @@ SELECT to_json(NULL);
 -- result:
 None
 -- !result
+select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY,ALLOW_THROW_EXCEPTION')*/ to_json(map{null:null});
+-- result:
+E: (1064, 'key of Map should not be null')
+-- !result
+select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY')*/ to_json(map{null:null});
+-- result:
+None
+-- !result

--- a/test/sql/test_json/T/to_json
+++ b/test/sql/test_json/T/to_json
@@ -17,3 +17,6 @@ select to_json(c1) from t0 order by c0;
 
 SELECT to_json(row(1, 1));
 SELECT to_json(NULL);
+
+select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY,ALLOW_THROW_EXCEPTION')*/ to_json(map{null:null});
+select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY')*/ to_json(map{null:null});


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
origin:
```
MySQL td> select to_json(map{null:null});
(1064, 'key of Map should not be null')
```

update:

```
MySQL td> select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY,ALLOW_THROW_EXCEPTION')*/ to_json(map{null:null});
(1064, 'key of Map should not be null')
MySQL td> select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY')*/ to_json(map{null:null});
+-------------------------+
| to_json(map{NULL:NULL}) |
+-------------------------+
| <null>                  |
+-------------------------+
0 rows in set
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
