### PR TITLE
[BugFix] enhance column pruning for query with predicates after mv rewrite (backport #45274)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -32,6 +33,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
 import java.util.Map;
@@ -90,6 +92,20 @@ public class MVColumnPruner {
                 builder.withOperator(scanOperator);
                 LogicalScanOperator.Builder scanBuilder = (LogicalScanOperator.Builder) builder;
                 scanBuilder.setColRefToColumnMetaMap(newColumnRefMap);
+                ColumnRefSet outputRefSet = new ColumnRefSet(outputColumns);
+                outputRefSet.except(requiredOutputColumns);
+                if (!outputRefSet.isEmpty() && projection == null) {
+                    // should add a projection
+                    Map<ColumnRefOperator, ScalarOperator> projectionMap = Maps.newHashMap();
+                    for (ColumnRefOperator columnRefOperator : outputColumns) {
+                        if (outputRefSet.contains(columnRefOperator)) {
+                            continue;
+                        }
+                        projectionMap.put(columnRefOperator, columnRefOperator);
+                    }
+                    Projection newProjection = new Projection(projectionMap);
+                    builder.setProjection(newProjection);
+                }
                 Operator newQueryOp = builder.build();
                 return OptExpression.create(newQueryOp);
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -5453,4 +5453,109 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             testRewriteOK(mv, query);
         }
     }
+
+    @Test
+    public void testColumnPruningWithPredicates() {
+        {
+            String mv = "select lo_orderkey, lo_orderdate, lo_linenumber," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_revenue) as total_revenue," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " group by lo_orderkey, lo_orderdate, lo_linenumber";
+            String query = "select lo_orderdate," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " group by lo_orderdate" +
+                    " having sum(lo_tax) > 100";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("4:Project\n" +
+                    "  |  <slot 6> : 21: lo_orderdate\n" +
+                    "  |  <slot 18> : 26: sum\n" +
+                    "  |  <slot 19> : 27: sum\n" +
+                    "  |  <slot 26> : clone(26: sum)\n" +
+                    "  |  <slot 27> : clone(27: sum)\n" +
+                    "  |  \n" +
+                    "  3:AGGREGATE (merge finalize)");
+        }
+
+        {
+            String mv = "select lo_orderdate, lo_linenumber, p_name, p_partkey" +
+                    " from lineorder join part on lo_partkey = p_partkey";
+            String query = "select lo_orderdate, lo_linenumber, p_name" +
+                    " from lineorder join part on lo_partkey = p_partkey" +
+                    " where p_partkey = 1";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("1:Project\n" +
+                    "  |  <slot 2> : 28: lo_linenumber\n" +
+                    "  |  <slot 6> : 27: lo_orderdate\n" +
+                    "  |  <slot 19> : 29: p_name\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: mv0");
+        }
+
+        {
+            String mv = "select lo_orderkey, lo_orderdate, lo_linenumber," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_revenue) as total_revenue," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " group by lo_orderkey, lo_orderdate, lo_linenumber";
+            String query = "select lo_orderdate," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " where lo_orderkey = 100" +
+                    " group by lo_orderdate";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("1:Project\n" +
+                    "|  <slot 21> : col$: lo_orderdate\n" +
+                    "|  <slot 23> : col$: total_quantity\n" +
+                    "|  <slot 25> : col$: total_tax");
+        }
+
+        {
+            String mv = "select lo_orderkey, lo_orderdate, lo_linenumber," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_revenue) as total_revenue," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " group by lo_orderkey, lo_orderdate, lo_linenumber";
+            String query = "select lo_orderdate," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " where lo_orderkey = 100 and lo_linenumber = 1" +
+                    " group by lo_orderdate";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("1:Project\n" +
+                    "|  <slot 6> : col$: lo_orderdate\n" +
+                    "|  <slot 18> : col$: total_quantity\n" +
+                    "|  <slot 19> : col$: total_tax");
+        }
+
+        {
+            String mv = "select lo_orderkey, lo_orderdate, lo_linenumber," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_revenue) as total_revenue," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " group by lo_orderkey, lo_orderdate, lo_linenumber";
+            String query = "select lo_orderdate," +
+                    " sum(lo_quantity) total_quantity," +
+                    " sum(lo_tax) as total_tax" +
+                    " from lineorder" +
+                    " group by lo_orderdate";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("1:AGGREGATE (update serialize)\n" +
+                    "|  STREAMING\n" +
+                    "|  output: sum(col$: total_quantity), sum(col$: total_tax)\n" +
+                    "|  group by: col$: lo_orderdate\n" +
+                    "|\n" +
+                    "0:OlapScanNode\n" +
+                    "TABLE: mv0");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -276,7 +276,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
                     "WHERE l_orderkey>1 GROUP BY `l_suppkey`;";
             String plan = getFragmentPlan(query);
             System.out.println(plan);
-            PlanTestBase.assertContains(plan, "1:AGGREGATE (update serialize)\n" +
+            PlanTestBase.assertContains(plan, "AGGREGATE (update serialize)\n" +
                             "  |  STREAMING\n" +
                             "  |  output: sum(21: sum(l_orderkey))\n" +
                             "  |  group by: 19: l_suppkey");


### PR DESCRIPTION
## Why I'm doing:
the query with predicates may be rewritten by mv without a projection above scan node

## What I'm doing:
add a projection above scan node after query rewritten to reduce the size of data.

Fixes #45272

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

