### PR TITLE
[BugFix] retry get spark state from spark client log when yarn queue expire

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkClientLogHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkClientLogHelper.java
@@ -1,0 +1,166 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLauncherMonitor.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.load.loadv2;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SparkClientLogHelper {
+    private static final Logger LOG = LogManager.getLogger(SparkClientLogHelper.class);
+
+    public static final String STATE = "state:";
+    public static final String QUEUE = "queue:";
+    public static final String START_TIME = "start time:";
+    public static final String FINAL_STATUS = "final status:";
+    public static final String URL = "tracking URL:";
+    public static final String USER = "user:";
+
+    // e.g.
+    // input: "final status: SUCCEEDED"
+    // output: "SUCCEEDED"
+    public static String getValue(String line) {
+        String result = null;
+        List<String> entry = Splitter.onPattern(":").trimResults().limit(2).splitToList(line);
+        if (entry.size() == 2) {
+            result = entry.get(1);
+        }
+        return result;
+    }
+
+    // e.g.
+    // input: "Application report for application_1573630236805_6864759 (state: ACCEPTED)"
+    // output: "ACCEPTED"
+    public static String regexGetState(String line) {
+        String result = null;
+        Matcher stateMatcher = Pattern.compile("(?<=\\(state: )(.+?)(?=\\))").matcher(line);
+        if (stateMatcher.find()) {
+            result = stateMatcher.group();
+        }
+        return result;
+    }
+
+    // e.g.
+    // input: "Application report for application_1573630236805_6864759 (state: ACCEPTED)"
+    // output: "application_1573630236805_6864759"
+    public static String regexGetAppId(String line) {
+        String result = null;
+        Matcher appIdMatcher = Pattern.compile("application_[0-9]+_[0-9]+").matcher(line);
+        if (appIdMatcher.find()) {
+            result = appIdMatcher.group();
+        }
+        return result;
+    }
+
+    public static SparkLoadAppHandle.State fromYarnState(YarnApplicationState yarnState) {
+        switch (yarnState) {
+            case SUBMITTED:
+            case ACCEPTED:
+                return SparkLoadAppHandle.State.SUBMITTED;
+            case RUNNING:
+                return SparkLoadAppHandle.State.RUNNING;
+            case FINISHED:
+                return SparkLoadAppHandle.State.FINISHED;
+            case FAILED:
+                return SparkLoadAppHandle.State.FAILED;
+            case KILLED:
+                return SparkLoadAppHandle.State.KILLED;
+            default:
+                // NEW NEW_SAVING
+                return SparkLoadAppHandle.State.UNKNOWN;
+        }
+    }
+
+    public static void readLine4State(String line, SparkLoadAppHandle sparkLoadAppHandle) {
+        SparkLoadAppHandle.State oldState = sparkLoadAppHandle.getState();
+        SparkLoadAppHandle.State newState = oldState;
+        if (line.contains(STATE)) {
+            // 1. state
+            String state = SparkClientLogHelper.regexGetState(line);
+            if (state != null) {
+                YarnApplicationState yarnState = YarnApplicationState.valueOf(state);
+                newState = SparkClientLogHelper.fromYarnState(yarnState);
+                if (newState != oldState) {
+                    sparkLoadAppHandle.setState(newState);
+                }
+            }
+            // 2. appId
+            String appId = SparkClientLogHelper.regexGetAppId(line);
+            if (appId != null) {
+                if (!appId.equals(sparkLoadAppHandle.getAppId())) {
+                    sparkLoadAppHandle.setAppId(appId);
+                }
+            }
+        }
+    }
+
+    public static boolean checkLineFinalContain(String line) {
+        return line.contains(QUEUE)
+                || line.contains(START_TIME)
+                || line.contains(FINAL_STATUS)
+                || line.contains(URL)
+                || line.contains(USER);
+    }
+
+    public static void readLine4OtherValues(String line, SparkLoadAppHandle sparkLoadAppHandle) {
+        if (checkLineFinalContain(line)) {
+            String value = getValue(line);
+            if (!Strings.isNullOrEmpty(value)) {
+                try {
+                    if (line.contains(QUEUE)) {
+                        sparkLoadAppHandle.setQueue(value);
+                    } else if (line.contains(START_TIME)) {
+                        sparkLoadAppHandle.setStartTime(Long.parseLong(value));
+                    } else if (line.contains(FINAL_STATUS)) {
+                        sparkLoadAppHandle.setFinalStatus(FinalApplicationStatus.valueOf(value));
+                    } else if (line.contains(URL)) {
+                        sparkLoadAppHandle.setUrl(value);
+                    } else if (line.contains(USER)) {
+                        sparkLoadAppHandle.setUser(value);
+                    }
+                } catch (IllegalArgumentException e) {
+                    LOG.warn("parse log encounter an error, line: {}, msg: {}", line, e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkClientLogParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkClientLogParser.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLauncherMonitor.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+package com.starrocks.load.loadv2;
+
+import com.starrocks.common.LoadException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SparkClientLogParser extends Thread {
+    private static final Logger LOG = LogManager.getLogger(SparkClientLogParser.class);
+    private SparkLoadAppHandle sparkLoadAppHandle;
+
+    public static SparkClientLogParser createLogParser(SparkLoadAppHandle handle) throws IOException {
+        return new SparkClientLogParser(handle);
+    }
+
+    public SparkClientLogParser(SparkLoadAppHandle handle) throws IOException {
+        this.sparkLoadAppHandle = handle;
+    }
+
+    @Override
+    public void run() {
+        try (BufferedReader outReader =
+                    new BufferedReader(new InputStreamReader(sparkLoadAppHandle.getProcess().getInputStream()));
+                BufferedWriter fileWriter =
+                    new BufferedWriter(new FileWriter(sparkLoadAppHandle.getLogPath()))) {
+            String line;
+            Set<String> stateUniqueSet = new HashSet<>();
+            while ((line = outReader.readLine()) != null) {
+                if (SparkClientLogHelper.checkLineFinalContain(line)) {
+                    fileWriter.write(line);
+                    fileWriter.newLine();
+                }
+                // get spark state
+                if (line.contains(SparkClientLogHelper.STATE)) {
+                    String state = SparkClientLogHelper.regexGetState(line);
+                    if (state == null || state.isEmpty()) {
+                        continue;
+                    }
+                    // filter line if contain duplicate states
+                    if (!stateUniqueSet.contains(state)) {
+                        fileWriter.write(line);
+                        fileWriter.newLine();
+                    }
+                    stateUniqueSet.add(state);
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn("Exception spark client log process.", e);
+        }
+    }
+
+    public void readLog() throws LoadException {
+        String filePath = sparkLoadAppHandle.getLogPath();
+        if (filePath == null || filePath.isEmpty()) {
+            throw new LoadException("can not get log path from spark load app handler");
+        }
+        try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                SparkClientLogHelper.readLine4State(line, sparkLoadAppHandle);
+                SparkClientLogHelper.readLine4OtherValues(line, sparkLoadAppHandle);
+            }
+        } catch (IOException e) {
+            LOG.error("Failed to read the log file: " + e.getMessage());
+        }
+    }
+
+    public boolean checkSparkAbnormal() {
+        boolean abnormal = true;
+        String appId = sparkLoadAppHandle.getAppId();
+        String state = sparkLoadAppHandle.getState().toString();
+        if (appId != null && !appId.isEmpty() && state != null && !state.isEmpty()) {
+            abnormal = false;
+        }
+        return abnormal;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkClientLogParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkClientLogParserTest.java
@@ -32,8 +32,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+
 package com.starrocks.load.loadv2;
 
+import com.starrocks.common.LoadException;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.junit.After;
 import org.junit.Assert;
@@ -44,7 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
-public class SparkLauncherMonitorTest {
+public class SparkClientLogParserTest {
     private String appId;
     private SparkLoadAppHandle.State state;
     private String queue;
@@ -57,34 +59,40 @@ public class SparkLauncherMonitorTest {
     @Before
     public void setUp() {
         appId = "application_1573630236805_6864759";
-        state = SparkLoadAppHandle.State.RUNNING;
+        state = SparkLoadAppHandle.State.FINISHED;
         queue = "spark-queue";
         startTime = 1597916263384L;
-        finalApplicationStatus = FinalApplicationStatus.UNDEFINED;
-        trackingUrl = "http://myhost:8388/proxy/application_1573630236805_6864759/";
+        finalApplicationStatus = FinalApplicationStatus.SUCCEEDED;
+        trackingUrl = "http://myhost:8388/proxy/application_1573630236805_6864759/A";
         user = "testugi";
         logPath = "./spark-launcher.log";
     }
 
+
     @Test
-    public void testLogMonitorNormal() {
+    public void testWriteSparkClientLogNormal() {
         URL log = getClass().getClassLoader().getResource("spark_launcher_monitor.log");
         String cmd = "cat " + log.getPath();
         SparkLoadAppHandle handle = null;
+        SparkClientLogParser parser = null;
         try {
             Process process = Runtime.getRuntime().exec(cmd);
             handle = new SparkLoadAppHandle(process);
             handle.setLogPath(logPath);
-            SparkLauncherMonitor.LogMonitor logMonitor = SparkLauncherMonitor.createLogMonitor(handle);
-            logMonitor.start();
+            parser = SparkClientLogParser.createLogParser(handle);
+            parser.start();
             try {
-                logMonitor.join();
+                parser.join();
             } catch (InterruptedException e) {
             }
         } catch (IOException e) {
             Assert.fail();
         }
-
+        try {
+            parser.readLog();
+        } catch (LoadException e) {
+            Assert.fail();
+        }
         // check values
         Assert.assertEquals(appId, handle.getAppId());
         Assert.assertEquals(state, handle.getState());
@@ -93,10 +101,6 @@ public class SparkLauncherMonitorTest {
         Assert.assertEquals(finalApplicationStatus, handle.getFinalStatus());
         Assert.assertEquals(trackingUrl, handle.getUrl());
         Assert.assertEquals(user, handle.getUser());
-
-        // check log
-        File file = new File(logPath);
-        Assert.assertTrue(file.exists());
     }
 
     @After


### PR DESCRIPTION
## Why I'm doing:
Yarn maintains two lists: the running tasks in list 1 and the finished tasks in list 2. To avoid excessive memory usage, 5000 lists are configured for the number of completed applications.
This will cause a boundary problem. After yarn clears the appid, the asynchronous thread (load etl checker) checks the APPID after 5s. This will cause the boundary problem

## What I'm doing:
After the spark task is submitted, the spark interaction log is maintained on the client. As long as the log is persisted to the disk, when the boundary problem occurs in the future, the spark log is parsed again to know the actual execution status of the task

Fixes #45694

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5