### PR TITLE
[Enhancement] allow be start without configuring spill_local_storage_dir

### DIFF
--- a/be/src/exec/spill/dir_manager.cpp
+++ b/be/src/exec/spill/dir_manager.cpp
@@ -26,9 +26,10 @@ namespace starrocks::spill {
 
 Status DirManager::init(const std::string& spill_dirs) {
     std::vector<starrocks::StorePath> spill_local_storage_paths;
-    RETURN_IF_ERROR(parse_conf_store_paths(spill_dirs, &spill_local_storage_paths));
-    if (spill_local_storage_paths.empty()) {
-        return Status::InvalidArgument("cannot find spill_local_storage_dir");
+    auto status = parse_conf_store_paths(spill_dirs, &spill_local_storage_paths);
+    if (!status.ok()) {
+        LOG(WARNING) << "parse spill_local_storage_dir failed: " << status.to_string();
+        return Status::OK();
     }
 
     auto storage_paths = starrocks::StorageEngine::instance()->get_store_paths();

--- a/be/src/exec/spill/dir_manager.h
+++ b/be/src/exec/spill/dir_manager.h
@@ -96,6 +96,8 @@ public:
 
     StatusOr<DirPtr> acquire_writable_dir(const AcquireDirOptions& opts);
 
+    bool is_empty() const { return _dirs.empty(); }
+
 private:
     bool is_same_disk(const std::string& path1, const std::string& path2) {
         struct statfs stat1, stat2;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5