### PR TITLE
[Enhancement] improve cloud native pk table memory cost when handle large ingestion

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -523,7 +523,7 @@ Status DeltaWriterImpl::fill_auto_increment_id(const Chunk& chunk) {
     auto metadata = _tablet_manager->get_latest_cached_tablet_metadata(_tablet_id);
     Status st;
     if (metadata != nullptr) {
-        st = tablet.update_mgr()->get_rowids_from_pkindex(&tablet, metadata->version(), upserts, &rss_rowids, true);
+        st = tablet.update_mgr()->get_rowids_from_pkindex(tablet.id(), metadata->version(), upserts, &rss_rowids, true);
     }
 
     std::vector<uint8_t> filter;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -333,28 +333,4 @@ bool is_primary_key(const TabletMetadata& metadata) {
     return metadata.schema().keys_type() == KeysType::PRIMARY_KEYS;
 }
 
-void rowset_rssid_to_path(const TabletMetadata& metadata, const TxnLogPB_OpWrite* op_write,
-                          std::unordered_map<uint32_t, FileInfo>& rssid_to_file_info) {
-    auto get_file_info_from_rowset = [&](const RowsetMetadataPB& meta, const uint32_t rowset_id) -> void {
-        bool has_segment_size = (meta.segments_size() == meta.segment_size_size());
-        for (int i = 0; i < meta.segments_size(); i++) {
-            FileInfo segment_info{.path = meta.segments(i)};
-            if (LIKELY(has_segment_size)) {
-                segment_info.size = meta.segment_size(i);
-            }
-            rssid_to_file_info[rowset_id + i] = segment_info;
-        }
-    };
-
-    for (auto& rs : metadata.rowsets()) {
-        get_file_info_from_rowset(rs, rs.id());
-    }
-    if (op_write != nullptr) {
-        const uint32_t rowset_id = metadata.next_rowset_id();
-        for (int i = 0; i < op_write->rowset().segments_size(); i++) {
-            get_file_info_from_rowset(op_write->rowset(), rowset_id);
-        }
-    }
-}
-
 } // namespace starrocks::lake

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -83,9 +83,5 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, ui
 bool is_primary_key(TabletMetadata* metadata);
 bool is_primary_key(const TabletMetadata& metadata);
 
-// TODO(yixin): cache rowset_rssid_to_path
-void rowset_rssid_to_path(const TabletMetadata& metadata, const TxnLogPB_OpWrite* op_write,
-                          std::unordered_map<uint32_t, FileInfo>& rssid_to_path);
-
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -35,11 +35,7 @@ namespace starrocks::lake {
 
 RowsetUpdateState::RowsetUpdateState() = default;
 
-RowsetUpdateState::~RowsetUpdateState() {
-    if (!_status.ok()) {
-        LOG(WARNING) << "bad RowsetUpdateState released tablet:" << _tablet_id;
-    }
-}
+RowsetUpdateState::~RowsetUpdateState() = default;
 
 // Restore state to what it was before the data was loaded
 void RowsetUpdateState::_reset() {
@@ -49,65 +45,64 @@ void RowsetUpdateState::_reset() {
     _auto_increment_partial_update_states.clear();
     _auto_increment_delete_pks.clear();
     _memory_usage = 0;
-    _base_version = 0;
+    _base_versions.clear();
     _schema_version = 0;
+    _segment_iters.clear();
+    _rowset_ptr.reset();
 }
 
-Status RowsetUpdateState::load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version,
-                               Tablet* tablet, const MetaFileBuilder* builder, bool need_resolve_conflict,
-                               bool need_lock) {
-    DCHECK_GT(metadata.version(), 0);
-    DCHECK_EQ(tablet->id(), metadata.id());
-    if (UNLIKELY(!_status.ok())) {
-        return _status;
-    }
-    if (_base_version > 0 && _schema_version < metadata.schema().schema_version()) {
+void RowsetUpdateState::init(const RowsetUpdateStateParams& params) {
+    DCHECK_GT(params.metadata.version(), 0);
+    DCHECK_EQ(params.tablet->id(), params.metadata.id());
+    if (!_base_versions.empty() && _schema_version < params.metadata.schema().schema_version()) {
         LOG(INFO) << "schema version has changed from " << _schema_version << " to "
-                  << metadata.schema().schema_version() << ", need to reload the update state."
-                  << " tablet_id: " << tablet->id() << " old base version: " << _base_version
-                  << " new base version: " << metadata.version();
+                  << params.metadata.schema().schema_version() << ", need to reload the update state."
+                  << " tablet_id: " << params.tablet->id() << " old base version: " << _base_versions[0]
+                  << " new base version: " << params.metadata.version();
         // The data has been loaded, but the schema has changed and needs to be reloaded according to the new schema
         _reset();
     }
-    if (_base_version == 0) {
-        TRACE_COUNTER_SCOPE_LATENCY_US("update_state_load_latency_us");
-        _base_version = base_version;
-        _builder = builder;
-        _tablet_id = metadata.id();
-        _schema_version = metadata.schema().schema_version();
-        _status = _do_load(op_write, metadata, tablet, need_lock);
-        if (!_status.ok()) {
-            if (!_status.is_uninitialized() && !_status.is_cancelled()) {
-                LOG(WARNING) << "load RowsetUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"
-                             << get_stack_trace();
-            }
-            if (_status.is_mem_limit_exceeded()) {
-                LOG(WARNING) << CurrentThread::mem_tracker()->debug_string();
-            }
-        }
-    }
-    if (need_resolve_conflict && _status.ok()) {
-        RETURN_IF_ERROR(_resolve_conflict(op_write, metadata, base_version, tablet, builder));
-    }
-    return _status;
+    _tablet_id = params.metadata.id();
+    _schema_version = params.metadata.schema().schema_version();
 }
 
-Status RowsetUpdateState::_do_load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
-                                   bool need_lock) {
-    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
-    Rowset rowset(tablet->tablet_mgr(), tablet->id(), &op_write.rowset(), -1 /*unused*/, tablet_schema);
+Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version,
+                                       bool need_resolve_conflict, bool need_lock) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("load_segment_us");
+    if (_rowset_ptr == nullptr) {
+        _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(),
+                                               &params.op_write.rowset(), -1 /*unused*/, params.tablet_schema);
+    }
+    _upserts.resize(_rowset_ptr->num_segments());
+    _base_versions.resize(_rowset_ptr->num_segments());
+    _partial_update_states.resize(_rowset_ptr->num_segments());
+    _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
+    _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
 
-    RETURN_IF_ERROR(_do_load_upserts_deletes(op_write, tablet_schema, tablet, &rowset));
-
-    if (!op_write.has_txn_meta() || rowset.num_segments() == 0 || op_write.txn_meta().has_merge_condition()) {
+    if (_upserts.size() == 0) {
+        // Empty rowset
         return Status::OK();
     }
-    if (!op_write.txn_meta().partial_update_column_unique_ids().empty()) {
-        RETURN_IF_ERROR(_prepare_partial_update_states(op_write, metadata, tablet, tablet_schema, need_lock));
+    if (_upserts[segment_id] == nullptr) {
+        _base_versions[segment_id] = base_version;
+        RETURN_IF_ERROR(_do_load_upserts(segment_id, params));
     }
-    if (op_write.txn_meta().has_auto_increment_partial_update_column_id()) {
-        RETURN_IF_ERROR(
-                _prepare_auto_increment_partial_update_states(op_write, metadata, tablet, tablet_schema, need_lock));
+
+    if (!params.op_write.has_txn_meta() || params.op_write.txn_meta().has_merge_condition()) {
+        return Status::OK();
+    }
+    if (!params.op_write.txn_meta().partial_update_column_unique_ids().empty()) {
+        if (_partial_update_states[segment_id].src_rss_rowids.empty()) {
+            RETURN_IF_ERROR(_prepare_partial_update_states(segment_id, params, need_lock));
+        }
+    }
+    if (params.op_write.txn_meta().has_auto_increment_partial_update_column_id()) {
+        if (_auto_increment_partial_update_states[segment_id].src_rss_rowids.empty()) {
+            RETURN_IF_ERROR(_prepare_auto_increment_partial_update_states(segment_id, params, need_lock));
+        }
+    }
+    if (need_resolve_conflict) {
+        RETURN_IF_ERROR(_resolve_conflict(segment_id, params, base_version));
     }
     return Status::OK();
 }
@@ -187,80 +182,43 @@ void RowsetUpdateState::plan_read_by_rssid(const std::vector<uint64_t>& rowids, 
     }
 }
 
-Status RowsetUpdateState::_do_load_upserts_deletes(const TxnLogPB_OpWrite& op_write,
-                                                   const TabletSchemaCSPtr& tablet_schema, Tablet* tablet,
-                                                   Rowset* rowset_ptr) {
+Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpdateStateParams& params) {
     vector<uint32_t> pk_columns;
-    for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
+    for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
-    Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
     std::unique_ptr<Column> pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
 
-    auto root_path = tablet->metadata_root_location();
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_path));
-    // always one file for now.
-    for (const std::string& path : op_write.dels()) {
-        ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(tablet->del_location(path)));
-        ASSIGN_OR_RETURN(auto file_size, read_file->get_size());
-        std::vector<uint8_t> read_buffer(file_size);
-        RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
-        auto col = pk_column->clone();
-        if (serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()) == nullptr) {
-            return Status::InternalError("column deserialization failed");
-        }
-        _deletes.emplace_back(std::move(col));
+    if (_segment_iters.empty()) {
+        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, &_stats));
     }
-    if (op_write.dels_size() > 0) {
-        TRACE("end read $0 deletes files", op_write.dels_size());
-    }
-
-    OlapReaderStatistics stats;
-    auto res = rowset_ptr->get_each_segment_iterator(pkey_schema, &stats);
-    if (!res.ok()) {
-        return res.status();
-    }
-    auto& itrs = res.value();
-    RETURN_ERROR_IF_FALSE(itrs.size() == rowset_ptr->num_segments(),
-                          "itrs.size != num_segments " + std::to_string(itrs.size()) + ", " +
-                                  std::to_string(rowset_ptr->num_segments()));
-    _upserts.resize(rowset_ptr->num_segments());
+    RETURN_ERROR_IF_FALSE(_segment_iters.size() == _rowset_ptr->num_segments());
     // only hold pkey, so can use larger chunk size
     auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
     auto chunk = chunk_shared_ptr.get();
-    for (size_t i = 0; i < itrs.size(); i++) {
-        auto& dest = _upserts[i];
-        auto col = pk_column->clone();
-        auto itr = itrs[i].get();
-        if (itr != nullptr) {
-            while (true) {
-                chunk->reset();
-                auto st = itr->get_next(chunk);
-                if (st.is_end_of_file()) {
-                    break;
-                } else if (!st.ok()) {
-                    return st;
-                } else {
-                    PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
-                }
-            }
-            itr->close();
-        }
-        dest = std::move(col);
-    }
-    if (itrs.size() > 0) {
-        TRACE("end read $0 upserts files", itrs.size());
-    }
 
-    for (const auto& upsert : _upserts) {
-        upsert->raw_data();
-        _memory_usage += upsert != nullptr ? upsert->memory_usage() : 0;
+    auto itr = _segment_iters[segment_id].get();
+    auto& dest = _upserts[segment_id];
+    auto col = pk_column->clone();
+    if (itr != nullptr) {
+        while (true) {
+            chunk->reset();
+            auto st = itr->get_next(chunk);
+            if (st.is_end_of_file()) {
+                break;
+            } else if (!st.ok()) {
+                return st;
+            } else {
+                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+            }
+        }
+        itr->close();
     }
-    for (const auto& one_delete : _deletes) {
-        one_delete->raw_data();
-        _memory_usage += one_delete != nullptr ? one_delete->memory_usage() : 0;
-    }
+    dest = std::move(col);
+    dest->raw_data();
+    _memory_usage += dest->memory_usage();
 
     return Status::OK();
 }
@@ -284,101 +242,88 @@ static std::vector<ColumnId> get_read_columns_ids(const TxnLogPB_OpWrite& op_wri
     return unmodified_column_ids;
 }
 
-Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const TxnLogPB_OpWrite& op_write,
-                                                                        const TabletMetadata& metadata, Tablet* tablet,
-                                                                        const TabletSchemaCSPtr& tablet_schema,
+Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t segment_id,
+                                                                        const RowsetUpdateStateParams& params,
                                                                         bool need_lock) {
-    const auto& txn_meta = op_write.txn_meta();
-    size_t num_segments = op_write.rowset().segments_size();
-    _auto_increment_partial_update_states.resize(num_segments);
-    _auto_increment_delete_pks.resize(num_segments);
+    const auto& txn_meta = params.op_write.txn_meta();
 
     uint32_t auto_increment_column_id = 0;
-    for (int i = 0; i < tablet_schema->num_columns(); ++i) {
-        if (tablet_schema->column(i).is_auto_increment()) {
+    for (int i = 0; i < params.tablet_schema->num_columns(); ++i) {
+        if (params.tablet_schema->column(i).is_auto_increment()) {
             auto_increment_column_id = i;
             break;
         }
     }
     std::vector<uint32_t> column_id{auto_increment_column_id};
-    auto auto_inc_column_schema = ChunkHelper::convert_schema(tablet_schema, column_id);
+    auto auto_inc_column_schema = ChunkHelper::convert_schema(params.tablet_schema, column_id);
     auto column = ChunkHelper::column_from_field(*auto_inc_column_schema.field(0).get());
-    std::vector<std::vector<std::unique_ptr<Column>>> read_column(num_segments);
+    std::vector<std::unique_ptr<Column>> read_column;
 
     std::shared_ptr<TabletSchema> modified_columns_schema = nullptr;
     if (!txn_meta.partial_update_column_unique_ids().empty()) {
         std::vector<ColumnUID> update_column_ids(txn_meta.partial_update_column_unique_ids().begin(),
                                                  txn_meta.partial_update_column_unique_ids().end());
-        modified_columns_schema = TabletSchema::create_with_uid(tablet_schema, update_column_ids);
+        modified_columns_schema = TabletSchema::create_with_uid(params.tablet_schema, update_column_ids);
     } else {
         std::vector<int32_t> all_column_ids;
-        all_column_ids.resize(tablet_schema->num_columns());
+        all_column_ids.resize(params.tablet_schema->num_columns());
         std::iota(all_column_ids.begin(), all_column_ids.end(), 0);
-        modified_columns_schema = TabletSchema::create(tablet_schema, all_column_ids);
+        modified_columns_schema = TabletSchema::create(params.tablet_schema, all_column_ids);
     }
 
-    for (size_t i = 0; i < num_segments; i++) {
-        _auto_increment_partial_update_states[i].init(modified_columns_schema,
-                                                      txn_meta.auto_increment_partial_update_column_id(), i);
-        _auto_increment_partial_update_states[i].src_rss_rowids.resize(_upserts[i]->size());
-        read_column[i].resize(1);
-        read_column[i][0] = column->clone_empty();
-        _auto_increment_partial_update_states[i].write_column = column->clone_empty();
+    _auto_increment_partial_update_states[segment_id].init(
+            modified_columns_schema, txn_meta.auto_increment_partial_update_column_id(), segment_id);
+    _auto_increment_partial_update_states[segment_id].src_rss_rowids.resize(_upserts[segment_id]->size());
+    read_column.resize(1);
+    read_column[0] = column->clone_empty();
+    _auto_increment_partial_update_states[segment_id].write_column = column->clone_empty();
+
+    // use upserts to get rowids in this segment
+    RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
+            params.tablet->id(), _base_versions[segment_id], _upserts[segment_id],
+            &(_auto_increment_partial_update_states[segment_id].src_rss_rowids), need_lock));
+
+    std::vector<uint32_t> rowids;
+    uint32_t n = _auto_increment_partial_update_states[segment_id].src_rss_rowids.size();
+    for (uint32_t j = 0; j < n; j++) {
+        uint64_t v = _auto_increment_partial_update_states[segment_id].src_rss_rowids[j];
+        uint32_t rssid = v >> 32;
+        if (rssid == (uint32_t)-1) {
+            rowids.emplace_back(j);
+        }
+    }
+    std::swap(_auto_increment_partial_update_states[segment_id].rowids, rowids);
+
+    size_t new_rows = 0;
+    std::vector<uint32_t> idxes;
+    std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
+    plan_read_by_rssid(_auto_increment_partial_update_states[segment_id].src_rss_rowids, &new_rows, &rowids_by_rssid,
+                       &idxes);
+
+    if (new_rows == n) {
+        _auto_increment_partial_update_states[segment_id].skip_rewrite = true;
     }
 
-    // segment id -> [rowids list]
-    std::vector<std::vector<uint64_t>*> rss_rowids;
-    rss_rowids.resize(num_segments);
-    for (size_t i = 0; i < num_segments; ++i) {
-        rss_rowids[i] = &(_auto_increment_partial_update_states[i].src_rss_rowids);
-    }
-    DCHECK_EQ(_upserts.size(), num_segments);
-    // use upserts to get rowids in each segment
-    RETURN_IF_ERROR(
-            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids, need_lock));
-
-    for (size_t i = 0; i < num_segments; i++) {
-        std::vector<uint32_t> rowids;
-        uint32_t n = _auto_increment_partial_update_states[i].src_rss_rowids.size();
-        for (uint32_t j = 0; j < n; j++) {
-            uint64_t v = _auto_increment_partial_update_states[i].src_rss_rowids[j];
-            uint32_t rssid = v >> 32;
-            if (rssid == (uint32_t)-1) {
-                rowids.emplace_back(j);
+    if (new_rows > 0) {
+        uint32_t last = idxes.size() - new_rows;
+        for (unsigned int& idx : idxes) {
+            if (idx != 0) {
+                --idx;
+            } else {
+                idx = last;
+                ++last;
             }
         }
-        std::swap(_auto_increment_partial_update_states[i].rowids, rowids);
+    }
 
-        size_t new_rows = 0;
-        std::vector<uint32_t> idxes;
-        std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
-        plan_read_by_rssid(_auto_increment_partial_update_states[i].src_rss_rowids, &new_rows, &rowids_by_rssid,
-                           &idxes);
+    RETURN_IF_ERROR(params.tablet->update_mgr()->get_column_values(params, column_id, new_rows > 0, rowids_by_rssid,
+                                                                   &read_column,
+                                                                   &_auto_increment_partial_update_states[segment_id]));
 
-        if (new_rows == n) {
-            _auto_increment_partial_update_states[i].skip_rewrite = true;
-        }
+    _auto_increment_partial_update_states[segment_id].write_column->append_selective(*read_column[0], idxes.data(), 0,
+                                                                                     idxes.size());
 
-        if (new_rows > 0) {
-            uint32_t last = idxes.size() - new_rows;
-            for (unsigned int& idx : idxes) {
-                if (idx != 0) {
-                    --idx;
-                } else {
-                    idx = last;
-                    ++last;
-                }
-            }
-        }
-
-        RETURN_IF_ERROR(tablet->update_mgr()->get_column_values(tablet, metadata, op_write, tablet_schema, column_id,
-                                                                new_rows > 0, false, rowids_by_rssid, &read_column[i],
-                                                                &_auto_increment_partial_update_states[i]));
-
-        _auto_increment_partial_update_states[i].write_column->append_selective(*read_column[i][0], idxes.data(), 0,
-                                                                                idxes.size());
-
-        /*
+    /*
         * Suppose we have auto increment ids for the rows which are not exist in the previous version.
         * The ids are allocated by system for partial update in this case. It is impossible that the ids
         * contain 0 in the normal case. But if the delete-partial update conflict happen with the previous transaction,
@@ -390,91 +335,63 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const Tx
         *    in the previous version, all the partial update ops after delete ops maybe lost for this row if they contained in
         *    different segment file.
         */
-        _auto_increment_delete_pks[i].reset();
-        _auto_increment_delete_pks[i] = _upserts[i]->clone_empty();
-        std::vector<uint32_t> delete_idxes;
-        const int64* data =
-                reinterpret_cast<const int64*>(_auto_increment_partial_update_states[i].write_column->raw_data());
+    _auto_increment_delete_pks[segment_id].reset();
+    _auto_increment_delete_pks[segment_id] = _upserts[segment_id]->clone_empty();
+    std::vector<uint32_t> delete_idxes;
+    const int64* data =
+            reinterpret_cast<const int64*>(_auto_increment_partial_update_states[segment_id].write_column->raw_data());
 
-        // just check the rows which are not exist in the previous version
-        // because the rows exist in the previous version may contain 0 which are specified by the user
-        for (unsigned int row_idx : _auto_increment_partial_update_states[i].rowids) {
-            if (data[row_idx] == 0) {
-                delete_idxes.emplace_back(row_idx);
-            }
+    // just check the rows which are not exist in the previous version
+    // because the rows exist in the previous version may contain 0 which are specified by the user
+    for (unsigned int row_idx : _auto_increment_partial_update_states[segment_id].rowids) {
+        if (data[row_idx] == 0) {
+            delete_idxes.emplace_back(row_idx);
         }
+    }
 
-        if (delete_idxes.size() != 0) {
-            _auto_increment_delete_pks[i]->append_selective(*_upserts[i], delete_idxes.data(), 0, delete_idxes.size());
-        }
+    if (delete_idxes.size() != 0) {
+        _auto_increment_delete_pks[segment_id]->append_selective(*_upserts[segment_id], delete_idxes.data(), 0,
+                                                                 delete_idxes.size());
     }
     return Status::OK();
 }
 
-Status RowsetUpdateState::_prepare_partial_update_states(const TxnLogPB_OpWrite& op_write,
-                                                         const TabletMetadata& metadata, Tablet* tablet,
-                                                         const TabletSchemaCSPtr& tablet_schema, bool need_lock) {
-    int64_t t_start = MonotonicMillis();
-    std::vector<ColumnId> read_column_ids = get_read_columns_ids(op_write, tablet_schema);
+Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, const RowsetUpdateStateParams& params,
+                                                         bool need_lock) {
+    std::vector<ColumnId> read_column_ids = get_read_columns_ids(params.op_write, params.tablet_schema);
 
-    auto read_column_schema = ChunkHelper::convert_schema(tablet_schema, read_column_ids);
-    size_t num_segments = op_write.rowset().segments_size();
-    // segment id -> column list
-    std::vector<std::vector<std::unique_ptr<Column>>> read_columns;
-    read_columns.resize(num_segments);
-    _partial_update_states.resize(num_segments);
-    for (size_t i = 0; i < num_segments; i++) {
-        read_columns[i].resize(read_column_ids.size());
-        _partial_update_states[i].write_columns.resize(read_columns[i].size());
-        _partial_update_states[i].src_rss_rowids.resize(_upserts[i]->size());
-        for (uint32_t j = 0; j < read_columns[i].size(); ++j) {
-            auto column = ChunkHelper::column_from_field(*read_column_schema.field(j).get());
-            read_columns[i][j] = column->clone_empty();
-            _partial_update_states[i].write_columns[j] = column->clone_empty();
-        }
+    auto read_column_schema = ChunkHelper::convert_schema(params.tablet_schema, read_column_ids);
+    // column list that need to read from source segment
+    std::vector<std::unique_ptr<Column>> read_columns;
+    read_columns.resize(read_column_ids.size());
+    _partial_update_states[segment_id].write_columns.resize(read_columns.size());
+    _partial_update_states[segment_id].src_rss_rowids.resize(_upserts[segment_id]->size());
+    for (uint32_t j = 0; j < read_columns.size(); ++j) {
+        auto column = ChunkHelper::column_from_field(*read_column_schema.field(j).get());
+        read_columns[j] = column->clone_empty();
+        _partial_update_states[segment_id].write_columns[j] = column->clone_empty();
     }
 
-    int64_t t_read_index = MonotonicMillis();
-    // segment id -> [rowids list]
-    std::vector<std::vector<uint64_t>*> rss_rowids;
-    rss_rowids.resize(num_segments);
-    for (size_t i = 0; i < num_segments; ++i) {
-        rss_rowids[i] = &(_partial_update_states[i].src_rss_rowids);
-    }
-    DCHECK_EQ(_upserts.size(), num_segments);
-    // use upserts to get rowids in each segment
-    RETURN_IF_ERROR(
-            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids, need_lock));
+    // use upsert to get rowids for this segment
+    RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
+            params.tablet->id(), _base_versions[segment_id], _upserts[segment_id],
+            &(_partial_update_states[segment_id].src_rss_rowids), need_lock));
 
-    int64_t t_read_values = MonotonicMillis();
-    size_t total_rows = 0;
-    // rows actually needed to be read, excluding rows with default values
-    size_t total_nondefault_rows = 0;
-    for (size_t i = 0; i < num_segments; i++) {
-        size_t num_default = 0;
-        std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
-        vector<uint32_t> idxes;
-        plan_read_by_rssid(_partial_update_states[i].src_rss_rowids, &num_default, &rowids_by_rssid, &idxes);
-        total_rows += _partial_update_states[i].src_rss_rowids.size();
-        total_nondefault_rows += _partial_update_states[i].src_rss_rowids.size() - num_default;
-        // get column values by rowid, also get default values if needed
-        RETURN_IF_ERROR(tablet->update_mgr()->get_column_values(tablet, metadata, op_write, tablet_schema,
-                                                                read_column_ids, num_default > 0, false,
-                                                                rowids_by_rssid, &read_columns[i]));
-        for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
-            _partial_update_states[i].write_columns[col_idx]->append_selective(*read_columns[i][col_idx], idxes.data(),
-                                                                               0, idxes.size());
-        }
-        // release read column memory
-        read_columns[i].clear();
+    size_t num_default = 0;
+    std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
+    vector<uint32_t> idxes;
+    plan_read_by_rssid(_partial_update_states[segment_id].src_rss_rowids, &num_default, &rowids_by_rssid, &idxes);
+    size_t total_rows = _partial_update_states[segment_id].src_rss_rowids.size();
+    // get column values by rowid, also get default values if needed
+    RETURN_IF_ERROR(params.tablet->update_mgr()->get_column_values(params, read_column_ids, num_default > 0,
+                                                                   rowids_by_rssid, &read_columns));
+    for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
+        _partial_update_states[segment_id].write_columns[col_idx]->append_selective(*read_columns[col_idx],
+                                                                                    idxes.data(), 0, idxes.size());
     }
-    int64_t t_end = MonotonicMillis();
+    TRACE_COUNTER_INCREMENT("partial_upt_total_rows", total_rows);
+    TRACE_COUNTER_INCREMENT("partial_upt_default_rows", num_default);
 
-    LOG(INFO) << strings::Substitute(
-            "prepare lake PartialUpdateState tablet:$0 #segment:$1 #row:$2(#non-default:$3) #column:$4 "
-            "time:$5ms(index:$6/value:$7)",
-            _tablet_id, num_segments, total_rows, total_nondefault_rows, read_columns.size(), t_end - t_start,
-            t_read_values - t_read_index, t_end - t_read_values);
     return Status::OK();
 }
 
@@ -490,27 +407,27 @@ StatusOr<bool> RowsetUpdateState::file_exist(const std::string& full_path) {
     }
 }
 
-Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                          Tablet* tablet, std::map<int, FileInfo>* replace_segments,
+Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, const RowsetUpdateStateParams& params,
+                                          std::map<int, FileInfo>* replace_segments,
                                           std::vector<std::string>* orphan_files) {
     TRACE_COUNTER_SCOPE_LATENCY_US("rewrite_segment_latency_us");
-    const RowsetMetadata& rowset_meta = op_write.rowset();
-    auto root_path = tablet->metadata_root_location();
+    const RowsetMetadata& rowset_meta = params.op_write.rowset();
+    auto root_path = params.tablet->metadata_root_location();
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_path));
-    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
+    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(params.metadata.schema());
     // get rowset schema
-    if (!op_write.has_txn_meta() || op_write.rewrite_segments_size() == 0 || rowset_meta.num_rows() == 0 ||
-        op_write.txn_meta().has_merge_condition()) {
+    if (!params.op_write.has_txn_meta() || params.op_write.rewrite_segments_size() == 0 ||
+        rowset_meta.num_rows() == 0 || params.op_write.txn_meta().has_merge_condition()) {
         return Status::OK();
     }
-    RETURN_ERROR_IF_FALSE(op_write.rewrite_segments_size() == rowset_meta.segments_size());
+    RETURN_ERROR_IF_FALSE(params.op_write.rewrite_segments_size() == rowset_meta.segments_size());
     // currently assume it's a partial update
-    const auto& txn_meta = op_write.txn_meta();
-    std::vector<ColumnId> unmodified_column_ids = get_read_columns_ids(op_write, tablet_schema);
+    const auto& txn_meta = params.op_write.txn_meta();
+    std::vector<ColumnId> unmodified_column_ids = get_read_columns_ids(params.op_write, params.tablet_schema);
 
     bool has_auto_increment_col = false;
-    for (uint32_t i = 0; i < tablet_schema->num_columns(); i++) {
-        if (tablet_schema->column(i).is_auto_increment()) {
+    for (uint32_t i = 0; i < params.tablet_schema->num_columns(); i++) {
+        if (params.tablet_schema->column(i).is_auto_increment()) {
             has_auto_increment_col = true;
         }
     }
@@ -520,135 +437,116 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
     // In this case, txn_meta.partial_update_column_unique_ids() will be always empty and we
     // will get unmodified_column_ids is full schema which is wrong.
     // To solve it, we can simply clear the unmodified_column_ids.
-    if (has_auto_increment_col && unmodified_column_ids.size() == tablet_schema->num_columns() &&
+    if (has_auto_increment_col && unmodified_column_ids.size() == params.tablet_schema->num_columns() &&
         _partial_update_states.size() == 0) {
         unmodified_column_ids.clear();
     }
 
-    std::vector<bool> need_rename(rowset_meta.segments_size(), true);
-    for (int i = 0; i < rowset_meta.segments_size(); i++) {
-        const auto& src_path = rowset_meta.segments(i);
-        const auto& dest_path = op_write.rewrite_segments(i);
-        DCHECK(src_path != dest_path);
+    bool need_rename = true;
+    const auto& src_path = rowset_meta.segments(segment_id);
+    const auto& dest_path = params.op_write.rewrite_segments(segment_id);
+    DCHECK(src_path != dest_path);
 
-        bool skip_because_file_exist = false;
-        int64_t t_rewrite_start = MonotonicMillis();
-        if (op_write.txn_meta().has_auto_increment_partial_update_column_id() &&
-            !_auto_increment_partial_update_states[i].skip_rewrite) {
-            FileInfo file_info{.path = tablet->segment_location(dest_path)};
-            ASSIGN_OR_RETURN(bool skip_rewrite, file_exist(file_info.path));
-            if (!skip_rewrite) {
-                RETURN_IF_ERROR(SegmentRewriter::rewrite(
-                        &file_info, tablet_schema, _auto_increment_partial_update_states[i], unmodified_column_ids,
-                        _partial_update_states.size() != 0 ? &_partial_update_states[i].write_columns : nullptr,
-                        op_write, tablet));
-            } else {
-                skip_because_file_exist = true;
-            }
-            file_info.path = dest_path;
-            (*replace_segments)[i] = file_info;
-        } else if (_partial_update_states.size() != 0) {
-            const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(i);
-            FileInfo file_info{.path = tablet->segment_location(dest_path)};
-            // if rewrite fail, let segment gc to clean dest segment file
-            ASSIGN_OR_RETURN(bool skip_rewrite, file_exist(file_info.path));
-            if (!skip_rewrite) {
-                RETURN_IF_ERROR(SegmentRewriter::rewrite(tablet->segment_location(src_path), &file_info, tablet_schema,
-                                                         unmodified_column_ids, _partial_update_states[i].write_columns,
-                                                         i, partial_rowset_footer));
-            } else {
-                skip_because_file_exist = true;
-            }
-            file_info.path = dest_path;
-            (*replace_segments)[i] = file_info;
+    bool skip_because_file_exist = false;
+    int64_t t_rewrite_start = MonotonicMillis();
+    if (params.op_write.txn_meta().has_auto_increment_partial_update_column_id() &&
+        !_auto_increment_partial_update_states[segment_id].skip_rewrite) {
+        FileInfo file_info{.path = params.tablet->segment_location(dest_path)};
+        ASSIGN_OR_RETURN(bool skip_rewrite, file_exist(file_info.path));
+        if (!skip_rewrite) {
+            RETURN_IF_ERROR(SegmentRewriter::rewrite(
+                    &file_info, params.tablet_schema, _auto_increment_partial_update_states[segment_id],
+                    unmodified_column_ids,
+                    _partial_update_states.size() != 0 ? &_partial_update_states[segment_id].write_columns : nullptr,
+                    params.op_write, params.tablet));
         } else {
-            need_rename[i] = false;
+            skip_because_file_exist = true;
         }
-        int64_t t_rewrite_end = MonotonicMillis();
-        LOG(INFO) << strings::Substitute(
-                "lake apply partial segment tablet:$0 rowset:$1 seg:$2 #column:$3 #rewrite:$4ms [$5 -> $6] "
-                "skip_because_file_exist:$7",
-                tablet->id(), rowset_meta.id(), i, unmodified_column_ids.size(), t_rewrite_end - t_rewrite_start,
-                src_path, dest_path, skip_because_file_exist);
+        file_info.path = dest_path;
+        (*replace_segments)[segment_id] = file_info;
+    } else if (_partial_update_states.size() != 0) {
+        const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
+        FileInfo file_info{.path = params.tablet->segment_location(dest_path)};
+        // if rewrite fail, let segment gc to clean dest segment file
+        ASSIGN_OR_RETURN(bool skip_rewrite, file_exist(file_info.path));
+        if (!skip_rewrite) {
+            RETURN_IF_ERROR(SegmentRewriter::rewrite(
+                    params.tablet->segment_location(src_path), &file_info, params.tablet_schema, unmodified_column_ids,
+                    _partial_update_states[segment_id].write_columns, segment_id, partial_rowset_footer));
+        } else {
+            skip_because_file_exist = true;
+        }
+        file_info.path = dest_path;
+        (*replace_segments)[segment_id] = file_info;
+    } else {
+        need_rename = false;
     }
+    int64_t t_rewrite_end = MonotonicMillis();
+    LOG(INFO) << strings::Substitute(
+            "lake apply partial segment tablet:$0 rowset:$1 seg:$2 #column:$3 #rewrite:$4ms [$5 -> $6] "
+            "skip_because_file_exist:$7",
+            params.tablet->id(), rowset_meta.id(), segment_id, unmodified_column_ids.size(),
+            t_rewrite_end - t_rewrite_start, src_path, dest_path, skip_because_file_exist);
 
     // rename segment file
-    for (int i = 0; i < rowset_meta.segments_size(); i++) {
-        if (need_rename[i]) {
-            // after rename, add old segment to orphan files, for gc later.
-            orphan_files->push_back(rowset_meta.segments(i));
-        }
+    if (need_rename) {
+        // after rename, add old segment to orphan files, for gc later.
+        orphan_files->push_back(rowset_meta.segments(segment_id));
     }
     TRACE("end rewrite segment");
     return Status::OK();
 }
 
-Status RowsetUpdateState::_resolve_conflict(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                            int64_t base_version, Tablet* tablet, const MetaFileBuilder* builder) {
-    _builder = builder;
+Status RowsetUpdateState::_resolve_conflict(uint32_t segment_id, const RowsetUpdateStateParams& params,
+                                            int64_t base_version) {
     // There are two cases that we must resolve conflict here:
     // 1. Current transaction's base version isn't equal latest base version, which means that conflict happens.
     // 2. We use batch publish here. This transaction may conflict with a transaction in the same batch.
-    if (base_version == _base_version && base_version + 1 == metadata.version()) {
+    if (base_version == _base_versions[segment_id] && base_version + 1 == params.metadata.version()) {
         return Status::OK();
     }
+    _base_versions[segment_id] = base_version;
     TRACE_COUNTER_SCOPE_LATENCY_US("resolve_conflict_latency_us");
-    _base_version = base_version;
     // skip resolve conflict when not partial update happen.
-    if (!op_write.has_txn_meta() || op_write.rowset().segments_size() == 0 ||
-        op_write.txn_meta().has_merge_condition()) {
+    if (!params.op_write.has_txn_meta() || params.op_write.rowset().segments_size() == 0 ||
+        params.op_write.txn_meta().has_merge_condition()) {
         return Status::OK();
     }
 
-    // we must get segment number from op_write but not _partial_update_states,
-    // because _resolve_conflict maybe done for auto increment col partial update only
-    const int num_segments = op_write.rowset().segments_size();
-    // use upserts to get rowids in each segment
-    // segment id -> [rowids list]
-    std::vector<std::vector<uint64_t>> new_rss_rowids_vec;
-    new_rss_rowids_vec.resize(num_segments);
-    for (uint32_t segment_id = 0; segment_id < num_segments; segment_id++) {
-        new_rss_rowids_vec[segment_id].resize(_upserts[segment_id]->size());
-    }
-    RETURN_IF_ERROR(
-            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &new_rss_rowids_vec, false));
+    // use upserts to get rowids in this segment
+    std::vector<uint64_t> new_rss_rowids(_upserts[segment_id]->size());
+    RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
+            params.tablet->id(), _base_versions[segment_id], _upserts[segment_id], &new_rss_rowids, false));
 
     size_t total_conflicts = 0;
-    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
-    std::vector<ColumnId> read_column_ids = get_read_columns_ids(op_write, tablet_schema);
+    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(params.metadata.schema());
+    std::vector<ColumnId> read_column_ids = get_read_columns_ids(params.op_write, params.tablet_schema);
     // get rss_rowids to identify conflict exist or not
     int64_t t_start = MonotonicMillis();
-    for (uint32_t segment_id = 0; segment_id < num_segments; segment_id++) {
-        std::vector<uint64_t>& new_rss_rowids = new_rss_rowids_vec[segment_id];
 
-        // reslove normal partial update
-        if (!op_write.txn_meta().partial_update_column_unique_ids().empty()) {
-            RETURN_IF_ERROR(_resolve_conflict_partial_update(op_write, metadata, tablet, new_rss_rowids,
-                                                             read_column_ids, segment_id, total_conflicts,
-                                                             tablet_schema));
-        }
+    // reslove normal partial update
+    if (!params.op_write.txn_meta().partial_update_column_unique_ids().empty()) {
+        RETURN_IF_ERROR(
+                _resolve_conflict_partial_update(params, new_rss_rowids, read_column_ids, segment_id, total_conflicts));
+    }
 
-        // reslove auto increment
-        if (op_write.txn_meta().has_auto_increment_partial_update_column_id()) {
-            RETURN_IF_ERROR(_resolve_conflict_auto_increment(op_write, metadata, tablet, new_rss_rowids, segment_id,
-                                                             total_conflicts, tablet_schema));
-        }
+    // reslove auto increment
+    if (params.op_write.txn_meta().has_auto_increment_partial_update_column_id()) {
+        RETURN_IF_ERROR(_resolve_conflict_auto_increment(params, new_rss_rowids, segment_id, total_conflicts));
     }
     int64_t t_end = MonotonicMillis();
     LOG(INFO) << strings::Substitute(
             "lake resolve_conflict tablet:$0 base_version:$1 #conflict-row:$2 "
             "#column:$3 time:$4ms",
-            tablet->id(), _base_version, total_conflicts, read_column_ids.size(), t_end - t_start);
+            params.tablet->id(), _base_versions[segment_id], total_conflicts, read_column_ids.size(), t_end - t_start);
 
     return Status::OK();
 }
 
-Status RowsetUpdateState::_resolve_conflict_partial_update(const TxnLogPB_OpWrite& op_write,
-                                                           const TabletMetadata& metadata, Tablet* tablet,
+Status RowsetUpdateState::_resolve_conflict_partial_update(const RowsetUpdateStateParams& params,
                                                            const std::vector<uint64_t>& new_rss_rowids,
                                                            std::vector<uint32_t>& read_column_ids, uint32_t segment_id,
-                                                           size_t& total_conflicts,
-                                                           const TabletSchemaCSPtr& tablet_schema) {
+                                                           size_t& total_conflicts) {
     uint32_t num_rows = new_rss_rowids.size();
     std::vector<uint32_t> conflict_idxes;
     std::vector<uint64_t> conflict_rowids;
@@ -676,9 +574,8 @@ Status RowsetUpdateState::_resolve_conflict_partial_update(const TxnLogPB_OpWrit
         std::vector<uint32_t> read_idxes;
         plan_read_by_rssid(conflict_rowids, &num_default, &rowids_by_rssid, &read_idxes);
         DCHECK_EQ(conflict_idxes.size(), read_idxes.size());
-        RETURN_IF_ERROR(tablet->update_mgr()->get_column_values(tablet, metadata, op_write, tablet_schema,
-                                                                read_column_ids, num_default > 0, false,
-                                                                rowids_by_rssid, &read_columns));
+        RETURN_IF_ERROR(params.tablet->update_mgr()->get_column_values(params, read_column_ids, num_default > 0,
+                                                                       rowids_by_rssid, &read_columns));
 
         for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
             std::unique_ptr<Column> new_write_column =
@@ -692,11 +589,9 @@ Status RowsetUpdateState::_resolve_conflict_partial_update(const TxnLogPB_OpWrit
     return Status::OK();
 }
 
-Status RowsetUpdateState::_resolve_conflict_auto_increment(const TxnLogPB_OpWrite& op_write,
-                                                           const TabletMetadata& metadata, Tablet* tablet,
+Status RowsetUpdateState::_resolve_conflict_auto_increment(const RowsetUpdateStateParams& params,
                                                            const std::vector<uint64_t>& new_rss_rowids,
-                                                           uint32_t segment_id, size_t& total_conflicts,
-                                                           const TabletSchemaCSPtr& tablet_schema) {
+                                                           uint32_t segment_id, size_t& total_conflicts) {
     uint32_t num_rows = new_rss_rowids.size();
     std::vector<uint32_t> conflict_idxes;
     std::vector<uint64_t> conflict_rowids;
@@ -747,8 +642,8 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const TxnLogPB_OpWrit
         }
 
         uint32_t auto_increment_column_id = 0;
-        for (int i = 0; i < tablet_schema->num_columns(); ++i) {
-            if (tablet_schema->column(i).is_auto_increment()) {
+        for (int i = 0; i < params.tablet_schema->num_columns(); ++i) {
+            if (params.tablet_schema->column(i).is_auto_increment()) {
                 auto_increment_column_id = i;
                 break;
             }
@@ -757,9 +652,9 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const TxnLogPB_OpWrit
         std::vector<std::unique_ptr<Column>> auto_increment_read_column;
         auto_increment_read_column.resize(1);
         auto_increment_read_column[0] = _auto_increment_partial_update_states[segment_id].write_column->clone_empty();
-        RETURN_IF_ERROR(tablet->update_mgr()->get_column_values(
-                tablet, metadata, op_write, tablet_schema, column_id, new_rows > 0, false, rowids_by_rssid,
-                &auto_increment_read_column, &_auto_increment_partial_update_states[segment_id]));
+        RETURN_IF_ERROR(params.tablet->update_mgr()->get_column_values(
+                params, column_id, new_rows > 0, rowids_by_rssid, &auto_increment_read_column,
+                &_auto_increment_partial_update_states[segment_id]));
 
         std::unique_ptr<Column> new_write_column =
                 _auto_increment_partial_update_states[segment_id].write_column->clone_empty();
@@ -790,8 +685,51 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const TxnLogPB_OpWrit
     return Status::OK();
 }
 
-const std::vector<std::unique_ptr<Column>>& RowsetUpdateState::auto_increment_deletes() const {
-    return _auto_increment_delete_pks;
+void RowsetUpdateState::release_segment(uint32_t segment_id) {
+    _upserts[segment_id].reset();
+    _partial_update_states[segment_id].reset();
+    _auto_increment_partial_update_states[segment_id].reset();
+    _auto_increment_delete_pks[segment_id].reset();
+}
+
+Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStateParams& params) {
+    // always one file for now.
+    TRACE_COUNTER_SCOPE_LATENCY_US("load_delete_us");
+    _deletes.resize(params.op_write.dels_size());
+    if (_deletes[del_id] != nullptr) {
+        // Already load.
+        return Status::OK();
+    }
+    vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
+        pk_columns.push_back((uint32_t)i);
+    }
+    Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
+    std::unique_ptr<Column> pk_column;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+
+    auto root_path = params.tablet->metadata_root_location();
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_path));
+    const std::string& path = params.op_write.dels(del_id);
+    ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(params.tablet->del_location(path)));
+    ASSIGN_OR_RETURN(auto file_size, read_file->get_size());
+    std::vector<uint8_t> read_buffer(file_size);
+    RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
+    auto col = pk_column->clone();
+    if (serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()) == nullptr) {
+        return Status::InternalError("column deserialization failed");
+    }
+    _deletes[del_id] = std::move(col);
+    TRACE("end read $0-th deletes files", del_id);
+    return Status::OK();
+}
+
+void RowsetUpdateState::release_delete(uint32_t del_id) {
+    _deletes[del_id].reset();
+}
+
+const std::unique_ptr<Column>& RowsetUpdateState::auto_increment_deletes(uint32_t segment_id) const {
+    return _auto_increment_delete_pks[segment_id];
 }
 
 std::string RowsetUpdateState::to_string() const {

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -25,11 +25,15 @@
 
 namespace starrocks::lake {
 
-class MetaFileBuilder;
+class RssidFileInfoContainer;
 
 struct PartialUpdateState {
     std::vector<uint64_t> src_rss_rowids;
     std::vector<std::unique_ptr<Column>> write_columns;
+    void reset() {
+        src_rss_rowids.clear();
+        write_columns.clear();
+    }
 };
 
 struct AutoIncrementPartialUpdateState {
@@ -52,6 +56,20 @@ struct AutoIncrementPartialUpdateState {
         this->id = id;
         this->segment_id = segment_id;
     }
+    void reset() {
+        src_rss_rowids.clear();
+        write_column.reset();
+        schema.reset();
+        rowids.clear();
+    }
+};
+
+struct RowsetUpdateStateParams {
+    const TxnLogPB_OpWrite& op_write;
+    const TabletSchemaPtr& tablet_schema;
+    const TabletMetadata& metadata;
+    const Tablet* tablet;
+    const RssidFileInfoContainer& container;
 };
 
 class RowsetUpdateState {
@@ -63,65 +81,89 @@ public:
 
     DISALLOW_COPY_AND_MOVE(RowsetUpdateState);
 
-    Status load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version, Tablet* tablet,
-                const MetaFileBuilder* builder, bool need_check_conflict, bool need_lock);
+    // How to use `RowsetUpdateState` when publish:
+    //
+    // init()
+    //
+    // for each segment:
+    //      load_segment()
+    //      rewrite_segment()
+    //      ...
+    //      release_segment()
+    //
+    // for each del file:
+    //      load_delete()
+    //      ...
+    //      release_delete()
 
-    Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
+    // init params in RowsetUpdateState.
+    void init(const RowsetUpdateStateParams& params);
+
+    // Load `segment_id`-th segment file's state.
+    Status load_segment(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version,
+                        bool need_resolve_conflict, bool need_lock);
+
+    // Handle `segment_id`-th segment file's partial update request.
+    Status rewrite_segment(uint32_t segment_id, const RowsetUpdateStateParams& params,
                            std::map<int, FileInfo>* replace_segments, std::vector<std::string>* orphan_files);
 
-    const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
-    const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }
+    // Release `segment_id`-th segment file's state.
+    void release_segment(uint32_t segment_id);
+
+    // Load `del_id`-th delete file's state.
+    Status load_delete(uint32_t del_id, const RowsetUpdateStateParams& params);
+
+    // Release `del_id`-th delete file's state.
+    void release_delete(uint32_t del_id);
+
+    const ColumnUniquePtr& upserts(uint32_t segment_id) const { return _upserts[segment_id]; }
+    const ColumnUniquePtr& deletes(uint32_t segment_id) const { return _deletes[segment_id]; }
 
     std::size_t memory_usage() const { return _memory_usage; }
 
     std::string to_string() const;
 
-    const std::vector<PartialUpdateState>& parital_update_states() { return _partial_update_states; }
+    const PartialUpdateState& parital_update_states(uint32_t segment_id) { return _partial_update_states[segment_id]; }
 
     static void plan_read_by_rssid(const std::vector<uint64_t>& rowids, size_t* num_default,
                                    std::map<uint32_t, std::vector<uint32_t>>* rowids_by_rssid,
                                    std::vector<uint32_t>* idxes);
 
-    const std::vector<std::unique_ptr<Column>>& auto_increment_deletes() const;
+    const std::unique_ptr<Column>& auto_increment_deletes(uint32_t segment_id) const;
 
     static StatusOr<bool> file_exist(const std::string& full_path);
 
 private:
-    Status _do_load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet, bool need_lock);
+    // Load segment state
+    Status _do_load_upserts(uint32_t segment_id, const RowsetUpdateStateParams& params);
 
-    Status _do_load_upserts_deletes(const TxnLogPB_OpWrite& op_write, const TabletSchemaCSPtr& tablet_schema,
-                                    Tablet* tablet, Rowset* rowset_ptr);
+    Status _prepare_partial_update_states(uint32_t segment_id, const RowsetUpdateStateParams& params, bool need_lock);
 
-    Status _prepare_partial_update_states(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                          Tablet* tablet, const TabletSchemaCSPtr& tablet_schema, bool need_lock);
+    Status _prepare_auto_increment_partial_update_states(uint32_t segment_id, const RowsetUpdateStateParams& params,
+                                                         bool need_lock);
 
-    Status _resolve_conflict(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version,
-                             Tablet* tablet, const MetaFileBuilder* builder);
+    // resolve conflict when publish transaction
+    Status _resolve_conflict(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version);
 
-    Status _resolve_conflict_partial_update(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                            Tablet* tablet, const std::vector<uint64_t>& new_rss_rowids,
+    Status _resolve_conflict_partial_update(const RowsetUpdateStateParams& params,
+                                            const std::vector<uint64_t>& new_rss_rowids,
                                             std::vector<uint32_t>& read_column_ids, uint32_t segment_id,
-                                            size_t& total_conflicts, const TabletSchemaCSPtr& tablet_schema);
+                                            size_t& total_conflicts);
 
-    Status _resolve_conflict_auto_increment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                            Tablet* tablet, const std::vector<uint64_t>& new_rss_rowids,
-                                            uint32_t segment_id, size_t& total_conflicts,
-                                            const TabletSchemaCSPtr& tablet_schema);
-
-    Status _prepare_auto_increment_partial_update_states(const TxnLogPB_OpWrite& op_write,
-                                                         const TabletMetadata& metadata, Tablet* tablet,
-                                                         const TabletSchemaCSPtr& tablet_schema, bool need_lock);
+    Status _resolve_conflict_auto_increment(const RowsetUpdateStateParams& params,
+                                            const std::vector<uint64_t>& new_rss_rowids, uint32_t segment_id,
+                                            size_t& total_conflicts);
 
     void _reset();
 
-    Status _status;
     // one for each segment file
     std::vector<ColumnUniquePtr> _upserts;
     // one for each delete file
     std::vector<ColumnUniquePtr> _deletes;
     size_t _memory_usage = 0;
     int64_t _tablet_id = 0;
-    int64_t _base_version = 0;
+    // Because we can load partial segments when preload, so need vector to track their version.
+    std::vector<int64_t> _base_versions;
     int64_t _schema_version = 0;
 
     // TODO: dump to disk if memory usage is too large
@@ -131,7 +173,11 @@ private:
 
     std::vector<std::unique_ptr<Column>> _auto_increment_delete_pks;
 
-    const MetaFileBuilder* _builder;
+    std::unique_ptr<Rowset> _rowset_ptr;
+
+    // to be destructed after segment iters
+    OlapReaderStatistics _stats;
+    std::vector<ChunkIteratorPtr> _segment_iters;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetUpdateState& o) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -90,6 +90,35 @@ void PersistentIndexBlockCache::update_memory_usage() {
     _memory_usage = current_mem_usage;
 }
 
+void RssidFileInfoContainer::add_rssid_to_file(const TabletMetadata& metadata) {
+    for (auto& rs : metadata.rowsets()) {
+        bool has_segment_size = (rs.segments_size() == rs.segment_size_size());
+        for (int i = 0; i < rs.segments_size(); i++) {
+            FileInfo segment_info{.path = rs.segments(i)};
+            if (LIKELY(has_segment_size)) {
+                segment_info.size = rs.segment_size(i);
+            }
+            _rssid_to_file_info[rs.id() + i] = segment_info;
+        }
+    }
+}
+
+void RssidFileInfoContainer::add_rssid_to_file(const RowsetMetadataPB& meta, uint32_t rowset_id, uint32_t segment_id,
+                                               const std::map<int, FileInfo>& replace_segments) {
+    DCHECK(segment_id < meta.segments_size());
+    if (replace_segments.count(segment_id) > 0) {
+        // partial update
+        _rssid_to_file_info[rowset_id + segment_id] = replace_segments.at(segment_id);
+    } else {
+        bool has_segment_size = (meta.segments_size() == meta.segment_size_size());
+        FileInfo segment_info{.path = meta.segments(segment_id)};
+        if (LIKELY(has_segment_size)) {
+            segment_info.size = meta.segment_size(segment_id);
+        }
+        _rssid_to_file_info[rowset_id + segment_id] = segment_info;
+    }
+}
+
 StatusOr<IndexEntry*> UpdateManager::prepare_primary_index(
         const TabletMetadataPtr& metadata, MetaFileBuilder* builder, int64_t base_version, int64_t new_version,
         std::unique_ptr<std::lock_guard<std::shared_timed_mutex>>& guard) {
@@ -158,43 +187,63 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // only use state entry once, remove it when publish finish or fail
     DeferOp remove_state_entry([&] { _update_state_cache.remove(state_entry); });
     auto& state = state_entry->value();
-    RETURN_IF_ERROR(state.load(op_write, metadata, base_version, tablet, builder, true, false));
-    TRACE_COUNTER_INCREMENT("state_bytes", state.memory_usage());
-    _update_state_cache.update_object_size(state_entry, state.memory_usage());
-    // 2. rewrite segment file if it is partial update
+
     std::vector<std::string> orphan_files;
     std::map<int, FileInfo> replace_segments;
-    RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet, &replace_segments, &orphan_files));
+    RssidFileInfoContainer rssid_fileinfo_container;
+    rssid_fileinfo_container.add_rssid_to_file(metadata);
+    // Init update state.
+    RowsetUpdateStateParams params{
+            .op_write = op_write,
+            .tablet_schema = tablet_schema,
+            .metadata = metadata,
+            .tablet = tablet,
+            .container = rssid_fileinfo_container,
+    };
+    state.init(params);
+    // Init delvec state.
     PrimaryIndex::DeletesMap new_deletes;
-    for (uint32_t i = 0; i < op_write.rowset().segments_size(); i++) {
-        new_deletes[rowset_id + i] = {};
+    for (uint32_t segment_id = 0; segment_id < op_write.rowset().segments_size(); segment_id++) {
+        new_deletes[rowset_id + segment_id] = {};
     }
-    auto& upserts = state.upserts();
-    // handle merge condition, skip update row which's merge condition column value is smaller than current row
-    int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
-    // 3. update primary index, and generate delete info.
-    TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
-    for (uint32_t i = 0; i < upserts.size(); i++) {
-        if (upserts[i] != nullptr) {
-            if (condition_column < 0) {
-                RETURN_IF_ERROR(_do_update(rowset_id, i, upserts, index, tablet->id(), &new_deletes));
-            } else {
-                RETURN_IF_ERROR(_do_update_with_condition(tablet, metadata, op_write, tablet_schema, rowset_id, i,
-                                                          condition_column, upserts, index, tablet->id(),
-                                                          &new_deletes));
-            }
-            _index_cache.update_object_size(index_entry, index.memory_usage());
+    // 2. Handle segment one by one to save memory usage.
+    for (uint32_t segment_id = 0; segment_id < op_write.rowset().segments_size(); segment_id++) {
+        RETURN_IF_ERROR(state.load_segment(segment_id, params, base_version, true /*reslove conflict*/,
+                                           false /*no need lock*/));
+        _update_state_cache.update_object_size(state_entry, state.memory_usage());
+        // 2.1 rewrite segment file if it is partial update
+        RETURN_IF_ERROR(state.rewrite_segment(segment_id, params, &replace_segments, &orphan_files));
+        rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata.next_rowset_id(), segment_id,
+                                                   replace_segments);
+        // handle merge condition, skip update row which's merge condition column value is smaller than current row
+        int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
+        // 2.2 update primary index, and generate delete info.
+        TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
+        DCHECK(state.upserts(segment_id) != nullptr);
+        if (condition_column < 0) {
+            RETURN_IF_ERROR(_do_update(rowset_id, segment_id, state.upserts(segment_id), index, &new_deletes));
+        } else {
+            RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, segment_id, condition_column,
+                                                      state.upserts(segment_id), index, &new_deletes));
         }
+        // 2.3 handle auto increment deletes
+        if (state.auto_increment_deletes(segment_id) != nullptr) {
+            RETURN_IF_ERROR(index.erase(*state.auto_increment_deletes(segment_id), &new_deletes));
+        }
+        _index_cache.update_object_size(index_entry, index.memory_usage());
+        state.release_segment(segment_id);
+        _update_state_cache.update_object_size(state_entry, state.memory_usage());
     }
 
-    for (const auto& one_delete : state.deletes()) {
-        RETURN_IF_ERROR(index.erase(*one_delete, &new_deletes));
+    // 3. Handle del files one by one.
+    for (uint32_t del_id = 0; del_id < op_write.dels_size(); del_id++) {
+        RETURN_IF_ERROR(state.load_delete(del_id, params));
+        DCHECK(state.deletes(del_id) != nullptr);
+        RETURN_IF_ERROR(index.erase(*state.deletes(del_id), &new_deletes));
         _index_cache.update_object_size(index_entry, index.memory_usage());
+        state.release_delete(del_id);
     }
-    for (const auto& one_delete : state.auto_increment_deletes()) {
-        RETURN_IF_ERROR(index.erase(*one_delete, &new_deletes));
-        _index_cache.update_object_size(index_entry, index.memory_usage());
-    }
+
     _block_cache->update_memory_usage();
     // 4. generate delvec
     size_t ndelvec = new_deletes.size();
@@ -254,8 +303,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     RETURN_IF_ERROR(builder->update_num_del_stat(segment_id_to_add_dels));
 
     TRACE_COUNTER_INCREMENT("rowsetid", rowset_id);
-    TRACE_COUNTER_INCREMENT("upserts", upserts.size());
-    TRACE_COUNTER_INCREMENT("deletes", state.deletes().size());
+    TRACE_COUNTER_INCREMENT("upserts", op_write.rowset().segments_size());
+    TRACE_COUNTER_INCREMENT("deletes", op_write.dels_size());
     TRACE_COUNTER_INCREMENT("new_del", new_del);
     TRACE_COUNTER_INCREMENT("total_del", total_del);
     TRACE_COUNTER_INCREMENT("upsert_rows", op_write.rowset().num_rows());
@@ -264,26 +313,24 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     return Status::OK();
 }
 
-Status UpdateManager::_do_update(uint32_t rowset_id, int32_t upsert_idx, const std::vector<ColumnUniquePtr>& upserts,
-                                 PrimaryIndex& index, int64_t tablet_id, DeletesMap* new_deletes) {
+Status UpdateManager::_do_update(uint32_t rowset_id, int32_t upsert_idx, const ColumnUniquePtr& upsert,
+                                 PrimaryIndex& index, DeletesMap* new_deletes) {
     TRACE_COUNTER_SCOPE_LATENCY_US("do_update_latency_us");
-    return index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], new_deletes);
+    return index.upsert(rowset_id + upsert_idx, 0, *upsert, new_deletes);
 }
 
-Status UpdateManager::_do_update_with_condition(Tablet* tablet, const TabletMetadata& metadata,
-                                                const TxnLogPB_OpWrite& op_write,
-                                                const TabletSchemaCSPtr& tablet_schema, uint32_t rowset_id,
+Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& params, uint32_t rowset_id,
                                                 int32_t upsert_idx, int32_t condition_column,
-                                                const std::vector<ColumnUniquePtr>& upserts, PrimaryIndex& index,
-                                                int64_t tablet_id, DeletesMap* new_deletes) {
+                                                const ColumnUniquePtr& upsert, PrimaryIndex& index,
+                                                DeletesMap* new_deletes) {
     RETURN_ERROR_IF_FALSE(condition_column >= 0);
     TRACE_COUNTER_SCOPE_LATENCY_US("do_update_latency_us");
-    const auto& tablet_column = tablet_schema->column(condition_column);
+    const auto& tablet_column = params.tablet_schema->column(condition_column);
     std::vector<uint32_t> read_column_ids;
     read_column_ids.push_back(condition_column);
 
-    std::vector<uint64_t> old_rowids(upserts[upsert_idx]->size());
-    RETURN_IF_ERROR(index.get(*upserts[upsert_idx], &old_rowids));
+    std::vector<uint64_t> old_rowids(upsert->size());
+    RETURN_IF_ERROR(index.get(*upsert, &old_rowids));
     bool non_old_value = std::all_of(old_rowids.begin(), old_rowids.end(), [](int id) { return -1 == id; });
     if (!non_old_value) {
         std::map<uint32_t, std::vector<uint32_t>> old_rowids_by_rssid;
@@ -294,14 +341,13 @@ Status UpdateManager::_do_update_with_condition(Tablet* tablet, const TabletMeta
         auto old_unordered_column =
                 ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
         old_columns[0] = old_unordered_column->clone_empty();
-        RETURN_IF_ERROR(get_column_values(tablet, metadata, op_write, tablet_schema, read_column_ids, num_default > 0,
-                                          true, old_rowids_by_rssid, &old_columns));
+        RETURN_IF_ERROR(get_column_values(params, read_column_ids, num_default > 0, old_rowids_by_rssid, &old_columns));
         auto old_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
         old_column->append_selective(*old_columns[0], idxes.data(), 0, idxes.size());
 
         std::map<uint32_t, std::vector<uint32_t>> new_rowids_by_rssid;
         std::vector<uint32_t> rowids;
-        for (int j = 0; j < upserts[upsert_idx]->size(); ++j) {
+        for (int j = 0; j < upsert->size(); ++j) {
             rowids.push_back(j);
         }
         new_rowids_by_rssid[rowset_id + upsert_idx] = rowids;
@@ -309,8 +355,7 @@ Status UpdateManager::_do_update_with_condition(Tablet* tablet, const TabletMeta
         std::vector<std::unique_ptr<Column>> new_columns(1);
         auto new_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
         new_columns[0] = new_column->clone_empty();
-        RETURN_IF_ERROR(get_column_values(tablet, metadata, op_write, tablet_schema, read_column_ids, false, true,
-                                          new_rowids_by_rssid, &new_columns));
+        RETURN_IF_ERROR(get_column_values(params, read_column_ids, false, new_rowids_by_rssid, &new_columns));
 
         int idx_begin = 0;
         int upsert_idx_step = 0;
@@ -321,7 +366,7 @@ Status UpdateManager::_do_update_with_condition(Tablet* tablet, const TabletMeta
             } else {
                 int r = old_column->compare_at(j, j, *new_columns[0].get(), -1);
                 if (r > 0) {
-                    RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], idx_begin,
+                    RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upsert, idx_begin,
                                                  idx_begin + upsert_idx_step, new_deletes));
 
                     idx_begin = j + 1;
@@ -336,22 +381,22 @@ Status UpdateManager::_do_update_with_condition(Tablet* tablet, const TabletMeta
         }
 
         if (idx_begin < old_column->size()) {
-            RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], idx_begin,
-                                         idx_begin + upsert_idx_step, new_deletes));
+            RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upsert, idx_begin, idx_begin + upsert_idx_step,
+                                         new_deletes));
         }
     } else {
-        RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], new_deletes));
+        RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upsert, new_deletes));
     }
 
     return Status::OK();
 }
 
-Status UpdateManager::_handle_index_op(Tablet* tablet, int64_t base_version, bool need_lock,
+Status UpdateManager::_handle_index_op(int64_t tablet_id, int64_t base_version, bool need_lock,
                                        const std::function<void(LakePrimaryIndex&)>& op) {
     TRACE_COUNTER_SCOPE_LATENCY_US("handle_index_op_latency_us");
-    auto index_entry = _index_cache.get(tablet->id());
+    auto index_entry = _index_cache.get(tablet_id);
     if (index_entry == nullptr) {
-        return Status::Uninitialized(fmt::format("Primary index not load yet, tablet_id: {}", tablet->id()));
+        return Status::Uninitialized(fmt::format("Primary index not load yet, tablet_id: {}", tablet_id));
     }
     index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     // release index entry but keep it in cache
@@ -362,11 +407,11 @@ Status UpdateManager::_handle_index_op(Tablet* tablet, int64_t base_version, boo
     if (need_lock) {
         guard = index.try_fetch_guard();
         if (guard == nullptr) {
-            return Status::Cancelled(fmt::format("Fail to fetch primary index guard, tablet_id: {}", tablet->id()));
+            return Status::Cancelled(fmt::format("Fail to fetch primary index guard, tablet_id: {}", tablet_id));
         }
     }
     if (!index.is_load(base_version)) {
-        return Status::Uninitialized(fmt::format("Primary index not load yet, tablet_id: {}", tablet->id()));
+        return Status::Uninitialized(fmt::format("Primary index not load yet, tablet_id: {}", tablet_id));
     }
     op(index);
     _block_cache->update_memory_usage();
@@ -374,11 +419,11 @@ Status UpdateManager::_handle_index_op(Tablet* tablet, int64_t base_version, boo
     return Status::OK();
 }
 
-Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, int64_t base_version,
+Status UpdateManager::get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version,
                                               const std::vector<ColumnUniquePtr>& upserts,
                                               std::vector<std::vector<uint64_t>*>* rss_rowids, bool need_lock) {
     Status st;
-    st.update(_handle_index_op(tablet, base_version, need_lock, [&](LakePrimaryIndex& index) {
+    st.update(_handle_index_op(tablet_id, base_version, need_lock, [&](LakePrimaryIndex& index) {
         // get rss_rowids for each segment of rowset
         uint32_t num_segments = upserts.size();
         for (size_t i = 0; i < num_segments; i++) {
@@ -389,25 +434,18 @@ Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, int64_t base_versi
     return st;
 }
 
-Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, int64_t base_version,
-                                              const std::vector<ColumnUniquePtr>& upserts,
-                                              std::vector<std::vector<uint64_t>>* rss_rowids, bool need_lock) {
+Status UpdateManager::get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version, const ColumnUniquePtr& upsert,
+                                              std::vector<uint64_t>* rss_rowids, bool need_lock) {
     Status st;
-    st.update(_handle_index_op(tablet, base_version, need_lock, [&](LakePrimaryIndex& index) {
-        // get rss_rowids for each segment of rowset
-        uint32_t num_segments = upserts.size();
-        for (size_t i = 0; i < num_segments; i++) {
-            auto& pks = *upserts[i];
-            st.update(index.get(pks, &((*rss_rowids)[i])));
-        }
+    st.update(_handle_index_op(tablet_id, base_version, need_lock, [&](LakePrimaryIndex& index) {
+        // get rss_rowids for segment's pk
+        st.update(index.get(*upsert, rss_rowids));
     }));
     return st;
 }
 
-Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& metadata,
-                                        const TxnLogPB_OpWrite& op_write, const TabletSchemaCSPtr& tablet_schema,
-                                        std::vector<uint32_t>& column_ids, bool with_default, bool include_op_write,
-                                        std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
+Status UpdateManager::get_column_values(const RowsetUpdateStateParams& params, std::vector<uint32_t>& column_ids,
+                                        bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                                         vector<std::unique_ptr<Column>>* columns,
                                         AutoIncrementPartialUpdateState* auto_increment_state) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_column_values_latency_us");
@@ -417,7 +455,7 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
 
     if (with_default && auto_increment_state == nullptr) {
         for (auto i = 0; i < column_ids.size(); ++i) {
-            const TabletColumn& tablet_column = tablet_schema->column(column_ids[i]);
+            const TabletColumn& tablet_column = params.tablet_schema->column(column_ids[i]);
             if (tablet_column.has_default_value()) {
                 const TypeInfoPtr& type_info = get_type_info(tablet_column);
                 std::unique_ptr<DefaultValueColumnIterator> default_value_iter =
@@ -435,18 +473,11 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
     cost_str << " [with_default] " << watch.elapsed_time();
     watch.reset();
 
-    std::unordered_map<uint32_t, FileInfo> rssid_to_file_info;
-    // When `include_op_write` is true, that means we want to get columns from segment in op_write log too.
-    // It happens when using condition update.
-    rowset_rssid_to_path(metadata, include_op_write ? &op_write : nullptr, rssid_to_file_info);
-    cost_str << " [catch rssid_to_path] " << watch.elapsed_time();
-    watch.reset();
-
     std::shared_ptr<FileSystem> fs;
     auto fetch_values_from_segment = [&](const FileInfo& segment_info, uint32_t segment_id,
                                          const TabletSchemaCSPtr& tablet_schema, const std::vector<uint32_t>& rowids,
                                          const std::vector<uint32_t>& read_column_ids) -> Status {
-        FileInfo file_info{.path = tablet->segment_location(segment_info.path)};
+        FileInfo file_info{.path = params.tablet->segment_location(segment_info.path)};
         if (segment_info.size.has_value()) {
             file_info.size = segment_info.size;
         }
@@ -476,28 +507,30 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
 
     for (const auto& [rssid, rowids] : rowids_by_rssid) {
         if (fs == nullptr) {
-            auto root_path = tablet->metadata_root_location();
+            auto root_path = params.tablet->metadata_root_location();
             ASSIGN_OR_RETURN(fs, FileSystem::CreateSharedFromString(root_path));
         }
 
-        if (rssid_to_file_info.count(rssid) == 0) {
+        if (params.container.rssid_to_file().count(rssid) == 0) {
             // It may happen when preload partial update state by old tablet meta
-            return Status::Cancelled(fmt::format("tablet id {} version {} rowset_segment_id {} no exist", metadata.id(),
-                                                 metadata.version(), rssid));
+            return Status::Cancelled(fmt::format("tablet id {} version {} rowset_segment_id {} no exist",
+                                                 params.metadata.id(), params.metadata.version(), rssid));
         }
         // use 0 segment_id is safe, because we need not get either delvector or dcg here
-        RETURN_IF_ERROR(fetch_values_from_segment(rssid_to_file_info[rssid], 0, tablet_schema, rowids, column_ids));
+        RETURN_IF_ERROR(fetch_values_from_segment(params.container.rssid_to_file().at(rssid), 0, params.tablet_schema,
+                                                  rowids, column_ids));
     }
     if (auto_increment_state != nullptr && with_default) {
         if (fs == nullptr) {
-            auto root_path = tablet->metadata_root_location();
+            auto root_path = params.tablet->metadata_root_location();
             ASSIGN_OR_RETURN(fs, FileSystem::CreateSharedFromString(root_path));
         }
         uint32_t segment_id = auto_increment_state->segment_id;
         const std::vector<uint32_t>& rowids = auto_increment_state->rowids;
         const std::vector<uint32_t> auto_increment_col_partial_id(1, auto_increment_state->id);
 
-        RETURN_IF_ERROR(fetch_values_from_segment(FileInfo{.path = op_write.rowset().segments(segment_id)}, segment_id,
+        RETURN_IF_ERROR(fetch_values_from_segment(FileInfo{.path = params.op_write.rowset().segments(segment_id)},
+                                                  segment_id,
                                                   // use partial segment column offset id to get the column
                                                   auto_increment_state->schema, rowids, auto_increment_col_partial_id));
     }
@@ -862,9 +895,29 @@ void UpdateManager::preload_update_state(const TxnLog& txnlog, Tablet* tablet) {
     _update_state_cache.update_object_size(state_entry, state.memory_usage());
     // get latest metadata from cache, it is not matter if it isn't the real latest metadata.
     auto metadata_ptr = _tablet_mgr->get_latest_cached_tablet_metadata(tablet->id());
+    const int segments_size = txnlog.op_write().rowset().segments_size();
     // skip preload if memory limit exceed
-    if (metadata_ptr != nullptr && !_update_state_mem_tracker->any_limit_exceeded()) {
-        auto st = state.load(txnlog.op_write(), *metadata_ptr, metadata_ptr->version(), tablet, nullptr, false, true);
+    if (metadata_ptr != nullptr && segments_size > 0 && !_update_state_mem_tracker->any_limit_exceeded()) {
+        auto tablet_schema = std::make_shared<TabletSchema>(metadata_ptr->schema());
+        RssidFileInfoContainer rssid_fileinfo_container;
+        rssid_fileinfo_container.add_rssid_to_file(*metadata_ptr);
+        RowsetUpdateStateParams params{
+                .op_write = txnlog.op_write(),
+                .tablet_schema = tablet_schema,
+                .metadata = *metadata_ptr,
+                .tablet = tablet,
+                .container = rssid_fileinfo_container,
+        };
+        state.init(params);
+        auto st = Status::OK();
+        for (uint32_t segment_id = 0; segment_id < segments_size && !_update_state_mem_tracker->any_limit_exceeded();
+             segment_id++) {
+            st = state.load_segment(segment_id, params, metadata_ptr->version(), false /* resolve conflict*/,
+                                    true /* need lock */);
+            if (!st.ok()) {
+                break;
+            }
+        }
         if (!st.ok()) {
             _update_state_cache.remove(state_entry);
             if (!st.is_uninitialized() && !st.is_cancelled()) {

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -68,6 +68,22 @@ private:
     std::unique_ptr<MemTracker> _mem_tracker;
 };
 
+// This is a converter between rowset segment id and segment file info. We need this converter
+// because we store rowset segment id instead of real file info in PrimaryKey Index value to save memory,
+// and this converter can help us to find segment file info that we want.
+class RssidFileInfoContainer {
+public:
+    void add_rssid_to_file(const TabletMetadata& metadata);
+    void add_rssid_to_file(const RowsetMetadataPB& meta, uint32_t rowset_id, uint32_t segment_id,
+                           const std::map<int, FileInfo>& replace_segments);
+
+    const std::unordered_map<uint32_t, FileInfo>& rssid_to_file() const { return _rssid_to_file_info; }
+
+private:
+    // From rowset segment id to segment file
+    std::unordered_map<uint32_t, FileInfo> _rssid_to_file_info;
+};
+
 class UpdateManager {
 public:
     UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker);
@@ -83,16 +99,14 @@ public:
                                       int64_t base_version);
 
     // get rowids from primary index by each upserts
-    Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
+    Status get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
                                    std::vector<std::vector<uint64_t>*>* rss_rowids, bool need_lock);
-    Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
-                                   std::vector<std::vector<uint64_t>>* rss_rowids, bool need_lock);
+    Status get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version, const ColumnUniquePtr& upsert,
+                                   std::vector<uint64_t>* rss_rowids, bool need_lock);
 
     // get column data by rssid and rowids
-    Status get_column_values(Tablet* tablet, const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
-                             const TabletSchemaCSPtr& tablet_schema, std::vector<uint32_t>& column_ids,
-                             bool with_default, bool include_op_write,
-                             std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
+    Status get_column_values(const RowsetUpdateStateParams& params, std::vector<uint32_t>& column_ids,
+                             bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                              vector<std::unique_ptr<Column>>* columns,
                              AutoIncrementPartialUpdateState* auto_increment_state = nullptr);
     // get delvec by version
@@ -189,17 +203,16 @@ public:
 private:
     // print memory tracker state
     void _print_memory_stats();
-    Status _do_update(uint32_t rowset_id, int32_t upsert_idx, const std::vector<ColumnUniquePtr>& upserts,
-                      PrimaryIndex& index, int64_t tablet_id, DeletesMap* new_deletes);
+    Status _do_update(uint32_t rowset_id, int32_t upsert_idx, const ColumnUniquePtr& upsert, PrimaryIndex& index,
+                      DeletesMap* new_deletes);
 
-    Status _do_update_with_condition(Tablet* tablet, const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
-                                     const TabletSchemaCSPtr& tablet_schema, uint32_t rowset_id, int32_t upsert_idx,
-                                     int32_t condition_column, const std::vector<ColumnUniquePtr>& upserts,
-                                     PrimaryIndex& index, int64_t tablet_id, DeletesMap* new_deletes);
+    Status _do_update_with_condition(const RowsetUpdateStateParams& params, uint32_t rowset_id, int32_t upsert_idx,
+                                     int32_t condition_column, const ColumnUniquePtr& upsert, PrimaryIndex& index,
+                                     DeletesMap* new_deletes);
 
     int32_t _get_condition_column(const TxnLogPB_OpWrite& op_write, const TabletSchema& tablet_schema);
 
-    Status _handle_index_op(Tablet* tablet, int64_t base_version, bool need_lock,
+    Status _handle_index_op(int64_t tablet_id, int64_t base_version, bool need_lock,
                             const std::function<void(LakePrimaryIndex&)>& op);
 
     std::shared_mutex& _get_pk_index_shard_lock(int64_t tabletId) { return _get_pk_index_shard(tabletId).lock; }

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -171,7 +171,7 @@ Status SegmentRewriter::rewrite(FileInfo* dest_path, const TabletSchemaCSPtr& ts
                                 starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                                 const std::vector<ColumnId>& unmodified_column_ids,
                                 std::vector<std::unique_ptr<Column>>* unmodified_column_data,
-                                const starrocks::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet) {
+                                const starrocks::TxnLogPB_OpWrite& op_write, const starrocks::lake::Tablet* tablet) {
     if (unmodified_column_ids.size() == 0) {
         DCHECK_EQ(unmodified_column_data, nullptr);
     }

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -40,7 +40,7 @@ public:
                           starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                           const std::vector<uint32_t>& unmodified_column_ids,
                           std::vector<std::unique_ptr<Column>>* unmodified_column_data,
-                          const starrocks::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet);
+                          const starrocks::TxnLogPB_OpWrite& op_write, const starrocks::lake::Tablet* tablet);
 };
 
 } // namespace starrocks

--- a/be/test/storage/lake/auto_increment_partial_update_test.cpp
+++ b/be/test/storage/lake/auto_increment_partial_update_test.cpp
@@ -221,6 +221,8 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
     });
 
     // partial update with normal column and auto increment column
+    const int64_t old_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
@@ -235,6 +237,8 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
                                                    .set_table_id(next_id())
                                                    .build());
         ASSERT_OK(delta_writer->open());
+        // multi segment
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
@@ -242,6 +246,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
+    config::write_buffer_size = old_size;
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -1115,6 +1115,79 @@ TEST_P(LakePartialUpdateTest, test_partial_update_retry_rewrite_check) {
     }
 }
 
+TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 5);
+    auto chunk2 = generate_data(kChunkSize, 0, true, 6);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+
+    // partial update, and make it generate two segment files in one rowset
+    const int64_t old_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    const int64_t old_limit = _update_mgr->update_state_mem_tracker()->limit();
+    _update_mgr->update_state_mem_tracker()->set_limit(1);
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->write(chunk2, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+    }
+    config::write_buffer_size = old_size;
+    _update_mgr->update_state_mem_tracker()->set_limit(old_limit);
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 6 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    // check segment size in last metadata
+    EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
+}
+
 TEST_P(LakePartialUpdateTest, test_partial_update_retry_check_file_exist) {
     if (GetParam().enable_persistent_index) return;
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);


### PR DESCRIPTION
## Why I'm doing:
In current implementation, if one ingest in tablet has multi segment files, and SR will load all segment file state at once, which will cost lots of memory if this ingestion is large, and it will lead to OOM. We need to avoid OOM when handle large ingestion.

## What I'm doing:
1. Load segment files one by one, so max memory use by one tablet when publish version will be less than 100MB, because max memtable when loading is 100MB (be.conf `write_buffer_size`).
2. Also allow SR to preload more segment when `update` memory is not limited.
3. Refactor the code.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
