### PR TITLE
[BugFix] fix stale histogram lead to unexpected stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -187,7 +187,9 @@ public class BinaryPredicateStatisticCalculator {
                                                              Optional<ConstantOperator> constant,
                                                              Statistics statistics,
                                                              BinaryType binaryType) {
-        if (columnStatistic.getHistogram() == null || !constant.isPresent()) {
+        Optional<Histogram> hist = updateHistWithLessThan(columnStatistic, constant,
+                binaryType.equals(BinaryType.LE));
+        if (!hist.isPresent()) {
             StatisticRangeValues predicateRange;
             if (constant.isPresent()) {
                 Optional<Double> d = StatisticUtils.convertStatisticsToDouble(
@@ -202,8 +204,7 @@ public class BinaryPredicateStatisticCalculator {
             }
             return estimatePredicateRange(columnRefOperator, columnStatistic, predicateRange, statistics);
         } else {
-            Histogram estimatedHistogram = estimateLessThanWithHistogram(columnStatistic, constant.get(),
-                    binaryType.equals(BinaryType.LE));
+            Histogram estimatedHistogram = hist.get();
 
             long rowCountInHistogram = estimatedHistogram.getTotalRows();
             double rowCount = statistics.getOutputRowCount()
@@ -222,7 +223,9 @@ public class BinaryPredicateStatisticCalculator {
                                                                 Optional<ConstantOperator> constant,
                                                                 Statistics statistics,
                                                                 BinaryType binaryType) {
-        if (columnStatistic.getHistogram() == null || !constant.isPresent()) {
+        Optional<Histogram> hist = updateHistWithGreaterThan(columnStatistic, constant,
+                binaryType.equals(BinaryType.GE));
+        if (!hist.isPresent()) {
             StatisticRangeValues predicateRange;
             if (constant.isPresent()) {
                 Optional<Double> d = StatisticUtils.convertStatisticsToDouble(
@@ -238,9 +241,7 @@ public class BinaryPredicateStatisticCalculator {
             return estimatePredicateRange(columnRefOperator, columnStatistic, predicateRange, statistics);
 
         } else {
-            Histogram estimatedHistogram = estimateGreaterThanWithHistogram(columnStatistic, constant.get(),
-                    binaryType.equals(BinaryType.GE));
-
+            Histogram estimatedHistogram = hist.get();
             long rowCountInHistogram = estimatedHistogram.getTotalRows();
             double rowCount = statistics.getOutputRowCount()
                     * ((double) rowCountInHistogram / (double) columnStatistic.getHistogram().getTotalRows());
@@ -382,12 +383,20 @@ public class BinaryPredicateStatisticCalculator {
                 orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
     }
 
-    public static Histogram estimateLessThanWithHistogram(ColumnStatistic columnStatistic, ConstantOperator constant,
-                                                          boolean containUpper) {
-        Optional<Double> optionalDouble = StatisticUtils.convertStatisticsToDouble(constant.getType(), constant.toString());
-        if (!optionalDouble.isPresent()) {
-            return columnStatistic.getHistogram();
+    public static Optional<Histogram> updateHistWithLessThan(ColumnStatistic columnStatistic,
+                                                   Optional<ConstantOperator> constant,
+                                                   boolean containUpper) {
+        if (columnStatistic.getHistogram() == null || !constant.isPresent()) {
+            return Optional.empty();
         }
+
+        Optional<Double> optionalDouble = StatisticUtils.convertStatisticsToDouble(constant.get().getType(),
+                constant.get().toString());
+
+        if (!optionalDouble.isPresent()) {
+            return Optional.empty();
+        }
+
         double constantDouble = optionalDouble.get();
         Histogram histogram = columnStatistic.getHistogram();
 
@@ -420,38 +429,42 @@ public class BinaryPredicateStatisticCalculator {
             } else if (bucket.getLower() > constantDouble) {
                 break;
             }
-
             bucketList.add(bucket);
         }
 
         Map<String, Long> mostCommonValues = histogram.getMCV();
         Map<String, Long> estimatedMCV = new HashMap<>();
         for (Map.Entry<String, Long> entry : mostCommonValues.entrySet()) {
-            Optional<Double> optionalKey = StatisticUtils.convertStatisticsToDouble(constant.getType(), entry.getKey());
+            Optional<Double> optionalKey = StatisticUtils.convertStatisticsToDouble(constant.get().getType(), entry.getKey());
             if (!optionalKey.isPresent()) {
-                estimatedMCV.put(entry.getKey(), entry.getValue());
-                continue;
-            }
-            double key = optionalKey.get();
-            if (key < constantDouble) {
-                estimatedMCV.put(entry.getKey(), entry.getValue());
-            } else if (key == constantDouble && containUpper) {
+               return Optional.empty();
+            } else if (optionalKey.get() < constantDouble || (optionalKey.get() == constantDouble && containUpper)) {
                 estimatedMCV.put(entry.getKey(), entry.getValue());
             }
         }
 
-        return new Histogram(bucketList, estimatedMCV);
+        if (bucketList.isEmpty() && estimatedMCV.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Histogram(bucketList, estimatedMCV));
     }
 
-    public static Histogram estimateGreaterThanWithHistogram(ColumnStatistic columnStatistic, ConstantOperator constant,
-                                                             boolean containUpper) {
-        Optional<Double> optionalDouble = StatisticUtils.convertStatisticsToDouble(constant.getType(), constant.toString());
+    public static Optional<Histogram> updateHistWithGreaterThan(ColumnStatistic columnStatistic,
+                                                                Optional<ConstantOperator> constant,
+                                                                boolean containUpper) {
+        if (columnStatistic.getHistogram() == null || !constant.isPresent()) {
+            return Optional.empty();
+        }
+
+        Optional<Double> optionalDouble = StatisticUtils.convertStatisticsToDouble(constant.get().getType(),
+                constant.get().toString());
+
         if (!optionalDouble.isPresent()) {
-            return columnStatistic.getHistogram();
+            return Optional.empty();
         }
         double constantDouble = optionalDouble.get();
         Histogram histogram = columnStatistic.getHistogram();
-
         List<Bucket> bucketList = new ArrayList<>();
         int i = 0;
         long previousTotalRowCount = 0;
@@ -500,20 +513,19 @@ public class BinaryPredicateStatisticCalculator {
         Map<String, Long> mostCommonValues = histogram.getMCV();
         Map<String, Long> estimatedMCV = new HashMap<>();
         for (Map.Entry<String, Long> entry : mostCommonValues.entrySet()) {
-            Optional<Double> optionalKey = StatisticUtils.convertStatisticsToDouble(constant.getType(), entry.getKey());
+            Optional<Double> optionalKey = StatisticUtils.convertStatisticsToDouble(constant.get().getType(), entry.getKey());
             if (!optionalKey.isPresent()) {
-                estimatedMCV.put(entry.getKey(), entry.getValue());
-                continue;
-            }
-            double key = optionalKey.get();
-            if (key > constantDouble) {
-                estimatedMCV.put(entry.getKey(), entry.getValue());
-            } else if (key == constantDouble && containUpper) {
+                return Optional.empty();
+            } else if ( optionalKey.get() > constantDouble || (optionalKey.get() == constantDouble && containUpper)) {
                 estimatedMCV.put(entry.getKey(), entry.getValue());
             }
         }
 
-        return new Histogram(bucketList, estimatedMCV);
+        if (bucketList.isEmpty() && estimatedMCV.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Histogram(bucketList, estimatedMCV));
     }
 
     public static ColumnStatistic estimateColumnStatisticsWithHistogram(ColumnStatistic columnStatistic,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -437,7 +437,7 @@ public class BinaryPredicateStatisticCalculator {
         for (Map.Entry<String, Long> entry : mostCommonValues.entrySet()) {
             Optional<Double> optionalKey = StatisticUtils.convertStatisticsToDouble(constant.get().getType(), entry.getKey());
             if (!optionalKey.isPresent()) {
-               return Optional.empty();
+                return Optional.empty();
             } else if (optionalKey.get() < constantDouble || (optionalKey.get() == constantDouble && containUpper)) {
                 estimatedMCV.put(entry.getKey(), entry.getValue());
             }
@@ -516,7 +516,7 @@ public class BinaryPredicateStatisticCalculator {
             Optional<Double> optionalKey = StatisticUtils.convertStatisticsToDouble(constant.get().getType(), entry.getKey());
             if (!optionalKey.isPresent()) {
                 return Optional.empty();
-            } else if ( optionalKey.get() > constantDouble || (optionalKey.get() == constantDouble && containUpper)) {
+            } else if (optionalKey.get() > constantDouble || (optionalKey.get() == constantDouble && containUpper)) {
                 estimatedMCV.put(entry.getKey(), entry.getValue());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
@@ -36,7 +36,7 @@ public class Histogram {
         if (mcv != null) {
             totalRows += mcv.values().stream().reduce(Long::sum).orElse(0L);
         }
-        return totalRows;
+        return Math.max(1, totalRows);
     }
 
     public List<Bucket> getBuckets() {
@@ -52,9 +52,9 @@ public class Histogram {
         StringBuilder sb = new StringBuilder();
         sb.append("MCV: [");
         mcv.entrySet().stream().sorted(Map.Entry.comparingByValue(
-                Comparator.reverseOrder())).limit(printMcvSize).forEach(entry -> {
-                    sb.append("[").append(entry.getKey()).append(":").append(entry.getValue()).append("]");
-                });
+                Comparator.reverseOrder())).limit(printMcvSize).forEach(entry ->
+                    sb.append("[").append(entry.getKey()).append(":").append(entry.getValue()).append("]")
+                );
         sb.append("]");
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
@@ -51,10 +51,9 @@ public class Histogram {
         int printMcvSize = 5;
         StringBuilder sb = new StringBuilder();
         sb.append("MCV: [");
-        mcv.entrySet().stream().sorted(Map.Entry.comparingByValue(
-                Comparator.reverseOrder())).limit(printMcvSize).forEach(entry ->
-                    sb.append("[").append(entry.getKey()).append(":").append(entry.getValue()).append("]")
-                );
+        mcv.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                .limit(printMcvSize)
+                .forEach(entry -> sb.append("[").append(entry.getKey()).append(":").append(entry.getValue()).append("]"));
         sb.append("]");
         return sb.toString();
     }

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q19.sql
@@ -1,55 +1,95 @@
 [fragment statistics]
-PLAN FRAGMENT 0(F03)
+PLAN FRAGMENT 0(F05)
 Output Exprs:29: sum
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-7:AGGREGATE (update finalize)
-|  aggregate: sum[([28: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
-|  cardinality: 0
+9:AGGREGATE (merge finalize)
+|  aggregate: sum[([29: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
+|  cardinality: 1
 |  column statistics:
-|  * sum-->[810.9, NaN, 0.0, 8.0, NaN] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 8.0, 1.0] ESTIMATE
 |
-6:EXCHANGE
+8:EXCHANGE
 distribution type: GATHER
-cardinality: 0
+cardinality: 1
 
-PLAN FRAGMENT 1(F00)
+PLAN FRAGMENT 1(F04)
 
-Input Partition: RANDOM
+Input Partition: HASH_PARTITIONED: 2: L_PARTKEY
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 06
+OutPut Exchange Id: 08
 
-5:Project
-|  output columns:
-|  28 <-> [6: L_EXTENDEDPRICE, DOUBLE, false] * 1.0 - [7: L_DISCOUNT, DOUBLE, false]
-|  cardinality: 0
+7:AGGREGATE (update serialize)
+|  aggregate: sum[([6: L_EXTENDEDPRICE, DOUBLE, false] * 1.0 - [7: L_DISCOUNT, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
+|  cardinality: 1
 |  column statistics:
-|  * expr-->[810.9, 104949.5, 0.0, 8.0, 22735.940088981562] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 8.0, 1.0] ESTIMATE
 |
-4:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
+6:Project
+|  output columns:
+|  6 <-> [6: L_EXTENDEDPRICE, DOUBLE, false]
+|  7 <-> [7: L_DISCOUNT, DOUBLE, false]
+|  cardinality: 21702
+|  column statistics:
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 21702.324135626324] ESTIMATE
+|  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] MCV: [[0.05:54639500][0.07:54619200][0.02:54617300][0.01:54583400][0.10:54581500]] ESTIMATE
+|
+5:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
 |  equal join conjunct: [2: L_PARTKEY, INT, false] = [18: P_PARTKEY, INT, false]
 |  other join predicates: (((((21: P_BRAND = 'Brand#45') AND (24: P_CONTAINER IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'))) AND ((5: L_QUANTITY >= 5.0) AND (5: L_QUANTITY <= 15.0))) AND (23: P_SIZE <= 5)) OR ((((21: P_BRAND = 'Brand#11') AND (24: P_CONTAINER IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'))) AND ((5: L_QUANTITY >= 15.0) AND (5: L_QUANTITY <= 25.0))) AND (23: P_SIZE <= 10))) OR ((((21: P_BRAND = 'Brand#21') AND (24: P_CONTAINER IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'))) AND ((5: L_QUANTITY >= 25.0) AND (5: L_QUANTITY <= 35.0))) AND (23: P_SIZE <= 15))
 |  build runtime filters:
-|  - filter_id = 0, build_expr = (18: P_PARTKEY), remote = false
+|  - filter_id = 0, build_expr = (18: P_PARTKEY), remote = true
 |  output columns: 6, 7
-|  cardinality: 0
+|  cardinality: 21702
 |  column statistics:
-|  * L_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 22735.940088981562] ESTIMATE
+|  * L_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 21702.324135626324] ESTIMATE
 |  * L_QUANTITY-->[NaN, NaN, 0.0, 8.0, 50.0] MCV: [[9.00:12050300][15.00:12032400][8.00:12015300][7.00:12011400][12.00:11991300]] ESTIMATE
-|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 22735.940088981562] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 21702.324135626324] ESTIMATE
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] MCV: [[0.05:54639500][0.07:54619200][0.02:54617300][0.01:54583400][0.10:54581500]] ESTIMATE
-|  * P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 22735.940088981562] ESTIMATE
+|  * P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 21702.324135626324] ESTIMATE
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 3.0] ESTIMATE
 |  * P_SIZE-->[NaN, NaN, 0.0, 4.0, 50.0] MCV: [[3:412300][5:406200][2:406000][1:402000][4:400600]] ESTIMATE
 |  * P_CONTAINER-->[-Infinity, Infinity, 0.0, 10.0, 12.0] ESTIMATE
-|  * expr-->[810.9, 104949.5, 0.0, 8.0, 22735.940088981562] ESTIMATE
+|  * expr-->[810.9, 104949.5, 0.0, 8.0, 21702.324135626324] ESTIMATE
 |
-|----3:EXCHANGE
-|       distribution type: BROADCAST
+|----4:EXCHANGE
+|       distribution type: SHUFFLE
+|       partition exprs: [18: P_PARTKEY, INT, false]
 |       cardinality: 6051300
 |
+2:EXCHANGE
+distribution type: SHUFFLE
+partition exprs: [2: L_PARTKEY, INT, false]
+cardinality: 26568218
+
+PLAN FRAGMENT 2(F02)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 18: P_PARTKEY
+OutPut Exchange Id: 04
+
+3:OlapScanNode
+table: part, rollup: part
+preAggregation: on
+Predicates: 21: P_BRAND IN ('Brand#45', 'Brand#11', 'Brand#21'), [23: P_SIZE, INT, false] <= 15, 24: P_CONTAINER IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG', 'MED BAG', 'MED BOX', 'MED PKG', 'MED PACK', 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'), [23: P_SIZE, INT, false] >= 1
+partitionsRatio=1/1, tabletsRatio=10/10
+tabletList=10263,10265,10267,10269,10271,10273,10275,10277,10279,10281
+actualRows=0, avgRowSize=32.0
+cardinality: 6051300
+column statistics:
+* P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 6051299.999999999] ESTIMATE
+* P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] MCV: [[Brand#35:823300][Brand#12:816700][Brand#52:815800][Brand#33:814100][Brand#53:808800]] ESTIMATE
+* P_SIZE-->[NaN, NaN, 0.0, 4.0, 50.0] MCV: [[10:417700][14:415300][3:412300][7:407900][5:406200]] ESTIMATE
+* P_CONTAINER-->[-Infinity, Infinity, 0.0, 10.0, 40.0] MCV: [[SM DRUM:515300][JUMBO JAR:511500][LG JAR:510300][LG BOX:509600][MED CAN:509100]] ESTIMATE
+
+PLAN FRAGMENT 3(F00)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 2: L_PARTKEY
+OutPut Exchange Id: 02
+
 1:Project
 |  output columns:
 |  2 <-> [2: L_PARTKEY, INT, false]
@@ -80,24 +120,4 @@ column statistics:
 * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] MCV: [[0.05:54639500][0.07:54619200][0.02:54617300][0.01:54583400][0.10:54581500]] ESTIMATE
 * L_SHIPINSTRUCT-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
 * L_SHIPMODE-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-
-PLAN FRAGMENT 2(F01)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 03
-
-2:OlapScanNode
-table: part, rollup: part
-preAggregation: on
-Predicates: 21: P_BRAND IN ('Brand#45', 'Brand#11', 'Brand#21'), [23: P_SIZE, INT, false] <= 15, 24: P_CONTAINER IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG', 'MED BAG', 'MED BOX', 'MED PKG', 'MED PACK', 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'), [23: P_SIZE, INT, false] >= 1
-partitionsRatio=1/1, tabletsRatio=10/10
-tabletList=10263,10265,10267,10269,10271,10273,10275,10277,10279,10281
-actualRows=0, avgRowSize=32.0
-cardinality: 6051300
-column statistics:
-* P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 6051299.999999999] ESTIMATE
-* P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] MCV: [[Brand#35:823300][Brand#12:816700][Brand#52:815800][Brand#33:814100][Brand#53:808800]] ESTIMATE
-* P_SIZE-->[NaN, NaN, 0.0, 4.0, 50.0] MCV: [[10:417700][14:415300][3:412300][7:407900][5:406200]] ESTIMATE
-* P_CONTAINER-->[-Infinity, Infinity, 0.0, 10.0, 40.0] MCV: [[SM DRUM:515300][JUMBO JAR:511500][LG JAR:510300][LG BOX:509600][MED CAN:509100]] ESTIMATE
 [end]


### PR DESCRIPTION
## Why I'm doing:
Column histogram may not updated after the first collection.
If use the stale histogram to estimate row number may have a risk of divide zero exception because the estimated histogram may return 0 row count(a empty bucket and empty mcv).

## What I'm doing:
If the predicate range doesn't overlap with the histogram, we use the min/max value instead of histogram to estimate statistics.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
