### PR TITLE
[BugFix] Disallow setting version_info in share data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -606,6 +606,10 @@ public class PropertyAnalyzer {
     public static Long analyzeVersionInfo(Map<String, String> properties) throws AnalysisException {
         long versionInfo = Partition.PARTITION_INIT_VERSION;
         if (properties != null && properties.containsKey(PROPERTIES_VERSION_INFO)) {
+            if (RunMode.isSharedDataMode()) {
+                throw new AnalysisException(String.format("Does not support the table property \"%s\" in share data " +
+                                "mode, please remove it from the statement", PROPERTIES_VERSION_INFO));
+            }
             String versionInfoStr = properties.get(PROPERTIES_VERSION_INFO);
             try {
                 versionInfo = Long.parseLong(versionInfoStr);


### PR DESCRIPTION
## Why I'm doing:
The table property “version_info” will modify the
initial "visibleVersion" value of the table, but
in share data mode, the tablet version on the
object store still starts from 1, if the value
of "version_info" is not equal to 1, it will lead
to inconsistency of the table's "visibleVersion"
and the tablet version.

## What I'm doing:
Disable "version_info" in share data mode.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
