### PR TITLE
[BugFix] fix cloud native pk table memory statistic issue

### DIFF
--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -119,6 +119,7 @@ public:
         // if `_index_entry` is null, do nothing.
         if (_index_entry != nullptr) {
             RETURN_IF_ERROR(_index_entry->value().commit(_metadata, &_builder));
+            update_mgr->index_cache().update_object_size(_index_entry, _index_entry->value().memory_usage());
         }
         RETURN_IF_ERROR(_builder.finalize(_max_txn_id));
         _has_finalized = true;
@@ -422,8 +423,8 @@ private:
         }
         LOG(INFO) << "Compaction finish. tablet: " << _metadata->id() << ", version: " << _metadata->version()
                   << ", cumulative point: " << _metadata->cumulative_point() << ", rowsets: ["
-                  << JoinInts(rowset_ids, ",") << "]"
-                  << ", delete rowsets: [" << JoinInts(delete_rowset_ids, ",") + "]";
+                  << JoinInts(rowset_ids, ",") << "]" << ", delete rowsets: ["
+                  << JoinInts(delete_rowset_ids, ",") + "]";
         return Status::OK();
     }
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -119,7 +119,7 @@ public:
         // if `_index_entry` is null, do nothing.
         if (_index_entry != nullptr) {
             RETURN_IF_ERROR(_index_entry->value().commit(_metadata, &_builder));
-            update_mgr->index_cache().update_object_size(_index_entry, _index_entry->value().memory_usage());
+            _tablet.update_mgr()->index_cache().update_object_size(_index_entry, _index_entry->value().memory_usage());
         }
         RETURN_IF_ERROR(_builder.finalize(_max_txn_id));
         _has_finalized = true;
@@ -423,8 +423,8 @@ private:
         }
         LOG(INFO) << "Compaction finish. tablet: " << _metadata->id() << ", version: " << _metadata->version()
                   << ", cumulative point: " << _metadata->cumulative_point() << ", rowsets: ["
-                  << JoinInts(rowset_ids, ",") << "]" << ", delete rowsets: ["
-                  << JoinInts(delete_rowset_ids, ",") + "]";
+                  << JoinInts(rowset_ids, ",") << "]"
+                  << ", delete rowsets: [" << JoinInts(delete_rowset_ids, ",") + "]";
         return Status::OK();
     }
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -189,11 +189,12 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
 
     for (const auto& one_delete : state.deletes()) {
         RETURN_IF_ERROR(index.erase(*one_delete, &new_deletes));
+        _index_cache.update_object_size(index_entry, index.memory_usage());
     }
     for (const auto& one_delete : state.auto_increment_deletes()) {
         RETURN_IF_ERROR(index.erase(*one_delete, &new_deletes));
+        _index_cache.update_object_size(index_entry, index.memory_usage());
     }
-    _index_cache.update_object_size(index_entry, index.memory_usage());
     _block_cache->update_memory_usage();
     // 4. generate delvec
     size_t ndelvec = new_deletes.size();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -193,6 +193,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     for (const auto& one_delete : state.auto_increment_deletes()) {
         RETURN_IF_ERROR(index.erase(*one_delete, &new_deletes));
     }
+    _index_cache.update_object_size(index_entry, index.memory_usage());
     _block_cache->update_memory_usage();
     // 4. generate delvec
     size_t ndelvec = new_deletes.size();
@@ -628,6 +629,7 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
     auto resolver = std::make_unique<LakePrimaryKeyCompactionConflictResolver>(
             &metadata, &output_rowset, this, builder, &index, txn_id, base_version, &segment_id_to_add_dels, &delvecs);
     RETURN_IF_ERROR(resolver->execute());
+    _index_cache.update_object_size(index_entry, index.memory_usage());
     // 3. update TabletMeta and write to meta file
     for (auto&& each : delvecs) {
         builder->append_delvec(each.second, each.first);
@@ -689,6 +691,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
         {
             TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
             RETURN_IF_ERROR(index.try_replace(rssid, 0, *pk_col, max_src_rssid, &tmp_deletes));
+            _index_cache.update_object_size(index_entry, index.memory_usage());
         }
         DelVectorPtr dv = std::make_shared<DelVector>();
         if (tmp_deletes.empty()) {

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -152,6 +152,8 @@ public:
 
     MemTracker* update_state_mem_tracker() const { return _update_state_mem_tracker.get(); }
 
+    MemTracker* index_mem_tracker() const { return _index_cache_mem_tracker.get(); }
+
     // get or create primary index, and prepare primary index state
     StatusOr<IndexEntry*> prepare_primary_index(const TabletMetadataPtr& metadata, MetaFileBuilder* builder,
                                                 int64_t base_version, int64_t new_version,

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2296,8 +2296,9 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     size_t del_percent = _cur_total_rows == 0 ? 0 : (_cur_total_dels * 100) / _cur_total_rows;
     LOG(INFO) << "apply_compaction_commit finish tablet:" << tablet_id
               << " version:" << version_info.version.to_string() << " total del/row:" << _cur_total_dels << "/"
-              << _cur_total_rows << " " << del_percent << "%" << " rowset:" << rowset_id << " #row:" << total_rows
-              << " #del:" << total_deletes << " #delvec:" << delvecs.size() << " duration:" << t_write - t_start << "ms"
+              << _cur_total_rows << " " << del_percent << "%"
+              << " rowset:" << rowset_id << " #row:" << total_rows << " #del:" << total_deletes
+              << " #delvec:" << delvecs.size() << " duration:" << t_write - t_start << "ms"
               << strings::Substitute("($0/$1/$2)", t_load - t_start, t_index_delvec - t_load, t_write - t_index_delvec);
     VLOG(1) << "update compaction apply " << _debug_string(true, true);
     if (row_before != row_after) {
@@ -2322,7 +2323,8 @@ std::string TabletUpdates::_debug_compaction_stats(const std::vector<uint32_t>& 
     for (auto rowset_id : input_rowsets) {
         auto iter = _rowset_stats.find(rowset_id);
         if (iter == _rowset_stats.end()) {
-            ss << rowset_id << ":" << "NA";
+            ss << rowset_id << ":"
+               << "NA";
         } else {
             ss << rowset_id << ":" << iter->second->num_dels << "/" << iter->second->num_rows;
         }
@@ -2331,7 +2333,8 @@ std::string TabletUpdates::_debug_compaction_stats(const std::vector<uint32_t>& 
     ss << "output:";
     auto iter = _rowset_stats.find(output_rowset);
     if (iter == _rowset_stats.end()) {
-        ss << output_rowset << ":" << "NA";
+        ss << output_rowset << ":"
+           << "NA";
     } else {
         ss << output_rowset << ":" << iter->second->num_dels << "/" << iter->second->num_rows;
     }
@@ -3749,7 +3752,8 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version, Ch
             if (dcgs.size() != new_rowset_info.num_segments) {
                 std::stringstream ss;
                 ss << "The size of dcgs and segment file in src rowset is different, "
-                   << "base tablet id: " << base_tablet->tablet_id() << " " << "new tablet id: " << _tablet.tablet_id();
+                   << "base tablet id: " << base_tablet->tablet_id() << " "
+                   << "new tablet id: " << _tablet.tablet_id();
                 LOG(WARNING) << ss.str();
                 return Status::InternalError(ss.str());
             }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2214,6 +2214,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
                     strings::Substitute("_light_apply_compaction_commit error: $0 $1", st.to_string(), debug_string()));
             return;
         }
+        manager->index_cache().update_object_size(index_entry, index.memory_usage());
     }
     int64_t t_index_delvec = MonotonicMillis();
 
@@ -2295,9 +2296,8 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     size_t del_percent = _cur_total_rows == 0 ? 0 : (_cur_total_dels * 100) / _cur_total_rows;
     LOG(INFO) << "apply_compaction_commit finish tablet:" << tablet_id
               << " version:" << version_info.version.to_string() << " total del/row:" << _cur_total_dels << "/"
-              << _cur_total_rows << " " << del_percent << "%"
-              << " rowset:" << rowset_id << " #row:" << total_rows << " #del:" << total_deletes
-              << " #delvec:" << delvecs.size() << " duration:" << t_write - t_start << "ms"
+              << _cur_total_rows << " " << del_percent << "%" << " rowset:" << rowset_id << " #row:" << total_rows
+              << " #del:" << total_deletes << " #delvec:" << delvecs.size() << " duration:" << t_write - t_start << "ms"
               << strings::Substitute("($0/$1/$2)", t_load - t_start, t_index_delvec - t_load, t_write - t_index_delvec);
     VLOG(1) << "update compaction apply " << _debug_string(true, true);
     if (row_before != row_after) {
@@ -2322,8 +2322,7 @@ std::string TabletUpdates::_debug_compaction_stats(const std::vector<uint32_t>& 
     for (auto rowset_id : input_rowsets) {
         auto iter = _rowset_stats.find(rowset_id);
         if (iter == _rowset_stats.end()) {
-            ss << rowset_id << ":"
-               << "NA";
+            ss << rowset_id << ":" << "NA";
         } else {
             ss << rowset_id << ":" << iter->second->num_dels << "/" << iter->second->num_rows;
         }
@@ -2332,8 +2331,7 @@ std::string TabletUpdates::_debug_compaction_stats(const std::vector<uint32_t>& 
     ss << "output:";
     auto iter = _rowset_stats.find(output_rowset);
     if (iter == _rowset_stats.end()) {
-        ss << output_rowset << ":"
-           << "NA";
+        ss << output_rowset << ":" << "NA";
     } else {
         ss << output_rowset << ":" << iter->second->num_dels << "/" << iter->second->num_rows;
     }
@@ -3751,8 +3749,7 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version, Ch
             if (dcgs.size() != new_rowset_info.num_segments) {
                 std::stringstream ss;
                 ss << "The size of dcgs and segment file in src rowset is different, "
-                   << "base tablet id: " << base_tablet->tablet_id() << " "
-                   << "new tablet id: " << _tablet.tablet_id();
+                   << "base tablet id: " << base_tablet->tablet_id() << " " << "new tablet id: " << _tablet.tablet_id();
                 LOG(WARNING) << ss.str();
                 return Status::InternalError(ss.str());
             }


### PR DESCRIPTION
## Why I'm doing:
We need to update pk index memory usage after index been modified like:
1. load
2. upsert
3. delete
4. try_replace
5. commit

But now we miss to update index memory when `try_replace` , `delete` and `commit`. So this memory usage will be incorrect.

## What I'm doing:
Update memory usage when `try_replace` , `delete` and `commit` .

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
