### PR TITLE
[Enhancement] skip create rows mapper file when compaction output rowset is empty

### DIFF
--- a/be/src/storage/rows_mapper.cpp
+++ b/be/src/storage/rows_mapper.cpp
@@ -33,6 +33,10 @@ Status RowsMapperBuilder::_init() {
 }
 
 Status RowsMapperBuilder::append(const std::vector<uint64_t>& rssid_rowids) {
+    if (rssid_rowids.empty()) {
+        // skip create rows mapper file when output rowset is empty.
+        return Status::OK();
+    }
     if (_wfile == nullptr) {
         RETURN_IF_ERROR(_init());
     }

--- a/be/test/storage/rows_mapper_test.cpp
+++ b/be/test/storage/rows_mapper_test.cpp
@@ -43,6 +43,8 @@ TEST_F(RowsMapperTest, test_write_read) {
     const std::string filename = std::string(kTestDirectory) + "test_write_read.crm";
     RowsMapperBuilder builder(filename);
     std::vector<uint64_t> rssid_rowids;
+    ASSERT_OK(builder.append(rssid_rowids));
+    ASSERT_FALSE(fs::path_exist(filename));
     generate_rssid_rowids(&rssid_rowids, 0, 1000, 11);
     ASSERT_OK(builder.append(rssid_rowids));
     rssid_rowids.clear();


### PR DESCRIPTION
## Why I'm doing:
After we support light pk compaction publish (#43934), we will create a `.crm` file when compaction finish, but it will still create `.crm` file even when output rowset is empty, which is unnecessary.

## What I'm doing:
skip create rows mapper file when compaction output rowset is empty

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
