### PR TITLE
[BugFix] Fix NPE in show create db

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -670,7 +670,7 @@ public class ShowExecutor {
             createSqlBuilder.append("CREATE DATABASE `").append(statement.getDb()).append("`");
             if (!Strings.isNullOrEmpty(db.getLocation())) {
                 createSqlBuilder.append("\nPROPERTIES (\"location\" = \"").append(db.getLocation()).append("\")");
-            } else if (RunMode.isSharedDataMode() && !db.isSystemDatabase() && db.getCatalogName().isEmpty()) {
+            } else if (RunMode.isSharedDataMode() && !db.isSystemDatabase() && Strings.isNullOrEmpty(db.getCatalogName())) {
                 String volume = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeNameOfDb(db.getId());
                 createSqlBuilder.append("\nPROPERTIES (\"storage_volume\" = \"").append(volume).append("\")");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/ShowExecutorTest.java
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.qe;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.mysql.MysqlCommand;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.ShowCreateDbStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ShowExecutorTest {
+    private static ConnectContext ctx;
+
+    private GlobalStateMgr globalStateMgr;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        ctx = UtFrameUtils.createDefaultCtx();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        ctx = new ConnectContext(null);
+        ctx.setCommand(MysqlCommand.COM_SLEEP);
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        // mock internal database.
+        Database db = new Database();
+        new Expectations(db) {
+            {
+                db.getFullName();
+                minTimes = 0;
+                result = "testDb";
+            }};
+
+        // mock external database.
+        Database db1 = new Database();
+        new Expectations(db1) {
+            {
+                db1.getFullName();
+                minTimes = 0;
+                result = "testDb1";
+
+                db1.getCatalogName();
+                minTimes = 0;
+                result = "catalog";
+            }};
+
+        // mock globalStateMgr.
+        globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getDb("testDb");
+                minTimes = 0;
+                result = db;
+
+                globalStateMgr.getDb("testDb1");
+                minTimes = 0;
+                result = db1;
+            }
+        };
+    }
+
+    @Test
+    public void testShowCreateDb() throws DdlException {
+        ctx.setGlobalStateMgr(globalStateMgr);
+        ctx.setQualifiedUser("testUser");
+
+        ShowCreateDbStmt stmt = new ShowCreateDbStmt("testDb");
+        ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals("testDb", resultSet.getString(0));
+        Assert.assertEquals(resultSet.getString(1), "CREATE DATABASE `testDb`\n" +
+                        "PROPERTIES (\"storage_volume\" = \"builtin_storage_volume\")");
+        Assert.assertFalse(resultSet.next());
+
+        stmt = new ShowCreateDbStmt("testDb1");
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals("testDb1", resultSet.getString(0));
+        Assert.assertEquals("CREATE DATABASE `testDb1`", resultSet.getString(1));
+        Assert.assertFalse(resultSet.next());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
In #45753 , storage volume info will not display if it is external catalog. But NPE is introduced if it is internal catalog.
## What I'm doing:
Use `Strings.isNullOrEmpty` to check whether catalog is external to avoid NPE.
Fixes https://github.com/StarRocks/StarRocksTest/issues/7493

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
