### PR TITLE
[Enhancement] UniqueMetrics of OlapTableSink's profile support runtime profile report

### DIFF
--- a/be/src/exec/pipeline/olap_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/olap_table_sink_operator.cpp
@@ -31,6 +31,7 @@ Status OlapTableSinkOperator::prepare(RuntimeState* state) {
     _sink->set_nonblocking_send_chunk(true);
     _automatic_partition_chunk.reset();
 
+    _sink->set_profile(_unique_metrics.get());
     RETURN_IF_ERROR(_sink->prepare(state));
 
     RETURN_IF_ERROR(_sink->try_open(state));
@@ -39,9 +40,6 @@ Status OlapTableSinkOperator::prepare(RuntimeState* state) {
 }
 
 void OlapTableSinkOperator::close(RuntimeState* state) {
-    _unique_metrics->copy_all_info_strings_from(_sink->profile());
-    _unique_metrics->copy_all_counters_from(_sink->profile());
-
     Operator::close(state);
 }
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -64,6 +64,7 @@
 #include "util/brpc_stub_cache.h"
 #include "util/compression/compression_utils.h"
 #include "util/defer_op.h"
+#include "util/stack_util.h"
 #include "util/thread.h"
 #include "util/thrift_rpc_helper.h"
 #include "util/uid_util.h"
@@ -122,30 +123,6 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
         _automatic_bucket_size = table_sink.automatic_bucket_size;
     }
 
-    // profile must add to state's object pool
-    _profile = state->obj_pool()->add(new RuntimeProfile("OlapTableSink"));
-    _ts_profile = state->obj_pool()->add(new TabletSinkProfile());
-
-    // add all counter
-    _ts_profile->runtime_profile = _profile;
-    _ts_profile->input_rows_counter = ADD_COUNTER(_profile, "RowsRead", TUnit::UNIT);
-    _ts_profile->output_rows_counter = ADD_COUNTER(_profile, "RowsReturned", TUnit::UNIT);
-    _ts_profile->filtered_rows_counter = ADD_COUNTER(_profile, "RowsFiltered", TUnit::UNIT);
-    _ts_profile->open_timer = ADD_TIMER(_profile, "OpenTime");
-    _ts_profile->close_timer = ADD_TIMER(_profile, "CloseWaitTime");
-    _ts_profile->prepare_data_timer = ADD_TIMER(_profile, "PrepareDataTime");
-    _ts_profile->convert_chunk_timer = ADD_CHILD_TIMER(_profile, "ConvertChunkTime", "PrepareDataTime");
-    _ts_profile->validate_data_timer = ADD_CHILD_TIMER(_profile, "ValidateDataTime", "PrepareDataTime");
-    _ts_profile->send_data_timer = ADD_TIMER(_profile, "SendDataTime");
-    _ts_profile->pack_chunk_timer = ADD_CHILD_TIMER(_profile, "PackChunkTime", "SendDataTime");
-    _ts_profile->send_rpc_timer = ADD_CHILD_TIMER(_profile, "SendRpcTime", "SendDataTime");
-    _ts_profile->wait_response_timer = ADD_CHILD_TIMER(_profile, "WaitResponseTime", "SendDataTime");
-    _ts_profile->serialize_chunk_timer = ADD_CHILD_TIMER(_profile, "SerializeChunkTime", "SendRpcTime");
-    _ts_profile->compress_timer = ADD_CHILD_TIMER(_profile, "CompressTime", "SendRpcTime");
-    _ts_profile->client_rpc_timer = ADD_TIMER(_profile, "RpcClientSideTime");
-    _ts_profile->server_rpc_timer = ADD_TIMER(_profile, "RpcServerSideTime");
-    _ts_profile->server_wait_flush_timer = ADD_TIMER(_profile, "RpcServerWaitFlushTime");
-
     _schema = std::make_shared<OlapTableSchemaParam>();
     RETURN_IF_ERROR(_schema->init(table_sink.schema, state));
     _vectorized_partition = _pool->add(new OlapTablePartitionParam(_schema, table_sink.partition));
@@ -182,15 +159,53 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     return Status::OK();
 }
 
-Status OlapTableSink::prepare(RuntimeState* state) {
-    _span->AddEvent("prepare");
-
+void OlapTableSink::_prepare_profile(RuntimeState* state) {
+    // For pipeline, the profile will be set in OlapTableSinkOperator::prepare
+    // For non-pipeline, the profile should be created and added to state's object pool
+    if (_profile == nullptr) {
+        _profile = state->obj_pool()->add(new RuntimeProfile("OlapTableSink"));
+    }
     _profile->add_info_string("TxnID", fmt::format("{}", _txn_id));
     _profile->add_info_string("IndexNum", fmt::format("{}", _schema->indexes().size()));
     _profile->add_info_string("ReplicatedStorage", fmt::format("{}", _enable_replicated_storage));
     _profile->add_info_string("AutomaticPartition", fmt::format("{}", _enable_automatic_partition));
     _profile->add_info_string("AutomaticBucketSize", fmt::format("{}", _automatic_bucket_size));
+
+    _ts_profile = state->obj_pool()->add(new TabletSinkProfile());
+    _ts_profile->runtime_profile = _profile;
+    _ts_profile->input_rows_counter = ADD_COUNTER(_profile, "RowsRead", TUnit::UNIT);
+    _ts_profile->output_rows_counter = ADD_COUNTER(_profile, "RowsReturned", TUnit::UNIT);
+    _ts_profile->filtered_rows_counter = ADD_COUNTER(_profile, "RowsFiltered", TUnit::UNIT);
+    _ts_profile->open_timer = ADD_TIMER(_profile, "OpenTime");
+    _ts_profile->close_timer = ADD_TIMER(_profile, "CloseWaitTime");
+    _ts_profile->prepare_data_timer = ADD_TIMER(_profile, "PrepareDataTime");
+    _ts_profile->convert_chunk_timer = ADD_CHILD_TIMER(_profile, "ConvertChunkTime", "PrepareDataTime");
+    _ts_profile->validate_data_timer = ADD_CHILD_TIMER(_profile, "ValidateDataTime", "PrepareDataTime");
+    _ts_profile->send_data_timer = ADD_TIMER(_profile, "SendDataTime");
+    _ts_profile->pack_chunk_timer = ADD_CHILD_TIMER(_profile, "PackChunkTime", "SendDataTime");
+    _ts_profile->send_rpc_timer = ADD_CHILD_TIMER(_profile, "SendRpcTime", "SendDataTime");
+    _ts_profile->wait_response_timer = ADD_CHILD_TIMER(_profile, "WaitResponseTime", "SendDataTime");
+    _ts_profile->serialize_chunk_timer = ADD_CHILD_TIMER(_profile, "SerializeChunkTime", "SendRpcTime");
+    _ts_profile->compress_timer = ADD_CHILD_TIMER(_profile, "CompressTime", "SendRpcTime");
+    _ts_profile->client_rpc_timer = ADD_TIMER(_profile, "RpcClientSideTime");
+    _ts_profile->server_rpc_timer = ADD_TIMER(_profile, "RpcServerSideTime");
+    _ts_profile->server_wait_flush_timer = ADD_TIMER(_profile, "RpcServerWaitFlushTime");
     _ts_profile->alloc_auto_increment_timer = ADD_TIMER(_profile, "AllocAutoIncrementTime");
+}
+
+void OlapTableSink::set_profile(RuntimeProfile* profile) {
+    if (_profile != nullptr) {
+        LOG(WARNING) << "OlapTableSink profile is set duplicated, load_id: " << print_id(_load_id)
+                     << ", txn_id: " << _txn_id << ", stack\n"
+                     << get_stack_trace();
+        return;
+    }
+    _profile = profile;
+}
+
+Status OlapTableSink::prepare(RuntimeState* state) {
+    _span->AddEvent("prepare");
+    _prepare_profile(state);
 
     SCOPED_TIMER(_profile->total_time_counter());
 

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -87,6 +87,8 @@ public:
     // sync close() interface
     Status close(RuntimeState* state, Status close_status) override;
 
+    // This should be called in OlapTableSinkOperator::prepare only once
+    void set_profile(RuntimeProfile* profile);
     // Returns the runtime profile for the sink.
     RuntimeProfile* profile() override { return _profile; }
 
@@ -100,6 +102,8 @@ public:
     TabletSinkProfile* ts_profile() const { return _ts_profile; }
 
 private:
+    void _prepare_profile(RuntimeState* state);
+
     template <LogicalType LT>
     void _validate_decimal(RuntimeState* state, Chunk* chunk, Column* column, const SlotDescriptor* desc,
                            std::vector<uint8_t>* validate_selection);


### PR DESCRIPTION
## Why I'm doing:
For pipeline engine, unique metrics of OlapTableSink profile only be reported after the load finishes, and the runtime profile can't get the metrics.

## What I'm doing:
To support runtime profile report, OlapTableSink should update the `OlapTableSinkOperator::_unique_metrics` directly, rather than copying the metrics to it in `OlapTableSinkOperator::close`. `OlapTableSinkOperator::_unique_metrics` will be report to FE at runtime.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
