### PR TITLE
[BugFix] The hdfs directory is not synchronized when drop spark resource

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.LoadException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.proc.BaseProcResult;
@@ -183,20 +184,43 @@ public class ResourceMgr implements Writable {
     public void dropResource(DropResourceStmt stmt) throws DdlException {
         this.writeLock();
         try {
+            // check if exists
             String name = stmt.getResourceName();
-            Resource resource = nameToResource.remove(name);
+            Resource resource = nameToResource.get(name);
             if (resource == null) {
-                throw new DdlException("Resource(" + name + ") does not exist");
+                if (!stmt.isSetIfExists()) {
+                    throw new DdlException("Resource(" + name + ") does not exist");
+                }
+                LOG.info("Resource(" + name + ") does not exist");
+                return;
             }
 
+            // check if used in spark load
+            if (resource instanceof SparkResource) {
+                // check if any spark load unfinished use this resource
+                SparkResource sparkResource = (SparkResource) resource;
+                long num = GlobalStateMgr.getCurrentState().getLoadMgr().getUnFinishedLoadJobNumByResource(sparkResource);
+                if (num > 0) {
+                    throw new DdlException("drop resource fail, " +
+                            "There are currently " + num + " sparkload tasks that use this resource [" + name + "] " +
+                            "and are not yet executed");
+                }
+                // drop spark repository
+                sparkResource.deleteArchive();
+            }
+
+            // check catalog and remove
             if (resource.needMappingCatalog()) {
                 String catalogName = getResourceMappingCatalogName(resource.name, resource.type.name().toLowerCase(Locale.ROOT));
                 DropCatalogStmt dropCatalogStmt = new DropCatalogStmt(catalogName);
                 GlobalStateMgr.getCurrentState().getCatalogMgr().dropCatalog(dropCatalogStmt);
             }
+
             // log drop
             GlobalStateMgr.getCurrentState().getEditLog().logDropResource(new DropResourceOperationLog(name));
             LOG.info("drop resource success. resource name: {}", name);
+        } catch (LoadException e) {
+            throw new DdlException("drop resource fail, reason: " + e.getMessage());
         } finally {
             this.writeUnLock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.SparkResource;
 import com.starrocks.common.Config;
 import com.starrocks.common.DataQualityException;
 import com.starrocks.common.DdlException;
@@ -357,6 +358,20 @@ public class LoadMgr implements Writable, MemoryTrackable {
     public long getLoadJobNum(JobState jobState, EtlJobType jobType) {
         return idToLoadJob.values().stream().filter(j -> j.getState() == jobState && j.getJobType() == jobType)
                 .count();
+    }
+
+    public long getUnFinishedLoadJobNumByResource(SparkResource sparkResource) {
+        readLock();
+        try {
+            return idToLoadJob.values()
+                    .stream()
+                    .filter(j -> j.getState() != JobState.CANCELLED && j.getState() != JobState.FINISHED)
+                    .filter(loadJob ->  (loadJob instanceof SparkLoadJob)
+                            && loadJob.getResourceName().equals(sparkResource.getName()))
+                    .count();
+        } finally {
+            readUnlock();
+        }
     }
 
     private void unprotectedRemoveJobReleatedMeta(LoadJob job) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkRepository.java
@@ -110,6 +110,14 @@ public class SparkRepository {
         }
     }
 
+    public String getCurrentDppVersion() {
+        return currentDppVersion;
+    }
+
+    public String getRemoteRepositoryPath() {
+        return remoteRepositoryPath;
+    }
+
     public void prepare() throws LoadException {
         initRepository();
     }
@@ -236,7 +244,7 @@ public class SparkRepository {
         }
     }
 
-    private void getLibraries(String remoteArchivePath, List<SparkLibrary> libraries) throws LoadException {
+    public void getLibraries(String remoteArchivePath, List<SparkLibrary> libraries) throws LoadException {
         List<TBrokerFileStatus> fileStatuses = Lists.newArrayList();
         try {
             if (brokerDesc.hasBroker()) {
@@ -360,7 +368,7 @@ public class SparkRepository {
 
     // eg:
     // .../__spark_repository__/__archive_1_0_0
-    private String getRemoteArchivePath(String version) {
+    public String getRemoteArchivePath(String version) {
         return Joiner.on(PATH_DELIMITER).join(remoteRepositoryPath, joinPrefix(PREFIX_ARCHIVE, version));
     }
 
@@ -423,4 +431,19 @@ public class SparkRepository {
             this.size = size;
         }
     }
+
+    public void delete(String destFilePath) throws LoadException {
+        try {
+            if (brokerDesc.hasBroker()) {
+                BrokerUtil.deletePath(destFilePath, brokerDesc);
+            } else {
+                HdfsUtil.deletePath(destFilePath, brokerDesc);
+            }
+            LOG.info("finished to delete file, destFilePath={}", destFilePath);
+        } catch (UserException e) {
+            throw new LoadException("failed to upload lib to repository, " +
+                    "destPath=" + destFilePath + " message=" + e.getMessage());
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropResourceStmt.java
@@ -19,19 +19,25 @@ import com.starrocks.sql.parser.NodePosition;
 
 // DROP RESOURCE resource_name
 public class DropResourceStmt extends DdlStmt {
+    private final boolean ifExists;
     private final String resourceName;
 
-    public DropResourceStmt(String resourceName) {
-        this(resourceName, NodePosition.ZERO);
+    public DropResourceStmt(String resourceNam, NodePosition pos, boolean ifExists) {
+        super(pos);
+        this.ifExists = ifExists;
+        this.resourceName = resourceNam;
     }
 
-    public DropResourceStmt(String resourceName, NodePosition pos) {
-        super(pos);
-        this.resourceName = resourceName;
+    public DropResourceStmt(String resourceName, boolean ifExists) {
+        this(resourceName, NodePosition.ZERO, ifExists);
     }
 
     public String getResourceName() {
         return resourceName;
+    }
+
+    public boolean isSetIfExists() {
+        return ifExists;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2560,8 +2560,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     public ParseNode visitDropResourceStatement(StarRocksParser.DropResourceStatementContext context) {
+        boolean ifExists = context.IF() != null;
         Identifier identifier = (Identifier) visit(context.identifierOrString());
-        return new DropResourceStmt(identifier.getValue(), createPos(context));
+        return new DropResourceStmt(identifier.getValue(), createPos(context), ifExists);
     }
 
     public ParseNode visitAlterResourceStatement(StarRocksParser.AlterResourceStatementContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1231,7 +1231,7 @@ alterResourceStatement
     ;
 
 dropResourceStatement
-    : DROP RESOURCE resourceName=identifierOrString
+    : DROP RESOURCE (IF EXISTS)? resourceName=identifierOrString
     ;
 
 showResourceStatement

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
@@ -91,7 +91,7 @@ public class ResourceMgrTest {
         addSparkResource(mgr, brokerMgr, editLog, globalStateMgr);
 
         // drop
-        DropResourceStmt dropStmt = new DropResourceStmt(name);
+        DropResourceStmt dropStmt = new DropResourceStmt(name, false);
         mgr.dropResource(dropStmt);
         Assert.assertEquals(0, mgr.getResourceNum());
     }
@@ -114,7 +114,7 @@ public class ResourceMgrTest {
         // drop
         ResourceMgr mgr = new ResourceMgr();
         Assert.assertEquals(0, mgr.getResourceNum());
-        DropResourceStmt stmt = new DropResourceStmt(name);
+        DropResourceStmt stmt = new DropResourceStmt(name, false);
         mgr.dropResource(stmt);
     }
 


### PR DESCRIPTION
…ce is deleted

## Why I'm doing:
fix the bug of drop resource and sync remove the hdfs directory

## What I'm doing:
+ 1. support the sql of drop resource if exists
+ 2. check if any spark load doesn't finished when drop resource
+ 3. drop resource and delete the hdfs directory

Fixes #45886 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5