### PR TITLE
[Refactor] Introduce ColumnId to support Column renaming (part3)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
@@ -16,6 +16,7 @@
 package com.starrocks.alter;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
 import com.starrocks.common.UserException;
 
@@ -32,7 +33,7 @@ public abstract class AlterJobV2Builder {
     protected long startTime = 0;
     protected long timeoutMs = 0;
     protected boolean bloomFilterColumnsChanged = false;
-    protected Set<String> bloomFilterColumns;
+    protected Set<ColumnId> bloomFilterColumns;
     protected double bloomFilterFpp;
     protected boolean hasIndexChanged = false;
     protected List<Index> indexes;
@@ -70,7 +71,7 @@ public abstract class AlterJobV2Builder {
         return this;
     }
 
-    public AlterJobV2Builder withBloomFilterColumns(@Nullable Set<String> bfColumns, double bfFpp) {
+    public AlterJobV2Builder withBloomFilterColumns(@Nullable Set<ColumnId> bfColumns, double bfFpp) {
         this.bloomFilterColumns = bfColumns;
         this.bloomFilterFpp = bfFpp;
         return this;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
@@ -119,7 +120,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
     @SerializedName(value = "hasBfChange")
     private boolean hasBfChange;
     @SerializedName(value = "bfColumns")
-    private Set<String> bfColumns = null;
+    private Set<ColumnId> bfColumns = null;
     @SerializedName(value = "bfFpp")
     private double bfFpp = 0;
 
@@ -156,7 +157,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
         super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs);
     }
 
-    void setBloomFilterInfo(boolean hasBfChange, Set<String> bfColumns, double bfFpp) {
+    void setBloomFilterInfo(boolean hasBfChange, Set<ColumnId> bfColumns, double bfFpp) {
         this.hasBfChange = hasBfChange;
         this.bfColumns = bfColumns;
         this.bfFpp = bfFpp;
@@ -838,7 +839,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
 
         for (Column column : table.getColumns()) {
             if (Type.VARCHAR.equals(column.getType())) {
-                IDictManager.getInstance().removeGlobalDict(table.getId(), column.getName());
+                IDictManager.getInstance().removeGlobalDict(table.getId(), column.getColumnId());
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -333,7 +333,7 @@ public class MaterializedViewHandler extends AlterHandler {
             mvKeysType = olapTable.getKeysType();
         }
         // get rollup schema hash
-        int mvSchemaHash = Util.schemaHash(0 /* init schema version */, mvColumns, olapTable.getCopiedBfColumns(),
+        int mvSchemaHash = Util.schemaHash(0 /* init schema version */, mvColumns, olapTable.getBfColumnNames(),
                 olapTable.getBfFpp());
         // get short key column count
         short mvShortKeyColumnCount = GlobalStateMgr.calcShortKeyColumnCount(mvColumns, properties);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -297,7 +297,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         .setShortKeyColumnCount(rollupShortKeyColumnCount)
                         .setSchemaHash(rollupSchemaHash)
                         .setStorageType(TStorageType.COLUMN)
-                        .setBloomFilterColumnNames(tbl.getCopiedBfColumns())
+                        .setBloomFilterColumnNames(tbl.getBfColumnIds())
                         .setBloomFilterFpp(tbl.getBfFpp())
                         .setIndexes(tbl.getCopiedIndexes())
                         .setSortKeyIndexes(null) // Rollup tablets does not have sort key

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.OlapTable;
@@ -36,7 +37,7 @@ class SchemaChangeData {
     private final Map<Long, List<Column>> newIndexSchema;
     private final List<Index> indexes;
     private final boolean bloomFilterColumnsChanged;
-    private final Set<String> bloomFilterColumns;
+    private final Set<ColumnId> bloomFilterColumns;
     private final double bloomFilterFpp;
     private final boolean hasIndexChanged;
     private final Map<Long, Short> newIndexShortKeyCount;
@@ -77,7 +78,7 @@ class SchemaChangeData {
     }
 
     @Nullable
-    Set<String> getBloomFilterColumns() {
+    Set<ColumnId> getBloomFilterColumns() {
         return bloomFilterColumns;
     }
 
@@ -132,7 +133,7 @@ class SchemaChangeData {
         private Map<Long, List<Column>> newIndexSchema = new HashMap<>();
         private List<Index> indexes;
         private boolean bloomFilterColumnsChanged = false;
-        private Set<String> bloomFilterColumns;
+        private Set<ColumnId> bloomFilterColumns;
         private double bloomFilterFpp;
         private boolean hasIndexChanged = false;
         private Map<Long, Short> newIndexShortKeyCount = new HashMap<>();
@@ -163,7 +164,7 @@ class SchemaChangeData {
             return this;
         }
 
-        Builder withBloomFilterColumns(@Nullable Set<String> bfColumns, double bfFpp) {
+        Builder withBloomFilterColumns(@Nullable Set<ColumnId> bfColumns, double bfFpp) {
             this.bloomFilterColumns = bfColumns;
             this.bloomFilterFpp = bfFpp;
             return this;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -51,6 +51,7 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
@@ -160,7 +161,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     @SerializedName(value = "hasBfChange")
     private boolean hasBfChange;
     @SerializedName(value = "bfColumns")
-    private Set<String> bfColumns = null;
+    private Set<ColumnId> bfColumns = null;
     @SerializedName(value = "bfFpp")
     private double bfFpp = 0;
 
@@ -238,7 +239,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         return this.waitingCreatingReplica.get();
     }
 
-    public void setBloomFilterInfo(boolean hasBfChange, Set<String> bfColumns, double bfFpp) {
+    public void setBloomFilterInfo(boolean hasBfChange, Set<ColumnId> bfColumns, double bfFpp) {
         this.hasBfChange = hasBfChange;
         this.bfColumns = bfColumns;
         this.bfFpp = bfFpp;
@@ -846,7 +847,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         // dictionary invalid after schema change.
         for (Column column : tbl.getColumns()) {
             if (column.getType().isVarchar()) {
-                IDictManager.getInstance().removeGlobalDict(tbl.getId(), column.getName());
+                IDictManager.getInstance().removeGlobalDict(tbl.getId(), column.getColumnId());
             }
         }
         // replace the origin index with shadow index, set index state as NORMAL

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
@@ -16,14 +16,18 @@ package com.starrocks.analysis;
 
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.NgramBfIndexParamsKey;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.sql.common.MetaUtils;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -104,14 +108,16 @@ public class BloomFilterIndexUtil {
         addDefaultProperties(properties);
     }
 
-    public static void analyseBfWithNgramBf(Set<Index> newIndexs, Set<String> bfColumns) throws AnalysisException {
+    public static void analyseBfWithNgramBf(Table table, Set<Index> newIndexs, Set<ColumnId> bfColumns) throws AnalysisException {
         if (newIndexs.isEmpty() || bfColumns == null || bfColumns.isEmpty()) {
             return;
         }
 
         for (Index index : newIndexs) {
-            if (index.getIndexType() == IndexDef.IndexType.NGRAMBF && bfColumns.contains(index.getColumns().get(0))) {
-                throw new AnalysisException("column " + index.getColumns().get(0) +
+            List<ColumnId> indexColumns = index.getColumns();
+            if (index.getIndexType() == IndexDef.IndexType.NGRAMBF && bfColumns.contains(indexColumns.get(0))) {
+                Column column = table.getColumn(indexColumns.get(0));
+                throw new AnalysisException("column " + column.getName() +
                         " should only have one bloom filter index " +
                         "or ngram bloom filter index");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -56,6 +56,7 @@ import com.starrocks.backup.RestoreFileMapping.IdChain;
 import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FsBroker;
@@ -895,7 +896,7 @@ public class RestoreJob extends AbstractJob {
     }
 
     protected void createReplicas(OlapTable localTbl, Partition restorePart) {
-        Set<String> bfColumns = localTbl.getCopiedBfColumns();
+        Set<ColumnId> bfColumns = localTbl.getBfColumnIds();
         double bfFpp = localTbl.getBfFpp();
         for (PhysicalPartition physicalPartition : restorePart.getSubPartitions()) {
             for (MaterializedIndex restoredIdx : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -230,7 +230,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         Preconditions.checkArgument(this.type.isComplexType() ||
                 this.type.getPrimitiveType() != PrimitiveType.INVALID_TYPE);
         this.uniqueId = column.getUniqueId();
-        this.generatedColumnExpr = column.generatedColumnExpr();
+        this.generatedColumnExpr = column.generatedColumnExpr;
     }
 
     public Column deepCopy() {
@@ -842,16 +842,16 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return this.uniqueId;
     }
 
-    public void setIndexFlag(TColumn tColumn, List<Index> indexes, Set<String> bfColumns) {
+    public void setIndexFlag(TColumn tColumn, List<Index> indexes, Set<ColumnId> bfColumns) {
         for (Index index : indexes) {
             if (index.getIndexType() == IndexDef.IndexType.BITMAP) {
-                List<String> columns = index.getColumns();
-                if (tColumn.getColumn_name().equals(columns.get(0))) {
+                List<ColumnId> columns = index.getColumns();
+                if (tColumn.getColumn_name().equalsIgnoreCase(columns.get(0).getId())) {
                     tColumn.setHas_bitmap_index(true);
                 }
             }
         }
-        if (bfColumns != null && bfColumns.contains(this.name)) {
+        if (bfColumns != null && bfColumns.contains(this.columnId)) {
             tColumn.setIs_bloom_filter_column(true);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
@@ -14,27 +14,29 @@
 
 package com.starrocks.catalog;
 
+
 import java.util.Comparator;
 import java.util.Objects;
 
 public class ColumnId {
+
     private final String id;
 
-    public ColumnId(String id) {
+    private ColumnId(String id) {
         this.id = id;
-    }
-
-    public String getId() {
-        return id;
     }
 
     public static ColumnId create(String id) {
         return new ColumnId(id);
     }
 
+    public String getId() {
+        return id;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(getId());
     }
 
     @Override
@@ -48,24 +50,27 @@ public class ColumnId {
         }
 
         ColumnId columnId = (ColumnId) o;
-        return Objects.equals(id, columnId.id);
+        return Objects.equals(getId(), columnId.getId());
     }
 
-    public boolean equalsIgnoreCase(ColumnId anotherId) {
-        if (this == anotherId) {
+    public boolean equalsIgnoreCase(ColumnId anotherColumnId) {
+        if (this == anotherColumnId) {
             return true;
         }
 
-        if (anotherId == null) {
+        if (anotherColumnId == null) {
             return false;
         }
 
-        return id != null ? id.equalsIgnoreCase(anotherId.id) : anotherId.id == null;
+        String myId = getId();
+        String anotherId = anotherColumnId.getId();
+
+        return myId != null ? myId.equalsIgnoreCase(anotherId) : anotherId == null;
     }
 
     @Override
     public String toString() {
-        return id;
+        return getId();
     }
 
     public static final Comparator<ColumnId> CASE_INSENSITIVE_ORDER =
@@ -73,7 +78,7 @@ public class ColumnId {
 
     private static class CaseInsensitiveComparator implements Comparator<ColumnId> {
         public int compare(ColumnId n1, ColumnId n2) {
-            return String.CASE_INSENSITIVE_ORDER.compare(n1.id, n2.id);
+            return String.CASE_INSENSITIVE_ORDER.compare(n1.getId(), n2.getId());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -31,6 +31,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.system.Backend;
 import com.starrocks.system.Backend.BackendState;
 import com.starrocks.system.SystemInfoService;
@@ -377,7 +378,8 @@ public class ExternalOlapTable extends OlapTable {
         if (meta.isSetIndex_infos()) {
             List<Index> indexList = new ArrayList<>();
             for (TIndexInfo indexInfo : meta.getIndex_infos()) {
-                Index index = new Index(indexInfo.getIndex_name(), indexInfo.getColumns(),
+                Index index = new Index(indexInfo.getIndex_name(),
+                        MetaUtils.getColumnIdsByColumnNames(this, indexInfo.getColumns()),
                         IndexDef.IndexType.valueOf(indexInfo.getIndex_type()), indexInfo.getComment(),
                         Collections.emptyMap());
                 indexList.add(index);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
@@ -45,6 +45,7 @@ import com.starrocks.common.util.PrintableMap;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.sql.ast.IndexDef.IndexType;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TIndexType;
 import com.starrocks.thrift.TOlapTableIndex;
 
@@ -74,7 +75,7 @@ public class Index implements Writable {
     @SerializedName(value = "indexName")
     private String indexName;
     @SerializedName(value = "columns")
-    private List<String> columns;
+    private List<ColumnId> columns;
     @SerializedName(value = "indexType")
     private IndexDef.IndexType indexType;
     @SerializedName(value = "comment")
@@ -82,17 +83,17 @@ public class Index implements Writable {
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
-    public Index(String indexName, List<String> columns, IndexDef.IndexType indexType, String comment) {
+    public Index(String indexName, List<ColumnId> columns, IndexDef.IndexType indexType, String comment) {
         this(-1, indexName, columns, indexType, comment, Collections.emptyMap());
     }
 
-    public Index(String indexName, List<String> columns, IndexDef.IndexType indexType, String comment,
+    public Index(String indexName, List<ColumnId> columns, IndexDef.IndexType indexType, String comment,
                  Map<String, String> properties) {
         this(-1, indexName, columns, indexType, comment, properties);
     }
 
-    public Index(long indexId, String indexName, List<String> columns, IndexDef.IndexType indexType, String comment,
-                 Map<String, String> properties) {
+    public Index(long indexId, String indexName, List<ColumnId> columns, IndexDef.IndexType indexType,
+                 String comment, Map<String, String> properties) {
         this.indexId = indexId;
         this.indexName = indexName;
         this.columns = columns;
@@ -126,11 +127,11 @@ public class Index implements Writable {
         this.indexName = indexName;
     }
 
-    public List<String> getColumns() {
+    public List<ColumnId> getColumns() {
         return columns;
     }
 
-    public void setColumns(List<String> columns) {
+    public void setColumns(List<ColumnId> columns) {
         this.columns = columns;
     }
 
@@ -203,7 +204,7 @@ public class Index implements Writable {
 
     @Override
     public String toString() {
-        return toSql();
+        return toSql(null);
     }
 
     public String getPropertiesString() {
@@ -215,18 +216,24 @@ public class Index implements Writable {
                 new PrintableMap<>(properties, "=", true, false, ","));
     }
 
-    public String toSql() {
+    public String toSql(Table table) {
         StringBuilder sb = new StringBuilder("INDEX ");
         sb.append(indexName);
         sb.append(" (");
         boolean first = true;
-        for (String col : columns) {
+        List<String> columnNames;
+        if (table != null) {
+            columnNames = MetaUtils.getColumnNamesByColumnIds(table, columns);
+        } else {
+            columnNames = columns.stream().map(ColumnId::getId).collect(Collectors.toList());
+        }
+        for (String col : columnNames) {
             if (first) {
                 first = false;
             } else {
                 sb.append(",");
             }
-            sb.append("`" + col + "`");
+            sb.append("`").append(col).append("`");
         }
         sb.append(")");
         if (indexType != null) {
@@ -245,7 +252,7 @@ public class Index implements Writable {
         TOlapTableIndex tIndex = new TOlapTableIndex();
         tIndex.setIndex_id(indexId);
         tIndex.setIndex_name(indexName);
-        tIndex.setColumns(columns);
+        tIndex.setColumns(columns.stream().map(ColumnId::getId).collect(Collectors.toList()));
         tIndex.setIndex_type(TIndexType.valueOf(indexType.toString()));
         if (columns != null) {
             tIndex.setComment(comment);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1180,7 +1180,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         if (CollectionUtils.isNotEmpty(getIndexes())) {
             for (Index index : getIndexes()) {
                 sb.append(",\n");
-                sb.append("  ").append(index.toSql());
+                sb.append("  ").append(index.toSql(this));
             }
         }
 
@@ -1279,7 +1279,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
 
         // bloom filter
-        Set<String> bfColumnNames = getCopiedBfColumns();
+        Set<String> bfColumnNames = getBfColumnNames();
         if (bfColumnNames != null) {
             sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_BF_COLUMNS)
                     .append("\" = \"");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -208,7 +208,7 @@ public class OlapTable extends Table {
 
     // bloom filter columns
     @SerializedName(value = "bfColumns")
-    protected Set<String> bfColumns;
+    protected Set<ColumnId> bfColumns;
 
     @SerializedName(value = "bfFpp")
     protected double bfFpp;
@@ -328,7 +328,12 @@ public class OlapTable extends Table {
         olapTable.indexNameToId = Maps.newHashMap(this.indexNameToId);
         olapTable.indexIdToMeta = Maps.newHashMap(this.indexIdToMeta);
         olapTable.indexes = indexes == null ? null : indexes.shallowCopy();
-        olapTable.bfColumns = bfColumns == null ? null : Sets.newHashSet(bfColumns);
+        if (bfColumns != null) {
+            olapTable.bfColumns = Sets.newTreeSet(ColumnId.CASE_INSENSITIVE_ORDER);
+            olapTable.bfColumns.addAll(bfColumns);
+        } else {
+            olapTable.bfColumns = null;
+        }
 
         olapTable.keysType = this.keysType;
         if (this.relatedMaterializedViews != null) {
@@ -1514,15 +1519,24 @@ public class OlapTable extends Table {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public Set<String> getBfColumns() {
+    public Set<ColumnId> getBfColumnIds() {
         return bfColumns;
     }
 
-    public Set<String> getCopiedBfColumns() {
+    public Set<String> getBfColumnNames() {
         if (bfColumns == null) {
             return null;
         }
-        return Sets.newHashSet(bfColumns);
+
+        Set<String> columnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        for (ColumnId columnId : bfColumns) {
+            Column column = idToColumn.get(columnId);
+            if (column == null) {
+                throw new SemanticException(String.format("can not find column by column id: %s", columnId));
+            }
+            columnNames.add(column.getName());
+        }
+        return columnNames;
     }
 
     public List<Index> getCopiedIndexes() {
@@ -1536,7 +1550,7 @@ public class OlapTable extends Table {
         return bfFpp;
     }
 
-    public void setBloomFilterInfo(Set<String> bfColumns, double bfFpp) {
+    public void setBloomFilterInfo(Set<ColumnId> bfColumns, double bfFpp) {
         this.bfColumns = bfColumns;
         this.bfFpp = bfFpp;
     }
@@ -1649,8 +1663,8 @@ public class OlapTable extends Table {
 
         // bloom filter
         if (bfColumns != null && !bfColumns.isEmpty()) {
-            for (String bfCol : bfColumns) {
-                adler32.update(bfCol.getBytes());
+            for (ColumnId bfCol : bfColumns) {
+                adler32.update(bfCol.getId().getBytes());
                 LOG.debug("signature. bf col: {}", bfCol);
             }
             adler32.update(String.valueOf(bfFpp).getBytes());
@@ -1724,8 +1738,8 @@ public class OlapTable extends Table {
 
         // bloom filter
         if (bfColumns != null && !bfColumns.isEmpty()) {
-            for (String bfCol : bfColumns) {
-                adler32.update(bfCol.getBytes());
+            for (ColumnId bfCol : bfColumns) {
+                adler32.update(bfCol.getId().getBytes());
                 checkSumList.add(new Pair(Math.abs((int) adler32.getValue()), "bloom filter is inconsistent"));
             }
             adler32.update(String.valueOf(bfFpp).getBytes());
@@ -2536,7 +2550,7 @@ public class OlapTable extends Table {
         }
 
         for (Column column : getColumns()) {
-            IDictManager.getInstance().removeGlobalDict(this.getId(), column.getName());
+            IDictManager.getInstance().removeGlobalDict(this.getId(), column.getColumnId());
         }
     }
 
@@ -2565,7 +2579,7 @@ public class OlapTable extends Table {
         renamePartition(tempPartitionName, sourcePartitionName);
 
         for (Column column : getColumns()) {
-            IDictManager.getInstance().removeGlobalDict(this.getId(), column.getName());
+            IDictManager.getInstance().removeGlobalDict(this.getId(), column.getColumnId());
         }
     }
 
@@ -2932,7 +2946,7 @@ public class OlapTable extends Table {
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, getDefaultReplicationNum().toString());
 
         // bloom filter
-        Set<String> bfColumnNames = getCopiedBfColumns();
+        Set<String> bfColumnNames = getBfColumnNames();
         if (bfColumnNames != null && !bfColumnNames.isEmpty()) {
             properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, Joiner.on(", ").join(bfColumnNames));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -51,7 +51,7 @@ public class SchemaInfo {
     @SerializedName("indexes")
     private final List<Index> indexes;
     @SerializedName("bfColumns")
-    private final Set<String> bloomFilterColumnNames;
+    private final Set<ColumnId> bloomFilterColumnNames;
     @SerializedName("bfColumnFpp")
     private final double bloomFilterFpp; // false positive probability
 
@@ -106,7 +106,7 @@ public class SchemaInfo {
         return indexes;
     }
 
-    public Set<String> getBloomFilterColumnNames() {
+    public Set<ColumnId> getBloomFilterColumnNames() {
         return bloomFilterColumnNames;
     }
 
@@ -128,7 +128,7 @@ public class SchemaInfo {
         for (Column column : columns) {
             TColumn tColumn = column.toThrift();
             // is bloom filter column
-            if (bloomFilterColumnNames != null && bloomFilterColumnNames.contains(column.getName())) {
+            if (bloomFilterColumnNames != null && bloomFilterColumnNames.contains(column.getColumnId())) {
                 tColumn.setIs_bloom_filter_column(true);
             }
             tColumns.add(tColumn);
@@ -166,7 +166,7 @@ public class SchemaInfo {
         private List<Integer> sortKeyIndexes;
         private List<Integer> sortKeyUniqueIds;
         private List<Index> indexes;
-        private Set<String> bloomFilterColumnNames;
+        private Set<ColumnId> bloomFilterColumnNames;
         private double bloomFilterFpp; // false positive probability
 
         private Builder() {
@@ -231,7 +231,7 @@ public class SchemaInfo {
             return this;
         }
 
-        public Builder setBloomFilterColumnNames(Collection<String> bloomFilterColumnNames) {
+        public Builder setBloomFilterColumnNames(Collection<ColumnId> bloomFilterColumnNames) {
             Preconditions.checkState(this.bloomFilterColumnNames == null);
             if (bloomFilterColumnNames != null) {
                 this.bloomFilterColumnNames = new HashSet<>(bloomFilterColumnNames);

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -944,7 +944,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     .setStorageType(indexMeta.getStorageType())
                     .setVersion(indexMeta.getSchemaVersion())
                     .addColumns(indexMeta.getSchema())
-                    .setBloomFilterColumnNames(olapTable.getCopiedBfColumns())
+                    .setBloomFilterColumnNames(olapTable.getBfColumnIds())
                     .setBloomFilterFpp(olapTable.getBfFpp())
                     .setIndexes(olapTable.getCopiedIndexes())
                     .setSortKeyIndexes(indexMeta.getSortKeyIdxes())

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
@@ -148,7 +148,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
                 if (schema == null) {
                     throw new AnalysisException("Index " + idxId + " does not exist");
                 }
-                bfColumns = olapTable.getCopiedBfColumns();
+                bfColumns = olapTable.getBfColumnNames();
             } else {
                 schema = table.getBaseSchema();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -50,6 +50,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ForeignKeyConstraint;
@@ -1354,7 +1355,14 @@ public class PropertyAnalyzer {
                 } else if (bfColumns == null) {
                     bfFpp = 0;
                 }
-                materializedView.setBloomFilterInfo(bfColumns, bfFpp);
+                Set<ColumnId> bfColumnIds = null;
+                if (bfColumns != null && !bfColumns.isEmpty()) {
+                    bfColumnIds = Sets.newTreeSet(ColumnId.CASE_INSENSITIVE_ORDER);
+                    for (String colName : bfColumns) {
+                        bfColumnIds.add(materializedView.getColumn(colName).getColumnId());
+                    }
+                }
+                materializedView.setBloomFilterInfo(bfColumnIds, bfFpp);
             }
             // mv_rewrite_staleness second.
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_MV_REWRITE_STALENESS_SECOND)) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/IndexView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/IndexView.java
@@ -15,6 +15,7 @@
 package com.starrocks.http.rest.v2.vo;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
 import com.starrocks.sql.ast.IndexDef;
 
@@ -34,7 +35,7 @@ public class IndexView {
     private String indexType;
 
     @SerializedName("columns")
-    private List<String> columns;
+    private List<ColumnId> columns;
 
     @SerializedName("comment")
     private String comment;
@@ -85,11 +86,11 @@ public class IndexView {
         this.indexType = indexType;
     }
 
-    public List<String> getColumns() {
+    public List<ColumnId> getColumns() {
         return columns;
     }
 
-    public void setColumns(List<String> columns) {
+    public void setColumns(List<ColumnId> columns) {
         this.columns = columns;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -924,8 +924,8 @@ public class LeaderImpl {
             tableMeta.setDb_name(dbName);
             tableMeta.setState(olapTable.getState().name());
             tableMeta.setBloomfilter_fpp(olapTable.getBfFpp());
-            if (olapTable.getCopiedBfColumns() != null) {
-                for (String bfColumn : olapTable.getCopiedBfColumns()) {
+            if (olapTable.getBfColumnNames() != null) {
+                for (String bfColumn : olapTable.getBfColumnNames()) {
                     tableMeta.addToBloomfilter_columns(bfColumn);
                 }
             }
@@ -1018,7 +1018,7 @@ public class LeaderImpl {
                 indexInfo.setIndex_name(index.getIndexName());
                 indexInfo.setIndex_type(index.getIndexType().name());
                 indexInfo.setComment(index.getComment());
-                for (String column : index.getColumns()) {
+                for (String column : MetaUtils.getColumnNamesByColumnIds(olapTable, index.getColumns())) {
                     indexInfo.addToColumns(column);
                 }
                 tableMeta.addToIndex_infos(indexInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -48,6 +48,7 @@ import com.google.common.collect.Table;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.catalog.KeysType;
@@ -915,7 +916,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                                     + " and it is lost. create an empty replica to recover it",
                                             tabletId, replica.getId(), backendId);
                                     MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
-                                    Set<String> bfColumns = olapTable.getCopiedBfColumns();
+                                    Set<ColumnId> bfColumns = olapTable.getBfColumnIds();
                                     double bfFpp = olapTable.getBfFpp();
                                     TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                                             .setId(indexMeta.getSchemaId())
@@ -1627,14 +1628,13 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     continue;
                 }
 
-                List<String> columns = Lists.newArrayList();
                 List<TColumn> columnsDesc = Lists.newArrayList();
                 List<Integer> columnSortKeyUids = Lists.newArrayList();
 
                 for (Column column : indexMeta.getSchema()) {
                     TColumn tColumn = column.toThrift();
                     tColumn.setColumn_name(column.getColumnId().getId());
-                    column.setIndexFlag(tColumn, olapTable.getIndexes(), olapTable.getBfColumns());
+                    column.setIndexFlag(tColumn, olapTable.getIndexes(), olapTable.getBfColumnIds());
                     columnsDesc.add(tColumn);
                 }
                 if (indexMeta.getSortKeyUniqueIds() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -666,7 +666,7 @@ public class GsonUtils {
         @Override
         public ColumnId deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
-            return new ColumnId(json.getAsJsonPrimitive().getAsString());
+            return ColumnId.create(json.getAsJsonPrimitive().getAsString());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -16,7 +16,6 @@ package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.TupleDescriptor;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -51,6 +51,7 @@ import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.KeysType;
@@ -905,7 +906,7 @@ public class OlapScanNode extends ScanNode {
         List<String> keyColumnNames = new ArrayList<String>();
         List<TPrimitiveType> keyColumnTypes = new ArrayList<TPrimitiveType>();
         List<TColumn> columnsDesc = new ArrayList<TColumn>();
-        Set<String> bfColumns = olapTable.getBfColumns();
+        Set<ColumnId> bfColumns = olapTable.getBfColumnIds();
 
         if (selectedIndexId != -1) {
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -39,7 +39,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
-import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.LiteralExpr;
@@ -346,7 +345,7 @@ public class OlapTableSink extends DataSink {
             for (Column column : indexMeta.getSchema()) {
                 TColumn tColumn = column.toThrift();
                 tColumn.setColumn_name(column.getColumnId().getId());
-                column.setIndexFlag(tColumn, table.getIndexes(), table.getBfColumns());
+                column.setIndexFlag(tColumn, table.getIndexes(), table.getBfColumnIds());
                 columnsDesc.add(tColumn);
             }
             if (indexMeta.getSortKeyUniqueIds() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -174,8 +174,8 @@ public class StreamLoadPlanner {
 
             if (col.getType().isVarchar() && Config.enable_dict_optimize_stream_load &&
                     IDictManager.getInstance().hasGlobalDict(destTable.getId(),
-                            col.getName())) {
-                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable.getId(), col.getName());
+                            col.getColumnId())) {
+                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable.getId(), col.getColumnId());
                 dict.ifPresent(columnDict -> globalDicts.add(new Pair<>(slotDesc.getId().asInt(), columnDict)));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -2209,8 +2209,9 @@ public class ShowExecutor {
                 } else if (table instanceof OlapTable) {
                     List<Index> indexes = ((OlapTable) table).getIndexes();
                     for (Index index : indexes) {
+                        List<String> indexColumnNames = MetaUtils.getColumnNamesByColumnIds(table, index.getColumns());
                         rows.add(Lists.newArrayList(statement.getTableName().toString(), "",
-                                index.getIndexName(), "", String.join(",", index.getColumns()), "", "", "", "",
+                                index.getIndexName(), "", String.join(",", indexColumnNames), "", "", "", "",
                                 "", String.format("%s%s", index.getIndexType().name(), index.getPropertiesString()),
                                 index.getComment()));
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1944,7 +1944,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 .setIndexes(table.getIndexes())
                 .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                 .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
-                .setBloomFilterColumnNames(table.getBfColumns())
+                .setBloomFilterColumnNames(table.getBfColumnIds())
                 .setBloomFilterFpp(table.getBfFpp())
                 .addColumns(indexMeta.getSchema())
                 .build().toTabletSchema();
@@ -3715,7 +3715,7 @@ public class LocalMetastore implements ConnectorMetadata {
     private void renameColumnInternal(OlapTable olapTable, String colName, String newColName) {
         olapTable.renameColumn(colName, newColName);
 
-        Set<String> bfColumns = olapTable.getBfColumns();
+        Set<String> bfColumns = olapTable.getBfColumnNames();
         if (bfColumns != null) {
             Iterator<String> iterator = bfColumns.iterator();
             while (iterator.hasNext()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -16,10 +16,12 @@ package com.starrocks.server;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.BloomFilterIndexUtil;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
@@ -288,9 +290,14 @@ public class OlapTableFactory implements AbstractTableFactory {
                     bfFpp = 0;
                 }
 
-                table.setBloomFilterInfo(bfColumns, bfFpp);
+                Set<ColumnId> bfColumnIds = null;
+                if (bfColumns != null && !bfColumns.isEmpty()) {
+                    bfColumnIds = Sets.newTreeSet(ColumnId.CASE_INSENSITIVE_ORDER);
+                    bfColumnIds.addAll(bfColumns.stream().map(ColumnId::create).collect(Collectors.toSet()));
+                }
+                table.setBloomFilterInfo(bfColumnIds, bfFpp);
 
-                BloomFilterIndexUtil.analyseBfWithNgramBf(new HashSet<>(stmt.getIndexes()), bfColumns);
+                BloomFilterIndexUtil.analyseBfWithNgramBf(table, new HashSet<>(stmt.getIndexes()), bfColumnIds);
             } catch (AnalysisException e) {
                 throw new DdlException(e.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -329,8 +329,8 @@ public class InsertPlanner {
                 slotDescriptor.setColumn(column);
                 slotDescriptor.setIsNullable(column.isAllowNull());
                 if (column.getType().isVarchar() &&
-                        IDictManager.getInstance().hasGlobalDict(tableId, column.getName())) {
-                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getName());
+                        IDictManager.getInstance().hasGlobalDict(tableId, column.getColumnId())) {
+                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getColumnId());
                     dict.ifPresent(
                             columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -377,8 +377,8 @@ public class LoadPlanner {
 
             if (col.getType().isVarchar() && enableDictOptimize
                     && IDictManager.getInstance().hasGlobalDict(destTable.getId(),
-                    col.getName())) {
-                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable.getId(), col.getName());
+                    col.getColumnId())) {
+                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable.getId(), col.getColumnId());
                 dict.ifPresent(columnDict -> globalDicts.add(new Pair<>(slotDesc.getId().asInt(), columnDict)));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlannerHybrid.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlannerHybrid.java
@@ -48,7 +48,7 @@ public class ShortCircuitPlannerHybrid {
             }
 
             for (Column column : table.getFullSchema()) {
-                if (IDictManager.getInstance().hasGlobalDict(table.getId(), column.getName())) {
+                if (IDictManager.getInstance().hasGlobalDict(table.getId(), column.getColumnId())) {
                     return false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -123,8 +123,8 @@ public class UpdatePlanner {
                 slotDescriptor.setColumn(column);
                 slotDescriptor.setIsNullable(column.isAllowNull());
                 if (column.getType().isVarchar() &&
-                        IDictManager.getInstance().hasGlobalDict(tableId, column.getName())) {
-                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getName());
+                        IDictManager.getInstance().hasGlobalDict(tableId, column.getColumnId())) {
+                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getColumnId());
                     dict.ifPresent(
                             columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -128,10 +128,12 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
         // Only assign meaningful indexId for OlapTable
         if (table.isOlapTableOrMaterializedView()) {
             long indexId = IndexType.isCompatibleIndex(indexDef.getIndexType()) ? ((OlapTable) table).incAndGetMaxIndexId() : -1;
-            index = new Index(indexId, indexDef.getIndexName(), indexDef.getColumns(),
+            index = new Index(indexId, indexDef.getIndexName(),
+                    MetaUtils.getColumnIdsByColumnNames(table, indexDef.getColumns()),
                     indexDef.getIndexType(), indexDef.getComment(), indexDef.getProperties());
         } else {
-            index = new Index(indexDef.getIndexName(), indexDef.getColumns(),
+            index = new Index(indexDef.getIndexName(),
+                    MetaUtils.getColumnIdsByColumnNames(table, indexDef.getColumns()),
                     indexDef.getIndexType(), indexDef.getComment(), indexDef.getProperties());
         }
         clause.setIndex(index);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1514,7 +1514,7 @@ public class AstToStringBuilder {
             if (CollectionUtils.isNotEmpty(olapTable.getIndexes())) {
                 for (Index index : olapTable.getIndexes()) {
                     sb.append(",\n");
-                    sb.append("  ").append(index.toSql());
+                    sb.append("  ").append(index.toSql(table));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -25,6 +25,7 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
@@ -649,12 +650,14 @@ public class CreateTableAnalyzer {
                 if (!statement.isOlapEngine()) {
                     throw new SemanticException("index only support in olap engine at current version", indexDef.getPos());
                 }
+                List<ColumnId> columnIds = new ArrayList<>(indexDef.getColumns().size());
                 for (String indexColName : indexDef.getColumns()) {
                     boolean found = false;
                     for (Column column : columns) {
                         if (column.getName().equalsIgnoreCase(indexColName)) {
                             indexDef.checkColumn(column, keysDesc.getKeysType());
                             found = true;
+                            columnIds.add(column.getColumnId());
                             break;
                         }
                     }
@@ -665,7 +668,7 @@ public class CreateTableAnalyzer {
                                 indexDef.getPos());
                     }
                 }
-                indexes.add(new Index(indexDef.getIndexName(), indexDef.getColumns(), indexDef.getIndexType(),
+                indexes.add(new Index(indexDef.getIndexName(), columnIds, indexDef.getIndexType(),
                         indexDef.getComment(), indexDef.getProperties()));
 
                 distinct.add(indexDef.getIndexName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -34,6 +34,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveMetaStoreTable;
@@ -574,12 +575,14 @@ public class MaterializedViewAnalyzer {
 
                 for (IndexDef indexDef : indexDefs) {
                     indexDef.analyze();
+                    List<ColumnId> columnIds = new ArrayList<>(indexDef.getColumns().size());
                     for (String indexColName : indexDef.getColumns()) {
                         boolean found = false;
                         for (Column column : columns) {
                             if (column.getName().equalsIgnoreCase(indexColName)) {
                                 indexDef.checkColumn(column, statement.getKeysType());
                                 found = true;
+                                columnIds.add(column.getColumnId());
                                 break;
                             }
                         }
@@ -588,7 +591,7 @@ public class MaterializedViewAnalyzer {
                                     indexDef.getPos());
                         }
                     }
-                    indexes.add(new Index(indexDef.getIndexName(), indexDef.getColumns(), indexDef.getIndexType(),
+                    indexes.add(new Index(indexDef.getIndexName(), columnIds, indexDef.getIndexType(),
                             indexDef.getComment()));
                     indexMultiMap.put(indexDef.getIndexName().toLowerCase(), 1);
                     colMultiMap.put(String.join(",", indexDef.getColumns()), 1);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -409,7 +409,7 @@ public class ShowStmtAnalyzer {
                     if (table.isNativeTableOrMaterializedView()) {
                         node.setOlapTable(true);
                         OlapTable olapTable = (OlapTable) table;
-                        Set<String> bfColumns = olapTable.getCopiedBfColumns();
+                        Set<String> bfColumns = olapTable.getBfColumnNames();
                         Map<Long, List<Column>> indexIdToSchema = olapTable.getIndexIdToSchema();
 
                         // indices order

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -285,20 +285,8 @@ public class MetaUtils {
         }
     }
 
-    public static List<Column> getColumnsByColumnIds(List<Column> schema, List<ColumnId> ids) {
-        return getColumnsByColumnIds(buildIdToColumn(schema), ids);
-    }
-
     public static List<Column> getColumnsByColumnIds(Table table, List<ColumnId> ids) {
-        List<Column> result = new ArrayList<>(ids.size());
-        for (ColumnId columnId : ids) {
-            Column column = table.getColumn(columnId);
-            if (column == null) {
-                throw new SemanticException(String.format("can not find column by column id: %s", columnId));
-            }
-            result.add(column);
-        }
-        return result;
+        return getColumnsByColumnIds(table.getIdToColumn(), ids);
     }
 
     public static List<Column> getColumnsByColumnIds(Map<ColumnId, Column> idToColumn, List<ColumnId> ids) {
@@ -319,6 +307,10 @@ public class MetaUtils {
             result.put(column.getColumnId(), column);
         }
         return result;
+    }
+
+    public static List<String> getColumnNamesByColumnIds(Table table, List<ColumnId> columnIds) {
+        return getColumnNamesByColumnIds(table.getIdToColumn(), columnIds);
     }
 
     public static List<String> getColumnNamesByColumnIds(Map<ColumnId, Column> idToColumn, List<ColumnId> columnIds) {
@@ -348,5 +340,26 @@ public class MetaUtils {
             result.put(column.getName(), column);
         }
         return result;
+    }
+
+    public static String getColumnNameByColumnId(long dbId, long tableId, ColumnId columnId) {
+        Table table = getTable(dbId, tableId);
+        Column column = table.getColumn(columnId);
+        if (column == null) {
+            throw new SemanticException(String.format("can not find column by column id: %s", columnId));
+        }
+        return column.getName();
+    }
+
+    public static List<ColumnId> getColumnIdsByColumnNames(Table table, List<String> names) {
+        List<ColumnId> columnIds = new ArrayList<>(names.size());
+        for (String name : names) {
+            Column column = table.getColumn(name);
+            if (column == null) {
+                throw new SemanticException(String.format("can not find column by name: %s", name));
+            }
+            columnIds.add(column.getColumnId());
+        }
+        return columnIds;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnIdentifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnIdentifier.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.sql.optimizer.base;
 
+import com.starrocks.catalog.ColumnId;
+
 import java.util.Objects;
 
 /**
@@ -23,16 +25,16 @@ import java.util.Objects;
  */
 public final class ColumnIdentifier {
     private final long tableId;
-    private final String columnName;
+    private final ColumnId columnName;
 
     private long dbId = -1;
 
-    public ColumnIdentifier(long tableId, String columnName) {
+    public ColumnIdentifier(long tableId, ColumnId columnName) {
         this.tableId = tableId;
         this.columnName = columnName;
     }
 
-    public ColumnIdentifier(long dbId, long tableId, String columnName) {
+    public ColumnIdentifier(long dbId, long tableId, ColumnId columnName) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.columnName = columnName;
@@ -42,7 +44,7 @@ public final class ColumnIdentifier {
         return tableId;
     }
 
-    public String getColumnName() {
+    public ColumnId getColumnName() {
         return columnName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -955,9 +955,11 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                 }
 
                 // Condition 3: the varchar column has collected global dict
-                if (IDictManager.getInstance().hasGlobalDict(table.getId(), column.getName(), version)) {
+                Column columnObj = table.getColumn(column.getName());
+                if (columnObj != null
+                        && IDictManager.getInstance().hasGlobalDict(table.getId(), columnObj.getColumnId(), version)) {
                     Optional<ColumnDict> dict =
-                            IDictManager.getInstance().getGlobalDict(table.getId(), column.getName());
+                            IDictManager.getInstance().getGlobalDict(table.getId(), columnObj.getColumnId());
                     // cache reaches capacity limit, randomly eliminate some keys
                     // then we will get an empty dictionary.
                     if (!dict.isPresent()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.ArrayType;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KeysType;
@@ -555,12 +556,13 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             }
 
             // Condition 3: the varchar column has collected global dict
-            if (!IDictManager.getInstance().hasGlobalDict(table.getId(), column.getName(), version)) {
+            Column columnObj = table.getColumn(column.getName());
+            if (!IDictManager.getInstance().hasGlobalDict(table.getId(), columnObj.getColumnId(), version)) {
                 LOG.debug("{} doesn't have global dict", column.getName());
                 continue;
             }
 
-            Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(table.getId(), column.getName());
+            Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(table.getId(), columnObj.getColumnId());
             // cache reaches capacity limit, randomly eliminate some keys
             // then we will get an empty dictionary.
             if (dict.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
@@ -15,25 +15,26 @@
 
 package com.starrocks.sql.optimizer.statistics;
 
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.FeConstants;
 
 import java.util.Optional;
 
 public interface IDictManager {
-    boolean hasGlobalDict(long tableId, String columnName, long versionTime);
+    boolean hasGlobalDict(long tableId, ColumnId columnName, long versionTime);
 
-    void updateGlobalDict(long tableId, String columnName, long collectedVersion, long versionTime);
+    void updateGlobalDict(long tableId, ColumnId columnName, long collectedVersion, long versionTime);
 
-    boolean hasGlobalDict(long tableId, String columnName);
+    boolean hasGlobalDict(long tableId, ColumnId columnName);
 
-    void removeGlobalDict(long tableId, String columnName);
+    void removeGlobalDict(long tableId, ColumnId columnName);
 
     void disableGlobalDict(long tableId);
 
     void enableGlobalDict(long tableId);
 
     // You should call `hasGlobalDict` firstly to ensure the global dict exist
-    Optional<ColumnDict> getGlobalDict(long tableId, String columnName);
+    Optional<ColumnDict> getGlobalDict(long tableId, ColumnId columnName);
 
     static IDictManager getInstance() {
         if (FeConstants.USE_MOCK_DICT_MANAGER) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.ColumnId;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -37,21 +38,21 @@ public class MockDictManager implements IDictManager {
     }
 
     @Override
-    public boolean hasGlobalDict(long tableId, String columnName, long versionTime) {
+    public boolean hasGlobalDict(long tableId, ColumnId columnName, long versionTime) {
         return true;
     }
 
     @Override
-    public void updateGlobalDict(long tableId, String columnName,  long collectedVersion, long versionTime) {
+    public void updateGlobalDict(long tableId, ColumnId columnName, long collectedVersion, long versionTime) {
     }
 
     @Override
-    public boolean hasGlobalDict(long tableId, String columnName) {
+    public boolean hasGlobalDict(long tableId, ColumnId columnName) {
         return true;
     }
 
     @Override
-    public void removeGlobalDict(long tableId, String columnName) {
+    public void removeGlobalDict(long tableId, ColumnId columnName) {
     }
 
     @Override
@@ -64,7 +65,7 @@ public class MockDictManager implements IDictManager {
     }
 
     @Override
-    public Optional<ColumnDict> getGlobalDict(long tableId, String columnName) {
+    public Optional<ColumnDict> getGlobalDict(long tableId, ColumnId columnName) {
         return Optional.of(COLUMN_DICT);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -15,6 +15,7 @@
 package com.starrocks.statistic;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
@@ -179,7 +180,7 @@ public class StatisticExecutor {
     }
 
     // If you call this function, you must ensure that the db lock is added
-    public static Pair<List<TStatisticData>, Status> queryDictSync(Long dbId, Long tableId, String column)
+    public static Pair<List<TStatisticData>, Status> queryDictSync(Long dbId, Long tableId, ColumnId columnId)
             throws Exception {
         if (dbId == -1) {
             return Pair.create(Collections.emptyList(), Status.OK);
@@ -195,10 +196,11 @@ public class StatisticExecutor {
         OlapTable olapTable = (OlapTable) table;
         long version = olapTable.getPartitions().stream().map(Partition::getVisibleVersionTime)
                 .max(Long::compareTo).orElse(0L);
+        String columnName = MetaUtils.getColumnNameByColumnId(dbId, tableId, columnId);
         String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
         String sql = "select cast(" + StatsConstants.STATISTIC_DICT_VERSION + " as Int), " +
                 "cast(" + version + " as bigint), " +
-                "dict_merge(" + StatisticUtils.quoting(column) + ") as _dict_merge_" + column +
+                "dict_merge(" + StatisticUtils.quoting(columnName) + ") as _dict_merge_" + columnName +
                 " from " + StatisticUtils.quoting(catalogName, db.getOriginName(), table.getName()) + " [_META_]";
 
         ConnectContext context = StatisticUtils.buildConnectContext();

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -231,7 +231,7 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
             Map<String, Expr> defineExprs = rollupJobV2Params.getDefineExprs();
             Expr whereExpr = rollupJobV2Params.getWhereExpr();
             DescriptorTable descTable = rollupJobV2Params.getDescTabl();
-            List<ColumnId> baseTableColNames = rollupJobV2Params.getBaseTableColIds();
+            List<ColumnId> baseTableColIds = rollupJobV2Params.getBaseTableColIds();
             if (defineExprs != null) {
                 for (Map.Entry<String, Expr> entry : defineExprs.entrySet()) {
                     List<SlotRef> slots = Lists.newArrayList();
@@ -258,9 +258,7 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
             if (descTable != null) {
                 req.setDesc_tbl(descTable.toThrift());
             }
-            req.setBase_table_column_names(baseTableColNames
-                    .stream()
-                    .map(ColumnId::getId)
+            req.setBase_table_column_names(baseTableColIds.stream().map(ColumnId::getId)
                     .collect(Collectors.toList()));
         }
         req.setMaterialized_column_req(generatedColumnReq);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -16,6 +16,7 @@ package com.starrocks.transaction;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
@@ -58,7 +59,7 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
     }
 
     public void applyVisibleLog(TransactionState txnState, TableCommitInfo commitInfo, Database db) {
-        List<String> validDictCacheColumns = Lists.newArrayList();
+        List<ColumnId> validDictCacheColumns = Lists.newArrayList();
         List<Long> dictCollectedVersions = Lists.newArrayList();
 
         long maxPartitionVersionTime = -1;
@@ -88,7 +89,7 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
                 compactionManager.handleLoadingFinished(partitionIdentifier, version, versionTime, compactionScore);
             }
             if (!partitionCommitInfo.getInvalidDictCacheColumns().isEmpty()) {
-                for (String column : partitionCommitInfo.getInvalidDictCacheColumns()) {
+                for (ColumnId column : partitionCommitInfo.getInvalidDictCacheColumns()) {
                     IDictManager.getInstance().removeGlobalDict(tableId, column);
                 }
             }
@@ -103,7 +104,7 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
 
         if (!GlobalStateMgr.isCheckpointThread() && dictCollectedVersions.size() == validDictCacheColumns.size()) {
             for (int i = 0; i < validDictCacheColumns.size(); i++) {
-                String columnName = validDictCacheColumns.get(i);
+                ColumnId columnName = validDictCacheColumns.get(i);
                 long collectedVersion = dictCollectedVersions.get(i);
                 IDictManager.getInstance()
                         .updateGlobalDict(tableId, columnName, collectedVersion, maxPartitionVersionTime);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
@@ -57,8 +58,8 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
     private final OlapTable table;
 
     private Set<Long> dirtyPartitionSet;
-    private Set<String> invalidDictCacheColumns;
-    private Map<String, Long> validDictCacheColumns;
+    private Set<ColumnId> invalidDictCacheColumns;
+    private Map<ColumnId, Long> validDictCacheColumns;
     private final CompactionMgr compactionMgr;
 
     public LakeTableTxnStateListener(@NotNull DatabaseTransactionMgr dbTxnMgr, @NotNull OlapTable table) {
@@ -118,7 +119,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
                     !finishedTablets.get(i).getValidDictCacheColumns().isEmpty()) {
                 TabletCommitInfo tabletCommitInfo = finishedTablets.get(i);
                 List<Long> validDictCollectedVersions = tabletCommitInfo.getValidDictCollectedVersions();
-                List<String> validDictCacheColumns = tabletCommitInfo.getValidDictCacheColumns();
+                List<ColumnId> validDictCacheColumns = tabletCommitInfo.getValidDictCacheColumns();
                 for (int j = 0; j < validDictCacheColumns.size(); j++) {
                     long version = 0;
                     // validDictCollectedVersions != validDictCacheColumns means be has not upgrade
@@ -174,7 +175,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
             PartitionCommitInfo partitionCommitInfo;
             long version = -1;
             if (isFirstPartition) {
-                List<String> validDictCacheColumnNames = Lists.newArrayList();
+                List<ColumnId> validDictCacheColumnNames = Lists.newArrayList();
                 List<Long> validDictCacheColumnVersions = Lists.newArrayList();
 
                 validDictCacheColumns.forEach((name, dictVersion) -> {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -15,6 +15,7 @@
 package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
@@ -89,7 +90,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             LOG.warn("table {} is dropped, ignore", tableId);
             return;
         }
-        List<String> validDictCacheColumns = Lists.newArrayList();
+        List<ColumnId> validDictCacheColumns = Lists.newArrayList();
         List<Long> dictCollectedVersions = Lists.newArrayList();
 
         long maxPartitionVersionTime = -1;
@@ -174,7 +175,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                 partition.updateVisibleVersion(version, versionTime, txnState.getTransactionId());
             }
             if (!partitionCommitInfo.getInvalidDictCacheColumns().isEmpty()) {
-                for (String column : partitionCommitInfo.getInvalidDictCacheColumns()) {
+                for (ColumnId column : partitionCommitInfo.getInvalidDictCacheColumns()) {
                     IDictManager.getInstance().removeGlobalDict(tableId, column);
                 }
             }
@@ -189,7 +190,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
 
         if (!GlobalStateMgr.isCheckpointThread() && dictCollectedVersions.size() == validDictCacheColumns.size()) {
             for (int i = 0; i < validDictCacheColumns.size(); i++) {
-                String columnName = validDictCacheColumns.get(i);
+                ColumnId columnName = validDictCacheColumns.get(i);
                 long collectedVersion = dictCollectedVersions.get(i);
                 IDictManager.getInstance()
                         .updateGlobalDict(tableId, columnName, collectedVersion, maxPartitionVersionTime);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -55,8 +56,8 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
     private Set<Long> totalInvolvedBackends;
     private Set<Long> errorReplicaIds;
     private Set<Long> dirtyPartitionSet;
-    private Set<String> invalidDictCacheColumns;
-    private Map<String, Long> validDictCacheColumns;
+    private Set<ColumnId> invalidDictCacheColumns;
+    private Map<ColumnId, Long> validDictCacheColumns;
 
     public OlapTableTxnStateListener(DatabaseTransactionMgr dbTxnMgr, OlapTable table) {
         this.dbTxnMgr = dbTxnMgr;
@@ -131,7 +132,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                     !tabletCommitInfos.get(i).getValidDictCacheColumns().isEmpty()) {
                 TabletCommitInfo tabletCommitInfo = tabletCommitInfos.get(i);
                 List<Long> validDictCollectedVersions = tabletCommitInfo.getValidDictCollectedVersions();
-                List<String> validDictCacheColumns = tabletCommitInfo.getValidDictCacheColumns();
+                List<ColumnId> validDictCacheColumns = tabletCommitInfo.getValidDictCacheColumns();
                 for (int j = 0; j < validDictCacheColumns.size(); j++) {
                     long version = 0;
                     // validDictCollectedVersions != validDictCacheColumns means be has not upgrade
@@ -258,7 +259,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
             long version = -1;
             if (isFirstPartition) {
 
-                List<String> validDictCacheColumnNames = Lists.newArrayList();
+                List<ColumnId> validDictCacheColumnNames = Lists.newArrayList();
                 List<Long> validDictCacheColumnVersions = Lists.newArrayList();
 
                 validDictCacheColumns.forEach((name, dictVersion) -> {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -36,6 +36,7 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.lake.compaction.Quantiles;
@@ -69,9 +70,9 @@ public class PartitionCommitInfo implements Writable {
     // not TableCommitInfo.
 
     @SerializedName(value = "invalidColumns")
-    private List<String> invalidDictCacheColumns = Lists.newArrayList();
+    private List<ColumnId> invalidDictCacheColumns = Lists.newArrayList();
     @SerializedName(value = "validColumns")
-    private List<String> validDictCacheColumns = Lists.newArrayList();
+    private List<ColumnId> validDictCacheColumns = Lists.newArrayList();
     @SerializedName(value = "DictCollectedVersion")
     private List<Long> dictCollectedVersions = Lists.newArrayList();
 
@@ -93,8 +94,8 @@ public class PartitionCommitInfo implements Writable {
     }
 
     public PartitionCommitInfo(long partitionId, long version, long visibleTime,
-                               List<String> invalidDictCacheColumns,
-                               List<String> validDictCacheColumns,
+                               List<ColumnId> invalidDictCacheColumns,
+                               List<ColumnId> validDictCacheColumns,
                                List<Long> dictCollectedVersions) {
         super();
         this.partitionId = partitionId;
@@ -144,11 +145,11 @@ public class PartitionCommitInfo implements Writable {
         return isDoubleWrite;
     }
 
-    public List<String> getInvalidDictCacheColumns() {
+    public List<ColumnId> getInvalidDictCacheColumns() {
         return invalidDictCacheColumns;
     }
 
-    public List<String> getValidDictCacheColumns() {
+    public List<ColumnId> getValidDictCacheColumns() {
         return validDictCacheColumns;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
@@ -36,6 +36,7 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.io.Writable;
 import com.starrocks.thrift.TTabletCommitInfo;
 
@@ -43,6 +44,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 public class TabletCommitInfo implements Writable {
@@ -51,8 +53,8 @@ public class TabletCommitInfo implements Writable {
     private long backendId;
 
     // For low cardinality string column with global dict
-    private List<String> invalidDictCacheColumns = Lists.newArrayList();
-    private List<String> validDictCacheColumns = Lists.newArrayList();
+    private List<ColumnId> invalidDictCacheColumns = Lists.newArrayList();
+    private List<ColumnId> validDictCacheColumns = Lists.newArrayList();
     private List<Long> validDictCollectedVersions = Lists.newArrayList();
 
     public TabletCommitInfo() {
@@ -64,8 +66,8 @@ public class TabletCommitInfo implements Writable {
         this.backendId = backendId;
     }
 
-    public TabletCommitInfo(long tabletId, long backendId, List<String> invalidDictCacheColumns,
-                            List<String> validDictCacheColumns, List<Long> validDictCollectedVersions) {
+    public TabletCommitInfo(long tabletId, long backendId, List<ColumnId> invalidDictCacheColumns,
+                            List<ColumnId> validDictCacheColumns, List<Long> validDictCollectedVersions) {
         this.tabletId = tabletId;
         this.backendId = backendId;
         this.invalidDictCacheColumns = invalidDictCacheColumns;
@@ -81,11 +83,11 @@ public class TabletCommitInfo implements Writable {
         return backendId;
     }
 
-    public List<String> getInvalidDictCacheColumns() {
+    public List<ColumnId> getInvalidDictCacheColumns() {
         return invalidDictCacheColumns;
     }
 
-    public List<String> getValidDictCacheColumns() {
+    public List<ColumnId> getValidDictCacheColumns() {
         return validDictCacheColumns;
     }
 
@@ -111,8 +113,14 @@ public class TabletCommitInfo implements Writable {
             if (tTabletCommitInfo.isSetInvalid_dict_cache_columns()) {
                 commitInfos.add(new TabletCommitInfo(tTabletCommitInfo.getTabletId(),
                         tTabletCommitInfo.getBackendId(),
-                        tTabletCommitInfo.getInvalid_dict_cache_columns(),
-                        tTabletCommitInfo.getValid_dict_cache_columns(),
+                        tTabletCommitInfo.getInvalid_dict_cache_columns()
+                                .stream()
+                                .map(ColumnId::create)
+                                .collect(Collectors.toList()),
+                        tTabletCommitInfo.getValid_dict_cache_columns()
+                                .stream()
+                                .map(ColumnId::create)
+                                .collect(Collectors.toList()),
                         tTabletCommitInfo.getValid_dict_collected_versions()
                 ));
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import static com.starrocks.common.InvertedIndexParams.CommonIndexParamKey.IMP_LIB;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
@@ -147,7 +149,7 @@ public class GINIndexTest extends PlanTestBase {
     public void testIndexToThrift() {
         int indexId = 0;
         String indexName = "test_index";
-        List<String> columns = Collections.singletonList("f1");
+        List<ColumnId> columns = Collections.singletonList(ColumnId.create("f1"));
 
         Index index = new Index(indexId, indexName, columns, IndexType.GIN, "", new HashMap<>() {{
             put(IMP_LIB.name().toLowerCase(Locale.ROOT), InvertedIndexImpType.CLUCENE.name());
@@ -164,7 +166,7 @@ public class GINIndexTest extends PlanTestBase {
         Assertions.assertEquals(indexId, olapIndex.getIndex_id());
         Assertions.assertEquals(indexName, olapIndex.getIndex_name());
         Assertions.assertEquals(TIndexType.GIN, olapIndex.getIndex_type());
-        Assertions.assertEquals(columns, olapIndex.getColumns());
+        Assertions.assertEquals(Lists.newArrayList("f1"), olapIndex.getColumns());
         Assertions.assertEquals(
                 Collections.singletonMap(IMP_LIB.name().toLowerCase(Locale.ROOT), InvertedIndexImpType.CLUCENE.name()),
                 olapIndex.getCommon_properties());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -338,10 +338,10 @@ public class ColumnTest {
                 new DefaultValueDef(true, NullLiteral.create(Type.INT)), "", 0);
 
         Index i0 = new Index("i0",
-                Collections.singletonList("f0"), IndexType.BITMAP, "");
+                Collections.singletonList(ColumnId.create("f0")), IndexType.BITMAP, "");
 
-        Set<String> bfColumns = new HashSet<>();
-        bfColumns.add("f0");
+        Set<ColumnId> bfColumns = new HashSet<>();
+        bfColumns.add(ColumnId.create("f0"));
         TColumn t0 = f0.toThrift();
         f0.setIndexFlag(t0, Collections.singletonList(i0), bfColumns);
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -102,7 +102,7 @@ public class OlapTableTest {
                 continue;
             }
             OlapTable tbl = (OlapTable) table;
-            tbl.setIndexes(Lists.newArrayList(new Index("index", Lists.newArrayList("col"),
+            tbl.setIndexes(Lists.newArrayList(new Index("index", Lists.newArrayList(ColumnId.create("col")),
                     IndexDef.IndexType.BITMAP, "xxxxxx")));
             System.out.println("orig table id: " + tbl.getId());
             MvId mvId1 = new MvId(db.getId(), 10L);

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -25,6 +25,7 @@ import com.staros.proto.ShardInfo;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
@@ -325,10 +326,10 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
         DistributionInfo defaultDistributionInfo = new HashDistributionInfo(8, Lists.newArrayList(c1));
 
         Index idx1 = new Index(
-                testIndexId, "idx1", Lists.newArrayList("c1"),
+                testIndexId, "idx1", Lists.newArrayList(ColumnId.create("c1")),
                 IndexDef.IndexType.BITMAP, "c_idx1", new HashMap<>());
         Index idx2 = new Index(
-                testIndexId + 1, "idx2", Lists.newArrayList("c2"),
+                testIndexId + 1, "idx2", Lists.newArrayList(ColumnId.create("c2")),
                 IndexDef.IndexType.NGRAMBF, "c_idx2", new HashMap<>());
         TableIndexes indexes = new TableIndexes(
                 Lists.newArrayList(idx1, idx2)

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
@@ -14,10 +14,12 @@
 
 package com.starrocks.http.rest.v2;
 
+import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
@@ -39,7 +41,6 @@ import com.starrocks.http.rest.v2.vo.IndexView;
 import com.starrocks.http.rest.v2.vo.MaterializedIndexMetaView;
 import com.starrocks.http.rest.v2.vo.PartitionInfoView;
 import com.starrocks.http.rest.v2.vo.TableSchemaView;
-import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.IndexDef;
@@ -176,7 +177,7 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
                 assertEquals("idx1", idx.getIndexName());
                 assertEquals(IndexDef.IndexType.BITMAP.getDisplayName(), idx.getIndexType());
                 assertEquals(1, idx.getColumns().size());
-                assertEquals("c1", idx.getColumns().get(0));
+                assertEquals(ColumnId.create("c1"), idx.getColumns().get(0));
                 assertEquals("c_idx1", idx.getComment());
                 assertTrue(idx.getProperties().isEmpty());
             }
@@ -187,7 +188,7 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
                 assertEquals("idx2", idx.getIndexName());
                 assertEquals(IndexDef.IndexType.NGRAMBF.getDisplayName(), idx.getIndexType());
                 assertEquals(1, idx.getColumns().size());
-                assertEquals("c2", idx.getColumns().get(0));
+                assertEquals(ColumnId.create("c2"), idx.getColumns().get(0));
                 assertEquals("c_idx2", idx.getComment());
                 assertTrue(idx.getProperties().isEmpty());
             }
@@ -218,10 +219,10 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
         DistributionInfo distributionInfo = new HashDistributionInfo(8, Lists.newArrayList(c1));
 
         Index idx1 = new Index(
-                tableId, "idx1", Lists.newArrayList("c1"),
+                tableId, "idx1", Lists.newArrayList(ColumnId.create("c1")),
                 IndexDef.IndexType.BITMAP, "c_idx1", new HashMap<>());
         Index idx2 = new Index(
-                tableId + 1, "idx2", Lists.newArrayList("c2"),
+                tableId + 1, "idx2", Lists.newArrayList(ColumnId.create("c2")),
                 IndexDef.IndexType.NGRAMBF, "c_idx2", new HashMap<>());
         TableIndexes indexes = new TableIndexes(
                 Lists.newArrayList(idx1, idx2)
@@ -264,7 +265,8 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
     private static RestBaseResultV2<TableSchemaView> parseResponseBody(String body) {
         try {
             System.out.println("resp: " + body);
-            return GsonUtils.GSON.fromJson(body, new TypeToken<RestBaseResultV2<TableSchemaView>>() {
+            Gson gson = new Gson();
+            return gson.fromJson(body, new TypeToken<RestBaseResultV2<TableSchemaView>>() {
             }.getType());
         } catch (Exception e) {
             fail("invalid resp body: " + body);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -234,7 +234,7 @@ public class ShowExecutorTest {
                 minTimes = 0;
                 result = partition;
 
-                table.getCopiedBfColumns();
+                table.getBfColumnNames();
                 minTimes = 0;
                 result = null;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -93,7 +93,7 @@ public class AnalyzeAlterTableStatementTest {
 
     @Test
     public void testCreateIndex() throws Exception {
-        String sql = "CREATE INDEX index1 ON `test`.`t0` (`col1`) USING BITMAP COMMENT 'balabala'";
+        String sql = "CREATE INDEX index1 ON `test`.`t0` (`v1`) USING BITMAP COMMENT 'balabala'";
         analyzeSuccess(sql);
 
         sql = "alter table t0 add index index1 (v2)";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -1574,9 +1575,9 @@ public class LowCardinalityTest extends PlanTestBase {
 
         new Expectations(dictManager) {
             {
-                dictManager.hasGlobalDict(anyLong, "S_ADDRESS", anyLong);
+                dictManager.hasGlobalDict(anyLong, ColumnId.create("S_ADDRESS"), anyLong);
                 result = true;
-                dictManager.getGlobalDict(anyLong, "S_ADDRESS");
+                dictManager.getGlobalDict(anyLong, ColumnId.create("S_ADDRESS"));
                 result = Optional.empty();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -1705,9 +1706,9 @@ public class LowCardinalityTest2 extends PlanTestBase {
 
         new Expectations(dictManager) {
             {
-                dictManager.hasGlobalDict(anyLong, "S_ADDRESS", anyLong);
+                dictManager.hasGlobalDict(anyLong, ColumnId.create("S_ADDRESS"), anyLong);
                 result = true;
-                dictManager.getGlobalDict(anyLong, "S_ADDRESS");
+                dictManager.getGlobalDict(anyLong, ColumnId.create("S_ADDRESS"));
                 result = Optional.empty();
             }
         };


### PR DESCRIPTION
## Why I'm doing:
We need a unique ID to identify the Column. This ID is used in all places that reference the Column. In this way, to change the attributes of the Column, such as name, we only need to change the attributes in the Column object. There is a uniqueId in the current Column, but it is only available in newly created tables. For compatibility reasons, we need to introduce another Id: ColumnID. The ColumnID of the historical table is the name of the column, because the name was previously immutable.

## What I'm doing:
There are currently three ways to reference Column: 1: direct copy of Column object, 2: reference to Column name, 3: sql expression reference.
This PR changes the Column name to ColumnId reference.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
