### PR TITLE
[BugFix] fix pk table compact crash when light compaction is disable

### DIFF
--- a/be/src/storage/chunk_iterator.h
+++ b/be/src/storage/chunk_iterator.h
@@ -151,9 +151,13 @@ protected:
     }
     virtual Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
                                std::vector<uint64_t>* rssid_rowids) {
-        return Status::NotSupported(
-                "Chunk* chunk, std::vector<RowSourceMask>* source_masks, vector<uint64_t>* rssid_rowids) not "
-                "supported");
+        if (source_masks == nullptr) {
+            return do_get_next(chunk, rssid_rowids);
+        } else {
+            return Status::NotSupported(
+                    "Chunk* chunk, std::vector<RowSourceMask>* source_masks, vector<uint64_t>* rssid_rowids) not "
+                    "supported");
+        }
     }
 
     Schema _schema;

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -366,8 +366,7 @@ private:
                 entry.segment_itr = new_empty_iterator(schema, _chunk_size);
             } else {
                 if (rowset->rowset_meta()->is_segments_overlapping()) {
-                    entry.segment_itr = 
-                            std::move(new_heap_merge_iterator(res.value(), entry.need_rssid_rowids));
+                    entry.segment_itr = std::move(new_heap_merge_iterator(res.value(), entry.need_rssid_rowids));
                 } else {
                     entry.segment_itr = std::move(new_union_iterator(res.value()));
                 }

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -58,6 +58,8 @@ struct MergeEntry {
     const Schema* encode_schema = nullptr;
     uint16_t order;
     std::vector<RowSourceMask>* source_masks = nullptr;
+    // rssid_rowids will be empty, when `need_rssid_rowids` is false.
+    bool need_rssid_rowids = false;
     std::vector<uint64_t> rssid_rowids;
 
     MergeEntry() = default;
@@ -84,6 +86,7 @@ struct MergeEntry {
     void close() {
         chunk_pk_column.reset();
         chunk.reset();
+        rssid_rowids.clear();
         if (segment_itr != nullptr) {
             segment_itr->close();
             segment_itr.reset();
@@ -102,7 +105,12 @@ struct MergeEntry {
         DCHECK(pk_cur == nullptr || pk_cur > pk_last);
         chunk->reset();
         rssid_rowids.clear();
-        auto st = segment_itr->get_next(chunk.get(), source_masks, &rssid_rowids);
+        auto st = Status::OK();
+        if (need_rssid_rowids) {
+            st = segment_itr->get_next(chunk.get(), source_masks, &rssid_rowids);
+        } else {
+            st = segment_itr->get_next(chunk.get(), source_masks);
+        }
         if (st.ok()) {
             // 1. setup chunk_pk_column
             if (encode_schema != nullptr) {
@@ -194,7 +202,7 @@ public:
                     if (source_masks) {
                         source_masks->insert(source_masks->end(), chunk->num_rows(), RowSourceMask{top.order, false});
                     }
-                    if (rssid_rowids) {
+                    if (rssid_rowids && !top.rssid_rowids.empty()) {
                         rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin(), top.rssid_rowids.end());
                     }
                     top.pk_cur = top.pk_last + 1;
@@ -207,7 +215,7 @@ public:
                     if (source_masks) {
                         source_masks->insert(source_masks->end(), nappend, RowSourceMask{top.order, false});
                     }
-                    if (rssid_rowids) {
+                    if (rssid_rowids && !top.rssid_rowids.empty()) {
                         rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin() + start_offset,
                                              top.rssid_rowids.begin() + start_offset + nappend);
                     }
@@ -234,7 +242,7 @@ public:
                     auto start_offset = top.offset(start);
                     auto end_offset = top.offset(top.pk_cur);
                     chunk->append(*top.chunk, start_offset, end_offset - start_offset);
-                    if (rssid_rowids) {
+                    if (rssid_rowids && !top.rssid_rowids.empty()) {
                         rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin() + start_offset,
                                              top.rssid_rowids.begin() + end_offset);
                     }
@@ -246,7 +254,7 @@ public:
                     auto start_offset = top.offset(start);
                     auto end_offset = top.offset(top.pk_cur);
                     chunk->append(*top.chunk, start_offset, end_offset - start_offset);
-                    if (rssid_rowids) {
+                    if (rssid_rowids && !top.rssid_rowids.empty()) {
                         rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin() + start_offset,
                                              top.rssid_rowids.begin() + end_offset);
                     }
@@ -353,12 +361,13 @@ private:
             }
             entry.rowset_seg_id = rowset->rowset_meta()->get_rowset_seg_id();
             entry.chunk = ChunkHelper::new_chunk(schema, _chunk_size);
+            entry.need_rssid_rowids = config::enable_light_pk_compaction_publish;
             if (res.value().empty()) {
                 entry.segment_itr = new_empty_iterator(schema, _chunk_size);
             } else {
                 if (rowset->rowset_meta()->is_segments_overlapping()) {
-                    entry.segment_itr = std::move(new_heap_merge_iterator(
-                            res.value(), StorageEngine::instance()->enable_light_pk_compaction_publish()));
+                    entry.segment_itr = 
+                            std::move(new_heap_merge_iterator(res.value(), entry.need_rssid_rowids));
                 } else {
                     entry.segment_itr = std::move(new_union_iterator(res.value()));
                 }

--- a/be/test/storage/union_iterator_test.cpp
+++ b/be/test/storage/union_iterator_test.cpp
@@ -49,6 +49,21 @@ protected:
             return Status::OK();
         }
 
+        // 10 elements at most every time. And also return rssid rowids
+        Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override {
+            if (_idx >= _numbers.size()) {
+                return Status::EndOfFile("eof");
+            }
+            size_t n = std::min(10LU, _numbers.size() - _idx);
+            ColumnPtr c = chunk->get_column_by_index(0);
+            (void)c->append_numbers(_numbers.data() + _idx, n * sizeof(int32_t));
+            _idx += n;
+            for (size_t i = 0; i < n; i++) {
+                rssid_rowids->push_back(i);
+            }
+            return Status::OK();
+        }
+
         void close() override {}
 
         static Schema schema() {
@@ -88,14 +103,21 @@ TEST_F(UnionIteratorTest, union_two) {
     ASSERT_EQ(8, get_row(chunk, 2));
 
     chunk->reset();
-    st = iter->get_next(chunk.get());
+    std::vector<uint64_t> rssid_rowids;
+    st = iter->get_next(chunk.get(), &rssid_rowids);
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(5U, chunk->num_rows());
+    ASSERT_EQ(5U, rssid_rowids.size());
     ASSERT_EQ(1, get_row(chunk, 0));
     ASSERT_EQ(2, get_row(chunk, 1));
     ASSERT_EQ(3, get_row(chunk, 2));
     ASSERT_EQ(4, get_row(chunk, 3));
     ASSERT_EQ(5, get_row(chunk, 4));
+    ASSERT_EQ(0, rssid_rowids[0]);
+    ASSERT_EQ(1, rssid_rowids[1]);
+    ASSERT_EQ(2, rssid_rowids[2]);
+    ASSERT_EQ(3, rssid_rowids[3]);
+    ASSERT_EQ(4, rssid_rowids[4]);
 
     chunk->reset();
     st = iter->get_next(chunk.get());

--- a/be/test/storage/union_iterator_test.cpp
+++ b/be/test/storage/union_iterator_test.cpp
@@ -104,7 +104,7 @@ TEST_F(UnionIteratorTest, union_two) {
 
     chunk->reset();
     std::vector<uint64_t> rssid_rowids;
-    st = iter->get_next(chunk.get(), &rssid_rowids);
+    st = iter->get_next(chunk.get(), nullptr, &rssid_rowids);
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(5U, chunk->num_rows());
     ASSERT_EQ(5U, rssid_rowids.size());
@@ -122,6 +122,10 @@ TEST_F(UnionIteratorTest, union_two) {
     chunk->reset();
     st = iter->get_next(chunk.get());
     ASSERT_TRUE(st.is_end_of_file());
+
+    std::vector<RowSourceMask> source_masks;
+    st = iter->get_next(chunk.get(), &source_masks, &rssid_rowids);
+    ASSERT_TRUE(st.is_not_supported());
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
## Why I'm doing:
There are two issues:
1. When BE config `enable_light_pk_compaction_publish` is false, `std::vector<uint64_t> rssid_rowids` in `MergeEntry` will be empty, and this code will cause crash:
```
rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin() + start_offset,
                                             top.rssid_rowids.begin() + start_offset + nappend);
```

And real crash stack will be:
```
*** Aborted at 1716106255 (unix time) try "date -d @1716106255" if you are using GNU date ***
PC: @     0x7f5fdc14e410 __memcpy_ssse3_back
*** SIGSEGV (@0x0) received by PID 94048 (TID 0x7f5ee4b2f700) from PID 0; stack trace: ***
    @          0x67c0e42 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f5fdccfc630 (unknown)
    @     0x7f5fdc14e410 __memcpy_ssse3_back
    @          0x52572c6 std::vector<>::insert<>()
    @          0x525a664 starrocks::RowsetMergerImpl<>::get_next()
    @          0x525bd3b starrocks::RowsetMergerImpl<>::_do_merge_horizontally()
    @          0x525d073 starrocks::RowsetMergerImpl<>::_do_merge_vertically()
    @          0x525ed88 starrocks::RowsetMergerImpl<>::do_merge()
    @          0x5250161 starrocks::compaction_merge_rowsets()
    @          0x51265a7 starrocks::TabletUpdates::_do_compaction()
    @          0x5128622 starrocks::TabletUpdates::compaction_for_size_tiered()
    @          0x51290da starrocks::TabletUpdates::compaction()
    @          0x506c2ab starrocks::StorageEngine::_perform_update_compaction()
    @          0x4ff9174 starrocks::StorageEngine::_update_compaction_thread_callback()
    @          0x8bf3cb0 execute_native_thread_routine
    @     0x7f5fdccf4ea5 start_thread
    @     0x7f5fdc0f5b0d __clone
    @                0x0 (unknown)
```
2. `union_iterator` doesn't support `Status UnionIterator::do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids)`.
Which will lead to compaction failure like:
```
Exxx xxxx compaction_scheduler.cpp:341] Fail to compact tablet xxx. version=xxx txn_id=xxx cost=xxs : Not supported: Chunk* chunk, vector<uint64_t>* rssid_rowids) not supported
/build/starrocks/be/src/storage/merge_iterator.cpp:194 fill(i)
/build/starrocks/be/src/storage/merge_iterator.cpp:251 init()
/build/starrocks/be/src/storage/lake/tablet_reader.cpp:210 _collect_iter->get_next(chunk, source_masks, rssid_rowids)
/build/starrocks/be/src/storage/lake/vertical_compaction_task.cpp:74 compact_column_group(is_key, i, column_group_size, column_groups[i], writer, mask_buffer.get(), source_masks.get(), cancel_func)
```

## What I'm doing:

Fix this crash.
Fix https://github.com/StarRocks/StarRocksTest/issues/7449

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
