### PR TITLE
[BugFix] deduplicate partition range for multi-table join mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -320,7 +320,9 @@ public abstract class ConnectorPartitionTraits {
 
         @Override
         public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
-            // TODO: check partition type
+            if (!((OlapTable) table).getPartitionInfo().isRangePartition()) {
+                throw new IllegalArgumentException("Must be range partitioned table");
+            }
             return ((OlapTable) table).getRangePartitionMap();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.util.UUIDUtil;
@@ -312,5 +313,33 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
                         }
                     }
                 });
+    }
+
+    @Test
+    public void testJoinMV_SlotRef() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE join_base_t1 (dt1 date, int1 int)\n" +
+                "                    PARTITION BY RANGE(dt1)\n" +
+                "                    (\n" +
+                "                    PARTITION p1 VALUES LESS THAN (\"2020-07-01\"),\n" +
+                "                    PARTITION p2 VALUES LESS THAN (\"2020-08-01\"),\n" +
+                "                    PARTITION p3 VALUES LESS THAN (\"2020-09-01\")\n" +
+                "                    );");
+        starRocksAssert.withTable("CREATE TABLE join_base_t2 (dt2 date, int2 int)\n" +
+                "                    PARTITION BY RANGE(dt2)\n" +
+                "                    (\n" +
+                "                    PARTITION p4 VALUES LESS THAN (\"2020-07-01\"),\n" +
+                "                    PARTITION p5 VALUES LESS THAN (\"2020-08-01\"),\n" +
+                "                    PARTITION p6 VALUES LESS THAN (\"2020-09-01\")\n" +
+                "                    );");
+        starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW join_mv1 " +
+                "PARTITION BY dt1 " +
+                "REFRESH MANUAL " +
+                "PROPERTIES (\"partition_refresh_number\"=\"3\") AS " +
+                "SELECT dt1,dt2,sum(int1) " +
+                "FROM join_base_t1 t1 " +
+                "JOIN join_base_t2 t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2;");
+
+        MaterializedView mv = starRocksAssert.getMv("test", "join_mv1");
+        Assert.assertEquals(Sets.newHashSet("p1", "p2", "p3"), mv.getPartitionNames());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -341,5 +341,38 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
 
         MaterializedView mv = starRocksAssert.getMv("test", "join_mv1");
         Assert.assertEquals(Sets.newHashSet("p1", "p2", "p3"), mv.getPartitionNames());
+        starRocksAssert.dropTable("join_base_t1");
+        starRocksAssert.dropTable("join_base_t2");
+        starRocksAssert.dropMaterializedView("join_mv1");
+    }
+
+    @Test
+    public void testJoinMV_ListPartition() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE join_base_t1 (dt1 date, int1 int)\n" +
+                "PARTITION BY RANGE(dt1)\n" +
+                "(\n" +
+                "    PARTITION p202006 VALUES LESS THAN (\"2020-07-01\"),\n" +
+                "    PARTITION p202007 VALUES LESS THAN (\"2020-08-01\"),\n" +
+                "    PARTITION p202008 VALUES LESS THAN (\"2020-09-01\")\n" +
+                ")");
+        starRocksAssert.withTable("CREATE TABLE join_base_t2 (dt2 date not null, int2 int)\n" +
+                "PARTITION BY LIST(dt2)\n" +
+                "(\n" +
+                "    PARTITION p202006 VALUES in (\"2020-06-23\"),\n" +
+                "    PARTITION p202007 VALUES in (\"2020-07-23\"),\n" +
+                "    PARTITION p202008 VALUES in (\"2020-08-23\")\n" +
+                ");");
+        Exception e = Assert.assertThrows(IllegalArgumentException.class, () ->
+                starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW join_mv1 " +
+                        "PARTITION BY dt1 REFRESH MANUAL PROPERTIES (\"partition_refresh_number\"=\"3\") AS \n" +
+                        "SELECT dt1,dt2,sum(int1) " +
+                        "FROM join_base_t1 t1 " +
+                        "JOIN join_base_t2 t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2")
+        );
+        Assert.assertEquals("Must be range partitioned table", e.getMessage());
+
+        starRocksAssert.dropTable("join_base_t1");
+        starRocksAssert.dropTable("join_base_t2");
+        starRocksAssert.dropMaterializedView("join_mv1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
- If base tables of Multi-table Join MV has different partition name, the partitions should be deduplicated, instead of creating duplicate overlapped partitions

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
