### PR TITLE
[Enhancement] Make these two configurations dynamically modifyable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1051,9 +1051,9 @@ CONF_String(directory_of_inject,
             "crossjoin,/src/exec/pipeline/sort,/src/exec/pipeline/exchange,/src/exec/pipeline/analysis");
 
 // Used by to_base64
-CONF_Int64(max_length_for_to_base64, "200000");
+CONF_mInt64(max_length_for_to_base64, "200000");
 // Used by bitmap functions
-CONF_Int64(max_length_for_bitmap_function, "1000000");
+CONF_mInt64(max_length_for_bitmap_function, "1000000");
 
 // Configuration items for datacache
 CONF_Bool(datacache_enable, "false");

--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -185,9 +185,10 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_and(FunctionContext* context, const 
 
 // bitmap_to_string
 DEFINE_STRING_UNARY_FN_WITH_IMPL(bitmapToStingImpl, bitmap_ptr) {
-    if (bitmap_ptr->cardinality() > config::max_length_for_bitmap_function) {
+    auto max_cardinality = config::max_length_for_bitmap_function;
+    if (bitmap_ptr->cardinality() > max_cardinality) {
         std::stringstream ss;
-        ss << "bitmap_to_string not supported size > " << config::max_length_for_bitmap_function;
+        ss << "bitmap_to_string not supported size > " << max_cardinality;
         throw std::runtime_error(ss.str());
     }
     return bitmap_ptr->to_string();

--- a/be/src/exprs/encryption_functions.cpp
+++ b/be/src/exprs/encryption_functions.cpp
@@ -137,12 +137,13 @@ StatusOr<ColumnPtr> EncryptionFunctions::to_base64(FunctionContext* ctx, const C
         }
 
         auto src_value = src_viewer.value(row);
+        auto limit = config::max_length_for_to_base64;
         if (src_value.size == 0) {
             result.append_null();
             continue;
-        } else if (src_value.size > config::max_length_for_to_base64) {
+        } else if (src_value.size > limit) {
             std::stringstream ss;
-            ss << "to_base64 not supported length > " << config::max_length_for_to_base64;
+            ss << "to_base64 not supported length > " << limit;
             throw std::runtime_error(ss.str());
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Make be config `max_length_for_to_base64` and `max_length_for_bitmap_function` modifyable.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
