### PR TITLE
[Enhancement] Support get_keys in DynamicCache

### DIFF
--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -330,6 +330,20 @@ public:
         return _evict(target_capacity, entry_list);
     }
 
+    std::vector<Key> get_keys() const {
+        std::vector<Key> ret;
+        { // Introduce scope for lock_guard
+            std::lock_guard<std::mutex> lg(_lock);
+            ret.reserve(_map.size());
+            auto itr = _list.begin();
+            while (itr != _list.end()) {
+                ret.emplace_back((*itr)->key());
+                itr++;
+            }
+        } // Lock is released here
+        return ret;
+    }
+
 private:
     bool _evict(size_t target_capacity, std::vector<Entry*>* entry_list) {
         auto itr = _list.begin();

--- a/be/test/util/dynamic_cache_test.cpp
+++ b/be/test/util/dynamic_cache_test.cpp
@@ -86,4 +86,16 @@ TEST(DynamicCacheTest, cache2) {
     }
 }
 
+TEST(DynamicCacheTest, test_get_keys) {
+    DynamicCache<int32_t, int64_t> cache(10);
+    for (int i = 0; i < 20; i++) {
+        cache.get_or_create(i);
+    }
+    const auto keys = cache.get_keys();
+    int i = 0;
+    for (auto& key : keys) {
+        ASSERT_EQ(key, i++);
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
There is no `get_keys` in DynamicCache now. In some scenario, we want to get keys from DynamicCache.
## What I'm doing:
Support `get_keys` in DynamicCache
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
