### PR TITLE
[BugFix] fix pk compaction crash when light pk compaction is disable

### DIFF
--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -407,7 +407,9 @@ Status TabletReader::init_collector(const TabletReaderParams& params) {
         if (_is_vertical_merge && !_is_key) {
             _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer);
         } else {
-            _collect_iter = new_heap_merge_iterator(seg_iters, (keys_type == PRIMARY_KEYS));
+            _collect_iter = new_heap_merge_iterator(
+                    seg_iters,
+                    (keys_type == PRIMARY_KEYS) && StorageEngine::instance()->enable_light_pk_compaction_publish());
         }
     } else if (params.sorted_by_keys_per_tablet && (keys_type == DUP_KEYS || keys_type == PRIMARY_KEYS) &&
                seg_iters.size() > 1) {

--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -268,8 +268,9 @@ inline Status HeapMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
                 // so here we swap the whole min_chunk out.
                 if (rows == 0) {
                     chunk->swap_chunk(*min_chunk._chunk);
-                    if (rssid_rowids != nullptr) {
-                        DCHECK(need_rssid_rowids);
+                    if (rssid_rowids != nullptr && need_rssid_rowids) {
+                        // insert into `rssid_rowids` only when need_rssid_rowids is true.
+                        DCHECK(min_chunk._rssid_rowids != nullptr);
                         rssid_rowids->insert(rssid_rowids->end(), min_chunk._rssid_rowids->begin(),
                                              min_chunk._rssid_rowids->end());
                     }
@@ -302,8 +303,9 @@ inline Status HeapMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
         DCHECK_GT(append_row_num, 0);
 
         chunk->append(*min_chunk._chunk, offset, append_row_num);
-        if (rssid_rowids != nullptr) {
-            DCHECK(need_rssid_rowids);
+        if (rssid_rowids != nullptr && need_rssid_rowids) {
+            // insert into `rssid_rowids` only when need_rssid_rowids is true.
+            DCHECK(min_chunk._rssid_rowids != nullptr);
             rssid_rowids->insert(rssid_rowids->end(), min_chunk._rssid_rowids->begin() + offset,
                                  min_chunk._rssid_rowids->begin() + offset + append_row_num);
         }


### PR DESCRIPTION
## Why I'm doing:
When `enable_light_pk_compaction_publish` is false, `min_chunk._rssid_rowids` in merge_iterator will be null, it will lead to BE crash.
![img_v3_02au_3fb70af6-9736-4856-94db-4121d6bf471g](https://github.com/StarRocks/starrocks/assets/10725468/91b18939-a712-403a-a785-3bb64e7cb8a0)


## What I'm doing:
Fix this.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
