### PR TITLE
[BugFix] Fix miss tokenization for standard parser when writing GIN and compatibility when downgrade and then upgrade

### DIFF
--- a/be/src/storage/inverted/clucene/clucene_inverted_writer.cpp
+++ b/be/src/storage/inverted/clucene/clucene_inverted_writer.cpp
@@ -133,7 +133,8 @@ public:
 
     void new_fulltext_field(const char* field_value_data, size_t field_value_size) {
         if (_parser_type == InvertedIndexParserType::PARSER_ENGLISH ||
-            _parser_type == InvertedIndexParserType::PARSER_CHINESE) {
+            _parser_type == InvertedIndexParserType::PARSER_CHINESE ||
+            _parser_type == InvertedIndexParserType::PARSER_STANDARD) {
             new_char_token_stream(field_value_data, field_value_size, _field);
         } else {
             new_field_value(field_value_data, field_value_size, _field);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
@@ -171,7 +171,7 @@ public class Index implements Writable {
     @Override
     public int hashCode() {
         return 31 * (Long.hashCode(indexId) + indexName.hashCode()
-                + columns.hashCode() + indexType.hashCode() +
+                + columns.hashCode() + ((indexType != null) ? indexType.hashCode() : 0) +
                 ((properties != null) ? properties.hashCode() : 0));
     }
 

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1362,14 +1362,14 @@ SELECT * FROM t_alter_gin_col_into_other_type;
 DROP TABLE t_alter_gin_col_into_other_type;
 -- result:
 -- !result
--- name: test_gin_var
+-- name: test_gin_var @sequential
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 -- result:
 -- !result
 CREATE TABLE `t_gin_var` (
   `id` bigint(20) NOT NULL COMMENT "",
   `v1` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+  INDEX gin_none (`v1`) USING GIN ("parser" = "standard")
 ) ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 1
@@ -1411,7 +1411,7 @@ ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "false");
 CREATE TABLE `t_gin_var` (
   `id` bigint(20) NOT NULL COMMENT "",
   `v1` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+  INDEX gin_none (`v1`) USING GIN ("parser" = "standard")
 ) ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 1
@@ -1438,7 +1438,7 @@ PROPERTIES (
 );
 -- result:
 -- !result
-ALTER TABLE t_gin_var add index idx (v1) USING GIN('parser' = 'english');
+ALTER TABLE t_gin_var add index idx (v1) USING GIN('parser' = 'standard');
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: The inverted index is disabled, enable it by setting FE config `enable_experimental_gin` to true.')
 -- !result
@@ -1451,7 +1451,7 @@ DROP TABLE t_gin_var;
 CREATE TABLE `t_gin_var` (
   `id` bigint(20) NOT NULL COMMENT "",
   `v1` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+  INDEX gin_none (`v1`) USING GIN ("parser" = "standard")
 ) ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 1

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -748,12 +748,12 @@ SHOW CREATE TABLE t_alter_gin_col_into_other_type;
 SELECT * FROM t_alter_gin_col_into_other_type;
 DROP TABLE t_alter_gin_col_into_other_type;
 
--- name: test_gin_var
+-- name: test_gin_var @sequential
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 CREATE TABLE `t_gin_var` (
   `id` bigint(20) NOT NULL COMMENT "",
   `v1` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+  INDEX gin_none (`v1`) USING GIN ("parser" = "standard")
 ) ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 1
@@ -776,7 +776,7 @@ ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "false");
 CREATE TABLE `t_gin_var` (
   `id` bigint(20) NOT NULL COMMENT "",
   `v1` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+  INDEX gin_none (`v1`) USING GIN ("parser" = "standard")
 ) ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 1
@@ -799,13 +799,13 @@ PROPERTIES (
 "replicated_storage" = "false",
 "compression" = "LZ4"
 );
-ALTER TABLE t_gin_var add index idx (v1) USING GIN('parser' = 'english');
+ALTER TABLE t_gin_var add index idx (v1) USING GIN('parser' = 'standard');
 ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
 DROP TABLE t_gin_var;
 CREATE TABLE `t_gin_var` (
   `id` bigint(20) NOT NULL COMMENT "",
   `v1` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+  INDEX gin_none (`v1`) USING GIN ("parser" = "standard")
 ) ENGINE=OLAP
 DUPLICATE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 1


### PR DESCRIPTION
Fix two bug in this pr:
1. Miss tokenization for standard parser when writing GIN.
2. Fix NPE problem in hashCode when change version: v3.3->v3.2->v3.3

Fixes https://github.com/StarRocks/starrocks/issues/44268

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
