### PR TITLE
[BugFix] Fix partition mv with self joins refresh bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -19,23 +19,18 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
-import com.starrocks.analysis.IsNullPredicate;
-import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
-import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.ListPartitionInfo;
@@ -45,12 +40,10 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
-import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.MaterializedViewExceptions;
@@ -78,14 +71,13 @@ import com.starrocks.planner.ScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.scheduler.mv.MVPCTRefreshPlanBuilder;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
-import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
-import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropPartitionClause;
@@ -96,14 +88,10 @@ import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.PartitionValue;
-import com.starrocks.sql.ast.QueryRelation;
-import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RandomDistributionDesc;
 import com.starrocks.sql.ast.RangePartitionDesc;
-import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.ListPartitionDiff;
 import com.starrocks.sql.common.MvPartitionDiffResult;
@@ -422,11 +410,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             throw new LockTimeoutException("Failed to lock database in prepareRefreshPlan");
         }
 
+        MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(materializedView, mvContext);
         try {
             // 4. Analyze and prepare partition & Rebuild insert statement by
             // considering to-refresh partitions of ref tables/ mv
-            insertStmt = analyzeInsertStmt(insertStmt, refTablePartitionNames, materializedView, ctx);
-
+            insertStmt = planBuilder.analyzeAndBuildInsertPlan(insertStmt, refTablePartitionNames, ctx);
             // Must set execution id before StatementPlanner.plan
             ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
 
@@ -1391,208 +1379,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     definition);
         }
         return insertStmt;
-    }
-
-    @VisibleForTesting
-    public InsertStmt analyzeInsertStmt(InsertStmt insertStmt,
-                                        Map<String, Set<String>> refTableRefreshPartitions,
-                                        MaterializedView materializedView,
-                                        ConnectContext ctx) throws AnalysisException {
-        // analyze the insert stmt
-        Analyzer.analyze(insertStmt, ctx);
-
-        // after analyze, we could get the table meta info of the tableRelation.
-        QueryStatement queryStatement = insertStmt.getQueryStatement();
-        Multimap<String, TableRelation> tableRelations =
-                AnalyzerUtils.collectAllTableRelation(queryStatement);
-
-        for (Map.Entry<String, TableRelation> nameTableRelationEntry : tableRelations.entries()) {
-            if (refTableRefreshPartitions.containsKey(nameTableRelationEntry.getKey())) {
-                // set partition names for ref base table
-                Set<String> tablePartitionNames = refTableRefreshPartitions.get(nameTableRelationEntry.getKey());
-                TableRelation tableRelation = nameTableRelationEntry.getValue();
-                // external table doesn't support query with partitionNames
-                if (!tableRelation.getTable().isExternalTableWithFileSystem()) {
-                    LOG.info("Optimize materialized view {} refresh task, generate table relation {} target partition names:{} ",
-                            materializedView.getName(), tableRelation.getName(), Joiner.on(",").join(tablePartitionNames));
-                    tableRelation.setPartitionNames(
-                            new PartitionNames(false, new ArrayList<>(tablePartitionNames)));
-                }
-
-                // generate partition predicate for the select relation, so can generate partition predicates
-                // for non-ref base tables.
-                // eg:
-                //  mv: create mv mv1 partition by t1.dt
-                //  as select  * from t1 join t2 on t1.dt = t2.dt.
-                //  ref-base-table      : t1.dt
-                //  non-ref-base-table  : t2.dt
-                // so add partition predicates for select relation when refresh partitions incrementally(eg: dt=20230810):
-                // (select * from t1 join t2 on t1.dt = t2.dt) where t1.dt=20230810
-                Expr partitionPredicates = generatePartitionPredicate(tableRelation.getTable(),
-                        tablePartitionNames, queryStatement, materializedView.getPartitionInfo());
-                if (partitionPredicates != null) {
-                    List<SlotRef> slots = Lists.newArrayList();
-                    partitionPredicates.collect(SlotRef.class, slots);
-
-                    // try to push down into table relation
-                    Scope tableRelationScope = tableRelation.getScope();
-                    if (canResolveSlotsInTheScope(slots, tableRelationScope)) {
-                        LOG.info("Optimize materialized view {} refresh task, generate table relation {} " +
-                                        "partition predicate:{} ",
-                                materializedView.getName(), tableRelation.getName(), partitionPredicates.toSql());
-                        tableRelation.setPartitionPredicate(partitionPredicates);
-                    }
-
-                    // try to push down into query relation so can push down filter into both sides
-                    // NOTE: it's safe here to push the partition predicate into query relation directly because
-                    // partition predicates always belong to the relation output expressions and can be resolved
-                    // by the query analyzer.
-                    QueryRelation queryRelation = queryStatement.getQueryRelation();
-                    if (queryRelation instanceof SelectRelation) {
-                        SelectRelation selectRelation = ((SelectRelation) queryStatement.getQueryRelation());
-                        Expr finalExpr = Expr.compoundAnd(Lists.newArrayList(selectRelation.getWhereClause(),
-                                partitionPredicates));
-                        selectRelation.setWhereClause(finalExpr);
-                        LOG.info("Optimize materialized view {} refresh task, generate table relation {} " +
-                                        "final predicate:{} ",
-                                materializedView.getName(), tableRelation.getName(), finalExpr.toSql());
-                    }
-                }
-            }
-        }
-        return insertStmt;
-    }
-
-    /**
-     * Check whether to push down predicate expr with the slot refs into the scope.
-     *
-     * @param slots : slot refs that are contained in the predicate expr
-     * @param scope : scope that try to push down into.
-     * @return
-     */
-    private boolean canResolveSlotsInTheScope(List<SlotRef> slots, Scope scope) {
-        return slots.stream().allMatch(s -> scope.tryResolveField(s).isPresent());
-    }
-
-    /**
-     * Generate partition predicates to refresh the materialized view so can be refreshed by the incremental partitions.
-     *
-     * @param tablePartitionNames : the need pruned partition tables of the ref base table
-     * @param queryStatement      : the materialized view's defined query statement
-     * @param mvPartitionInfo     : the materialized view's partition information
-     * @return
-     * @throws AnalysisException
-     */
-    private Expr generatePartitionPredicate(Table table, Set<String> tablePartitionNames,
-                                            QueryStatement queryStatement, PartitionInfo mvPartitionInfo)
-            throws AnalysisException {
-        SlotRef partitionSlot = MaterializedView.getRefBaseTablePartitionSlotRef(materializedView);
-        List<String> columnOutputNames = queryStatement.getQueryRelation().getColumnOutputNames();
-        List<Expr> outputExpressions = queryStatement.getQueryRelation().getOutputExpression();
-        Expr outputPartitionSlot = null;
-        for (int i = 0; i < outputExpressions.size(); ++i) {
-            if (columnOutputNames.get(i).equalsIgnoreCase(partitionSlot.getColumnName())) {
-                outputPartitionSlot = outputExpressions.get(i);
-                break;
-            } else if (outputExpressions.get(i) instanceof FunctionCallExpr) {
-                FunctionCallExpr functionCallExpr = (FunctionCallExpr) outputExpressions.get(i);
-                if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)
-                        && functionCallExpr.getChild(0) instanceof SlotRef) {
-                    SlotRef slot = functionCallExpr.getChild(0).cast();
-                    if (slot.getColumnName().equalsIgnoreCase(partitionSlot.getColumnName())) {
-                        outputPartitionSlot = slot;
-                        break;
-                    }
-                }
-            } else {
-                // alias name.
-                SlotRef slotRef = outputExpressions.get(i).unwrapSlotRef();
-                if (slotRef != null && slotRef.getColumnName().equals(partitionSlot.getColumnName())) {
-                    outputPartitionSlot = outputExpressions.get(i);
-                    break;
-                }
-            }
-        }
-
-        if (outputPartitionSlot == null) {
-            LOG.warn("Generate partition predicate failed: " +
-                    "cannot find partition slot ref {} from query relation", partitionSlot);
-            return null;
-        }
-
-        if (mvPartitionInfo.isRangePartition()) {
-            List<Range<PartitionKey>> sourceTablePartitionRange = Lists.newArrayList();
-            for (String partitionName : tablePartitionNames) {
-                sourceTablePartitionRange.add(mvContext.getRefBaseTableRangePartitionMap()
-                        .get(table).get(partitionName));
-            }
-            sourceTablePartitionRange = MvUtils.mergeRanges(sourceTablePartitionRange);
-            // for nested mv, the base table may be another mv, which is partition by str2date(dt, '%Y%m%d')
-            // here we should convert date into '%Y%m%d' format
-            Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
-            Pair<Table, Column> partitionTableAndColumn = materializedView.getDirectTableAndPartitionColumn();
-            boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, partitionTableAndColumn.second);
-            if (isConvertToDate && partitionExpr instanceof FunctionCallExpr
-                    && !sourceTablePartitionRange.isEmpty() && MvUtils.isDateRange(sourceTablePartitionRange.get(0))) {
-                Optional<FunctionCallExpr> functionCallExprOpt = getStr2DateExpr(partitionExpr);
-                if (!functionCallExprOpt.isPresent()) {
-                    LOG.warn("invalid partition expr:{}", partitionExpr);
-                    return null;
-                }
-                FunctionCallExpr functionCallExpr = functionCallExprOpt.get();
-                Preconditions.checkState(
-                        functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE));
-                String dateFormat = ((StringLiteral) functionCallExpr.getChild(1)).getStringValue();
-                List<Range<PartitionKey>> converted = Lists.newArrayList();
-                for (Range<PartitionKey> range : sourceTablePartitionRange) {
-                    Range<PartitionKey> varcharPartitionKey = MvUtils.convertToVarcharRange(range, dateFormat);
-                    converted.add(varcharPartitionKey);
-                }
-                sourceTablePartitionRange = converted;
-            }
-            List<Expr> partitionPredicates =
-                    MvUtils.convertRange(outputPartitionSlot, sourceTablePartitionRange);
-            // range contains the min value could be null value
-            Optional<Range<PartitionKey>> nullRange = sourceTablePartitionRange.stream().
-                    filter(range -> range.lowerEndpoint().isMinValue()).findAny();
-            if (nullRange.isPresent()) {
-                Expr isNullPredicate = new IsNullPredicate(outputPartitionSlot, false);
-                partitionPredicates.add(isNullPredicate);
-            }
-
-            return Expr.compoundOr(partitionPredicates);
-        } else if (mvPartitionInfo.getType() == PartitionType.LIST) {
-            Map<String, List<List<String>>> baseListPartitionMap = mvContext.getRefBaseTableListPartitionMap();
-            Type partitionType = mvContext.getRefBaseTablePartitionColumn().getType();
-            List<LiteralExpr> sourceTablePartitionList = Lists.newArrayList();
-            for (String tablePartitionName : tablePartitionNames) {
-                List<List<String>> values = baseListPartitionMap.get(tablePartitionName);
-                for (List<String> value : values) {
-                    LiteralExpr partitionValue = new PartitionValue(value.get(0)).getValue(partitionType);
-                    sourceTablePartitionList.add(partitionValue);
-                }
-            }
-            List<Expr> partitionPredicates = MvUtils.convertList(outputPartitionSlot, sourceTablePartitionList);
-            return Expr.compoundOr(partitionPredicates);
-        } else {
-            LOG.warn("Generate partition predicate failed: " +
-                    "partition slot {} is not supported yet: {}", partitionSlot, mvPartitionInfo);
-            return null;
-        }
-    }
-
-    private Optional<FunctionCallExpr> getStr2DateExpr(Expr partitionExpr) {
-        List<Expr> matches = Lists.newArrayList();
-        partitionExpr.collect(expr -> isStr2Date(expr), matches);
-        if (matches.size() != 1) {
-            return Optional.empty();
-        }
-        return Optional.of(matches.get(0).cast());
-    }
-
-    private boolean isStr2Date(Expr expr) {
-        return expr instanceof FunctionCallExpr
-                && ((FunctionCallExpr) expr).getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE);
     }
 
     private boolean checkBaseTableSnapshotInfoChanged(TableSnapshotInfo snapshotInfo) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
@@ -1,0 +1,280 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.scheduler.mv;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.IsNullPredicate;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.PartitionNames;
+import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getStr2DateExpr;
+
+public class MVPCTRefreshPlanBuilder {
+    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshPlanBuilder.class);
+    private final MaterializedView mv;
+    private final MvTaskRunContext mvContext;
+
+    public MVPCTRefreshPlanBuilder(MaterializedView mv, MvTaskRunContext mvContext) {
+        this.mv = mv;
+        this.mvContext = mvContext;
+    }
+
+    public InsertStmt analyzeAndBuildInsertPlan(InsertStmt insertStmt,
+                                                Map<String, Set<String>> refTableRefreshPartitions,
+                                                ConnectContext ctx) throws AnalysisException {
+        // analyze the insert stmt
+        Analyzer.analyze(insertStmt, ctx);
+        // if the refTableRefreshPartitions is empty(not partitioned mv), no need to generate partition predicate
+        if (refTableRefreshPartitions.isEmpty()) {
+            return insertStmt;
+        }
+
+        // after analyze, we could get the table meta info of the tableRelation.
+        QueryStatement queryStatement = insertStmt.getQueryStatement();
+        // try to push down into query relation so can push down filter into both sides
+        // NOTE: it's safe here to push the partition predicate into query relation directly because
+        // partition predicates always belong to the relation output expressions and can be resolved
+        // by the query analyzer.
+        QueryRelation queryRelation = queryStatement.getQueryRelation();
+        List<Expr> extraPartitionPredicates = Lists.newArrayList();
+        Multimap<String, TableRelation> tableRelations = AnalyzerUtils.collectAllTableRelation(queryStatement);
+        for (String tblName : tableRelations.keys()) {
+            // skip to generate partition predicate for non-ref base tables
+            if (!refTableRefreshPartitions.containsKey(tblName) || !tableRelations.containsKey(tblName)) {
+                continue;
+            }
+            // set partition names for ref base table
+            Set<String> tablePartitionNames = refTableRefreshPartitions.get(tblName);
+            Collection<TableRelation> relations = tableRelations.get(tblName);
+            TableRelation tableRelation = relations.iterator().next();
+
+            // if there are multiple table relations, don't push down partition predicate into table relation
+            boolean isPushDownBelowTable = (relations.size() == 1);
+            Table table = tableRelation.getTable();
+            if (table == null) {
+                LOG.warn("Optimize materialized view {} refresh task, generate table relation {} failed: " +
+                                "table is null", mv.getName(), tableRelation.getName());
+                continue;
+            }
+            // external table doesn't support query with partitionNames
+            if (isPushDownBelowTable && !table.isExternalTableWithFileSystem()) {
+                LOG.info("Optimize materialized view {} refresh task, generate table relation {} target partition names:{} ",
+                        mv.getName(), tableRelation.getName(), Joiner.on(",").join(tablePartitionNames));
+                tableRelation.setPartitionNames(
+                        new PartitionNames(false, new ArrayList<>(tablePartitionNames)));
+            }
+
+            Pair<Table, Column> refBaseTableAndCol = mv.getDirectTableAndPartitionColumn();
+            if (refBaseTableAndCol == null || !refBaseTableAndCol.first.equals(table)) {
+                continue;
+            }
+            // generate partition predicate for the select relation, so can generate partition predicates
+            // for non-ref base tables.
+            // eg:
+            //  mv: create mv mv1 partition by t1.dt
+            //  as select  * from t1 join t2 on t1.dt = t2.dt.
+            //  ref-base-table      : t1.dt
+            //  non-ref-base-table  : t2.dt
+            // so add partition predicates for select relation when refresh partitions incrementally(eg: dt=20230810):
+            // (select * from t1 join t2 on t1.dt = t2.dt) where t1.dt=20230810
+            Expr partitionPredicate = generatePartitionPredicate(table, tablePartitionNames,
+                    queryStatement, mv.getPartitionInfo());
+            if (partitionPredicate == null) {
+                continue;
+            }
+            // try to push down into table relation
+            List<SlotRef> slots = Lists.newArrayList();
+            partitionPredicate.collect(SlotRef.class, slots);
+            Scope tableRelationScope = tableRelation.getScope();
+            if (isPushDownBelowTable && canResolveSlotsInTheScope(slots, tableRelationScope)) {
+                LOG.info("Optimize materialized view {} refresh task, generate table relation {} " +
+                                "partition predicate:{} ",
+                        mv.getName(), tableRelation.getName(), partitionPredicate.toSql());
+                tableRelation.setPartitionPredicate(partitionPredicate);
+            }
+            extraPartitionPredicates.add(partitionPredicate);
+        }
+        if (extraPartitionPredicates.isEmpty()) {
+            return insertStmt;
+        }
+
+        if (queryRelation instanceof SelectRelation) {
+            SelectRelation selectRelation = (SelectRelation) queryRelation;
+            extraPartitionPredicates.add(selectRelation.getWhereClause());
+            Expr finalPredicate = Expr.compoundAnd(extraPartitionPredicates);
+            selectRelation.setWhereClause(finalPredicate);
+            LOG.info("Optimize materialized view {} refresh task, generate insert stmt final " +
+                            "predicate(select relation):{} ", mv.getName(), finalPredicate.toSql());
+        }
+        return insertStmt;
+    }
+
+    /**
+     * Check whether to push down predicate expr with the slot refs into the scope.
+     *
+     * @param slots : slot refs that are contained in the predicate expr
+     * @param scope : scope that try to push down into.
+     * @return
+     */
+    private boolean canResolveSlotsInTheScope(List<SlotRef> slots, Scope scope) {
+        return slots.stream().allMatch(s -> scope.tryResolveField(s).isPresent());
+    }
+
+    /**
+     * Generate partition predicates to refresh the materialized view so can be refreshed by the incremental partitions.
+     *
+     * @param tablePartitionNames : the need pruned partition tables of the ref base table
+     * @param queryStatement      : the materialized view's defined query statement
+     * @param mvPartitionInfo     : the materialized view's partition information
+     * @return
+     * @throws AnalysisException
+     */
+    private Expr generatePartitionPredicate(Table table, Set<String> tablePartitionNames,
+                                            QueryStatement queryStatement, PartitionInfo mvPartitionInfo)
+            throws AnalysisException {
+        SlotRef partitionSlot = MaterializedView.getRefBaseTablePartitionSlotRef(mv);
+        List<String> columnOutputNames = queryStatement.getQueryRelation().getColumnOutputNames();
+        List<Expr> outputExpressions = queryStatement.getQueryRelation().getOutputExpression();
+        Expr outputPartitionSlot = null;
+        for (int i = 0; i < outputExpressions.size(); ++i) {
+            if (columnOutputNames.get(i).equalsIgnoreCase(partitionSlot.getColumnName())) {
+                outputPartitionSlot = outputExpressions.get(i);
+                break;
+            } else if (outputExpressions.get(i) instanceof FunctionCallExpr) {
+                FunctionCallExpr functionCallExpr = (FunctionCallExpr) outputExpressions.get(i);
+                if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)
+                        && functionCallExpr.getChild(0) instanceof SlotRef) {
+                    SlotRef slot = functionCallExpr.getChild(0).cast();
+                    if (slot.getColumnName().equalsIgnoreCase(partitionSlot.getColumnName())) {
+                        outputPartitionSlot = slot;
+                        break;
+                    }
+                }
+            } else {
+                // alias name.
+                SlotRef slotRef = outputExpressions.get(i).unwrapSlotRef();
+                if (slotRef != null && slotRef.getColumnName().equals(partitionSlot.getColumnName())) {
+                    outputPartitionSlot = outputExpressions.get(i);
+                    break;
+                }
+            }
+        }
+
+        if (outputPartitionSlot == null) {
+            LOG.warn("Generate partition predicate failed: " +
+                    "cannot find partition slot ref {} from query relation", partitionSlot);
+            return null;
+        }
+
+        if (mvPartitionInfo.isRangePartition()) {
+            List<Range<PartitionKey>> sourceTablePartitionRange = Lists.newArrayList();
+            for (String partitionName : tablePartitionNames) {
+                sourceTablePartitionRange.add(mvContext.getRefBaseTableRangePartitionMap()
+                        .get(table).get(partitionName));
+            }
+            sourceTablePartitionRange = MvUtils.mergeRanges(sourceTablePartitionRange);
+            // for nested mv, the base table may be another mv, which is partition by str2date(dt, '%Y%m%d')
+            // here we should convert date into '%Y%m%d' format
+            Expr partitionExpr = mv.getFirstPartitionRefTableExpr();
+            Pair<Table, Column> partitionTableAndColumn = mv.getDirectTableAndPartitionColumn();
+            boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, partitionTableAndColumn.second);
+            if (isConvertToDate && partitionExpr instanceof FunctionCallExpr
+                    && !sourceTablePartitionRange.isEmpty() && MvUtils.isDateRange(sourceTablePartitionRange.get(0))) {
+                Optional<FunctionCallExpr> functionCallExprOpt = getStr2DateExpr(partitionExpr);
+                if (!functionCallExprOpt.isPresent()) {
+                    LOG.warn("invalid partition expr:{}", partitionExpr);
+                    return null;
+                }
+                FunctionCallExpr functionCallExpr = functionCallExprOpt.get();
+                Preconditions.checkState(
+                        functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE));
+                String dateFormat = ((StringLiteral) functionCallExpr.getChild(1)).getStringValue();
+                List<Range<PartitionKey>> converted = Lists.newArrayList();
+                for (Range<PartitionKey> range : sourceTablePartitionRange) {
+                    Range<PartitionKey> varcharPartitionKey = MvUtils.convertToVarcharRange(range, dateFormat);
+                    converted.add(varcharPartitionKey);
+                }
+                sourceTablePartitionRange = converted;
+            }
+            List<Expr> partitionPredicates =
+                    MvUtils.convertRange(outputPartitionSlot, sourceTablePartitionRange);
+            // range contains the min value could be null value
+            Optional<Range<PartitionKey>> nullRange = sourceTablePartitionRange.stream().
+                    filter(range -> range.lowerEndpoint().isMinValue()).findAny();
+            if (nullRange.isPresent()) {
+                Expr isNullPredicate = new IsNullPredicate(outputPartitionSlot, false);
+                partitionPredicates.add(isNullPredicate);
+            }
+
+            return Expr.compoundOr(partitionPredicates);
+        } else if (mvPartitionInfo.getType() == PartitionType.LIST) {
+            Map<String, List<List<String>>> baseListPartitionMap = mvContext.getRefBaseTableListPartitionMap();
+            Type partitionType = mvContext.getRefBaseTablePartitionColumn().getType();
+            List<LiteralExpr> sourceTablePartitionList = Lists.newArrayList();
+            for (String tablePartitionName : tablePartitionNames) {
+                List<List<String>> values = baseListPartitionMap.get(tablePartitionName);
+                for (List<String> value : values) {
+                    LiteralExpr partitionValue = new PartitionValue(value.get(0)).getValue(partitionType);
+                    sourceTablePartitionList.add(partitionValue);
+                }
+            }
+            List<Expr> partitionPredicates = MvUtils.convertList(outputPartitionSlot, sourceTablePartitionList);
+            return Expr.compoundOr(partitionPredicates);
+        } else {
+            LOG.warn("Generate partition predicate failed: " +
+                    "partition slot {} is not supported yet: {}", partitionSlot, mvPartitionInfo);
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -27,6 +27,7 @@ import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.ParseNode;
@@ -34,6 +35,7 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
@@ -1377,5 +1379,19 @@ public class MvUtils {
 
     public static Table getTableChecked(BaseTableInfo baseTableInfo) {
         return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableChecked(baseTableInfo);
+    }
+
+    public static Optional<FunctionCallExpr> getStr2DateExpr(Expr partitionExpr) {
+        List<Expr> matches = Lists.newArrayList();
+        partitionExpr.collect(expr -> isStr2Date(expr), matches);
+        if (matches.size() != 1) {
+            return Optional.empty();
+        }
+        return Optional.of(matches.get(0).cast());
+    }
+
+    public static boolean isStr2Date(Expr expr) {
+        return expr instanceof FunctionCallExpr
+                && ((FunctionCallExpr) expr).getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -1,0 +1,221 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.schema.MTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTestBase {
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        cleanupEphemeralMVs(starRocksAssert, startSuiteTime);
+    }
+
+    @Before
+    public void before() {
+        startCaseTime = Instant.now().getEpochSecond();
+    }
+
+    @After
+    public void after() throws Exception {
+        cleanupEphemeralMVs(starRocksAssert, startCaseTime);
+    }
+
+    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+    }
+
+    @Test
+    public void testMVRefreshWithTheSameTables1() {
+        starRocksAssert.withTables(List.of(
+                        new MTable("tt1", "k1",
+                                List.of(
+                                        "k1 int",
+                                        "k2 int",
+                                        "k3 string",
+                                        "dt date"
+                                ),
+                                "dt",
+                                List.of(
+                                        "PARTITION p0 values [('2021-12-01'),('2021-12-02'))",
+                                        "PARTITION p1 values [('2021-12-02'),('2021-12-03'))",
+                                        "PARTITION p2 values [('2021-12-03'),('2021-12-04'))"
+                                )
+                        )
+                ),
+                () -> {
+                    String[] mvSqls = {
+                            "create materialized view test_mv1 \n" +
+                                    "partition by dt \n" +
+                                    "distributed by RANDOM\n" +
+                                    "refresh deferred manual\n" +
+                                    "as select a.dt, b.k2 from tt1 a " +
+                                    "   join tt1 b on a.dt = substr(date_sub(b.dt, interval dayofyear(a.dt) day), 1, 10)" +
+                                    "   join tt1 c on a.dt = substr(date_add(c.dt, interval dayofyear(a.dt) day), 1, 10)" +
+                                    " where a.k1 > 1 and b.k1 > 2 and c.k1 > 3;",
+                            "create materialized view test_mv1 \n" +
+                                    "partition by dt \n" +
+                                    "distributed by RANDOM\n" +
+                                    "refresh deferred manual\n" +
+                                    "as select a.dt, b.k2 from tt1 a " +
+                                    "   join tt1 b on a.dt = date_sub(b.dt, interval dayofyear(a.dt) day)" +
+                                    "   join tt1 c on a.dt = date_add(c.dt, interval dayofyear(a.dt) day)" +
+                                    " where a.k1 > 1 and b.k1 > 2 and c.k1 > 3;",
+                    };
+                    for (String mvSql : mvSqls) {
+                        starRocksAssert.withMaterializedView(mvSql, (obj) -> {
+                            String mvName = (String) obj;
+                            assertPlanWithoutPushdownBelowScan(mvName);
+                        });
+                    };
+                });
+    }
+
+    private void assertPlanWithoutPushdownBelowScan(String mvName) throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+        Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        Map<String, String> testProperties = task.getProperties();
+        testProperties.put(TaskRun.IS_TEST, "true");
+
+        String insertSql = "insert into tt1 partition(p0) values(1, 1, 1, '2021-12-01');";
+        executeInsertSql(connectContext, insertSql);
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        PartitionBasedMvRefreshProcessor processor =
+                (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+        Assert.assertTrue(execPlan != null);
+        String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+        System.out.println(plan);
+        PlanTestBase.assertContains(plan, "     TABLE: tt1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 1: k1 > 1\n" +
+                "     partitions=1/3");
+        PlanTestBase.assertContains(plan, "     TABLE: tt1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 5: k1 > 2\n" +
+                "     partitions=3/3");
+        PlanTestBase.assertContains(plan, "     TABLE: tt1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 9: k1 > 3\n" +
+                "     partitions=3/3");
+    }
+
+    @Test
+    public void testMVRefreshWithTheSameTables22() {
+        starRocksAssert.withTables(List.of(
+                        new MTable("tt1", "k1",
+                                List.of(
+                                        "k1 int",
+                                        "k2 int",
+                                        "k3 string",
+                                        "dt date"
+                                ),
+                                "dt",
+                                List.of(
+                                        "PARTITION p0 values [('2021-12-01'),('2021-12-02'))",
+                                        "PARTITION p1 values [('2021-12-02'),('2021-12-03'))",
+                                        "PARTITION p2 values [('2021-12-03'),('2021-12-04'))"
+                                )
+                        )
+                ),
+                () -> {
+                    String[] mvSqls = {
+                            "create materialized view test_mv1 \n" +
+                                    "partition by dt \n" +
+                                    "distributed by RANDOM\n" +
+                                    "refresh deferred manual\n" +
+                                    "as select a.dt, b.k2 from tt1 a " +
+                                    "   join tt1 b on a.dt = b.dt" +
+                                    "   join tt1 c on a.dt = c.dt" +
+                                    " where a.k1 > 1 and b.k1 > 2 and c.k1 > 3;",
+                            "create materialized view test_mv1 \n" +
+                                    "partition by dt \n" +
+                                    "distributed by RANDOM\n" +
+                                    "refresh deferred manual\n" +
+                                    "as select a.dt, b.k2 from tt1 a " +
+                                    "   join tt1 b on a.dt = date_trunc('day', b.dt)" +
+                                    "   join tt1 c on a.dt = date_trunc('day', c.dt)" +
+                                    " where a.k1 > 1 and b.k1 > 2 and c.k1 > 3;",
+                    };
+                    for (String mvSql : mvSqls) {
+                        starRocksAssert.withMaterializedView(mvSql, (obj) -> {
+                            String mvName = (String) obj;
+                            assertPlanWithPushdownBelowScan(mvName);
+                        });
+                    };
+                });
+    }
+
+    private void assertPlanWithPushdownBelowScan(String mvName) throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+        Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        Map<String, String> testProperties = task.getProperties();
+        testProperties.put(TaskRun.IS_TEST, "true");
+
+        String insertSql = "insert into tt1 partition(p0) values(1, 1, 1, '2021-12-01');";
+        executeInsertSql(connectContext, insertSql);
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        PartitionBasedMvRefreshProcessor processor =
+                (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+        Assert.assertTrue(execPlan != null);
+        String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+        System.out.println(plan);
+        PlanTestBase.assertContains(plan, "     TABLE: tt1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 1: k1 > 1\n" +
+                "     partitions=1/3");
+        PlanTestBase.assertContains(plan, "     TABLE: tt1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 5: k1 > 2\n" +
+                "     partitions=1/3");
+        PlanTestBase.assertContains(plan, "     TABLE: tt1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 9: k1 > 3\n" +
+                "     partitions=1/3");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -47,6 +47,7 @@ import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TUniqueId;
@@ -284,7 +285,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            Assert.assertFalse(plan.contains("partitions=5/5"));
+            // TODO(fixme): for self join, forbid pushing down filter, but there are some cases to optimize.
+            PlanTestBase.assertContains(plan, "partitions=5/5");
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail(e.getMessage());

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_the_same_tables
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_the_same_tables
@@ -1,0 +1,154 @@
+-- name: test_mv_refresh_with_the_same_tables
+CREATE TABLE `t1` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` decimal(38, 8) NULL COMMENT "",
+  `k3` decimal(38, 8) NULL COMMENT "",
+  `dt`  DATE  NULL COMMENT ""
+) 
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE (dt) (
+    START ("2023-12-31") END ("2025-01-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW  test_mv1
+PARTITION BY dt
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"partition_refresh_number"="-1"
+) REFRESH deferred MANUAL as
+select k1,k3,dt from t1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv2
+PARTITION BY dt
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"partition_refresh_number"="-1"
+) REFRESH MANUAL as
+select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt 
+from t1 left outer join test_mv1 t4 
+on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10);
+-- result:
+-- !result
+insert into `t1` values 
+(1,4212332.27340000,4232.27340000,"2024-05-16"), (2,421111132.27340000,-4232.27340000,"2024-05-16"),(2,121111132.2340000,-332.27340000,"2024-05-16"),
+(3,123222.27340000,113163302.95000000,"2024-05-16"),(4,22312.27340000,709018.20810000,"2024-05-16"),(1,123222.27340000,11316330.95000000,"2023-12-31"),
+(1,22312.27340000,70901.20810000,"2023-12-31"),(2,421111132.27340000,-1232.27340000,"2023-12-31"),(3,123222.27340000,11316330.95000000,"2023-12-31"),
+(4,22312.27340000,70901.20810000,"2023-12-31");
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+function: check_hit_materialized_view("select k1,k3,dt from t1", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10)", "test_mv2")
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2, 3;
+-- result:
+1	4232.27340000	2024-05-16
+1	70901.20810000	2023-12-31
+1	11316330.95000000	2023-12-31
+2	-4232.27340000	2024-05-16
+2	-1232.27340000	2023-12-31
+2	-332.27340000	2024-05-16
+3	11316330.95000000	2023-12-31
+3	113163302.95000000	2024-05-16
+4	70901.20810000	2023-12-31
+4	709018.20810000	2024-05-16
+-- !result
+select * from test_mv2 order by 1, 2, 3;
+-- result:
+1	4232.27340000	70901.20810000	-66668.93470000	2024-05-16
+1	4232.27340000	11316330.95000000	-11312098.67660000	2024-05-16
+1	70901.20810000	None	None	2023-12-31
+1	11316330.95000000	None	None	2023-12-31
+2	-4232.27340000	-1232.27340000	-3000.00000000	2024-05-16
+2	-1232.27340000	None	None	2023-12-31
+2	-332.27340000	-1232.27340000	900.00000000	2024-05-16
+3	11316330.95000000	None	None	2023-12-31
+3	113163302.95000000	11316330.95000000	101846972.00000000	2024-05-16
+4	70901.20810000	None	None	2023-12-31
+4	709018.20810000	70901.20810000	638117.00000000	2024-05-16
+-- !result
+select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10) order by 1, 2, 3 limit 5;
+-- result:
+1	4232.27340000	70901.20810000	-66668.93470000	2024-05-16
+1	4232.27340000	11316330.95000000	-11312098.67660000	2024-05-16
+1	70901.20810000	None	None	2023-12-31
+1	11316330.95000000	None	None	2023-12-31
+2	-4232.27340000	-1232.27340000	-3000.00000000	2024-05-16
+-- !result
+insert into `t1` values (1,4212332.27340000,4232.27340000,"2024-05-17"),(2,421111132.27340000,-4232.27340000,"2024-05-17"),(3,123222.27340000,113163302.95000000,"2024-05-17"),(4,22312.27340000,709018.20810000,"2024-05-17");
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+function: check_hit_materialized_view("select k1,k3,dt from t1", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10)", "test_mv2")
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2, 3;
+-- result:
+1	4232.27340000	2024-05-16
+1	4232.27340000	2024-05-17
+1	70901.20810000	2023-12-31
+1	11316330.95000000	2023-12-31
+2	-4232.27340000	2024-05-16
+2	-4232.27340000	2024-05-17
+2	-1232.27340000	2023-12-31
+2	-332.27340000	2024-05-16
+3	11316330.95000000	2023-12-31
+3	113163302.95000000	2024-05-16
+3	113163302.95000000	2024-05-17
+4	70901.20810000	2023-12-31
+4	709018.20810000	2024-05-16
+4	709018.20810000	2024-05-17
+-- !result
+select * from test_mv2 order by 1, 2, 3;
+-- result:
+1	4232.27340000	70901.20810000	-66668.93470000	2024-05-17
+1	4232.27340000	70901.20810000	-66668.93470000	2024-05-16
+1	4232.27340000	11316330.95000000	-11312098.67660000	2024-05-17
+1	4232.27340000	11316330.95000000	-11312098.67660000	2024-05-16
+1	70901.20810000	None	None	2023-12-31
+1	11316330.95000000	None	None	2023-12-31
+2	-4232.27340000	-1232.27340000	-3000.00000000	2024-05-17
+2	-4232.27340000	-1232.27340000	-3000.00000000	2024-05-16
+2	-1232.27340000	None	None	2023-12-31
+2	-332.27340000	-1232.27340000	900.00000000	2024-05-16
+3	11316330.95000000	None	None	2023-12-31
+3	113163302.95000000	11316330.95000000	101846972.00000000	2024-05-17
+3	113163302.95000000	11316330.95000000	101846972.00000000	2024-05-16
+4	70901.20810000	None	None	2023-12-31
+4	709018.20810000	70901.20810000	638117.00000000	2024-05-17
+4	709018.20810000	70901.20810000	638117.00000000	2024-05-16
+-- !result
+select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10) order by 1, 2, 3 limit 5;
+-- result:
+1	4232.27340000	70901.20810000	-66668.93470000	2024-05-16
+1	4232.27340000	70901.20810000	-66668.93470000	2024-05-17
+1	4232.27340000	11316330.95000000	-11312098.67660000	2024-05-16
+1	4232.27340000	11316330.95000000	-11312098.67660000	2024-05-17
+1	70901.20810000	None	None	2023-12-31
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_the_same_tables
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_the_same_tables
@@ -1,0 +1,63 @@
+-- name: test_mv_refresh_with_the_same_tables
+CREATE TABLE `t1` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` decimal(38, 8) NULL COMMENT "",
+  `k3` decimal(38, 8) NULL COMMENT "",
+  `dt`  DATE  NULL COMMENT ""
+) 
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE (dt) (
+    START ("2023-12-31") END ("2025-01-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+
+CREATE MATERIALIZED VIEW  test_mv1
+PARTITION BY dt
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"partition_refresh_number"="-1"
+) REFRESH deferred MANUAL as
+select k1,k3,dt from t1;
+
+CREATE MATERIALIZED VIEW test_mv2
+PARTITION BY dt
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"partition_refresh_number"="-1"
+) REFRESH MANUAL as
+select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt 
+from t1 left outer join test_mv1 t4 
+on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10);
+
+insert into `t1` values 
+(1,4212332.27340000,4232.27340000,"2024-05-16"), (2,421111132.27340000,-4232.27340000,"2024-05-16"),(2,121111132.2340000,-332.27340000,"2024-05-16"),
+(3,123222.27340000,113163302.95000000,"2024-05-16"),(4,22312.27340000,709018.20810000,"2024-05-16"),(1,123222.27340000,11316330.95000000,"2023-12-31"),
+(1,22312.27340000,70901.20810000,"2023-12-31"),(2,421111132.27340000,-1232.27340000,"2023-12-31"),(3,123222.27340000,11316330.95000000,"2023-12-31"),
+(4,22312.27340000,70901.20810000,"2023-12-31");
+
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+
+function: check_hit_materialized_view("select k1,k3,dt from t1", "test_mv1")
+function: check_hit_materialized_view("select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10)", "test_mv2")
+
+select * from test_mv1 order by 1, 2, 3;
+select * from test_mv2 order by 1, 2, 3;
+select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10) order by 1, 2, 3 limit 5;
+insert into `t1` values (1,4212332.27340000,4232.27340000,"2024-05-17"),(2,421111132.27340000,-4232.27340000,"2024-05-17"),(3,123222.27340000,113163302.95000000,"2024-05-17"),(4,22312.27340000,709018.20810000,"2024-05-17");
+
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+function: check_hit_materialized_view("select k1,k3,dt from t1", "test_mv1")
+function: check_hit_materialized_view("select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10)", "test_mv2")
+
+select * from test_mv1 order by 1, 2, 3;
+select * from test_mv2 order by 1, 2, 3;
+select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt  from t1 left outer join test_mv1 t4  on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10) order by 1, 2, 3 limit 5;
+
+drop materialized view test_mv2;
+drop materialized view test_mv1;
+
+drop table t1;


### PR DESCRIPTION
## Why I'm doing:
- If mv contains multiple times for the same table, result may be wrong because of wrong partition pruning.
```
CREATE TABLE `t1` (
  `k1` int(11) NULL COMMENT "",
  `k2` decimal(38, 8) NULL COMMENT "",
  `k3` decimal(38, 8) NULL COMMENT "",
  `dt`  DATE  NULL COMMENT ""
) 
DUPLICATE KEY(`k1`)
PARTITION BY RANGE (dt) (
    START ("2023-12-31") END ("2025-01-01") EVERY (INTERVAL 1 DAY)
)
DISTRIBUTED BY HASH(`k1`) BUCKETS 3;

CREATE MATERIALIZED VIEW  test_mv1
PARTITION BY dt
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"replication_num" = "1",
"partition_refresh_number"="-1"
) REFRESH deferred MANUAL as
select k1,k3,dt from t1;

CREATE MATERIALIZED VIEW test_mv2
PARTITION BY dt
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"replication_num" = "1",
"partition_refresh_number"="-1"
) REFRESH MANUAL as
select t1.k1, t1.k3 t1k3, t4.k3 k4k3, t1.k3-t4.k3 as upyear, t1.dt dt 
from t1 left outer join test_mv1 t4 
on t1.k1=t4.k1 and t4.dt=substr(date_sub(t1.dt,interval dayofyear(t1.dt) day),1,10);

```
## What I'm doing:
- Only push down partition predicate below the table when there are no same tables in mv's defined query.
- Partition predicate is only added into mv's defined query if it cannot be pushed below scan node.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
