### PR TITLE
[Enhancement] Log Audit log as json format and deduplicate the logging

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -136,6 +136,8 @@ public class Config extends ConfigBase {
     public static String audit_log_roll_interval = "DAY";
     @ConfField
     public static String audit_log_delete_age = "30d";
+    @ConfField(mutable = true)
+    public static boolean audit_log_json_format = false;
 
     @ConfField(mutable = true)
     public static long slow_lock_threshold_ms = 3000L;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -84,7 +84,6 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
             long queryTime = 0;
 
             // get each field with annotation "AuditField" in AuditEvent
-            // and add them to the log map
             Field[] fields = event.getClass().getFields();
             for (Field f : fields) {
                 AuditField af = f.getAnnotation(AuditField.class);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.starrocks.common.AuditLog;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.DigitalVersion;
@@ -49,6 +50,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
 
 // A builtin Audit plugin, registered when FE start.
 // it will receive "AFTER_QUERY" AuditEventy and print it as a log in fe.audit.log
@@ -75,10 +79,12 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
     @Override
     public void exec(AuditEvent event) {
         try {
+            Map<String, Object> logMap = new HashMap<>();
             StringBuilder sb = new StringBuilder();
             long queryTime = 0;
+
             // get each field with annotation "AuditField" in AuditEvent
-            // and assemble them into a string.
+            // and add them to the log map
             Field[] fields = event.getClass().getFields();
             for (Field f : fields) {
                 AuditField af = f.getAnnotation(AuditField.class);
@@ -121,26 +127,42 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                         continue;
                     }
                 }
-                sb.append("|").append(af.value()).append("=").append(value);
+
+                if (Config.audit_log_json_format) {
+                    logMap.put(af.value(), value);
+                } else {
+                    sb.append("|").append(af.value()).append("=").append(value);
+                }
             }
 
-            String auditLog = sb.toString();
+            ObjectMapper objectMapper = new ObjectMapper();
+
             if (event.type == EventType.CONNECTION) {
-                AuditLog.getConnectionAudit().log(auditLog);
-            } else {
-                AuditLog.getQueryAudit().log(auditLog);
-                // slow query
-                if (queryTime > Config.qe_slow_log_ms) {
-                    AuditLog.getSlowAudit().log(auditLog);
+                if (Config.audit_log_json_format) {
+                    AuditLog.getConnectionAudit().log(objectMapper.writeValueAsString(logMap));
+                } else {
+                    AuditLog.getConnectionAudit().log(sb.toString());
                 }
 
+            } else {
                 if (isBigQuery(event)) {
-                    sb.append("|bigQueryLogCPUSecondThreshold=").append(event.bigQueryLogCPUSecondThreshold);
-                    sb.append("|bigQueryLogScanBytesThreshold=").append(event.bigQueryLogScanBytesThreshold);
-                    sb.append("|bigQueryLogScanRowsThreshold=").append(event.bigQueryLogScanRowsThreshold);
-                    String bigQueryLog = sb.toString();
-                    AuditLog.getBigQueryAudit().log(bigQueryLog);
+                    if (Config.audit_log_json_format) {
+                        logMap.put("bigQueryLogCPUSecondThreshold", event.bigQueryLogCPUSecondThreshold);
+                        logMap.put("bigQueryLogScanBytesThreshold", event.bigQueryLogScanBytesThreshold);
+                        logMap.put("bigQueryLogScanRowsThreshold", event.bigQueryLogScanRowsThreshold);
+                    } else {
+                        sb.append("|bigQueryLogCPUSecondThreshold=").append(event.bigQueryLogCPUSecondThreshold);
+                        sb.append("|bigQueryLogScanBytesThreshold=").append(event.bigQueryLogScanBytesThreshold);
+                        sb.append("|bigQueryLogScanRowsThreshold=").append(event.bigQueryLogScanRowsThreshold);
+                    }
                 }
+                if (Config.audit_log_json_format) {
+                    AuditLog.getQueryAudit().log(objectMapper.writeValueAsString(logMap));
+                } else {
+                    AuditLog.getQueryAudit().log(sb.toString());
+                }
+
+
             }
         } catch (Exception e) {
             LOG.warn("failed to process audit event", e);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.util.DigitalVersion;
 import com.starrocks.plugin.AuditEvent;
 import com.starrocks.plugin.AuditEvent.EventType;
@@ -74,6 +75,60 @@ public class AuditEventProcessorTest {
         Assert.assertEquals(200000, event.scanRows);
         Assert.assertEquals("catalog1", event.catalog);
         Assert.assertEquals("user2", event.authorizedUser);
+    }
+
+    @Test
+    public void testAuditLogBuilderCONNECTION() throws IOException {
+        try (AuditLogBuilder auditLogBuilder = new AuditLogBuilder()) {
+            AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.CONNECTION)
+                    .setTimestamp(System.currentTimeMillis())
+                    .setClientIp("127.0.0.1")
+                    .setUser("user1")
+                    .setAuthorizedUser("user2")
+                    .setDb("db1")
+                    .setState("EOF")
+                    .setQueryTime(2000)
+                    .setScanBytes(100000)
+                    .setScanRows(200000)
+                    .setReturnRows(1)
+                    .setStmtId(1234)
+                    .setStmt("select * from tbl1").build();
+
+            if (auditLogBuilder.eventFilter(event.type)) {
+                auditLogBuilder.exec(event);
+                Config.audit_log_json_format = true;
+                auditLogBuilder.exec(event);
+            }
+            Assert.assertEquals(EventType.CONNECTION,  event.type);
+        }
+    }
+
+    @Test
+    public void testAuditLogBuilderBigQuery() throws IOException {
+        try (AuditLogBuilder auditLogBuilder = new AuditLogBuilder()) {
+            AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.AFTER_QUERY)
+                    .setTimestamp(System.currentTimeMillis())
+                    .setClientIp("127.0.0.1")
+                    .setUser("user1")
+                    .setAuthorizedUser("user2")
+                    .setDb("db1")
+                    .setState("EOF")
+                    .setQueryTime(2000)
+                    .setScanBytes(100000)
+                    .setScanRows(200000)
+                    .setReturnRows(1)
+                    .setStmtId(1234)
+                    .setStmt("select * from tbl1")
+                    .setBigQueryLogCPUSecondThreshold(5)
+                    .setCpuCostNs(6 * 1000000000L).build();
+            if (auditLogBuilder.eventFilter(event.type)) {
+                auditLogBuilder.exec(event);
+                Config.audit_log_json_format = true;
+                auditLogBuilder.exec(event);
+            }
+            Assert.assertEquals(6 * 1000000000L, event.cpuCostNs);
+            Assert.assertEquals(5, event.bigQueryLogCPUSecondThreshold);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
 a SQL statement can contain the "|" character. There it will be confusing to parse out key/value from audit log when there is `|` in the statement.
This PR changes it to json format to improve the accuracy of parsing audit log.
## What I'm doing:
Log Audit log as json format and deduplicate the logging
Fixes #issue

## Test
have tested internally, by default it is the old format with `|` as delimiter of the fields.
when enable `audit_log_json_format = true` the audit logger logs json format.
Sample log in my internal test environment:
```
2024-05-16 15:26:26.914-07:00 INFO (AuditEventProcessor|77) [AuditLog.log():68] {"User":"root","Digest":"","PlanMemCost":0.0,"AuthorizedUser":"'root'@'%'","QueryId":"55ba8980-13d3-11ef-82ee-0692f40b65b6","feIp":"celostar-fe-0.celostar-fe-search.e2e-stateless-2.svc.cluster.local","Time":4,"Timestamp":1715898386909,"ReturnRows":1,"Catalog":"default_catalog","IsQuery":true,"Stmt":"select version()","ScanRows":0,"State":"EOF","CpuCostNs":43523,"IsForwardToLeader":false,"PlanCpuCost":0.0,"MemCostBytes":41120,"ErrorCode":"","StmtId":561,"Client":"10.1.46.100:60614","ResourceGroup":"default_wg","Db":"","ScanBytes":0}
2024-05-16 15:26:28.543-07:00 INFO (AuditEventProcessor|77) [AuditLog.log():68] {"User":"root","Digest":"","AuthorizedUser":"'root'@'%'","QueryId":"56b3b691-13d3-11ef-82ee-0692f40b65b6","feIp":"celostar-fe-0.celostar-fe-search.e2e-stateless-2.svc.cluster.local","Time":1,"Timestamp":1715898388542,"ReturnRows":0,"Catalog":"default_catalog","IsQuery":false,"Stmt":"set resource_group = 'rgSmall'","ScanRows":0,"State":"OK","IsForwardToLeader":false,"ErrorCode":"","StmtId":562,"Client":"10.1.46.100:59070","ResourceGroup":"","Db":"","ScanBytes":0}
2024-05-16 15:26:28.544-07:00 INFO (AuditEventProcessor|77) [AuditLog.log():68] {"User":"root","Digest":"","AuthorizedUser":"'root'@'%'","QueryId":"56b404b6-13d3-11ef-82ee-0692f40b65b6","feIp":"celostar-fe-0.celostar-fe-search.e2e-stateless-2.svc.cluster.local","Time":1,"Timestamp":1715898388543,"ReturnRows":0,"Catalog":"default_catalog","IsQuery":false,"Stmt":"set query_mem_limit = 100000000000; set query_timeout = 600; set pipeline_dop=16; set enable_profile=true; set choose_execute_instances_mode=\"LOCALITY\"; ","ScanRows":0,"State":"OK","IsForwardToLeader":false,"ErrorCode":"","StmtId":567,"Client":"10.1.46.100:59070","ResourceGroup":"","Db":"","ScanBytes":0}
```
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [X] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [X] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
