### PR TITLE
[Enhancement] Allow compute node to query information_schema

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -58,6 +58,7 @@ import com.starrocks.thrift.TUserIdentity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -338,7 +339,9 @@ public class SchemaScanNode extends ScanNode {
                     .map(id -> GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(id))
                     .collect(Collectors.toList());
         } else {
-            nodeList = Lists.newArrayList(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend().values());
+            nodeList = Lists.newArrayList();
+            nodeList.addAll(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends());
+            nodeList.addAll(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNodes());
         }
 
         for (ComputeNode node : nodeList) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -133,7 +133,11 @@ public class DefaultWorkerProvider implements WorkerProvider {
         this.selectedWorkerIds = Sets.newConcurrentHashSet();
 
         this.hasComputeNode = MapUtils.isNotEmpty(availableID2ComputeNode);
-        this.usedComputeNode = hasComputeNode && preferComputeNode;
+        if (MapUtils.isEmpty(availableID2Backend) && hasComputeNode) {
+            this.usedComputeNode = true;
+        } else {
+            this.usedComputeNode = hasComputeNode && preferComputeNode;
+        }
         this.preferComputeNode = preferComputeNode;
     }
 
@@ -197,7 +201,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
 
     @Override
     public boolean isDataNodeAvailable(long dataNodeId) {
-        return getBackend(dataNodeId) != null;
+        return getBackend(dataNodeId) != null || getComputeNode(dataNodeId) != null;
     }
 
     @Override
@@ -259,6 +263,11 @@ public class DefaultWorkerProvider implements WorkerProvider {
     @VisibleForTesting
     ComputeNode getBackend(Long backendID) {
         return availableID2Backend.get(backendID);
+    }
+
+    @VisibleForTesting
+    ComputeNode getComputeNode(Long computeNodeID) {
+        return availableID2ComputeNode.get(computeNodeID);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/planner/SchemaScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/SchemaScanNodeTest.java
@@ -102,4 +102,23 @@ public class SchemaScanNodeTest {
         SchemaScanNode scanNode = new SchemaScanNode(new PlanNodeId(0), desc);
         scanNode.computeBeScanRanges();
     }
+
+    @Test
+    public void testComputeNodeScanRanges() {
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public List<ComputeNode> getComputeNodes() {
+                ComputeNode computeNode = new ComputeNode(1L, "127.0.0.1", 9030);
+                computeNode.setAlive(true);
+                return List.of(computeNode);
+            }
+        };
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        SystemTable table = new SystemTable(0, "be_datacache_metrics", null, null, null);
+        desc.setTable(table);
+        SchemaScanNode scanNode = new SchemaScanNode(new PlanNodeId(0), desc);
+        scanNode.computeBeScanRanges();
+        Assert.assertEquals(1, scanNode.getScanRangeLocations(0).size());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -296,7 +296,7 @@ public class DefaultWorkerProviderTest {
                                                                      Map<Long, C> availableId2Worker) {
         // not allow using backup node
         Assert.assertFalse(workerProvider.allowUsingBackupNode());
-        for (long id = -1; id < 16; id++) {
+        for (long id = -1; id < 10; id++) {
             ComputeNode backend = workerProvider.getBackend(id);
             boolean isContained = workerProvider.isDataNodeAvailable(id);
             if (!availableId2Worker.containsKey(id)) {


### PR DESCRIPTION
## Why I'm doing:
cn can't query information_schema, which means we can't see tasks when there are only cns.

## What I'm doing:
support it

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
