### PR TITLE
[Enhancement] Add background warehouse and use the correct warehouse (backport #44456)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -59,6 +59,7 @@ import com.starrocks.thrift.BackendService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TTabletStat;
 import com.starrocks.thrift.TTabletStatResult;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -337,8 +338,9 @@ public class TabletStatMgr extends FrontendDaemon {
         private void sendTasks() {
             Map<ComputeNode, List<TabletInfo>> beToTabletInfos = new HashMap<>();
             for (Tablet tablet : tablets.values()) {
-                ComputeNode node = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                        .getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_WAREHOUSE_NAME, (LakeTablet) tablet);
+                WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+                Warehouse warehouse = manager.getBackgroundWarehouse();
+                ComputeNode node = manager.getComputeNodeAssignedToTablet(warehouse.getName(), (LakeTablet) tablet);
 
                 if (node == null) {
                     LOG.warn("Stop sending tablet stat task for partition {} because no alive node", debugName());

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2487,9 +2487,6 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int lake_compaction_fail_history_size = 12;
 
-    @ConfField(mutable = true)
-    public static String lake_compaction_warehouse = "default_warehouse";
-
     // e.g. "tableId1;tableId2"
     @ConfField(mutable = true)
     public static String lake_compaction_disable_tables = "";

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -239,7 +239,7 @@ public class BackendsProcDir implements ProcDirInterface {
 
             if (RunMode.isSharedDataMode()) {
                 backendInfo.add(String.valueOf(backend.getStarletPort()));
-                long workerId = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByBackendId(backendId);
+                long workerId = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByNodeId(backendId);
                 backendInfo.add(String.valueOf(workerId));
                 Warehouse wh = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(backend.getWarehouseId());
                 backendInfo.add(wh.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -171,7 +171,7 @@ public class ComputeNodeProcDir implements ProcDirInterface {
 
             if (RunMode.isSharedDataMode()) {
                 computeNodeInfo.add(String.valueOf(computeNode.getStarletPort()));
-                long workerId = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByBackendId(computeNodeId);
+                long workerId = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByNodeId(computeNodeId);
                 computeNodeInfo.add(String.valueOf(workerId));
                 Warehouse wh = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(computeNode.getWarehouseId());
                 computeNodeInfo.add(wh.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableCleaner.java
@@ -18,6 +18,9 @@ import com.staros.client.StarClientException;
 import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,7 +44,9 @@ class LakeTableCleaner {
         Set<String> removedPaths = new HashSet<>();
         for (PhysicalPartition partition : table.getAllPhysicalPartitions()) {
             try {
-                ShardInfo shardInfo = LakeTableHelper.getAssociatedShardInfo(partition).orElse(null);
+                WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+                Warehouse warehouse = manager.getBackgroundWarehouse();
+                ShardInfo shardInfo = LakeTableHelper.getAssociatedShardInfo(partition, warehouse.getId()).orElse(null);
                 if (shardInfo == null || removedPaths.contains(shardInfo.getFilePath().getFullPath())) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -32,6 +32,7 @@ import com.starrocks.proto.StatusPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
 import org.apache.commons.lang3.StringUtils;
@@ -101,7 +102,7 @@ public class LakeTableHelper {
         }
     }
 
-    static Optional<ShardInfo> getAssociatedShardInfo(PhysicalPartition partition) throws StarClientException {
+    static Optional<ShardInfo> getAssociatedShardInfo(PhysicalPartition partition, long warehouseId) throws StarClientException {
         List<MaterializedIndex> allIndices = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
         for (MaterializedIndex materializedIndex : allIndices) {
             List<Tablet> tablets = materializedIndex.getTablets();
@@ -113,8 +114,11 @@ public class LakeTableHelper {
                 if (GlobalStateMgr.isCheckpointThread()) {
                     throw new RuntimeException("Cannot call getShardInfo in checkpoint thread");
                 }
+                WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+                long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouseId)
+                        .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
                 ShardInfo shardInfo = GlobalStateMgr.getCurrentState().getStarOSAgent().getShardInfo(tablet.getShardId(),
-                        StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                        workerGroupId);
 
                 return Optional.of(shardInfo);
             } catch (StarClientException e) {
@@ -127,10 +131,10 @@ public class LakeTableHelper {
         return Optional.empty();
     }
 
-    static boolean removePartitionDirectory(Partition partition) throws StarClientException {
+    static boolean removePartitionDirectory(Partition partition, long warehouseId) throws StarClientException {
         boolean ret = true;
         for (PhysicalPartition subPartition : partition.getSubPartitions()) {
-            ShardInfo shardInfo = getAssociatedShardInfo(subPartition).orElse(null);
+            ShardInfo shardInfo = getAssociatedShardInfo(subPartition, warehouseId).orElse(null);
             if (shardInfo == null) {
                 LOG.info("Skipped remove directory of empty partition {}", subPartition.getId());
                 continue;
@@ -147,8 +151,8 @@ public class LakeTableHelper {
         return ret;
     }
 
-    public static boolean isSharedPartitionDirectory(PhysicalPartition partition) throws StarClientException {
-        ShardInfo shardInfo = getAssociatedShardInfo(partition).orElse(null);
+    public static boolean isSharedPartitionDirectory(PhysicalPartition partition, long warehouseId) throws StarClientException {
+        ShardInfo shardInfo = getAssociatedShardInfo(partition, warehouseId).orElse(null);
         if (shardInfo == null) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
@@ -19,6 +19,8 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.RecycleListPartitionInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.Warehouse;
 
 public class RecycleLakeListPartitionInfo extends RecycleListPartitionInfo {
     public RecycleLakeListPartitionInfo(long dbId, long tableId, Partition partition,
@@ -34,7 +36,9 @@ public class RecycleLakeListPartitionInfo extends RecycleListPartitionInfo {
             GlobalStateMgr.getCurrentState().getEditLog().logDisablePartitionRecovery(partition.getId());
         }
         try {
-            if (LakeTableHelper.removePartitionDirectory(partition)) {
+            WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            Warehouse warehouse = manager.getBackgroundWarehouse();
+            if (LakeTableHelper.removePartitionDirectory(partition, warehouse.getId())) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
                 return true;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
@@ -21,6 +21,8 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RecycleRangePartitionInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.Warehouse;
 
 public class RecycleLakeRangePartitionInfo extends RecycleRangePartitionInfo  {
     public RecycleLakeRangePartitionInfo(long dbId, long tableId, Partition partition,
@@ -37,7 +39,9 @@ public class RecycleLakeRangePartitionInfo extends RecycleRangePartitionInfo  {
             GlobalStateMgr.getCurrentState().getEditLog().logDisablePartitionRecovery(partition.getId());
         }
         try {
-            if (LakeTableHelper.removePartitionDirectory(partition)) {
+            WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            Warehouse warehouse = manager.getBackgroundWarehouse();
+            if (LakeTableHelper.removePartitionDirectory(partition, warehouse.getId())) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
                 return true;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -37,8 +37,10 @@ import com.starrocks.proto.DeleteTabletResponse;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -95,7 +97,11 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         // group shards by be
         for (long shardId : shardIds) {
             try {
-                long backendId = starOSAgent.getPrimaryComputeNodeIdByShard(shardId);
+                WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+                Warehouse warehouse = manager.getBackgroundWarehouse();
+                long workerGroupId = Utils.selectWorkerGroupByWarehouseId(manager, warehouse.getId())
+                        .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                long backendId = starOSAgent.getPrimaryComputeNodeIdByShard(shardId, workerGroupId);
                 shardIdsByBeMap.computeIfAbsent(backendId, k -> Sets.newHashSet()).add(shardId);
             } catch (UserException ignored1) {
                 // ignore error
@@ -206,7 +212,11 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
     public int deleteUnusedWorker() {
         int cnt = 0;
         try {
-            List<String> workerAddresses = GlobalStateMgr.getCurrentState().getStarOSAgent().listDefaultWorkerGroupIpPort();
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
+            long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouse.getId())
+                    .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+            List<String> workerAddresses = GlobalStateMgr.getCurrentState().getStarOSAgent().listWorkerGroupIpPort(workerGroupId);
 
             // filter backend
             List<Backend> backends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends();
@@ -229,8 +239,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             }
 
             for (String unusedWorkerAddress : workerAddresses) {
-                GlobalStateMgr.getCurrentState().getStarOSAgent()
-                        .removeWorker(unusedWorkerAddress, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                GlobalStateMgr.getCurrentState().getStarOSAgent().removeWorker(unusedWorkerAddress, workerGroupId);
                 LOG.info("unused worker {} removed from star mgr", unusedWorkerAddress);
                 cnt++;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -68,7 +68,7 @@ import javax.validation.constraints.NotNull;
 /**
  * StarOSAgent is responsible for
  * 1. Encapsulation of StarClient api.
- * 2. Maintenance of StarOS worker to StarRocks backend map.
+ * 2. Maintenance of StarOS worker to StarRocks node map.
  */
 public class StarOSAgent {
     private static final Logger LOG = LogManager.getLogger(StarOSAgent.class);
@@ -80,13 +80,14 @@ public class StarOSAgent {
     protected StarClient client;
     protected String serviceId;
     protected Map<String, Long> workerToId;
-    protected Map<Long, Long> workerToBackend;
+    // The value of this map is the id of backends or compute nodes
+    protected Map<Long, Long> workerToNode;
     protected ReentrantReadWriteLock rwLock;
 
     public StarOSAgent() {
         serviceId = "";
         workerToId = Maps.newHashMap();
-        workerToBackend = Maps.newHashMap();
+        workerToNode = Maps.newHashMap();
         rwLock = new ReentrantReadWriteLock();
     }
 
@@ -290,6 +291,13 @@ public class StarOSAgent {
         return 0;
     }
 
+    /**
+     * create a worker to represent the node in StarMgr
+     *
+     * @param nodeId can be backend id or compute node id
+     * @param workerIpPort
+     * @param workerGroupId
+     */
     public void addWorker(long nodeId, String workerIpPort, long workerGroupId) {
         prepare();
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
@@ -323,14 +331,14 @@ public class StarOSAgent {
             }
             tryRemovePreviousWorker(nodeId);
             workerToId.put(workerIpPort, workerId);
-            workerToBackend.put(workerId, nodeId);
-            LOG.info("add worker {} success, backendId is {}", workerId, nodeId);
+            workerToNode.put(workerId, nodeId);
+            LOG.info("add worker {} success, nodeId is {}", workerId, nodeId);
         }
     }
 
-    // remove previous worker with same backend id
-    private void tryRemovePreviousWorker(long backendId) {
-        long prevWorkerId = getWorkerIdByBackendIdInternal(backendId);
+    // remove previous worker with same node id
+    private void tryRemovePreviousWorker(long nodeId) {
+        long prevWorkerId = getWorkerIdByNodeIdInternal(nodeId);
         if (prevWorkerId < 0) {
             return;
         }
@@ -338,9 +346,9 @@ public class StarOSAgent {
             client.removeWorker(serviceId, prevWorkerId);
         } catch (StarClientException e) {
             // TODO: fix this corner case later in star mgr
-            LOG.error("Failed to remove worker {} with backend id {}. error: {}", prevWorkerId, backendId, e.getMessage());
+            LOG.error("Failed to remove worker {} with node id {}. error: {}", prevWorkerId, nodeId, e.getMessage());
         }
-        workerToBackend.remove(prevWorkerId);
+        workerToNode.remove(prevWorkerId);
         workerToId.entrySet().removeIf(e -> e.getValue() == prevWorkerId);
     }
 
@@ -365,7 +373,7 @@ public class StarOSAgent {
 
     public void removeWorkerFromMap(long workerId, String workerIpPort) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
-            workerToBackend.remove(workerId);
+            workerToNode.remove(workerId);
             workerToId.remove(workerIpPort);
         }
 
@@ -376,22 +384,28 @@ public class StarOSAgent {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
             Long workerId = workerToId.remove(workerIpPort);
             if (workerId != null) {
-                workerToBackend.remove(workerId);
+                workerToNode.remove(workerId);
             }
         }
         LOG.info("remove worker {} success from StarMgr", workerIpPort);
     }
 
-    public long getWorkerIdByBackendId(long backendId) {
+    /**
+     * get the worker id by node id
+     *
+     * @param nodeId can be backend id or compute node id
+     */
+    public long getWorkerIdByNodeId(long nodeId) {
         try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
-            return getWorkerIdByBackendIdInternal(backendId);
+            return getWorkerIdByNodeIdInternal(nodeId);
         }
     }
 
-    private long getWorkerIdByBackendIdInternal(long backendId) {
+    // nodeId can be backend id or compute node id
+    private long getWorkerIdByNodeIdInternal(long nodeId) {
         long workerId = -1;
-        for (Map.Entry<Long, Long> entry : workerToBackend.entrySet()) {
-            if (entry.getValue() == backendId) {
+        for (Map.Entry<Long, Long> entry : workerToNode.entrySet()) {
+            if (entry.getValue() == nodeId) {
                 workerId = entry.getKey();
                 break;
             }
@@ -507,17 +521,17 @@ public class StarOSAgent {
         }
     }
 
-    private Optional<Long> getBackendIdByHostStarletPort(String host, int starletPort) {
-        long backendId = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+    private Optional<Long> getNodeIdByHostStarletPort(String host, int starletPort) {
+        long nodeId = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
                 .getBackendIdWithStarletPort(host, starletPort);
-        if (backendId == -1L) {
-            backendId = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().
-                    getComputeNodeIdWithStarletPort(host, starletPort);
+        if (nodeId == -1L) {
+            nodeId = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                .getComputeNodeIdWithStarletPort(host, starletPort);
         }
-        return backendId == -1 ? Optional.empty() : Optional.of(backendId);
+        return nodeId == -1 ? Optional.empty() : Optional.of(nodeId);
     }
 
-    private Optional<Long> getBackendIdByHostHeartbeatPort(String host, int heartbeatPort) {
+    private Optional<Long> getNodeIdByHostHeartbeatPort(String host, int heartbeatPort) {
         ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
                 .getBackendWithHeartbeatPort(host, heartbeatPort);
         if (node == null) {
@@ -527,11 +541,11 @@ public class StarOSAgent {
         return node == null ? Optional.empty() : Optional.of(node.getId());
     }
 
-    private Optional<Long> getOrUpdateBackendIdByWorkerInfo(WorkerInfo info) {
+    private Optional<Long> getOrUpdateNodeIdByWorkerInfo(WorkerInfo info) {
         long workerId = info.getWorkerId();
         try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
             // get the backend id directly from workerToBackend
-            Long beId = workerToBackend.get(workerId);
+            Long beId = workerToNode.get(workerId);
             if (beId != null) {
                 return Optional.of(beId);
             }
@@ -546,7 +560,7 @@ public class StarOSAgent {
             LOG.warn("Malformed worker address info:" + workerAddr);
             return Optional.empty();
         }
-        Optional<Long> result = getBackendIdByHostStarletPort(host, starletPort);
+        Optional<Long> result = getNodeIdByHostStarletPort(host, starletPort);
         if (!result.isPresent()) {
             LOG.info("can't find backendId with starletPort for {}, try using be_heartbeat_port to search again",
                     workerAddr);
@@ -560,13 +574,13 @@ public class StarOSAgent {
                     LOG.warn("Malformed be_heartbeat_port for worker:" + workerAddr);
                     return Optional.empty();
                 }
-                result = getBackendIdByHostHeartbeatPort(host, heartbeatPort);
+                result = getNodeIdByHostHeartbeatPort(host, heartbeatPort);
             }
         }
         if (result.isPresent()) {
             try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
                 workerToId.put(workerAddr, workerId);
-                workerToBackend.put(workerId, result.get());
+                workerToNode.put(workerId, result.get());
             }
         }
         return result;
@@ -577,7 +591,7 @@ public class StarOSAgent {
     }
 
     public long getPrimaryComputeNodeIdByShard(long shardId, long workerGroupId) throws UserException {
-        Set<Long> backendIds = getAllBackendIdsByShard(shardId, workerGroupId, true);
+        Set<Long> backendIds = getAllNodeIdsByShard(shardId, workerGroupId, true);
         if (backendIds.isEmpty()) {
             // If BE stops, routine load task may catch UserException during load plan,
             // and the job state will changed to PAUSED.
@@ -589,32 +603,28 @@ public class StarOSAgent {
         return backendIds.iterator().next();
     }
 
-    public Set<Long> getBackendIdsByShard(long shardId, long workerGroupId) throws UserException {
-        return getAllBackendIdsByShard(shardId, workerGroupId, false);
-    }
-
-    public Set<Long> getAllBackendIdsByShard(long shardId, long workerGroupId, boolean onlyPrimary)
+    public Set<Long> getAllNodeIdsByShard(long shardId, long workerGroupId, boolean onlyPrimary)
             throws UserException {
         try {
             ShardInfo shardInfo = getShardInfo(shardId, workerGroupId);
-            return getAllBackendIdsByShard(shardInfo, onlyPrimary);
+            return getAllNodeIdsByShard(shardInfo, onlyPrimary);
         } catch (StarClientException e) {
             throw new UserException(e);
         }
     }
 
-    public Set<Long> getAllBackendIdsByShard(ShardInfo shardInfo, boolean onlyPrimary) {
+    public Set<Long> getAllNodeIdsByShard(ShardInfo shardInfo, boolean onlyPrimary) {
         List<ReplicaInfo> replicas = shardInfo.getReplicaInfoList();
         if (onlyPrimary) {
             replicas = replicas.stream().filter(x -> x.getReplicaRole() == ReplicaRole.PRIMARY)
                     .collect(Collectors.toList());
         }
-        Set<Long> backendIds = Sets.newHashSet();
+        Set<Long> nodeIds = Sets.newHashSet();
         replicas.stream()
-                .map(x -> getOrUpdateBackendIdByWorkerInfo(x.getWorkerInfo()))
-                .forEach(x -> x.ifPresent(backendIds::add));
+                .map(x -> getOrUpdateNodeIdByWorkerInfo(x.getWorkerInfo()))
+                .forEach(x -> x.ifPresent(nodeIds::add));
 
-        return backendIds;
+        return nodeIds;
     }
 
     public void createMetaGroup(long metaGroupId, List<Long> shardGroupIds) throws DdlException {
@@ -678,7 +688,7 @@ public class StarOSAgent {
                     listWorkerGroup(serviceId, Collections.singletonList(workerGroupId), true);
             for (WorkerGroupDetailInfo detailInfo : workerGroupDetailInfos) {
                 detailInfo.getWorkersInfoList()
-                        .forEach(x -> getOrUpdateBackendIdByWorkerInfo(x).ifPresent(nodeIds::add));
+                        .forEach(x -> getOrUpdateNodeIdByWorkerInfo(x).ifPresent(nodeIds::add));
             }
             return nodeIds;
         } catch (StarClientException e) {
@@ -686,12 +696,12 @@ public class StarOSAgent {
         }
     }
 
-    public List<String> listDefaultWorkerGroupIpPort() throws UserException {
+    public List<String> listWorkerGroupIpPort(long workerGroupId) throws UserException {
         List<String> addresses = new ArrayList<>();
         prepare();
         try {
             List<WorkerGroupDetailInfo> workerGroupDetailInfos = client.
-                    listWorkerGroup(serviceId, Collections.singletonList(DEFAULT_WORKER_GROUP_ID), true);
+                    listWorkerGroup(serviceId, Collections.singletonList(workerGroupId), true);
             Preconditions.checkState(1 == workerGroupDetailInfos.size());
             WorkerGroupDetailInfo workerGroupInfo = workerGroupDetailInfos.get(0);
             for (WorkerInfo workerInfo : workerGroupInfo.getWorkersInfoList()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
     }
 
     public static Long chooseNodeId(ShardInfo shardInfo) {
-        Set<Long> ids = GlobalStateMgr.getCurrentState().getStarOSAgent().getAllBackendIdsByShard(shardInfo, true);
+        Set<Long> ids = GlobalStateMgr.getCurrentState().getStarOSAgent().getAllNodeIdsByShard(shardInfo, true);
         if (!ids.isEmpty()) {
             return ids.iterator().next();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -34,6 +34,7 @@ import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -144,8 +145,8 @@ public class AutovacuumDaemon extends FrontendDaemon {
 
         for (Tablet tablet : tablets) {
             WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-            ComputeNode node = warehouseManager
-                    .getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_WAREHOUSE_ID, (LakeTablet) tablet);
+            Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
+            ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(warehouse.getName(), (LakeTablet) tablet);
 
             if (node == null) {
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -163,6 +163,9 @@ public class TaskBuilder {
         taskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID,
                 String.valueOf(materializedView.getId()));
         taskProperties.putAll(materializedView.getProperties());
+        // alter mv set warehouse
+        taskProperties.put(PropertyAnalyzer.PROPERTIES_WAREHOUSE_ID,
+                String.valueOf(materializedView.getWarehouseId()));
 
         task.setProperties(taskProperties);
         task.setDefinition(materializedView.getTaskDefinition());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -175,6 +175,11 @@ public class TaskRun implements Comparable<TaskRun> {
             MaterializedView materializedView = (MaterializedView) table;
             Preconditions.checkState(materializedView != null);
             newProperties = materializedView.getProperties();
+
+            // handle warehouse change
+            newProperties.put(PropertyAnalyzer.PROPERTIES_WAREHOUSE_ID,
+                    String.valueOf(materializedView.getWarehouseId()));
+
         } catch (Exception e) {
             LOG.warn("refresh task properties failed:", e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3658,6 +3658,13 @@ public class LocalMetastore implements ConnectorMetadata {
             if (optHints != null) {
                 Map<String, String> taskProperties = task.getProperties();
                 taskProperties.putAll(optHints);
+                if (materializedView.getWarehouseId() != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+                    taskProperties.put(PropertyAnalyzer.PROPERTIES_WAREHOUSE_ID,
+                            String.valueOf(materializedView.getWarehouseId()));
+
+                    LOG.debug("set warehouse {} in createTaskForMaterializedView",
+                            materializedView.getWarehouseId());
+                }
             }
 
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -25,6 +25,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
+import com.starrocks.lake.Utils;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.warehouse.DefaultWarehouse;
@@ -115,8 +116,10 @@ public class WarehouseManager implements Writable {
         }
 
         try {
-            return GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getWorkersByWorkerGroup(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouseId)
+                    .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+            return GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkersByWorkerGroup(workerGroupId);
         } catch (UserException e) {
             LOG.warn("Fail to get compute node ids from starMgr : {}", e.getMessage());
             return new ArrayList<>();
@@ -130,8 +133,11 @@ public class WarehouseManager implements Writable {
         }
 
         try {
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouse.getId())
+                    .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
             return GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getWorkersByWorkerGroup(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                    .getWorkersByWorkerGroup(workerGroupId);
         } catch (UserException e) {
             LOG.warn("Fail to get compute node ids from starMgr : {}", e.getMessage());
             return new ArrayList<>();
@@ -145,12 +151,15 @@ public class WarehouseManager implements Writable {
         }
 
         try {
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouseId)
+                    .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
             ShardInfo shardInfo = GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getShardInfo(tablet.getShardId(), StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                    .getShardInfo(tablet.getShardId(), workerGroupId);
 
             Long nodeId;
             Set<Long> ids = GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getAllBackendIdsByShard(shardInfo, true);
+                    .getAllNodeIdsByShard(shardInfo, true);
             if (!ids.isEmpty()) {
                 nodeId = ids.iterator().next();
                 return nodeId;
@@ -169,12 +178,15 @@ public class WarehouseManager implements Writable {
         }
 
         try {
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouse.getId())
+                    .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
             ShardInfo shardInfo = GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getShardInfo(tablet.getShardId(), StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                    .getShardInfo(tablet.getShardId(), workerGroupId);
 
             Long nodeId;
             Set<Long> ids = GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getAllBackendIdsByShard(shardInfo, true);
+                    .getAllNodeIdsByShard(shardInfo, true);
             if (!ids.isEmpty()) {
                 nodeId = ids.iterator().next();
                 return nodeId;
@@ -188,11 +200,14 @@ public class WarehouseManager implements Writable {
 
     public Set<Long> getAllComputeNodeIdsAssignToTablet(Long warehouseId, LakeTablet tablet) {
         try {
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            long workerGroupId = Utils.selectWorkerGroupByWarehouseId(warehouseManager, warehouseId)
+                    .orElse(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
             ShardInfo shardInfo = GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getShardInfo(tablet.getShardId(), StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                    .getShardInfo(tablet.getShardId(), workerGroupId);
 
             return GlobalStateMgr.getCurrentState().getStarOSAgent()
-                    .getAllBackendIdsByShard(shardInfo, true);
+                    .getAllNodeIdsByShard(shardInfo, true);
         } catch (StarClientException e) {
             return null;
         }
@@ -223,5 +238,13 @@ public class WarehouseManager implements Writable {
     public void write(DataOutput out) throws IOException {
         String json = GsonUtils.GSON.toJson(this);
         Text.writeString(out, json);
+    }
+
+    public Warehouse getCompactionWarehouse() {
+        return getWarehouse(DEFAULT_WAREHOUSE_ID);
+    }
+
+    public Warehouse getBackgroundWarehouse() {
+        return getWarehouse(DEFAULT_WAREHOUSE_ID);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2402,7 +2402,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         try {
                             // use default warehouse nodes
                             long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr().getComputeNodeId(
-                                    WarehouseManager.DEFAULT_WAREHOUSE_NAME, cloudNativeTablet);
+                                    txnState.getWarehouseId(), cloudNativeTablet);
                             TTabletLocation tabletLocation = new TTabletLocation(tablet.getId(),
                                     Collections.singletonList(computeNodeId));
                             tablets.add(tabletLocation);
@@ -2446,7 +2446,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setTablets(tablets);
 
         // build nodes
-        TNodesInfo nodesInfo = GlobalStateMgr.getCurrentState().createNodesInfo(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        TNodesInfo nodesInfo = GlobalStateMgr.getCurrentState().createNodesInfo(txnState.getWarehouseId());
         result.setNodes(nodesInfo.nodes);
         result.setStatus(new TStatus(OK));
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -53,6 +53,7 @@ import com.starrocks.load.streamload.StreamLoadTxnCommitAttachment;
 import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.common.ErrorType;
@@ -62,6 +63,7 @@ import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TableCommitInfo;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TxnCommitAttachment;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.iceberg.Snapshot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -101,6 +103,10 @@ public class StatisticUtils {
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setEnablePipelineEngine(true);
+        WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        Warehouse warehouse = manager.getBackgroundWarehouse();
+        context.getSessionVariable().setWarehouseName(warehouse.getName());
+
         context.setStatisticsContext(true);
         context.setDatabase(StatsConstants.STATISTICS_DB_NAME);
         context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -26,6 +26,7 @@ import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -341,9 +342,9 @@ public class CatalogRecycleBinLakeTableTest {
         Partition p2 = table1.getPartition("p2");
         Partition p3 = table1.getPartition("p3");
         Assert.assertNotNull(p1);
-        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p1));
-        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p2));
-        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p3));
+        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p1, WarehouseManager.DEFAULT_WAREHOUSE_ID));
+        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p2, WarehouseManager.DEFAULT_WAREHOUSE_ID));
+        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p3, WarehouseManager.DEFAULT_WAREHOUSE_ID));
 
         // Drop partition "p1"
         alterTable(connectContext, String.format("ALTER TABLE %s.t1 DROP PARTITION p1", dbName));
@@ -438,7 +439,7 @@ public class CatalogRecycleBinLakeTableTest {
                         "PROPERTIES('replication_num' = '1');", dbName));
 
         p1 = table2.getPartition("p1");
-        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p1));
+        Assert.assertFalse(LakeTableHelper.isSharedPartitionDirectory(p1, WarehouseManager.DEFAULT_WAREHOUSE_ID));
         // Drop partition "p1"
         alterTable(connectContext, String.format("ALTER TABLE %s.t2 DROP PARTITION p1", dbName));
         Assert.assertNull(table2.getPartition("p1"));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -53,6 +53,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
@@ -137,14 +138,22 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.RESOURCE_MA
 public class IcebergMetadataTest extends TableTestBase {
     private static final String CATALOG_NAME = "iceberg_catalog";
     public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
-    
+
     public static final IcebergCatalogProperties DEFAULT_CATALOG_PROPERTIES;
     public static final Map<String, String> DEFAULT_CONFIG = new HashMap<>();
-    
+
     static {
         DEFAULT_CONFIG.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732"); // non-exist ip, prevent to connect local service
         DEFAULT_CONFIG.put(ICEBERG_CATALOG_TYPE, "hive");
         DEFAULT_CATALOG_PROPERTIES = new IcebergCatalogProperties(DEFAULT_CONFIG);
+    }
+
+    @Mocked
+    private WarehouseManager warehouseManager;
+
+    public IcebergMetadataTest() {
+        warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableCleanerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableCleanerTest.java
@@ -25,8 +25,11 @@ import com.starrocks.proto.DropTableResponse;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.warehouse.DefaultWarehouse;
+import com.starrocks.warehouse.Warehouse;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -44,8 +47,13 @@ public class LakeTableCleanerTest {
     @Mocked
     private StarOSAgent starOSAgent;
 
+    @Mocked
+    private WarehouseManager warehouseManager;
+
     public LakeTableCleanerTest() {
         shardInfo = ShardInfo.newBuilder().setFilePath(FilePathInfo.newBuilder().setFullPath("oss://1/2")).build();
+        warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
     }
 
     @Before
@@ -84,6 +92,18 @@ public class LakeTableCleanerTest {
             @Mock
             public LakeService getLakeService(TNetworkAddress address) {
                 return lakeService;
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Warehouse getWarehouse(String warehouseName) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
             }
         };
 
@@ -159,6 +179,18 @@ public class LakeTableCleanerTest {
             }
         };
 
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Warehouse getWarehouse(String warehouseName) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+        };
+
         new Expectations() {
             {
                 table.getAllPhysicalPartitions();
@@ -188,6 +220,18 @@ public class LakeTableCleanerTest {
                                        @Mocked LakeTablet tablet,
                                        @Mocked LakeService lakeService) throws StarClientException {
         LakeTableCleaner cleaner = new LakeTableCleaner(table);
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Warehouse getWarehouse(String warehouseName) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+        };
 
         new Expectations() {
             {
@@ -233,6 +277,18 @@ public class LakeTableCleanerTest {
             }
         };
 
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Warehouse getWarehouse(String warehouseName) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+        };
+
         new Expectations() {
             {
                 table.getAllPhysicalPartitions();
@@ -267,6 +323,18 @@ public class LakeTableCleanerTest {
                                   @Mocked LakeTablet tablet,
                                   @Mocked LakeService lakeService) throws StarClientException {
         LakeTableCleaner cleaner = new LakeTableCleaner(table);
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Warehouse getWarehouse(String warehouseName) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+        };
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -83,6 +83,8 @@ public class StarMgrMetaSyncerTest {
     @Mocked
     private LocalMetastore localMetastore;
 
+    @Mocked
+    private WarehouseManager warehouseManager;
 
     @Before
     public void setUp() throws Exception {
@@ -114,6 +116,10 @@ public class StarMgrMetaSyncerTest {
                 globalStateMgr.getStarOSAgent();
                 minTimes = 0;
                 result = starOSAgent;
+
+                globalStateMgr.getWarehouseMgr();
+                minTimes = 0;
+                result = warehouseManager;
             }
         };
 
@@ -269,7 +275,7 @@ public class StarMgrMetaSyncerTest {
         };
         new MockUp<StarOSAgent>() {
             @Mock
-            public List<String> listDefaultWorkerGroupIpPort() {
+            public List<String> listWorkerGroupIpPort(long workerGroupId) {
                 List<String> addresses = new ArrayList<>();
                 addresses.add("host0:777");
                 addresses.add("host1:888");

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class StarOSAgentTest {
     private StarOSAgent starosAgent;
@@ -217,7 +218,7 @@ public class StarOSAgentTest {
         Assert.assertEquals(10, starosAgent.getWorkerId(workerHost));
 
         starosAgent.removeWorker(workerHost, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
-        Assert.assertEquals(-1, starosAgent.getWorkerIdByBackendId(5));
+        Assert.assertEquals(-1, starosAgent.getWorkerIdByNodeId(5));
     }
 
     @Test
@@ -236,7 +237,7 @@ public class StarOSAgentTest {
         long backendId = 5;
         Deencapsulation.setField(starosAgent, "serviceId", "1");
         starosAgent.addWorker(backendId, workerHost, 0);
-        Assert.assertEquals(workerId1, starosAgent.getWorkerIdByBackendId(backendId));
+        Assert.assertEquals(workerId1, starosAgent.getWorkerIdByNodeId(backendId));
 
         final String workerHost2 = "127.0.0.1:8091";
         new Expectations() {
@@ -251,7 +252,7 @@ public class StarOSAgentTest {
             }
         };
         starosAgent.addWorker(backendId, workerHost2, 0);
-        Assert.assertEquals(workerId2, starosAgent.getWorkerIdByBackendId(backendId));
+        Assert.assertEquals(workerId2, starosAgent.getWorkerIdByNodeId(backendId));
     }
 
     @Test
@@ -272,7 +273,7 @@ public class StarOSAgentTest {
         Deencapsulation.setField(starosAgent, "serviceId", "1");
         starosAgent.addWorker(5, workerHost, 0);
         Assert.assertEquals(6, starosAgent.getWorkerId(workerHost));
-        Assert.assertEquals(6, starosAgent.getWorkerIdByBackendId(5));
+        Assert.assertEquals(6, starosAgent.getWorkerIdByNodeId(5));
 
         new Expectations() {
             {
@@ -443,24 +444,24 @@ public class StarOSAgentTest {
         };
 
         Deencapsulation.setField(starosAgent, "serviceId", "1");
-        Map<Long, Long> workerToBackend = Maps.newHashMap();
-        Deencapsulation.setField(starosAgent, "workerToBackend", workerToBackend);
+        Map<Long, Long> workerToNode = Maps.newHashMap();
+        Deencapsulation.setField(starosAgent, "workerToNode", workerToNode);
 
         ExceptionChecker.expectThrowsWithMsg(UserException.class,
                 "Failed to get primary backend. shard id: 10",
                 () -> starosAgent.getPrimaryComputeNodeIdByShard(10L));
 
-        Assert.assertEquals(Sets.newHashSet(), starosAgent.getBackendIdsByShard(10L, 0));
+        Assert.assertEquals(Sets.newHashSet(), getBackendIdsByShard(10L, 0));
 
-        workerToBackend.put(1L, 10001L);
-        workerToBackend.put(2L, 10002L);
-        workerToBackend.put(3L, 10003L);
-        Deencapsulation.setField(starosAgent, "workerToBackend", workerToBackend);
+        workerToNode.put(1L, 10001L);
+        workerToNode.put(2L, 10002L);
+        workerToNode.put(3L, 10003L);
+        Deencapsulation.setField(starosAgent, "workerToNode", workerToNode);
 
         Deencapsulation.setField(starosAgent, "serviceId", "1");
         Assert.assertEquals(10001L, starosAgent.getPrimaryComputeNodeIdByShard(10L));
         Assert.assertEquals(Sets.newHashSet(10001L, 10002L, 10003L),
-                starosAgent.getBackendIdsByShard(10L, 0));
+                getBackendIdsByShard(10L, 0));
     }
 
     @Test
@@ -722,8 +723,12 @@ public class StarOSAgentTest {
                 return Lists.newArrayList(group);
             }
         };
-        List<String> addresses = starosAgent.listDefaultWorkerGroupIpPort();
+        List<String> addresses = starosAgent.listWorkerGroupIpPort(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
         Assert.assertEquals("127.0.0.1:8090", addresses.get(0));
         Assert.assertEquals("127.0.0.2:8091", addresses.get(1));
+    }
+
+    private Set<Long> getBackendIdsByShard(long shardId, long workerGroupId) throws UserException {
+        return starosAgent.getAllNodeIdsByShard(shardId, workerGroupId, false);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
@@ -95,7 +95,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testGetWarehouseIdByBackend() {
+    public void testGetWarehouseIdByNodeId() {
         SystemInfoService systemInfo = new SystemInfoService();
         Backend b1 = new Backend(10001L, "192.168.0.1", 9050);
         b1.setBePort(9060);

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -24,6 +24,7 @@ import com.starrocks.load.pipe.PipeFileRecord;
 import com.starrocks.load.pipe.PipeId;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.plan.ExecPlan;
@@ -47,6 +48,14 @@ import java.util.List;
 import java.util.Set;
 
 public class FileListRepoTest {
+
+    @Mocked
+    private WarehouseManager warehouseManager;
+
+    public FileListRepoTest() {
+        warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
+    }
 
     @Test
     public void testTestFileRecord() {

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -63,12 +63,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class PseudoCluster {
@@ -200,8 +198,8 @@ public class PseudoCluster {
         }
 
         @Override
-        public long getWorkerIdByBackendId(long backendId) {
-            Optional<Worker> worker = workers.stream().filter(w -> w.backendId == backendId).findFirst();
+        public long getWorkerIdByNodeId(long nodeId) {
+            Optional<Worker> worker = workers.stream().filter(w -> w.backendId == nodeId).findFirst();
             return worker.map(value -> value.workerId).orElse(-1L);
         }
 
@@ -254,17 +252,6 @@ public class PseudoCluster {
         @Override
         public long getPrimaryComputeNodeIdByShard(long shardId, long workerGroupId) throws UserException {
             return workers.isEmpty() ? -1 : workers.get((int) (shardId % workers.size())).backendId;
-        }
-
-        @Override
-        public Set<Long> getBackendIdsByShard(long shardId, long workerGroupId) throws UserException {
-            Set<Long> results = new HashSet<>();
-            shardInfos.stream().filter(x -> x.getShardId() == shardId).forEach(y -> {
-                for (ReplicaInfo info : y.getReplicaInfoList()) {
-                    results.add(info.getWorkerInfo().getWorkerId());
-                }
-            });
-            return results;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -752,7 +752,7 @@ public class ShowExecutorTest {
                 minTimes = 1;
                 result = tabletNum;
 
-                starosAgent.getWorkerIdByBackendId(anyLong);
+                starosAgent.getWorkerIdByNodeId(anyLong);
                 minTimes = 1;
                 result = workerId;
 


### PR DESCRIPTION
## Why I'm doing:

1. For background jobs, StarRocks uses a hard-coded approach to handle the Warehouse. For instance, jobs of the Statistics type initiated by TabletStatMgr. A configuration named lake_background_warehouse is provided to support these background operations.
2. Support for MV (Materialized View) jobs to run within a specified Warehouse.
3. Continue to fix certain misuses of the Default Warehouse.
4. Renamed some methods in the StarOSAgent class, the word "Backend" in the method names should be replaced with "Node". "Node" represents backend or compute node.
5. Hide the config of compaction and background warehouse.

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Why I'm doing:

1. For background jobs, StarRocks uses a hard-coded approach to handle the Warehouse. For instance, jobs of the Statistics type initiated by TabletStatMgr. A configuration named lake_background_warehouse is provided to support these background operations.
2. Support for MV (Materialized View) jobs to run within a specified Warehouse.
3. Continue to fix certain misuses of the Default Warehouse.
4. Renamed some methods in the StarOSAgent class, the word "Backend" in the method names should be replaced with "Node". "Node" represents backend or compute node.
5. Hide the config of compaction and background warehouse.

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

