### PR TITLE
[Feature] Bypass sdk read and write decoupling

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -712,6 +712,16 @@ if (ENABLE_FAULT_INJECTION)
     message(STATUS "enable fault injection")
 endif()
 
+option(ASSERT_STATUS_CHECKED "build with assert status checked" OFF)
+if (ASSERT_STATUS_CHECKED)
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DSTARROCKS_ASSERT_STATUS_CHECKED")
+endif()
+
+if (BUILD_FORMAT_LIB)
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fPIC -DBUILD_FORMAT_LIB")
+    message(STATUS "enable build format library")
+endif()
+
 # For CMAKE_BUILD_TYPE=Debug
 #   -ggdb: Enable gdb debugging
 # Debug information is stored as dwarf2 to be as compatible as possible
@@ -832,7 +842,6 @@ set(STARROCKS_DEPENDENCIES ${STARROCKS_DEPENDENCIES}
 
 
 set(STARROCKS_DEPENDENCIES ${STARROCKS_DEPENDENCIES}
-    hdfs
     jvm
 )
 set(JAVA_HOME ${THIRDPARTY_DIR}/open_jdk/)
@@ -955,29 +964,34 @@ if (${WITH_TENANN} STREQUAL "ON")
 endif()
 
 # Add all external dependencies. They should come after the starrocks libs.
-set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} ${STARROCKS_DEPENDENCIES})
 
+set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS}
+    ${STARROCKS_LINK_LIBS}
+    ${STARROCKS_DEPENDENCIES}
+    hdfs
+)
 set(BUILD_FOR_SANITIZE "OFF")
+
 # Add sanitize static link flags or jemalloc
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
     message("use jemalloc")
-    set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} jemalloc)
+    set(STARROCKS_MEMORY_DEPENDENCIES_LIBS jemalloc)
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} -static-libsan)
+        set(STARROCKS_MEMORY_DEPENDENCIES_LIBS -static-libsan)
     else()
-        set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} -static-libasan)
+        set(STARROCKS_MEMORY_DEPENDENCIES_LIBS -static-libasan)
     endif()
     set(BUILD_FOR_SANITIZE "ON")
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "LSAN")
-    set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} -static-liblsan)
-    set(BUILD_FOR_SANITIZE "ON")
+    set(STARROCKS_MEMORY_DEPENDENCIES_LIBS -static-liblsan)
+     set(BUILD_FOR_SANITIZE "ON")
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "UBSAN")
     message("use jemalloc")
-    set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} -static-libubsan jemalloc)
+    set(STARROCKS_MEMORY_DEPENDENCIES_LIBS -static-libubsan jemalloc)
     set(BUILD_FOR_SANITIZE "ON")
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "TSAN")
-    set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} -static-libtsan)
+    set(STARROCKS_MEMORY_DEPENDENCIES_LIBS -static-libtsan)
     set(BUILD_FOR_SANITIZE "ON")
 else()
     message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
@@ -1029,9 +1043,15 @@ if (${MAKE_TEST} STREQUAL "ON")
     add_definitions(-DBE_TEST)
     add_definitions(-DFIU_ENABLE)
 else()
-    # output *.a, *.so, *.dylib to output/tmp
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_DIR}/tmp/${CMAKE_BUILD_TYPE})
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}/tmp/${CMAKE_BUILD_TYPE})
+    if (BUILD_FORMAT_LIB)
+        # output *.a, *.so, *.dylib to output/format-lib-tmp
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_DIR}/format-lib-tmp/${CMAKE_BUILD_TYPE})
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}/format-lib-tmp/${CMAKE_BUILD_TYPE})
+    else()
+        # output *.a, *.so, *.dylib to output/tmp
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_DIR}/tmp/${CMAKE_BUILD_TYPE})
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}/tmp/${CMAKE_BUILD_TYPE})
+    endif ()
     # output *.exe to output/lib
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_DIR}/lib)
 endif ()
@@ -1101,8 +1121,13 @@ add_subdirectory(${SRC_DIR}/tools)
 add_subdirectory(${SRC_DIR}/util)
 add_subdirectory(${SRC_DIR}/script)
 
+if (BUILD_FORMAT_LIB)
+    message(STATUS "Build starrocks format lib")
+    add_subdirectory(${SRC_DIR}/starrocks_format)
+endif()
+
 if (WITH_BENCH STREQUAL "ON")
-     message(STATUS "Build binary with bench")
+    message(STATUS "Build binary with bench")
     add_subdirectory(${SRC_DIR}/bench)
 endif()
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -858,6 +858,11 @@ CONF_Int64(object_storage_request_timeout_ms, "-1");
 // if this parameter is 0, use object_storage_request_timeout_ms instead.
 CONF_Int64(object_storage_rename_file_request_timeout_ms, "30000");
 
+// Retry strategy for read operation. The following two parameters are the default value of Aws
+// DefaultRetryStrategy
+CONF_Int64(object_storage_max_retries, "10");
+CONF_Int64(object_storage_retry_scale_factor, "25");
+
 CONF_Strings(fallback_to_hadoop_fs_list, "");
 CONF_Strings(s3_compatible_fs_list, "s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://");
 CONF_mBool(s3_use_list_objects_v1, "false");

--- a/be/src/fs/CMakeLists.txt
+++ b/be/src/fs/CMakeLists.txt
@@ -32,8 +32,11 @@ set(EXEC_FILES
     s3/poco_http_client.cpp
     s3/poco_common.cpp
     fs_util.cpp
-    fs_starlet.cpp
     )
+
+if (NOT BUILD_FORMAT_LIB)
+    list(APPEND EXEC_FILES fs_starlet.cpp)
+endif()
 
 add_library(FileSystem STATIC
     ${EXEC_FILES}

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -22,7 +22,7 @@
 #include "fs/fs_util.h"
 #include "fs/hdfs/fs_hdfs.h"
 #include "runtime/file_result_writer.h"
-#ifdef USE_STAROS
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
 #include "fs/fs_starlet.h"
 #endif
 
@@ -52,7 +52,7 @@ std::unique_ptr<RandomAccessFile> RandomAccessFile::from(std::unique_ptr<io::See
 static thread_local std::shared_ptr<FileSystem> tls_fs_posix;
 static thread_local std::shared_ptr<FileSystem> tls_fs_s3;
 static thread_local std::shared_ptr<FileSystem> tls_fs_hdfs;
-#ifdef USE_STAROS
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
 static thread_local std::shared_ptr<FileSystem> tls_fs_starlet;
 #endif
 
@@ -77,7 +77,7 @@ inline std::shared_ptr<FileSystem> get_tls_fs_s3() {
     return tls_fs_s3;
 }
 
-#ifdef USE_STAROS
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
 inline std::shared_ptr<FileSystem> get_tls_fs_starlet() {
     if (tls_fs_starlet == nullptr) {
         tls_fs_starlet.reset(new_fs_starlet().release());
@@ -86,7 +86,16 @@ inline std::shared_ptr<FileSystem> get_tls_fs_starlet() {
 }
 #endif
 
-StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::string_view uri, FSOptions options) {
+StatusOr<std::shared_ptr<FileSystem>> FileSystem::Create(std::string_view uri, const FSOptions& options) {
+    if (!options._fs_options.empty()) {
+        return FileSystem::CreateUniqueFromString(uri, options);
+    } else {
+        return FileSystem::CreateSharedFromString(uri);
+    }
+}
+
+StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::string_view uri,
+                                                                         const FSOptions& options) {
     if (fs::is_fallback_to_hadoop_fs(uri)) {
         return new_fs_hdfs(options);
     }
@@ -101,7 +110,7 @@ StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::st
         // Now Azure storage and Google Cloud Storage both are using LibHdfs, we can use cpp sdk instead in the future.
         return new_fs_hdfs(options);
     }
-#ifdef USE_STAROS
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
     if (is_starlet_uri(uri)) {
         return new_fs_starlet();
     }
@@ -121,7 +130,7 @@ StatusOr<std::shared_ptr<FileSystem>> FileSystem::CreateSharedFromString(std::st
     if (fs::is_s3_uri(uri)) {
         return get_tls_fs_s3();
     }
-#ifdef USE_STAROS
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
     if (is_starlet_uri(uri)) {
         return get_tls_fs_starlet();
     }

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -37,7 +37,7 @@ namespace starrocks {
 
 class GetHdfsFileReadOnlyHandle {
 public:
-    GetHdfsFileReadOnlyHandle(const FSOptions options, std::string path, int buffer_size)
+    GetHdfsFileReadOnlyHandle(const FSOptions& options, std::string path, int buffer_size)
             : _options(std::move(options)), _path(std::move(path)), _buffer_size(buffer_size) {}
 
     StatusOr<hdfsFS> getOrCreateFS() {
@@ -384,7 +384,7 @@ Status HDFSWritableFile::close() {
 
 class HdfsFileSystem : public FileSystem {
 public:
-    HdfsFileSystem(const FSOptions& options) : _options(options) {}
+    HdfsFileSystem(const FSOptions& options) : _options(std::move(options)) {}
     ~HdfsFileSystem() override = default;
 
     HdfsFileSystem(const HdfsFileSystem&) = delete;

--- a/be/src/gutil/CMakeLists.txt
+++ b/be/src/gutil/CMakeLists.txt
@@ -56,6 +56,8 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
     set(SOURCE_FILES ${SOURCE_FILES} atomicops-internals-x86.cc)
 endif()
 
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
 add_library(Gutil STATIC ${SOURCE_FILES})
 
 set_target_properties(Gutil PROPERTIES COMPILE_FLAGS "-funsigned-char -Wno-deprecated -Wno-char-subscripts")

--- a/be/src/io/s3_input_stream.cpp
+++ b/be/src/io/s3_input_stream.cpp
@@ -42,28 +42,79 @@ StatusOr<int64_t> S3InputStream::read(void* out, int64_t count) {
     if (_offset >= _size) {
         return 0;
     }
+    count = std::min(count, _size - _offset);
 
-    auto real_length = std::min<int64_t>(_offset + count, _size) - _offset;
+    // prefetch case:
+    // case1: pretech is disable: _read_ahead_size = -1     -> direct read from s3
+    // case2: read size greater than _read_ahead_size       -> direct read from s3
+    // case3: read range is in buffer                       -> copy from buffer
+    // case4: read start is in buffer, end is outof buffer  -> copy part data from buffer, load data from s3 to buffer, copy remain from buffer
+    // case5: read start is greater than buffer end         -> load data from s3 to buffer, copy from buffer
+    // case6: read start is lower than buffer start         -> load data from s3 to buffer, copy from buffer
+    if (count > _read_ahead_size) {
+        auto real_length = std::min<int64_t>(_offset + count, _size) - _offset;
 
-    // https://www.rfc-editor.org/rfc/rfc9110.html#name-range
-    auto range = fmt::format("bytes={}-{}", _offset, _offset + real_length - 1);
-    Aws::S3::Model::GetObjectRequest request;
-    request.SetBucket(_bucket);
-    request.SetKey(_object);
-    request.SetRange(std::move(range));
-    request.SetResponseStreamFactory([out, real_length]() {
-        return Aws::New<S3ZeroCopyIOStream>(AWS_ALLOCATE_TAG, reinterpret_cast<char*>(out), real_length);
-    });
+        // https://www.rfc-editor.org/rfc/rfc9110.html#name-range
+        auto range = fmt::format("bytes={}-{}", _offset, _offset + real_length - 1);
+        Aws::S3::Model::GetObjectRequest request;
+        request.SetBucket(_bucket);
+        request.SetKey(_object);
+        request.SetRange(std::move(range));
+        request.SetResponseStreamFactory([out, real_length]() {
+            return Aws::New<S3ZeroCopyIOStream>(AWS_ALLOCATE_TAG, reinterpret_cast<char*>(out), real_length);
+        });
 
-    Aws::S3::Model::GetObjectOutcome outcome = _s3client->GetObject(request);
-    if (outcome.IsSuccess()) {
-        if (UNLIKELY(outcome.GetResult().GetContentLength() != real_length)) {
-            return Status::InternalError("The response length is different from request length for io stream!");
+        Aws::S3::Model::GetObjectOutcome outcome = _s3client->GetObject(request);
+        if (outcome.IsSuccess()) {
+            if (UNLIKELY(outcome.GetResult().GetContentLength() != real_length)) {
+                return Status::InternalError("The response length is different from request length for io stream!");
+            }
+            _offset += real_length;
+            return real_length;
+        } else {
+            return make_error_status(outcome.GetError());
         }
-        _offset += real_length;
-        return real_length;
     } else {
-        return make_error_status(outcome.GetError());
+        int64_t remain_to_read_length = count;
+        int64_t copy_length = 0;
+        if (_offset >= _buffer_start_offset && _offset < _buffer_start_offset + _buffer_data_length) {
+            // case 3: read range is in buffer, copy from buffer and remain_to_read_length will be zero.
+            // case 4: read start is in buffer, end is outof buffer,
+            //         copy partial from buffer and remain_to_read_length will be > 0.
+            copy_length = std::min<int64_t>(count, _buffer_data_length - (_offset - _buffer_start_offset));
+            memcpy(static_cast<char*>(out), _read_buffer.get() + (_offset - _buffer_start_offset), copy_length);
+            remain_to_read_length = remain_to_read_length - copy_length;
+        }
+        if (remain_to_read_length > 0) {
+            // case 4,5,6, load data from s3
+            // case 4: load from s3 to buffer from offset: _buffer_start_offset + _buffer_data_length
+            // case 5,6: load from s3 to buffer from offset: _offset
+            int64_t read_start_offset = _offset;
+            if (_offset >= _buffer_start_offset && _offset < _buffer_start_offset + _buffer_data_length) {
+                read_start_offset = _buffer_start_offset + _buffer_data_length;
+            }
+            int64_t read_end_offset = std::min<int64_t>(read_start_offset + _read_ahead_size, _size);
+            auto range = fmt::format("bytes={}-{}", read_start_offset, read_end_offset);
+            Aws::S3::Model::GetObjectRequest request;
+            request.SetBucket(_bucket);
+            request.SetKey(_object);
+            request.SetRange(std::move(range));
+
+            Aws::S3::Model::GetObjectOutcome outcome = _s3client->GetObject(request);
+            if (outcome.IsSuccess()) {
+                Aws::IOStream& body = outcome.GetResult().GetBody();
+                int64_t read_length = read_end_offset - read_start_offset;
+                body.read(reinterpret_cast<char*>(_read_buffer.get()), read_length);
+                _buffer_start_offset = read_start_offset;
+                _buffer_data_length = body.gcount();
+            } else {
+                return make_error_status(outcome.GetError());
+            }
+            memcpy(static_cast<char*>(out) + copy_length, _read_buffer.get(), remain_to_read_length);
+            copy_length += remain_to_read_length;
+        }
+        _offset += copy_length;
+        return copy_length;
     }
 }
 

--- a/be/src/io/s3_input_stream.h
+++ b/be/src/io/s3_input_stream.h
@@ -27,8 +27,14 @@ namespace starrocks::io {
 
 class S3InputStream final : public SeekableInputStream {
 public:
-    explicit S3InputStream(std::shared_ptr<Aws::S3::S3Client> client, std::string bucket, std::string object)
-            : _s3client(std::move(client)), _bucket(std::move(bucket)), _object(std::move(object)) {}
+    explicit S3InputStream(std::shared_ptr<Aws::S3::S3Client> client, std::string bucket, std::string object,
+                           int64_t read_ahead_size = 5 * 1024 * 1024)
+            : _s3client(std::move(client)), _bucket(std::move(bucket)), _object(std::move(object)) {
+        _read_ahead_size = read_ahead_size;
+        if (_read_ahead_size > 0) {
+            _read_buffer = std::make_unique<uint8_t[]>(_read_ahead_size);
+        }
+    }
 
     ~S3InputStream() override = default;
 
@@ -52,12 +58,20 @@ public:
 
     StatusOr<std::string> read_all() override;
 
+    // only for UT
+    int64_t get_read_ahead_size() const { return _read_ahead_size; }
+
 private:
     std::shared_ptr<Aws::S3::S3Client> _s3client;
     std::string _bucket;
     std::string _object;
     int64_t _offset{0};
     int64_t _size{-1};
+    int64_t _read_ahead_size{-1};
+    // _read_buffer start offset, indicate buffer[0]'s offset in s3 file.
+    int64_t _buffer_start_offset{-1};
+    int64_t _buffer_data_length{-1};
+    std::unique_ptr<uint8_t[]> _read_buffer;
 };
 
 } // namespace starrocks::io

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -772,7 +772,9 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
     for (const auto& tdesc : thrift_tbl.slotDescriptors) {
         SlotDescriptor* slot_d = pool->add(new SlotDescriptor(tdesc));
         (*tbl)->_slot_desc_map[tdesc.id] = slot_d;
-
+        if (!slot_d->col_name().empty()) {
+            (*tbl)->_slot_with_column_name_map[tdesc.id] = slot_d;
+        }
         // link to parent
         auto entry = (*tbl)->_tuple_desc_map.find(tdesc.parent);
 
@@ -809,6 +811,17 @@ SlotDescriptor* DescriptorTbl::get_slot_descriptor(SlotId id) const {
     auto i = _slot_desc_map.find(id);
 
     if (i == _slot_desc_map.end()) {
+        return nullptr;
+    } else {
+        return i->second;
+    }
+}
+
+SlotDescriptor* DescriptorTbl::get_slot_descriptor_with_column(SlotId id) const {
+    // TODO: is there some boost function to do exactly this?
+    auto i = _slot_with_column_name_map.find(id);
+
+    if (i == _slot_with_column_name_map.end()) {
         return nullptr;
     } else {
         return i->second;

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -488,6 +488,7 @@ public:
     TableDescriptor* get_table_descriptor(TableId id) const;
     TupleDescriptor* get_tuple_descriptor(TupleId id) const;
     SlotDescriptor* get_slot_descriptor(SlotId id) const;
+    SlotDescriptor* get_slot_descriptor_with_column(SlotId id) const;
 
     // return all registered tuple descriptors
     void get_tuple_descs(std::vector<TupleDescriptor*>* descs) const;
@@ -502,6 +503,7 @@ private:
     TableDescriptorMap _tbl_desc_map;
     TupleDescriptorMap _tuple_desc_map;
     SlotDescriptorMap _slot_desc_map;
+    SlotDescriptorMap _slot_with_column_name_map;
 
     DescriptorTbl() = default;
 };

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -507,8 +507,8 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
         exit(-1);
     }
 
-#if defined(USE_STAROS) && !defined(BE_TEST)
-    _lake_location_provider = new lake::StarletLocationProvider();
+#if defined(USE_STAROS) && !defined(BE_TEST) && !defined(BUILD_FORMAT_LIB)
+    _lake_location_provider = std::make_shared<lake::StarletLocationProvider>();
     _lake_update_manager =
             new lake::UpdateManager(_lake_location_provider, GlobalEnv::GetInstance()->update_mem_tracker());
     _lake_tablet_manager =
@@ -524,7 +524,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     }
 
 #elif defined(BE_TEST)
-    _lake_location_provider = new lake::FixedLocationProvider(_store_paths.front().path);
+    _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);
     _lake_update_manager =
             new lake::UpdateManager(_lake_location_provider, GlobalEnv::GetInstance()->update_mem_tracker());
     _lake_tablet_manager =
@@ -701,7 +701,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_stream_mgr);
     SAFE_DELETE(_external_scan_context_mgr);
     SAFE_DELETE(_lake_tablet_manager);
-    SAFE_DELETE(_lake_location_provider);
     SAFE_DELETE(_lake_update_manager);
     SAFE_DELETE(_lake_replication_txn_manager);
     SAFE_DELETE(_cache_mgr);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -314,7 +314,7 @@ public:
 
     lake::TabletManager* lake_tablet_manager() const { return _lake_tablet_manager; }
 
-    lake::LocationProvider* lake_location_provider() const { return _lake_location_provider; }
+    std::shared_ptr<lake::LocationProvider> lake_location_provider() const { return _lake_location_provider; }
 
     lake::UpdateManager* lake_update_manager() const { return _lake_update_manager; }
 
@@ -389,7 +389,7 @@ private:
     ProfileReportWorker* _profile_report_worker = nullptr;
 
     lake::TabletManager* _lake_tablet_manager = nullptr;
-    lake::LocationProvider* _lake_location_provider = nullptr;
+    std::shared_ptr<lake::LocationProvider> _lake_location_provider;
     lake::UpdateManager* _lake_update_manager = nullptr;
     lake::ReplicationTxnManager* _lake_replication_txn_manager = nullptr;
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -875,7 +875,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
             LOG(WARNING) << "tuple descriptor is null. id: " << slot_ref.tuple_id;
             return Status::InvalidArgument("tuple descriptor is null");
         }
-        auto* slot_desc = desc_tbl->get_slot_descriptor(slot_ref.slot_id);
+        auto* slot_desc = desc_tbl->get_slot_descriptor_with_column(slot_ref.slot_id);
         if (slot_desc == nullptr) {
             LOG(WARNING) << "slot descriptor is null. id: " << slot_ref.slot_id;
             return Status::InvalidArgument("slot descriptor is null");

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -239,7 +239,7 @@ public:
     // MIN_DATE | 0
     static const Timestamp MIN_TIMESTAMP = (1892325482100162560LL);
 
-    // seconds from 1970.01.01
+    // seconds since julian date epoch to 1970.01.01
     static const Timestamp UNIX_EPOCH_SECONDS = (210866803200LL);
 };
 

--- a/be/src/script/CMakeLists.txt
+++ b/be/src/script/CMakeLists.txt
@@ -21,6 +21,8 @@ set(EXEC_FILES
     ../thirdparty/wren/wren.c
 )
 
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
 add_library(Script STATIC ${EXEC_FILES})
 
 target_include_directories(Script PRIVATE ${SRC_DIR}/script ${SRC_DIR}/thirdparty/wren ${SRC_DIR}/thirdparty/wrenbind17)

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(Service
 )
 
 # only build starrocks_be when TEST is off
-if (NOT ${MAKE_TEST} STREQUAL "ON")
+if ((NOT ${MAKE_TEST} STREQUAL "ON") AND (NOT BUILD_FORMAT_LIB))
     add_executable(starrocks_be
         starrocks_main.cpp
         )

--- a/be/src/starrocks_format/CMakeLists.txt
+++ b/be/src/starrocks_format/CMakeLists.txt
@@ -1,0 +1,82 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/starrocks_format")
+
+# where to put generated binaries
+set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/starrocks_format")
+
+# Set starrocks libraries
+set(STARROCKS_LIBS
+    ${WL_START_GROUP}
+    Common
+    Column
+    Connector
+    Exec
+    Exprs
+    FileSystem
+    Formats
+    Gutil
+    IO
+    Serde
+    Storage
+    Rowset
+    Runtime
+    Types
+    Util
+    Script
+    StarRocksGen
+    Webserver
+    TestUtil
+    BlockCache
+    ${WL_END_GROUP}
+)
+
+add_library(hdfs_so SHARED IMPORTED GLOBAL)
+set_target_properties(hdfs_so PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/hadoop/lib/native/libhdfs.so)
+
+set(STARROCKS_THIRDPARTY_DEPENDENCIES
+    ${STARROCKS_DEPENDENCIES}
+    ${STARROCKS_STD_DEPENDENCIES}
+    ${STARROCKS_MEMORY_DEPENDENCIES_LIBS}
+    ${STARROCKS_DYNAMIC_DEPENDENCIES_LIBS}
+)
+
+# only build starrocks_be when TEST is off
+if (NOT ${MAKE_TEST} STREQUAL "ON")
+
+    add_library(starrocks_format SHARED
+        starrocks_lib.cpp
+        )
+
+    # This permits libraries loaded by dlopen to link to the symbols in the program.
+    target_link_libraries(starrocks_format
+        # -Wl,--whole-archive
+         ${STARROCKS_LIBS}
+        #   -Wl,--no-whole-archive
+        ${STARROCKS_DEPENDENCIES}
+        ${STARROCKS_STD_DEPENDENCIES}
+        ${STARROCKS_DYNAMIC_DEPENDENCIES_LIBS}
+        hdfs_so
+    )
+
+    install(DIRECTORY DESTINATION ${OUTPUT_DIR}/format-lib/)
+
+    install(TARGETS starrocks_format
+        DESTINATION ${OUTPUT_DIR}/format-lib/)
+
+endif()

--- a/be/src/starrocks_format/starrocks_lib.cpp
+++ b/be/src/starrocks_format/starrocks_lib.cpp
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <aws/core/Aws.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <glog/logging.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include "common/config.h"
+#include "fs/fs_s3.h"
+#include "runtime/time_types.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/olap_define.h"
+#include "util/timezone_utils.h"
+
+namespace starrocks::lake {
+
+static bool _starrocks_format_inited = false;
+Aws::SDKOptions aws_sdk_options;
+
+lake::TabletManager* _lake_tablet_manager = nullptr;
+
+void starrocks_format_initialize(void) {
+    setenv("STARROCKS_HOME", "./", 0);
+    setenv("UDF_RUNTIME_DIR", "./", 0);
+
+    if (!_starrocks_format_inited) {
+        fprintf(stderr, "starrocks format module start to initialize\n");
+        // load config file
+        std::string conffile = std::filesystem::current_path();
+        conffile += "/starrocks.conf";
+        const char* config_file_path = conffile.c_str();
+        std::ifstream ifs(config_file_path);
+        if (!ifs.good()) {
+            config_file_path = nullptr;
+        }
+        if (!starrocks::config::init(config_file_path)) {
+            LOG(WARNING) << "read config file:" << config_file_path << " failed!";
+            return;
+        }
+
+        Aws::InitAPI(aws_sdk_options);
+
+        date::init_date_cache();
+
+        TimezoneUtils::init_time_zones();
+
+        auto lake_location_provider = std::make_shared<FixedLocationProvider>("");
+        _lake_tablet_manager = new lake::TabletManager(lake_location_provider, config::lake_metadata_cache_limit);
+        LOG(INFO) << "starrocks format module has been initialized successfully";
+        _starrocks_format_inited = true;
+    } else {
+        LOG(INFO) << "starrocks format module has already been initialized";
+    }
+}
+
+void starrocks_format_shutdown(void) {
+    if (_starrocks_format_inited) {
+        LOG(INFO) << "starrocks format module start to deinitialize";
+        Aws::ShutdownAPI(aws_sdk_options);
+        SAFE_DELETE(_lake_tablet_manager);
+        // SAFE_DELETE(_lake_update_manager);
+        LOG(INFO) << "starrocks format module has been deinitialized successfully";
+    } else {
+        LOG(INFO) << "starrocks format module has already been deinitialized";
+    }
+}
+
+} // namespace starrocks::lake

--- a/be/src/starrocks_format/starrocks_lib.h
+++ b/be/src/starrocks_format/starrocks_lib.h
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/lake/tablet_manager.h"
+
+namespace starrocks::lake {
+
+extern lake::TabletManager* _lake_tablet_manager;
+
+void starrocks_format_initialize(void);
+
+void starrocks_format_shutdown(void);
+
+} // namespace starrocks::lake

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -19,7 +19,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/storage")
 
 add_subdirectory(rowset)
 
-add_library(Storage STATIC
+set(STORAGE_FILES
     aggregate_type.cpp
     base_tablet.cpp
     decimal12.cpp
@@ -224,6 +224,7 @@ add_library(Storage STATIC
     sstable/iterator.cpp
     sstable/options.cpp
     sstable/merger.cpp
+    lake/lake_delvec_loader.cpp
     binlog_util.cpp
     binlog_file_writer.cpp
     binlog_file_reader.cpp
@@ -234,6 +235,7 @@ add_library(Storage STATIC
     lake/txn_log_applier.cpp
     lake/lake_local_persistent_index.cpp
     persistent_index_compaction_manager.cpp
+    lake/local_pk_index_manager.cpp
     persistent_index_tablet_loader.cpp
     lake/lake_local_persistent_index_tablet_loader.cpp
     lake/lake_persistent_index.cpp
@@ -263,3 +265,11 @@ add_library(Storage STATIC
     index/vector/tenann/del_id_filter.cpp
     index/vector/tenann/tenann_index_builder.cpp
     index/vector/tenann/tenann_index_utils.cpp)
+
+if (NOT BUILD_FORMAT_LIB)
+    list(APPEND STORAGE_FILES  lake/starlet_location_provider.cpp)
+endif()
+
+add_library(Storage STATIC
+    ${STORAGE_FILES}
+)

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -145,9 +145,9 @@ StatusOr<int32_t> HorizontalCompactionTask::calculate_chunk_size() {
         total_num_rows += rowset->num_rows();
         total_input_segs += rowset->is_overlapped() ? rowset->num_segments() : 1;
         LakeIOOptions lake_io_opts{.fill_data_cache = false,
-                                   .buffer_size = config::lake_compaction_stream_buffer_size_bytes};
-        auto fill_meta_cache = false;
-        ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts, fill_meta_cache));
+                                   .buffer_size = config::lake_compaction_stream_buffer_size_bytes,
+                                   .fill_metadata_cache = false};
+        ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts));
         for (auto& segment : segments) {
             for (size_t i = 0; i < segment->num_columns(); ++i) {
                 auto uid = _tablet_schema->column(i).unique_id();

--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/lake_delvec_loader.h"
+
+#include "common/logging.h"
+#include "common/status.h"
+#include "storage/lake/location_provider.h"
+
+namespace starrocks::lake {
+
+Status LakeDelvecLoader::load(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec) {
+    if (_pk_builder != nullptr) {
+        // 1. find in meta builder first
+        auto found = _pk_builder->find_delvec(tsid, pdelvec);
+        if (!found.ok()) {
+            return found.status();
+        }
+        if (*found) {
+            return Status::OK();
+        }
+    }
+    return load_from_file(tsid, version, pdelvec);
+}
+
+Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec) {
+    (*pdelvec).reset(new DelVector());
+    // 2. find in delvec file
+    std::string filepath = _tablet_manager->tablet_metadata_location(tsid.tablet_id, version);
+    ASSIGN_OR_RETURN(auto metadata, _tablet_manager->get_tablet_metadata(_lake_io_opts.fs, filepath, _fill_cache));
+    RETURN_IF_ERROR(
+            lake::get_del_vec(_tablet_manager, *metadata, tsid.segment_id, _fill_cache, _lake_io_opts, pdelvec->get()));
+    return Status::OK();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/lake_delvec_loader.h
+++ b/be/src/storage/lake/lake_delvec_loader.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "common/statusor.h"
+#include "storage/del_vector.h"
+#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/update_manager.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage/olap_common.h"
+
+namespace starrocks::lake {
+
+class LakeDelvecLoader : public DelvecLoader {
+public:
+    LakeDelvecLoader(TabletManager* tablet_manager, const MetaFileBuilder* pk_builder, bool fill_cache,
+                     LakeIOOptions lake_io_opts)
+            : _tablet_manager(tablet_manager),
+              _pk_builder(pk_builder),
+              _fill_cache(fill_cache),
+              _lake_io_opts(std::move(lake_io_opts)) {}
+    Status load(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec);
+    Status load_from_file(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec);
+
+private:
+    TabletManager* _tablet_manager;
+    const MetaFileBuilder* _pk_builder = nullptr;
+    bool _fill_cache = false;
+    LakeIOOptions _lake_io_opts;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -17,6 +17,7 @@
 #include "runtime/exec_env.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/lake_delvec_loader.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/lake/update_manager.h"
@@ -47,7 +48,10 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     ASSIGN_OR_RETURN(auto segment_iters, _rowset->get_each_segment_iterator(pkey_schema, false, &stats));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset->num_segments());
     // init delvec loader
-    auto delvec_loader = std::make_unique<LakeDelvecLoader>(_update_manager, _builder, false /* fill cache */);
+    SegmentReadOptions seg_options;
+
+    auto delvec_loader =
+            std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, false /* fill cache */, seg_options.lake_io_opts);
     // init params
     CompactConflictResolveParams params;
     params.tablet_id = _rowset->tablet_id();

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
@@ -16,6 +16,7 @@
 
 #include "storage/lake/tablet_metadata.h"
 #include "storage/primary_key_compaction_conflict_resolver.h"
+#include "storage/tablet_manager.h"
 
 namespace starrocks::lake {
 
@@ -27,13 +28,13 @@ class LakePrimaryIndex;
 class LakePrimaryKeyCompactionConflictResolver : public PrimaryKeyCompactionConflictResolver {
 public:
     explicit LakePrimaryKeyCompactionConflictResolver(const TabletMetadata* metadata, Rowset* rowset,
-                                                      UpdateManager* update_manager, MetaFileBuilder* builder,
+                                                      TabletManager* tablet_mgr, MetaFileBuilder* builder,
                                                       LakePrimaryIndex* index, int64_t txn_id, int64_t base_version,
                                                       std::map<uint32_t, size_t>* segment_id_to_add_dels,
                                                       std::vector<std::pair<uint32_t, DelVectorPtr>>* delvecs)
             : _metadata(metadata),
               _rowset(rowset),
-              _update_manager(update_manager),
+              _tablet_mgr(tablet_mgr),
               _builder(builder),
               _index(index),
               _txn_id(txn_id),
@@ -53,7 +54,7 @@ private:
     // input
     const TabletMetadata* _metadata = nullptr;
     Rowset* _rowset = nullptr;
-    UpdateManager* _update_manager = nullptr;
+    TabletManager* _tablet_mgr = nullptr;
     MetaFileBuilder* _builder = nullptr;
     LakePrimaryIndex* _index = nullptr;
     int64_t _txn_id = 0;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -519,7 +519,7 @@ void MetaFileBuilder::finalize_sstable_meta(const PersistentIndexSstableMetaPB& 
 }
 
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, uint32_t segment_id, bool fill_cache,
-                   DelVector* delvec) {
+                   const LakeIOOptions& lake_io_opts, DelVector* delvec) {
     // find delvec by segment id
     auto iter = metadata.delvec_meta().delvecs().find(segment_id);
     if (iter != metadata.delvec_meta().delvecs().end()) {
@@ -542,9 +542,16 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, ui
             return Status::InternalError("Can't find delvec file name");
         }
         const auto& delvec_name = iter2->second.name();
-        RandomAccessFileOptions opts{.skip_fill_local_cache = !fill_cache};
-        ASSIGN_OR_RETURN(auto rf,
-                         fs::new_random_access_file(opts, tablet_mgr->delvec_location(metadata.id(), delvec_name)));
+        RandomAccessFileOptions opts{.skip_fill_local_cache = !lake_io_opts.fill_data_cache};
+        std::unique_ptr<RandomAccessFile> rf;
+        if (lake_io_opts.fs && lake_io_opts.location_provider) {
+            ASSIGN_OR_RETURN(
+                    rf, lake_io_opts.fs->new_random_access_file(
+                                opts, lake_io_opts.location_provider->delvec_location(metadata.id(), delvec_name)));
+        } else {
+            ASSIGN_OR_RETURN(rf,
+                             fs::new_random_access_file(opts, tablet_mgr->delvec_location(metadata.id(), delvec_name)));
+        }
         RETURN_IF_ERROR(rf->read_at_fully(iter->second.offset(), buf.data(), iter->second.size()));
         // parse delvec
         RETURN_IF_ERROR(delvec->load(iter->second.version(), buf.data(), iter->second.size()));

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -89,7 +89,7 @@ private:
 };
 
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, uint32_t segment_id, bool fill_cache,
-                   DelVector* delvec);
+                   const LakeIOOptions& lake_io_opts, DelVector* delvec);
 bool is_primary_key(TabletMetadata* metadata);
 bool is_primary_key(const TabletMetadata& metadata);
 

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -19,6 +19,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/delete_predicates.h"
 #include "storage/lake/column_mode_partial_update_handler.h"
+#include "storage/lake/lake_delvec_loader.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
@@ -96,9 +97,11 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
     DCHECK(partial_segments_compaction());
 
     std::vector<SegmentPtr> segments;
-    std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>> not_used_segments;
     LakeIOOptions lake_io_opts{.fill_data_cache = true};
-    RETURN_IF_ERROR(load_segments(&segments, lake_io_opts, true /* fill_metadata_cache */, &not_used_segments));
+    SegmentReadOptions seg_options;
+    seg_options.lake_io_opts = lake_io_opts;
+    std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>> not_used_segments;
+    RETURN_IF_ERROR(load_segments(&segments, seg_options, &not_used_segments));
 
     bool clear_file_size_info = false;
     bool clear_encryption_meta = (metadata().segments_size() != metadata().segment_encryption_metas_size());
@@ -169,9 +172,13 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
 }
 
 StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const RowsetReadOptions& options) {
-    auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
     SegmentReadOptions seg_options;
-    ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(root_loc));
+    if (options.lake_io_opts.fs) {
+        seg_options.fs = options.lake_io_opts.fs;
+    } else {
+        auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
+        ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(root_loc));
+    }
     seg_options.stats = options.stats;
     seg_options.ranges = options.ranges;
     seg_options.pred_tree = options.pred_tree;
@@ -190,8 +197,8 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     seg_options.has_preaggregation = options.has_preaggregation;
     if (options.is_primary_keys) {
         seg_options.is_primary_keys = true;
-        seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(_tablet_mgr->update_mgr(), nullptr,
-                                                                       seg_options.lake_io_opts.fill_data_cache);
+        seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(
+                _tablet_mgr, nullptr, seg_options.lake_io_opts.fill_data_cache, seg_options.lake_io_opts);
         seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
         seg_options.version = options.version;
         seg_options.tablet_id = tablet_id();
@@ -204,6 +211,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     if (options.short_key_ranges_option != nullptr) { // logical split.
         seg_options.short_key_ranges = options.short_key_ranges_option->short_key_ranges;
     }
+    seg_options.reader_type = options.reader_type;
 
     std::unique_ptr<Schema> segment_schema_guard;
     auto* segment_schema = const_cast<Schema*>(&schema);
@@ -230,7 +238,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     }
 
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(load_segments(&segments, options.lake_io_opts.fill_data_cache, options.lake_io_opts.buffer_size));
+    RETURN_IF_ERROR(load_segments(&segments, seg_options, nullptr));
     for (auto& seg_ptr : segments) {
         if (seg_ptr->num_rows() == 0) {
             continue;
@@ -326,9 +334,11 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     SegmentReadOptions seg_options;
     ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(root_loc));
     seg_options.stats = stats;
+    seg_options.lake_io_opts.fs = seg_options.fs;
+    seg_options.lake_io_opts.location_provider = _tablet_mgr->location_provider();
     seg_options.is_primary_keys = true;
     seg_options.delvec_loader =
-            std::make_shared<LakeDelvecLoader>(_tablet_mgr->update_mgr(), builder, true /*fill cache*/);
+            std::make_shared<LakeDelvecLoader>(_tablet_mgr, builder, true /*fill cache*/, seg_options.lake_io_opts);
     seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
     seg_options.version = version;
     seg_options.tablet_id = tablet_id();
@@ -366,25 +376,29 @@ std::vector<SegmentSharedPtr> Rowset::get_segments() {
 }
 
 StatusOr<std::vector<SegmentPtr>> Rowset::segments(bool fill_cache) {
-    LakeIOOptions lake_io_opts{.fill_data_cache = fill_cache};
-    return segments(lake_io_opts, fill_cache);
+    LakeIOOptions lake_io_opts{.fill_data_cache = fill_cache, .fill_metadata_cache = fill_cache};
+    return segments(lake_io_opts);
 }
 
-StatusOr<std::vector<SegmentPtr>> Rowset::segments(const LakeIOOptions& lake_io_opts, bool fill_metadata_cache) {
+StatusOr<std::vector<SegmentPtr>> Rowset::segments(const LakeIOOptions& lake_io_opts) {
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(load_segments(&segments, lake_io_opts, fill_metadata_cache, nullptr));
+    SegmentReadOptions seg_options;
+    seg_options.lake_io_opts = lake_io_opts;
+    RETURN_IF_ERROR(load_segments(&segments, seg_options, nullptr));
     return segments;
 }
 
 Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_cache, int64_t buffer_size) {
-    LakeIOOptions lake_io_opts{.fill_data_cache = fill_cache, .buffer_size = buffer_size};
-    return load_segments(segments, lake_io_opts, fill_cache, nullptr);
+    SegmentReadOptions seg_options;
+    seg_options.lake_io_opts.fill_data_cache = fill_cache;
+    seg_options.lake_io_opts.fill_metadata_cache = fill_cache;
+    seg_options.lake_io_opts.buffer_size = buffer_size;
+    return load_segments(segments, seg_options, nullptr);
 }
 
-Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOptions& lake_io_opts,
-                             bool fill_metadata_cache,
+Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptions& seg_options,
                              std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>>* not_used_segments) {
-#ifndef BE_TEST
+#if !defined BE_TEST && !defined(BUILD_FORMAT_LIB)
     RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("LoadSegments"));
 #endif
 
@@ -418,8 +432,14 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
     };
 
     for (const auto& seg_name : metadata().segments()) {
-        auto segment_path = _tablet_mgr->segment_location(tablet_id(), seg_name);
-        auto segment_info = FileInfo{.path = segment_path};
+        std::string segment_path;
+        auto lake_io_opts = seg_options.lake_io_opts;
+        if (lake_io_opts.location_provider) {
+            segment_path = lake_io_opts.location_provider->segment_location(tablet_id(), seg_name);
+        } else {
+            segment_path = _tablet_mgr->segment_location(tablet_id(), seg_name);
+        }
+        auto segment_info = FileInfo{.path = segment_path, .fs = seg_options.fs};
         if (LIKELY(has_segment_size)) {
             segment_info.size = files_to_size.Get(index);
         }
@@ -437,8 +457,8 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
 
         if (_parallel_load) {
             auto task = std::make_shared<std::packaged_task<std::pair<StatusOr<SegmentPtr>, std::string>()>>([=]() {
-                auto result = _tablet_mgr->load_segment(segment_info, seg_id, lake_io_opts, fill_metadata_cache,
-                                                        _tablet_schema);
+                auto result = _tablet_mgr->load_segment(segment_info, seg_id, lake_io_opts,
+                                                        lake_io_opts.fill_metadata_cache, _tablet_schema);
                 return std::make_pair(std::move(result), seg_name);
             });
 
@@ -449,7 +469,7 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
                 LOG(WARNING) << "sumbit_func failed: " << st.code_as_string()
                              << ", try to load segment serially, seg_id: " << seg_id;
                 auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id, &footer_size_hint, lake_io_opts,
-                                                            fill_metadata_cache, _tablet_schema);
+                                                            lake_io_opts.fill_metadata_cache, _tablet_schema);
                 if (auto status = check_status(segment_or, seg_name); !status.ok()) {
                     return status;
                 }
@@ -458,7 +478,7 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
             segment_futures.push_back(task->get_future());
         } else {
             auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, lake_io_opts,
-                                                        fill_metadata_cache, _tablet_schema);
+                                                        lake_io_opts.fill_metadata_cache, _tablet_schema);
             if (auto status = check_status(segment_or, seg_name); !status.ok()) {
                 return status;
             }

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -108,13 +108,13 @@ public:
 
     StatusOr<std::vector<SegmentPtr>> segments(bool fill_cache);
 
-    StatusOr<std::vector<SegmentPtr>> segments(const LakeIOOptions& lake_io_opts, bool fill_metadata_cache);
+    [[nodiscard]] StatusOr<std::vector<SegmentPtr>> segments(const LakeIOOptions& lake_io_opts);
 
     // `fill_cache` controls `fill_data_cache` and `fill_meta_cache`
     Status load_segments(std::vector<SegmentPtr>* segments, bool fill_cache, int64_t buffer_size = -1);
 
-    Status load_segments(std::vector<SegmentPtr>* segments, const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
-                         std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>>* not_used_segments);
+    [[nodiscard]] Status load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptions& seg_options,
+                                       std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>>* not_used_segments);
 
     int64_t tablet_id() const { return _tablet_id; }
 

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -20,6 +20,7 @@
 #include "runtime/exec_env.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/general_tablet_writer.h"
+#include "storage/lake/location_provider.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/metadata_iterator.h"
 #include "storage/lake/pk_tablet_writer.h"
@@ -108,7 +109,13 @@ const std::shared_ptr<const TabletSchema> Tablet::tablet_schema() const {
 }
 
 StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema() {
-    return _mgr->get_tablet_schema(_id, &_version_hint);
+    if (_tablet_schema) {
+        return _tablet_schema;
+    } else if (_tablet_metadata) {
+        return std::make_shared<TabletSchema>(_tablet_metadata->schema());
+    } else {
+        return _mgr->get_tablet_schema(_id, &_version_hint);
+    }
 }
 
 StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema_by_id(int64_t schema_id) {
@@ -125,15 +132,15 @@ std::vector<RowsetPtr> Tablet::get_rowsets(const TabletMetadataPtr& metadata) {
 }
 
 std::string Tablet::metadata_location(int64_t version) const {
-    return _mgr->tablet_metadata_location(_id, version);
+    return _location_provider->tablet_metadata_location(_id, version);
 }
 
 std::string Tablet::metadata_root_location() const {
-    return _mgr->tablet_metadata_root_location(_id);
+    return _location_provider->metadata_root_location(_id);
 }
 
 std::string Tablet::txn_log_location(int64_t txn_id) const {
-    return _mgr->txn_log_location(_id, txn_id);
+    return _location_provider->txn_log_location(_id, txn_id);
 }
 
 std::string Tablet::txn_slog_location(int64_t txn_id) const {
@@ -141,19 +148,19 @@ std::string Tablet::txn_slog_location(int64_t txn_id) const {
 }
 
 std::string Tablet::txn_vlog_location(int64_t version) const {
-    return _mgr->txn_vlog_location(_id, version);
+    return _location_provider->txn_vlog_location(_id, version);
 }
 
 std::string Tablet::segment_location(std::string_view segment_name) const {
-    return _mgr->segment_location(_id, segment_name);
+    return _location_provider->segment_location(_id, segment_name);
 }
 
 std::string Tablet::del_location(std::string_view del_name) const {
-    return _mgr->del_location(_id, del_name);
+    return _location_provider->del_location(_id, del_name);
 }
 
 std::string Tablet::delvec_location(std::string_view delvec_name) const {
-    return _mgr->delvec_location(_id, delvec_name);
+    return _location_provider->delvec_location(_id, delvec_name);
 }
 
 std::string Tablet::sst_location(std::string_view sst_name) const {
@@ -161,7 +168,7 @@ std::string Tablet::sst_location(std::string_view sst_name) const {
 }
 
 std::string Tablet::root_location() const {
-    return _mgr->tablet_root_location(_id);
+    return _location_provider->root_location(_id);
 }
 
 Status Tablet::delete_data(int64_t txn_id, const DeletePredicatePB& delete_predicate) {

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -19,6 +19,7 @@
 #include <string_view>
 
 #include "common/statusor.h"
+#include "fs/fs.h"
 #include "gen_cpp/types.pb.h"
 #include "storage/base_tablet.h"
 #include "storage/lake/metadata_iterator.h"
@@ -48,7 +49,25 @@ enum WriterType : int;
 
 class Tablet : public BaseTablet {
 public:
-    explicit Tablet(TabletManager* mgr, int64_t id) : _mgr(mgr), _id(id) {}
+    explicit Tablet(TabletManager* mgr, int64_t id) : _mgr(mgr), _id(id) {
+        if (_mgr != nullptr) {
+            _location_provider = _mgr->location_provider();
+        }
+    }
+
+    explicit Tablet(TabletManager* mgr, int64_t id, std::shared_ptr<LocationProvider> location_provider,
+                    TabletMetadataPtr tablet_metadata)
+            : _mgr(mgr), _id(id) {
+        _location_provider = std::move(location_provider);
+        _tablet_metadata = tablet_metadata;
+    }
+
+    explicit Tablet(TabletManager* mgr, int64_t id, std::shared_ptr<LocationProvider> location_provider,
+                    std::shared_ptr<TabletSchema> tablet_schema)
+            : _mgr(mgr), _id(id) {
+        _location_provider = std::move(location_provider);
+        _tablet_schema = tablet_schema;
+    }
 
     ~Tablet() override = default;
 
@@ -137,12 +156,17 @@ public:
 
     int64_t data_size();
 
+    const std::shared_ptr<LocationProvider>& location_provider() const { return _location_provider; }
+
     size_t num_rows() const override;
 
 private:
     TabletManager* _mgr;
     int64_t _id;
     int64_t _version_hint = 0;
+    std::shared_ptr<LocationProvider> _location_provider;
+    TabletMetadataPtr _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -60,13 +60,17 @@ static bvar::LatencyRecorder g_get_txn_log_latency("lake", "get_txn_log");
 static bvar::LatencyRecorder g_put_txn_log_latency("lake", "put_txn_log");
 static bvar::LatencyRecorder g_del_txn_log_latency("lake", "del_txn_log");
 
-TabletManager::TabletManager(LocationProvider* location_provider, UpdateManager* update_mgr, int64_t cache_capacity)
-        : _location_provider(location_provider),
+TabletManager::TabletManager(std::shared_ptr<LocationProvider> location_provider, UpdateManager* update_mgr,
+                             int64_t cache_capacity)
+        : _location_provider(std::move(location_provider)),
           _metacache(std::make_unique<Metacache>(cache_capacity)),
           _compaction_scheduler(std::make_unique<CompactionScheduler>(this)),
           _update_mgr(update_mgr) {
     _update_mgr->set_tablet_mgr(this);
 }
+
+TabletManager::TabletManager(std::shared_ptr<LocationProvider> location_provider, int64_t cache_capacity)
+        : _location_provider(std::move(location_provider)), _metacache(std::make_unique<Metacache>(cache_capacity)) {}
 
 TabletManager::~TabletManager() = default;
 
@@ -231,11 +235,12 @@ Status TabletManager::put_tablet_metadata(const TabletMetadata& metadata) {
     return put_tablet_metadata(std::move(metadata_ptr));
 }
 
-StatusOr<TabletMetadataPtr> TabletManager::load_tablet_metadata(const string& metadata_location, bool fill_cache) {
+StatusOr<TabletMetadataPtr> TabletManager::load_tablet_metadata(std::shared_ptr<FileSystem> fs,
+                                                                const string& metadata_location, bool fill_cache) {
     TEST_ERROR_POINT("TabletManager::load_tablet_metadata");
     auto t0 = butil::gettimeofday_us();
     auto metadata = std::make_shared<TabletMetadataPB>();
-    ProtobufFile file(metadata_location);
+    ProtobufFile file(metadata_location, std::move(fs));
     RETURN_IF_ERROR(file.load(metadata.get(), fill_cache));
     g_get_tablet_metadata_latency << (butil::gettimeofday_us() - t0);
     return std::move(metadata);
@@ -259,11 +264,17 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
 }
 
 StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& path, bool fill_cache) {
+    std::shared_ptr<FileSystem> fs;
+    return get_tablet_metadata(fs, path, fill_cache);
+}
+
+StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(std::shared_ptr<FileSystem> fs, const string& path,
+                                                               bool fill_cache) {
     if (auto ptr = _metacache->lookup_tablet_metadata(path); ptr != nullptr) {
         TRACE("got cached tablet metadata");
         return ptr;
     }
-    ASSIGN_OR_RETURN(auto ptr, load_tablet_metadata(path, fill_cache));
+    ASSIGN_OR_RETURN(auto ptr, load_tablet_metadata(std::move(fs), path, fill_cache));
     if (fill_cache) {
         _metacache->cache_tablet_metadata(path, ptr);
     }
@@ -494,7 +505,7 @@ StatusOr<int64_t> TabletManager::get_tablet_num_rows(int64_t tablet_id, int64_t 
     return num_rows;
 }
 
-#ifdef USE_STAROS
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
 bool TabletManager::is_tablet_in_worker(int64_t tablet_id) {
     bool in_worker = true;
     if (g_worker != nullptr) {
@@ -517,7 +528,7 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id, in
     RETURN_IF(ptr != nullptr, ptr);
 
     // Cache miss, load tablet metadata from remote storage use the hint version
-#ifdef USE_STAROS
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
     // TODO: Eliminate the explicit dependency on staros worker
     // 2. leverage `indexId` to lookup the global_schema from cache and if missing from file.
     if (g_worker != nullptr) {
@@ -771,7 +782,12 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
     //       but in meta cache, segment `a` still has segment id 10, it is not changed.
     auto segment = metacache()->lookup_segment(segment_info.path);
     if (segment == nullptr) {
-        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_info.path));
+        std::shared_ptr<FileSystem> fs;
+        if (segment_info.fs) {
+            fs = segment_info.fs;
+        } else {
+            ASSIGN_OR_RETURN(fs, FileSystem::CreateSharedFromString(segment_info.path));
+        }
         segment = std::make_shared<Segment>(std::move(fs), segment_info, segment_id, std::move(tablet_schema), this);
         if (fill_metadata_cache) {
             // NOTE: the returned segment may be not the same as the parameter passed in

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -57,7 +57,10 @@ public:
     // this TabletManager.
     // |cache_capacity| is the max number of bytes can be used by the
     // metadata cache.
-    explicit TabletManager(LocationProvider* location_provider, UpdateManager* update_mgr, int64_t cache_capacity);
+    explicit TabletManager(std::shared_ptr<LocationProvider> location_provider, UpdateManager* update_mgr,
+                           int64_t cache_capacity);
+
+    explicit TabletManager(std::shared_ptr<LocationProvider> location_provider, int64_t cache_capacity);
 
     ~TabletManager();
 
@@ -77,8 +80,9 @@ public:
 
     StatusOr<TabletMetadataPtr> get_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_cache = true);
 
-    // Do not use this function except in a list dir
     StatusOr<TabletMetadataPtr> get_tablet_metadata(const std::string& path, bool fill_cache = true);
+    StatusOr<TabletMetadataPtr> get_tablet_metadata(std::shared_ptr<FileSystem> fs, const std::string& path,
+                                                    bool fill_cache = true);
 
     TabletMetadataPtr get_latest_cached_tablet_metadata(int64_t tablet_id);
 
@@ -124,13 +128,17 @@ public:
                                                        const TabletMetadata* metadata);
 
 #ifdef USE_STAROS
+#if !defined(BUILD_FORMAT_LIB)
     bool is_tablet_in_worker(int64_t tablet_id);
+#else
+    bool is_tablet_in_worker(int64_t tablet_id) { return true; }
+#endif
 #endif // USE_STAROS
 
     void prune_metacache();
 
     // TODO: remove this method
-    LocationProvider* TEST_set_location_provider(LocationProvider* value) {
+    std::shared_ptr<LocationProvider> TEST_set_location_provider(std::shared_ptr<LocationProvider> value) {
         auto ret = _location_provider;
         _location_provider = value;
         return ret;
@@ -158,9 +166,8 @@ public:
 
     std::string delvec_location(int64_t tablet_id, std::string_view delvec_filename) const;
 
+    const std::shared_ptr<LocationProvider> location_provider() { return _location_provider; }
     std::string sst_location(int64_t tablet_id, std::string_view sst_filename) const;
-
-    const LocationProvider* location_provider() const { return _location_provider; }
 
     UpdateManager* update_mgr();
 
@@ -209,15 +216,17 @@ private:
     StatusOr<TabletSchemaPtr> load_and_parse_schema_file(const std::string& path);
     StatusOr<TabletSchemaPtr> get_tablet_schema_by_id(int64_t tablet_id, int64_t schema_id);
 
+    StatusOr<TabletMetadataPtr> load_tablet_metadata(std::shared_ptr<FileSystem> fs,
+                                                     const std::string& metadata_location, bool fill_cache);
     Status put_tablet_metadata(const TabletMetadataPtr& metadata, const std::string& metadata_location);
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_cache);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
     StatusOr<CombinedTxnLogPtr> load_combined_txn_log(const std::string& path, bool fill_cache);
 
-    LocationProvider* _location_provider;
+    std::shared_ptr<LocationProvider> _location_provider;
     std::unique_ptr<Metacache> _metacache;
     std::unique_ptr<CompactionScheduler> _compaction_scheduler;
-    UpdateManager* _update_mgr;
+    UpdateManager* _update_mgr = nullptr;
 
     std::shared_mutex _meta_lock;
     std::unordered_map<int64_t, int64_t> _tablet_in_writing_size;

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -104,7 +104,8 @@ Status TabletReader::prepare() {
 
 Status TabletReader::open(const TabletReaderParams& read_params) {
     if (read_params.reader_type != ReaderType::READER_QUERY && read_params.reader_type != ReaderType::READER_CHECKSUM &&
-        read_params.reader_type != ReaderType::READER_ALTER_TABLE && !is_compaction(read_params.reader_type)) {
+        read_params.reader_type != ReaderType::READER_ALTER_TABLE && !is_compaction(read_params.reader_type) &&
+        read_params.reader_type != ReaderType::READER_BYPASS_QUERY) {
         return Status::NotSupported("reader type not supported now");
     }
     RETURN_IF_ERROR(init_compaction_column_paths(read_params));
@@ -311,6 +312,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
         rs_opts.is_primary_keys = true;
         rs_opts.version = _tablet_metadata->version();
     }
+    rs_opts.reader_type = params.reader_type;
 
     if (keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS) {
         rs_opts.asc_hint = _is_asc_hint;

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -18,6 +18,7 @@
 #include "runtime/mem_pool.h"
 #include "storage/chunk_iterator.h"
 #include "storage/delete_predicates.h"
+#include "storage/lake/versioned_tablet.h"
 #include "storage/tablet_reader_params.h"
 #include "types_fwd.h"
 
@@ -80,6 +81,8 @@ public:
 
     size_t merged_rows() const override { return _collect_iter->merged_rows(); }
 
+    void set_tablet(std::shared_ptr<VersionedTablet> tablet) { _tablet = tablet; }
+
     void get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) { split_tasks->swap(_split_tasks); }
 
 protected:
@@ -135,6 +138,8 @@ private:
     bool _is_vertical_merge = false;
     bool _is_key = false;
     RowSourceMaskBuffer* _mask_buffer = nullptr;
+
+    std::shared_ptr<VersionedTablet> _tablet;
 
     // used for table internal parallel
     bool _need_split = false;

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -21,6 +21,7 @@
 #include "fs/fs.h" // FileInfo
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/lake_types.pb.h"
+#include "storage/lake/location_provider.h"
 #include "storage/tablet_schema.h"
 
 namespace starrocks {
@@ -128,6 +129,11 @@ public:
     // allow to set custom tablet schema for writer, used in partial update
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }
 
+    void set_fs(const std::shared_ptr<FileSystem> fs) { _fs = std::move(fs); }
+    void set_location_provider(const std::shared_ptr<LocationProvider> location_provider) {
+        _location_provider = std::move(location_provider);
+    }
+
     const OlapWriterStatistics& stats() const { return _stats; }
 
 protected:
@@ -141,6 +147,8 @@ protected:
     int64_t _data_size = 0;
     uint32_t _seg_id = 0;
     bool _finished = false;
+    std::shared_ptr<FileSystem> _fs;
+    std::shared_ptr<LocationProvider> _location_provider;
     OlapWriterStatistics _stats;
 
     bool _is_compaction = false;

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -42,18 +42,6 @@ class UpdateManager;
 struct AutoIncrementPartialUpdateState;
 using IndexEntry = DynamicCache<uint64_t, LakePrimaryIndex>::Entry;
 
-class LakeDelvecLoader : public DelvecLoader {
-public:
-    LakeDelvecLoader(UpdateManager* update_mgr, const MetaFileBuilder* pk_builder, bool fill_cache)
-            : _update_mgr(update_mgr), _pk_builder(pk_builder), _fill_cache(fill_cache) {}
-    Status load(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec);
-
-private:
-    UpdateManager* _update_mgr = nullptr;
-    const MetaFileBuilder* _pk_builder = nullptr;
-    bool _fill_cache = false;
-};
-
 class PersistentIndexBlockCache {
 public:
     explicit PersistentIndexBlockCache(MemTracker* mem_tracker, int64_t cache_limit);
@@ -90,7 +78,7 @@ private:
 
 class UpdateManager {
 public:
-    UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker);
+    UpdateManager(std::shared_ptr<LocationProvider> location_provider, MemTracker* mem_tracker);
     ~UpdateManager();
     void set_tablet_mgr(TabletManager* tablet_mgr) { _tablet_mgr = tablet_mgr; }
     void set_cache_expire_ms(int64_t expire_ms) { _cache_expire_ms = expire_ms; }
@@ -251,7 +239,7 @@ private:
     // compaction cache
     DynamicCache<string, CompactionState> _compaction_cache;
     std::atomic<int64_t> _last_clear_expired_cache_millis = 0;
-    LocationProvider* _location_provider = nullptr;
+    std::shared_ptr<LocationProvider> _location_provider;
     TabletManager* _tablet_mgr = nullptr;
 
     // memory checkers

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -118,9 +118,9 @@ StatusOr<int32_t> VerticalCompactionTask::calculate_chunk_size_for_column_group(
         // test case: 4k columns, 150 segments, 60w rows
         // compaction task cost: 272s (fill metadata cache) vs 2400s (not fill metadata cache)
         LakeIOOptions lake_io_opts{.fill_data_cache = config::lake_enable_vertical_compaction_fill_data_cache,
-                                   .buffer_size = config::lake_compaction_stream_buffer_size_bytes};
-        auto fill_meta_cache = true;
-        ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts, fill_meta_cache));
+                                   .buffer_size = config::lake_compaction_stream_buffer_size_bytes,
+                                   .fill_metadata_cache = true};
+        ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts));
         for (auto& segment : segments) {
             for (auto column_index : column_group) {
                 auto uid = _tablet_schema->column(column_index).unique_id();

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -149,10 +149,11 @@ enum ReaderType {
     READER_BASE_COMPACTION = 2,
     READER_CUMULATIVE_COMPACTION = 3,
     READER_CHECKSUM = 4,
+    READER_BYPASS_QUERY = 5,
 };
 
 inline bool is_query(ReaderType reader_type) {
-    return reader_type == READER_QUERY;
+    return reader_type == READER_QUERY || reader_type == READER_BYPASS_QUERY;
 }
 
 inline bool is_compaction(ReaderType reader_type) {

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -38,6 +38,8 @@
 #include <utility>
 #include <vector>
 
+#include "fs/fs.h"
+#include "storage/lake/location_provider.h"
 #include "storage/olap_define.h"
 #include "util/uid_util.h"
 
@@ -77,6 +79,10 @@ struct LakeIOOptions {
     bool fill_data_cache = false;
     // Specify different buffer size for different read scenarios
     int64_t buffer_size = -1;
+    bool fill_metadata_cache = false;
+    bool use_page_cache = false;
+    std::shared_ptr<FileSystem> fs;
+    std::shared_ptr<starrocks::lake::LocationProvider> location_provider;
 };
 
 } // namespace starrocks

--- a/be/src/storage/protobuf_file.h
+++ b/be/src/storage/protobuf_file.h
@@ -31,6 +31,8 @@ class ProtobufFile {
 public:
     explicit ProtobufFile(std::string path) : _path(std::move(path)) {}
 
+    explicit ProtobufFile(std::string path, std::shared_ptr<FileSystem> fs) : _path(std::move(path)), _fs(fs) {}
+
     DISALLOW_COPY_AND_MOVE(ProtobufFile);
 
     Status save(const ::google::protobuf::Message& message, bool sync = true);
@@ -39,11 +41,15 @@ public:
 
 private:
     std::string _path;
+    std::shared_ptr<FileSystem> _fs;
 };
 
 class ProtobufFileWithHeader {
 public:
     explicit ProtobufFileWithHeader(std::string path) : _path(std::move(path)) {}
+
+    explicit ProtobufFileWithHeader(std::string path, std::shared_ptr<FileSystem> fs)
+            : _path(std::move(path)), _fs(fs) {}
 
     DISALLOW_COPY_AND_MOVE(ProtobufFileWithHeader);
 
@@ -55,6 +61,7 @@ public:
 
 private:
     std::string _path;
+    std::shared_ptr<FileSystem> _fs;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/indexed_column_reader.cpp
+++ b/be/src/storage/rowset/indexed_column_reader.cpp
@@ -106,9 +106,9 @@ Status IndexedColumnReader::new_iterator(const IndexReadOptions& opts, std::uniq
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-IndexedColumnIterator::IndexedColumnIterator(const IndexedColumnReader* reader, const IndexReadOptions& opts)
+IndexedColumnIterator::IndexedColumnIterator(const IndexedColumnReader* reader, IndexReadOptions opts)
         : _reader(reader),
-          _opts(opts),
+          _opts(std::move(opts)),
           _ordinal_iter(&reader->_ordinal_index_reader),
           _value_iter(&reader->_value_index_reader) {}
 

--- a/be/src/storage/rowset/indexed_column_reader.h
+++ b/be/src/storage/rowset/indexed_column_reader.h
@@ -86,7 +86,7 @@ public:
     Status next_batch(size_t* n, Column* column);
 
 private:
-    IndexedColumnIterator(const IndexedColumnReader* reader, const IndexReadOptions& opts);
+    IndexedColumnIterator(const IndexedColumnReader* reader, IndexReadOptions opts);
 
     Status _read_data_page(const PagePointer& pp);
 

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -50,6 +50,7 @@
 #include "storage/rowset/base_rowset.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/rowset/segment.h"
+#include "storage/rowset/segment_options.h"
 
 namespace starrocks {
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -52,7 +52,7 @@ Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
     _opts = opts;
 
     IndexReadOptions index_opts;
-    index_opts.use_page_cache = !opts.temporary_data &&
+    index_opts.use_page_cache = !opts.temporary_data && opts.use_page_cache &&
                                 (config::enable_ordinal_index_memory_page_cache || !config::disable_storage_page_cache);
     index_opts.kept_in_memory = !opts.temporary_data && config::enable_ordinal_index_memory_page_cache;
     index_opts.lake_io_opts = opts.lake_io_opts;
@@ -382,7 +382,7 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
         }
 
         IndexReadOptions opts;
-        opts.use_page_cache = !_opts.temporary_data &&
+        opts.use_page_cache = !_opts.temporary_data && _opts.use_page_cache &&
                               (config::enable_zonemap_index_memory_page_cache || !config::disable_storage_page_cache);
         opts.kept_in_memory = !_opts.temporary_data && config::enable_zonemap_index_memory_page_cache;
         opts.lake_io_opts = _opts.lake_io_opts;
@@ -424,7 +424,7 @@ Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<co
     }
 
     IndexReadOptions opts;
-    opts.use_page_cache = !_opts.temporary_data && !config::disable_storage_page_cache;
+    opts.use_page_cache = !_opts.temporary_data && !config::disable_storage_page_cache && _opts.use_page_cache;
     opts.kept_in_memory = false;
     opts.lake_io_opts = _opts.lake_io_opts;
     opts.read_file = _opts.read_file;

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -365,7 +365,7 @@ Status Segment::_load_index(const LakeIOOptions& lake_io_opts) {
     ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(file_opts, _segment_file_info));
 
     PageReadOptions opts;
-    opts.use_page_cache = !config::disable_storage_page_cache;
+    opts.use_page_cache = lake_io_opts.use_page_cache;
     opts.read_file = read_file.get();
     opts.page_pointer = _short_key_index_page;
     opts.codec = nullptr; // short key index page uses NO_COMPRESSION for now

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2084,8 +2084,9 @@ Status SegmentIterator::_apply_bitmap_index() {
                     }
 
                     IndexReadOptions opts;
-                    opts.use_page_cache = !_opts.temporary_data && (config::enable_bitmap_index_memory_page_cache ||
-                                                                    !config::disable_storage_page_cache);
+                    opts.use_page_cache =
+                            !_opts.temporary_data && _opts.use_page_cache &&
+                            (config::enable_bitmap_index_memory_page_cache || !config::disable_storage_page_cache);
                     opts.kept_in_memory = !_opts.temporary_data && config::enable_bitmap_index_memory_page_cache;
                     opts.lake_io_opts = _opts.lake_io_opts;
                     opts.read_file = _column_files[cid].get();

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -62,7 +62,7 @@ struct TabletReaderParams {
     bool use_page_cache = false;
 
     // Options only applies to cloud-native table r/w IO
-    LakeIOOptions lake_io_opts{.fill_data_cache = true};
+    LakeIOOptions lake_io_opts{.fill_data_cache = true, .fill_metadata_cache = true};
 
     RangeStartOperation range = RangeStartOperation::GT;
     RangeEndOperation end_range = RangeEndOperation::LT;

--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -827,11 +827,22 @@ void TimestampValue::trunc_to_quarter() {
     _timestamp = timestamp::from_datetime(year, month_to_quarter[month], 1, 0, 0, 0, 0);
 }
 
+// return seconds since epoch.
 int64_t TimestampValue::to_unix_second() const {
     int64_t result = timestamp::to_julian(_timestamp);
     result *= SECS_PER_DAY;
     result += timestamp::to_time(_timestamp) / USECS_PER_SEC;
     result -= timestamp::UNIX_EPOCH_SECONDS;
+    return result;
+}
+
+// return microseconds since epoch.
+int64_t TimestampValue::to_unixtime() const {
+    int64_t result = timestamp::to_julian(_timestamp);
+    result *= SECS_PER_DAY;
+    result -= timestamp::UNIX_EPOCH_SECONDS;
+    result *= 1000L;
+    result += timestamp::to_time(_timestamp) / USECS_PER_MILLIS;
     return result;
 }
 

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -120,6 +120,7 @@ public:
     bool from_string(const char* date_str, size_t len);
 
     int64_t to_unix_second() const;
+    int64_t to_unixtime() const;
 
     bool from_unixtime(int64_t second, const std::string& timezone);
     void from_unixtime(int64_t second, const cctz::time_zone& ctz);

--- a/be/test/column/timestamp_value_test.cpp
+++ b/be/test/column/timestamp_value_test.cpp
@@ -114,4 +114,10 @@ TEST(TimestampValueTest, cast) {
     ASSERT_EQ("2004-02-29", ((DateValue)v).to_string());
 }
 
+TEST(TimestampValueTest, unixTime) {
+    auto v = TimestampValue::create(2004, 2, 29, 23, 30, 30);
+    std::cout << "unix time " << v.to_unixtime() << std::endl;
+    ASSERT_EQ(1078097430000, v.to_unixtime());
+}
+
 } // namespace starrocks

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -50,9 +50,9 @@ class LakeMetaScannerTest : public ::testing::Test {
 public:
     LakeMetaScannerTest() : _tablet_id(next_id()) {
         // setup TabletManager
-        _location_provider = std::make_unique<lake::FixedLocationProvider>(kRootLocation);
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(kRootLocation);
         _tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
-        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider.get());
+        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName));
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName));
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName));
@@ -113,8 +113,8 @@ public:
 public:
     constexpr static const char* const kRootLocation = "./LakeMetaScannerTest";
     lake::TabletManager* _tablet_mgr;
-    std::unique_ptr<lake::LocationProvider> _location_provider;
-    lake::LocationProvider* _backup_location_provider;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
     int64_t _tablet_id;
 
     ObjectPool _pool;

--- a/be/test/fs/fs_test.cpp
+++ b/be/test/fs/fs_test.cpp
@@ -61,6 +61,13 @@ TEST(FileSystemTest, test_good_construction) {
         ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString("unknown2://"));
         ASSERT_EQ(fs->type(), FileSystem::S3);
     }
+
+    {
+        std::unordered_map<std::string, std::string> params = {{"fs.s3a.readahead.range", "100"}};
+        std::unique_ptr<FSOptions> fs_options = std::make_unique<FSOptions>(params);
+        ASSIGN_OR_ABORT(auto fs, FileSystem::Create("unknown2://", *fs_options));
+        ASSERT_EQ(fs->type(), FileSystem::S3);
+    }
 }
 
 } // namespace starrocks

--- a/be/test/io/s3_output_stream_test.cpp
+++ b/be/test/io/s3_output_stream_test.cpp
@@ -137,7 +137,7 @@ TEST_F(S3OutputStreamTest, test_multipart_upload) {
     const char* kObjectName = "test_multipart_upload";
     delete_object(kObjectName);
     S3OutputStream os(g_s3client, kBucketName, kObjectName, 12, /*5MB=*/5 * 1024 * 1024);
-    S3InputStream is(g_s3client, kBucketName, kObjectName);
+    S3InputStream is(g_s3client, kBucketName, kObjectName, /*5MB=*/5 * 1024 * 1024);
 
     std::string s1("first line of multipart upload\n");
     std::string s2("second line of multipart upload\n");

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -59,9 +59,8 @@ public:
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
         _root_profile = std::make_unique<RuntimeProfile>("LoadChannel");
         _location_provider = std::make_unique<lake::FixedLocationProvider>(_test_directory);
-        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get(), _mem_tracker.get());
-        _tablet_manager =
-                std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
 
         _load_channel_mgr = std::make_unique<LoadChannelMgr>();
 
@@ -247,11 +246,10 @@ protected:
     int64_t _schema_id;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<RuntimeProfile> _root_profile;
-    std::unique_ptr<lake::FixedLocationProvider> _location_provider;
+    std::shared_ptr<lake::FixedLocationProvider> _location_provider;
     std::unique_ptr<lake::UpdateManager> _update_manager;
     std::unique_ptr<lake::TabletManager> _tablet_manager;
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
-    lake::LocationProvider* _backup_location_provider;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
     std::shared_ptr<OlapTableSchemaParam> _schema_param;

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -54,9 +54,8 @@ public:
         _schema_id = next_id();
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
         _location_provider = std::make_unique<lake::FixedLocationProvider>(kTestGroupPath);
-        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get(), _mem_tracker.get());
-        _tablet_manager =
-                std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
 
         _load_channel_mgr = std::make_unique<LoadChannelMgr>();
 
@@ -238,7 +237,7 @@ protected:
 
     int64_t _schema_id;
     std::unique_ptr<MemTracker> _mem_tracker;
-    std::unique_ptr<lake::FixedLocationProvider> _location_provider;
+    std::shared_ptr<lake::FixedLocationProvider> _location_provider;
     std::unique_ptr<lake::UpdateManager> _update_manager;
     std::unique_ptr<lake::TabletManager> _tablet_manager;
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -46,7 +46,7 @@ public:
     LakeServiceTest()
             : _tablet_id(next_id()),
               _partition_id(next_id()),
-              _location_provider(new lake::FixedLocationProvider(kRootLocation)),
+              _location_provider(std::make_shared<lake::FixedLocationProvider>(kRootLocation)),
               _tablet_mgr(ExecEnv::GetInstance()->lake_tablet_manager()),
               _lake_service(ExecEnv::GetInstance(), ExecEnv::GetInstance()->lake_tablet_manager()) {
         _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
@@ -58,7 +58,6 @@ public:
     ~LakeServiceTest() override {
         CHECK_OK(fs::remove_all(kRootLocation));
         (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
-        delete _location_provider;
     }
 
     void create_tablet() {
@@ -102,9 +101,9 @@ protected:
     constexpr static const char* const kRootLocation = "./lake_service_test";
     int64_t _tablet_id;
     int64_t _partition_id;
-    lake::LocationProvider* _location_provider;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
     lake::TabletManager* _tablet_mgr;
-    lake::LocationProvider* _backup_location_provider;
+    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
     LakeServiceImpl _lake_service;
 };
 

--- a/be/test/storage/lake/compaction_policy_test.cpp
+++ b/be/test/storage/lake/compaction_policy_test.cpp
@@ -17,7 +17,9 @@
 #include <gtest/gtest.h>
 
 #include "fs/fs_util.h"
+#include "runtime/exec_env.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "test_util.h"
 #include "testutil/assert.h"

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -61,16 +61,15 @@ public:
 
         _location_provider = std::make_unique<FixedLocationProvider>(kTestDir);
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
-        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get(), _mem_tracker.get());
-        _tablet_manager =
-                std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 1638400000);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1638400000);
     }
 
     void TearDown() { (void)FileSystem::Default()->delete_dir_recursive(kTestDir); }
 
 protected:
     constexpr static const char* const kTestDir = "./lake_meta_test";
-    std::unique_ptr<lake::LocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
     std::unique_ptr<TabletManager> _tablet_manager;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<UpdateManager> _update_manager;
@@ -124,8 +123,9 @@ TEST_F(MetaFileTest, test_delvec_rw) {
 
     // 3. read delvec
     DelVector after_delvec;
+    LakeIOOptions lake_io_opts;
     ASSIGN_OR_ABORT(auto metadata2, _tablet_manager->get_tablet_metadata(tablet_id, version));
-    EXPECT_TRUE(get_del_vec(_tablet_manager.get(), *metadata2, segment_id, true, &after_delvec).ok());
+    EXPECT_TRUE(get_del_vec(_tablet_manager.get(), *metadata2, segment_id, true, lake_io_opts, &after_delvec).ok());
     EXPECT_EQ(before_delvec, after_delvec.save());
 
     // 4. read meta
@@ -225,8 +225,9 @@ TEST_F(MetaFileTest, test_delvec_read_loop) {
 
         // 3. read delvec
         DelVector after_delvec;
+        LakeIOOptions lake_io_opts;
         ASSIGN_OR_ABORT(auto meta, _tablet_manager->get_tablet_metadata(tablet_id, version));
-        EXPECT_TRUE(get_del_vec(_tablet_manager.get(), *meta, segment_id, false, &after_delvec).ok());
+        EXPECT_TRUE(get_del_vec(_tablet_manager.get(), *meta, segment_id, false, lake_io_opts, &after_delvec).ok());
         EXPECT_EQ(before_delvec, after_delvec.save());
     };
     for (uint32_t segment_id = 1000; segment_id < 1200; segment_id++) {

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -58,13 +58,13 @@ public:
         std::vector<starrocks::StorePath> paths;
         CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
         _test_dir = paths[0].path + "/lake";
-        _location_provider = std::make_unique<lake::FixedLocationProvider>(_test_dir);
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(1)));
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(1)));
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->segment_root_location(1)));
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
-        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get(), _mem_tracker.get());
-        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 16384);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
         _replication_txn_manager = std::make_unique<lake::ReplicationTxnManager>(_tablet_manager.get());
 
         ASSERT_TRUE(_tablet_manager->create_tablet(get_create_tablet_req(_tablet_id, _version, _schema_hash)).ok());
@@ -209,7 +209,7 @@ public:
 protected:
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
     std::string _test_dir;
-    std::unique_ptr<lake::LocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<lake::UpdateManager> _update_manager;
     std::unique_ptr<lake::ReplicationTxnManager> _replication_txn_manager;

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -132,8 +132,8 @@ TEST_F(LakeRowsetTest, test_load_segments) {
     }
 
     // fill data cache: false, fill metadata cache: true
-    LakeIOOptions lake_io_opts{.fill_data_cache = false};
-    ASSIGN_OR_ABORT(auto segments2, rowset->segments(lake_io_opts, true));
+    LakeIOOptions lake_io_opts{.fill_data_cache = false, .fill_metadata_cache = true};
+    ASSIGN_OR_ABORT(auto segments2, rowset->segments(lake_io_opts));
     ASSERT_EQ(2, segments2.size());
     for (const auto& seg : segments2) {
         auto segment = cache->lookup_segment(seg->file_name());

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -64,8 +64,8 @@ public:
     SchemaChangeTest(const std::string& test_dir) {
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
         _location_provider = std::make_unique<FixedLocationProvider>(test_dir);
-        _update_manager = std::make_unique<UpdateManager>(_location_provider.get(), _mem_tracker.get());
-        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
     }
 
 protected:
@@ -105,7 +105,7 @@ protected:
     }
 
     std::unique_ptr<MemTracker> _mem_tracker;
-    std::unique_ptr<FixedLocationProvider> _location_provider;
+    std::shared_ptr<FixedLocationProvider> _location_provider;
     std::unique_ptr<UpdateManager> _update_manager;
     std::unique_ptr<TabletManager> _tablet_manager;
 

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -54,7 +54,7 @@ public:
         std::vector<starrocks::StorePath> paths;
         CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
         _test_dir = paths[0].path + "/lake";
-        _location_provider = new lake::FixedLocationProvider(_test_dir);
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(1)));
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(1)));
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->segment_root_location(1)));
@@ -65,13 +65,12 @@ public:
 
     void TearDown() override {
         delete _tablet_manager;
-        delete _location_provider;
-        (void)FileSystem::Default()->delete_dir_recursive(_test_dir);
+        FileSystem::Default()->delete_dir_recursive(_test_dir);
     }
 
     starrocks::lake::TabletManager* _tablet_manager{nullptr};
     std::string _test_dir;
-    lake::LocationProvider* _location_provider{nullptr};
+    std::shared_ptr<lake::LocationProvider> _location_provider{nullptr};
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<lake::UpdateManager> _update_manager;
 };
@@ -611,8 +610,8 @@ TCreateTabletReq build_create_tablet_request(int64_t tablet_id, int64_t index_id
 TEST_F(LakeTabletManagerTest, test_multi_partition_schema_file) {
     const static int kNumPartition = 4;
     const static int64_t kIndexId = 123454321;
-    auto lp = std::make_unique<PartitionedLocationProvider>(_test_dir, kNumPartition);
-    _tablet_manager->TEST_set_location_provider(lp.get());
+    auto lp = std::make_shared<PartitionedLocationProvider>(_test_dir, kNumPartition);
+    _tablet_manager->TEST_set_location_provider(lp);
     for (int i = 0; i < 10; i++) {
         auto req = build_create_tablet_request(next_id(), kIndexId);
         ASSERT_OK(_tablet_manager->create_tablet(req));

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -24,6 +24,7 @@
 #include "common/logging.h"
 #include "fs/fs_util.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/starlet_location_provider.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_options.h"
@@ -333,6 +334,25 @@ TEST_P(LakeTabletWriterTest, test_vertical_write_close_without_finish) {
     // `close()` directly without calling `finish()`
     writer->close();
 }
+
+#ifdef USE_STAROS
+
+TEST_P(LakeTabletWriterTest, test_write_sdk) {
+    auto provider = std::make_shared<starrocks::lake::StarletLocationProvider>();
+    auto location = provider->root_location(12345);
+
+    Tablet tablet(_tablet_mgr.get(), next_id(), provider, _tablet_metadata);
+    auto meta_location = tablet.metadata_location(0);
+    auto column_size = tablet.get_schema()->get()->num_columns();
+    auto txn_log_location = tablet.txn_log_location(0);
+    auto txn_vlog_location = tablet.txn_vlog_location(0);
+    auto test_segment_location = tablet.segment_location("test_segment");
+    auto root_location = tablet.root_location();
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kVertical, next_id(), 1));
+    writer->close();
+}
+
+#endif // USE_STAROS
 
 INSTANTIATE_TEST_SUITE_P(LakeTabletWriterTest, LakeTabletWriterTest,
                          ::testing::Values(DUP_KEYS, AGG_KEYS, UNIQUE_KEYS, PRIMARY_KEYS));

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -71,9 +71,9 @@ protected:
             : _test_dir(std::move(test_dir)),
               _parent_tracker(std::make_unique<MemTracker>(-1)),
               _mem_tracker(std::make_unique<MemTracker>(1024 * 1024, "", _parent_tracker.get())),
-              _lp(std::make_unique<FixedLocationProvider>(_test_dir)),
-              _update_mgr(std::make_unique<UpdateManager>(_lp.get(), _mem_tracker.get())),
-              _tablet_mgr(std::make_unique<TabletManager>(_lp.get(), _update_mgr.get(), cache_limit)) {}
+              _lp(std::make_shared<FixedLocationProvider>(_test_dir)),
+              _update_mgr(std::make_unique<UpdateManager>(_lp, _mem_tracker.get())),
+              _tablet_mgr(std::make_unique<TabletManager>(_lp, _update_mgr.get(), cache_limit)) {}
 
     void remove_test_dir_or_die() { ASSERT_OK(fs::remove_all(_test_dir)); }
 
@@ -103,7 +103,7 @@ protected:
     std::string _test_dir;
     std::unique_ptr<MemTracker> _parent_tracker;
     std::unique_ptr<MemTracker> _mem_tracker;
-    std::unique_ptr<LocationProvider> _lp;
+    std::shared_ptr<LocationProvider> _lp;
     std::unique_ptr<UpdateManager> _update_mgr;
     std::unique_ptr<TabletManager> _tablet_mgr;
 };

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -416,7 +416,7 @@ build_simdjson() {
     #ref: https://github.com/simdjson/simdjson/blob/master/HACKING.md
     mkdir -p $BUILD_DIR
     cd $BUILD_DIR
-    $CMAKE_CMD -G "${CMAKE_GENERATOR}" -DCMAKE_CXX_FLAGS="-O3" -DCMAKE_C_FLAGS="-O3" -DCMAKE_POSITION_INDEPENDENT_CODE=True -DSIMDJSON_AVX512_ALLOWED=OFF ..
+    $CMAKE_CMD -G "${CMAKE_GENERATOR}" -DCMAKE_CXX_FLAGS="-O3 -fPIC" -DCMAKE_C_FLAGS="-O3 -fPIC" -DCMAKE_POSITION_INDEPENDENT_CODE=True -DSIMDJSON_AVX512_ALLOWED=OFF ..
     $CMAKE_CMD --build .
     mkdir -p $TP_INSTALL_DIR/lib
 
@@ -528,7 +528,6 @@ build_lzo2() {
 build_bzip() {
     check_if_source_exist $BZIP_SOURCE
     cd $TP_SOURCE_DIR/$BZIP_SOURCE
-
     make -j$PARALLEL install PREFIX=$TP_INSTALL_DIR
 }
 


### PR DESCRIPTION
## Why I'm doing:
Fixes #47367

## What I'm doing:

You can learn more about the background from pr's https://github.com/StarRocks/starrocks/pull/38466.

This PR is mainly used to solve the problem that when BE directly reads and writes SR file format on S3, the code cannot be encapsulated into SDK form. This PR is mainly to decouple some code implementation and provide some compilation scripts.

build format lib 
```shell
BUILD_TYPE=Debug ./build.sh --format-lib  -j32
``` 
will install directory:
```
-- Installing: /data00/code/community/starrocks/be/output/format-lib/
-- Installing: /data00/code/community/starrocks/be/output/format-lib/libstarrocks_format.so
Skip Building Java Extensions
***************************************
Successfully build StarRocks  √ Format Lib ; StartTime:2024-05-20 09:52:29, EndTime:2024-05-20 09:58:21, TotalTime:352s
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
