### PR TITLE
[BugFix] Fix bug when showing external db with storage volume info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -670,7 +670,7 @@ public class ShowExecutor {
             createSqlBuilder.append("CREATE DATABASE `").append(statement.getDb()).append("`");
             if (!Strings.isNullOrEmpty(db.getLocation())) {
                 createSqlBuilder.append("\nPROPERTIES (\"location\" = \"").append(db.getLocation()).append("\")");
-            } else if (RunMode.isSharedDataMode() && !db.isSystemDatabase()) {
+            } else if (RunMode.isSharedDataMode() && !db.isSystemDatabase() && db.getCatalogName().isEmpty()) {
                 String volume = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeNameOfDb(db.getId());
                 createSqlBuilder.append("\nPROPERTIES (\"storage_volume\" = \"").append(volume).append("\")");
             }


### PR DESCRIPTION
## Why I'm doing:
Storage volume will be displayed when using `show create db` in external catalog.
```
mysql> set catalog iceberg_glue;
Query OK, 0 rows affected (0.01 sec)

mysql> show create database test;
+----------+---------------------------------------------------------------------------------+
| Database | Create Database                                                                 |
+----------+---------------------------------------------------------------------------------+
| test     | CREATE DATABASE `test`
PROPERTIES ("storage_volume" = "builtin_storage_volume") |
+----------+---------------------------------------------------------------------------------+
1 row in set (2.62 sec)
```
## What I'm doing:
Do not display when using `show create db` in external catalog.
```
mysql> set catalog iceberg_glue;
Query OK, 0 rows affected (0.00 sec)

mysql> show create database test;
+----------+------------------------+
| Database | Create Database        |
+----------+------------------------+
| test     | CREATE DATABASE `test` |
+----------+------------------------+
1 row in set (2.32 sec)
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
