### PR TITLE
[BugFix] arrangeTaskRun should not update task run state in follower FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -784,7 +784,7 @@ public class TaskManager implements MemoryTrackable {
 
                 // TODO: To avoid the same query id collision, use a new query id instead of an old query id
                 taskRun.initStatus(status.getQueryId(), status.getCreateTime());
-                if (!taskRunManager.arrangeTaskRun(taskRun)) {
+                if (!taskRunManager.arrangeTaskRun(taskRun, true)) {
                     LOG.warn("Submit task run to pending queue failed, reject the submit:{}", taskRun);
                 }
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -69,7 +69,7 @@ public class TaskRunManager implements MemoryTrackable {
         status.setPriority(option.getPriority());
         status.setMergeRedundant(option.isMergeRedundant());
         status.setProperties(option.getTaskRunProperties());
-        if (!arrangeTaskRun(taskRun)) {
+        if (!arrangeTaskRun(taskRun, false)) {
             LOG.warn("Submit task run to pending queue failed, reject the submit:{}", taskRun);
             return new SubmitResult(null, SubmitResult.SubmitStatus.REJECTED);
         }
@@ -96,17 +96,17 @@ public class TaskRunManager implements MemoryTrackable {
     // The manual priority is higher. For manual tasks, we do not merge operations.
     // For automatic tasks, we will compare the definition, and if they are the same,
     // we will perform the merge operation.
-    public boolean arrangeTaskRun(TaskRun taskRun) {
+    public boolean arrangeTaskRun(TaskRun taskRun, boolean isReplay) {
         if (!tryTaskRunLock()) {
             return false;
         }
+        List<TaskRun> mergedTaskRuns = Lists.newArrayList();
         try {
             long taskId = taskRun.getTaskId();
             Set<TaskRun> taskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);
             // If the task run is sync-mode, it will hang forever if the task run is merged because
             // user's using `future.get()` to wait and the future will not be set forever.
             ExecuteOption executeOption = taskRun.getExecuteOption();
-            List<TaskRun> mergedTaskRuns = Lists.newArrayList();
             if (taskRuns != null && executeOption.isMergeRedundant()) {
                 for (TaskRun oldTaskRun : taskRuns) {
                     if (oldTaskRun == null) {
@@ -143,20 +143,24 @@ public class TaskRunManager implements MemoryTrackable {
                     mergedTaskRuns.add(oldTaskRun);
                 }
             }
-            for (TaskRun oldTaskRun : mergedTaskRuns) {
-                // TODO: support batch update to reduce the number of edit logs.
-                oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
-                oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
-                TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
-                        oldTaskRun.getStatus().getState(), Constants.TaskRunState.MERGED);
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
-                taskRunScheduler.removePendingTaskRun(oldTaskRun);
-            }
             if (!taskRunScheduler.addPendingTaskRun(taskRun)) {
                 LOG.warn("failed to offer task: {}", taskRun);
                 return false;
             }
         } finally {
+            // NOTE: If isReplay is true, we don't need to update the status of the old TaskRun because follower FE cannot
+            // update edit log.
+            if (!isReplay && !mergedTaskRuns.isEmpty()) {
+                for (TaskRun oldTaskRun : mergedTaskRuns) {
+                    // TODO: support batch update to reduce the number of edit logs.
+                    oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
+                    oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
+                    TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
+                            oldTaskRun.getStatus().getState(), Constants.TaskRunState.MERGED);
+                    GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+                    taskRunScheduler.removePendingTaskRun(oldTaskRun);
+                }
+            }
             taskRunUnlock();
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -146,6 +146,7 @@ public class TaskRunManager implements MemoryTrackable {
             for (TaskRun oldTaskRun : mergedTaskRuns) {
                 // TODO: support batch update to reduce the number of edit logs.
                 oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
+                oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
                         oldTaskRun.getStatus().getState(), Constants.TaskRunState.MERGED);
                 GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -224,10 +224,13 @@ public class MvRewritePreprocessor {
     }
 
     public void prepare(OptExpression queryOptExpression, MvRewriteStrategy strategy) {
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
         // MV Rewrite will be used when cbo is enabled.
-        if (context.getOptimizerConfig().isRuleBased()) {
+        if (context.getOptimizerConfig().isRuleBased() || sessionVariable.isDisableMaterializedViewRewrite() ||
+                !sessionVariable.isEnableMaterializedViewRewrite()) {
             return;
         }
+
         try (Timer ignored = Tracers.watchScope("preprocessMvs")) {
             Set<Table> queryTables = MvUtils.getAllTables(queryOptExpression).stream().collect(Collectors.toSet());
             logMVParams(connectContext, queryTables);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -247,8 +247,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun1);
-        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1, false);
+        taskRunManager.arrangeTaskRun(taskRun2, false);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -283,8 +283,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun2);
-        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun2, false);
+        taskRunManager.arrangeTaskRun(taskRun1, false);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -320,8 +320,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(0);
 
-        taskRunManager.arrangeTaskRun(taskRun1);
-        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1, false);
+        taskRunManager.arrangeTaskRun(taskRun2, false);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -357,8 +357,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(0);
 
-        taskRunManager.arrangeTaskRun(taskRun2);
-        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun2, false);
+        taskRunManager.arrangeTaskRun(taskRun1, false);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -402,9 +402,9 @@ public class TaskManagerTest {
         taskRun3.initStatus("3", now + 10);
         taskRun3.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun2);
-        taskRunManager.arrangeTaskRun(taskRun1);
-        taskRunManager.arrangeTaskRun(taskRun3);
+        taskRunManager.arrangeTaskRun(taskRun2, false);
+        taskRunManager.arrangeTaskRun(taskRun1, false);
+        taskRunManager.arrangeTaskRun(taskRun3, false);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         Collection<TaskRun> taskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);


### PR DESCRIPTION
## Why I'm doing:


```
2024-05-20 14:50:41.881+08:00 WARN (LoadLabelCleaner|86) [TaskRunManager.tryTaskRunLock():208] task run lock is held by: dump thread: replayer, id: 95
    java.base@11.0.23/jdk.internal.misc.Unsafe.park(Native Method)
    java.base@11.0.23/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
    java.base@11.0.23/java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:885)
    java.base@11.0.23/java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1039)
    java.base@11.0.23/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1345)
    java.base@11.0.23/java.util.concurrent.CountDownLatch.await(CountDownLatch.java:232)
    app//com.starrocks.journal.JournalTask.get(JournalTask.java:84)
    app//com.starrocks.persist.EditLog.waitInfinity(EditLog.java:1298)
    app//com.starrocks.persist.EditLog.logEdit(EditLog.java:1231)
    app//com.starrocks.persist.EditLog.logUpdateTaskRun(EditLog.java:1372)
    app//com.starrocks.scheduler.TaskRunManager.arrangeTaskRun(TaskRunManager.java:150)
    app//com.starrocks.scheduler.TaskManager.replayCreateTaskRun(TaskManager.java:786)
    app//com.starrocks.persist.EditLog.loadJournal(EditLog.java:777)
    app//com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:1833)
    app//com.starrocks.server.GlobalStateMgr$5.runOneCycle(GlobalStateMgr.java:1688)
    app//com.starrocks.common.util.Daemon.run(Daemon.java:107)
    app//com.starrocks.server.GlobalStateMgr$5.run(GlobalStateMgr.java:1753)
```
## What I'm doing:
- arrangeTaskRun should not update task run state in follower FE by using `isReplay` variable.

Fixes https://github.com/StarRocks/StarRocksTest/issues/7497
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
