### PR TITLE
[Doc] remove excessive links

### DIFF
--- a/docs/en/administration/management/enable_fqdn.md
+++ b/docs/en/administration/management/enable_fqdn.md
@@ -28,8 +28,6 @@ By default, FE nodes in a new cluster are started via IP address access. To star
 
 The property `--host_type` specifies the access method that is used to start the node. Valid values include `FQDN` and `IP`. You only need to specify this property ONCE when you start the node for the first time.
 
-See [Deploy StarRocks](../../deployment/deploy_manually.md) for detailed instructions on how to install StarRocks.
-
 Each BE node identifies itself with `BE Address` defined in the FE metadata. Therefore, you DO NOT need to specify `--host_type` when you start BE nodes. If the `BE Address` defines a BE node with an FQDN, the BE node identifies itself with this FQDN.
 
 ## Enable FQDN access in an existing cluster

--- a/docs/en/data_source/catalog/unified_catalog.md
+++ b/docs/en/data_source/catalog/unified_catalog.md
@@ -834,7 +834,7 @@ INSERT INTO unified_catalog.test_database.test_table SELECT * FROM hive_table
 
 ## Create a database in a unified catalog
 
-Similar to the internal catalog of StarRocks, if you have the [CREATE DATABASE](../../administration/user_privs/privilege_overview.md#catalog) privilege on a unified catalog, you can use the [CREATE DATABASE](../../sql-reference/sql-statements/data-definition/CREATE_DATABASE.md) statement to create a database in that catalog.
+Similar to the internal catalog of StarRocks, if you have the CREATE DATABASE privilege on a unified catalog, you can use the CREATE DATABASE statement to create a database in that catalog.
 
 > **NOTE**
 >

--- a/docs/en/data_source/data_lakes.mdx
+++ b/docs/en/data_source/data_lakes.mdx
@@ -43,10 +43,6 @@ Separation of storage and compute reduces the complexity of scaling. Since the S
 
 Cache on the compute nodes is optional. If your compute nodes are spinning up and down quickly based on quickly changing load patterns or your queries are often only on the most recent data it might not make sense to cache data.
 
-## Learn by doing
-
-Try out a Docker based lakehouse. This [data lakehouse tutorial](../quick_start/iceberg.md) creates a data lake built with Iceberg and MinIO and connects StarRocks containers as the query engine. Load the provided dataset, or add your own.
-
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/en/integrations/data_lakes.mdx
+++ b/docs/en/integrations/data_lakes.mdx
@@ -43,8 +43,4 @@ Separation of storage and compute reduces the complexity of scaling. Since the S
 
 Cache on the compute nodes is optional. If your compute nodes are spinning up and down quickly based on quickly changing load patterns or your queries are often only on the most recent data it might not make sense to cache data.
 
-## Learn by doing
-
-Try out a Docker based lakehouse. This [data lakehouse tutorial](../quick_start/iceberg.md) creates a data lake built with Iceberg and MinIO and connects StarRocks containers as the query engine. Load the provided dataset, or add your own.
-
 More information is in the [Catalog docs](../data_source/catalog/catalog_intro.mdx).

--- a/docs/en/introduction/Features.md
+++ b/docs/en/introduction/Features.md
@@ -40,8 +40,6 @@ Users can choose to deploy StarRocks in public clouds, private clouds, or on-pre
 
 StarRocks in storage-compute separation mode provides the same functionalities as the storage-compute coupled mode. The data write and hot data query performance are also the same. Users can perform data updates, data lake analytics, and materialized view acceleration as they do in storage-compute coupled mode.
 
-For information about how to deploy a StarRocks cluster with decoupled storage and compute, see [Deploy shared-data cluster](../deployment/shared_data/s3.md).
-
 ## Cost-based optimizer
 
 ![CBO](../assets/1.1-5-cbo.png)

--- a/docs/en/loading/automq-routine-load.md
+++ b/docs/en/loading/automq-routine-load.md
@@ -18,7 +18,7 @@ For an understanding of the basic principles of Routine Load, refer to the secti
 
 ### Prepare StarRocks and test data
 
-Ensure you have a running StarRocks cluster. For demonstration purposes, this article follow the [deployment guide](../quick_start/shared-nothing.md) to install a StarRocks cluster on a Linux machine via Docker.
+Ensure you have a running StarRocks cluster.
 
 Creating a database and a Primary Key table for testing:
 

--- a/docs/en/reference/System_variable.md
+++ b/docs/en/reference/System_variable.md
@@ -906,8 +906,6 @@ Used to set the time zone of the current session. The time zone can affect the r
   * `command`: Return query trace profile logs as the **Explain String** after executing TRACE LOGS.
   * `file`: Return query trace profile logs in the FE log file **fe.log** with the class name being `FileLogTracer`.
 
-  For more information on query trace profile, see [Query Trace Profile](../developers/trace-tools/query_trace_profile.md).
-
 * **Default**: `command`
 * **Data type**: String
 * **Introduced in**: v3.2.0

--- a/docs/en/sql-reference/sql-statements/Administration/CREATE_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/Administration/CREATE_STORAGE_VOLUME.md
@@ -8,7 +8,7 @@ displayed_sidebar: "English"
 
 Creates a storage volume for a remote storage system. This feature is supported from v3.1.
 
-A storage volume consists of the properties and credential information of the remote data storage. You can reference a storage volume when you create databases and cloud-native tables in a [shared-data StarRocks cluster](../../../deployment/shared_data/shared_data.mdx).
+A storage volume consists of the properties and credential information of the remote data storage. You can reference a storage volume when you create databases and cloud-native tables in a shared-data StarRocks cluster.
 
 > **CAUTION**
 >

--- a/docs/en/sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW.md
@@ -274,7 +274,7 @@ Properties of the asynchronous materialized view. You can modify the properties 
     - If `mv_rewrite_staleness_second` is not specified, the materialized view can be used for query rewrite only when its data is consistent with the data in all base tables.
     - If `mv_rewrite_staleness_second` is specified, the materialized view can be used for query rewrite when its last refresh is within the staleness time interval.
   - `loose`: Enable automatic query rewrite directly, and no consistency check is required.
-- `storage_volume`: The name of the storage volume used to store the asynchronous materialized view you want to create if you are using a [shared-data cluster](../../../deployment/shared_data/shared_data.mdx). This property is supported from v3.1 onwards. If this property is not specified, the default storage volume is used. Example: `"storage_volume" = "def_volume"`.
+- `storage_volume`: The name of the storage volume used to store the asynchronous materialized view you want to create if you are using a shared-data cluster. This property is supported from v3.1 onwards. If this property is not specified, the default storage volume is used. Example: `"storage_volume" = "def_volume"`.
 - `force_external_table_query_rewrite`: Whether to enable query rewrite for external catalog-based materialized views. This property is supported from v3.2. Valid values:
   - `true`: Enable query rewrite for external catalog-based materialized views.
   - `false` (Default value): Disable query rewrite for external catalog-based materialized views.

--- a/docs/en/sql-reference/sql-statements/data-definition/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/data-definition/CREATE_TABLE.md
@@ -614,7 +614,7 @@ PROPERTIES (
 
 #### Create cloud-native tables for StarRocks Shared-data cluster
 
-To [use your StarRocks Shared-data cluster](../../../deployment/shared_data/shared_data.mdx), you must create cloud-native tables with the following properties:
+To use your StarRocks Shared-data cluster, you must create cloud-native tables with the following properties:
 
 ```SQL
 PROPERTIES (

--- a/docs/en/table_design/Data_distribution.md
+++ b/docs/en/table_design/Data_distribution.md
@@ -192,7 +192,7 @@ The number of buckets: By default, StarRocks automatically sets the number of bu
 
 > **NOTICE**
 >
-> Since v3.1,  StarRocks's [shared-data mode](../deployment/shared_data/shared_data.mdx) supports the time function expression and does not support the column expression.
+> Since v3.1,  StarRocks's shared-data mode supports the time function expression and does not support the column expression.
 
 Since v3.0, StarRocks supports [expression partitioning](./expression_partitioning.md) (previously known as automatic partitioning) which is more flexible and easy-to-use. This partitioning method is suitable for most scenarios such as querying and managing data based on continuous date ranges or enum values.
 

--- a/docs/en/table_design/expression_partitioning.md
+++ b/docs/en/table_design/expression_partitioning.md
@@ -253,7 +253,7 @@ MySQL > SHOW PARTITIONS FROM t_recharge_detail1;
 
 ## Limits
 
-- Since v3.1.0, StarRocks's [shared-data mode](../deployment/shared_data/shared_data.mdx) supports the [time function expression](#partitioning-based-on-a-time-function-expression). And since v3.1.1, StarRocks's [shared-data mode](../deployment/shared_data/shared_data.mdx) further supports the [column expression](#partitioning-based-on-the-column-expression-since-v31).
+- Since v3.1.0, StarRocks's shared-data mode supports the [time function expression](#partitioning-based-on-a-time-function-expression). And since v3.1.1, StarRocks's shared-data mode further supports the [column expression](#partitioning-based-on-the-column-expression-since-v31).
 - Currently, using CTAS to create tables configured expression partitioning is not supported.
 - Currently, using Spark Load to load data to tables that use expression partitioning is not supported.
 - When the `ALTER TABLE <table_name> DROP PARTITION <partition_name>` statement is used to delete a partition created by using the column expression, data in the partition is directly removed and cannot be recovered.


### PR DESCRIPTION
We have too many links. We do not need to link to the shared data quick start every time we mention shared data. Similarly, we don't need to link to the privs page every time we mention a priv.

If in doubt, leave links out.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
