### PR TITLE
[BugFix] Fix partition prune bug when use expr partition

### DIFF
--- a/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
@@ -205,3 +205,24 @@ DISTRIBUTED BY HASH (`rowkey`) BUCKETS 1;
 insert INTO site_access_par_3 values ("2023-01-04", 1704077791000);
 -- result:
 -- !result
+CREATE TABLE partition_unixtime2 (
+                        dt bigint,
+                        id int
+                )
+                PARTITION BY RANGE(from_unixtime(dt))(
+                START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+                );
+-- result:
+-- !result
+insert into partition_unixtime2 values(1609430400,1),(1609516800,2),(1609603200,3),(1609689600,4),(1609776000,5),
+                                      (1609862400,6),(1609948800,7),(1610035200,8),(1610121600,9),(1610207900,10);
+-- result:
+-- !result
+select * from partition_unixtime2 where dt<1609862400 order by dt;
+-- result:
+1609430400	1
+1609516800	2
+1609603200	3
+1609689600	4
+1609776000	5
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
@@ -111,3 +111,14 @@ START ("2023-12-30") END ("2024-01-05") EVERY (INTERVAL 1 DAY)
 )
 DISTRIBUTED BY HASH (`rowkey`) BUCKETS 1;
 insert INTO site_access_par_3 values ("2023-01-04", 1704077791000);
+
+CREATE TABLE partition_unixtime2 (
+                        dt bigint,
+                        id int
+                )
+                PARTITION BY RANGE(from_unixtime(dt))(
+                START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+                );
+insert into partition_unixtime2 values(1609430400,1),(1609516800,2),(1609603200,3),(1609689600,4),(1609776000,5),
+                                      (1609862400,6),(1609948800,7),(1610035200,8),(1610121600,9),(1610207900,10);
+select * from partition_unixtime2 where dt<1609862400 order by dt;


### PR DESCRIPTION
## Why I'm doing:
In the original logic, the types of partition columns and columns in the table are the same, but after expression partitioning is supported, the types may be different.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
