### PR TITLE
[BugFix] Paimon Table should not require warehouse with hms type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -71,7 +71,7 @@ public class PaimonConnector implements Connector {
                         HIVE_METASTORE_URIS);
             }
         }
-        if (Strings.isNullOrEmpty(warehousePath)) {
+        if (Strings.isNullOrEmpty(warehousePath) && !catalogType.equals("hive")) {
             throw new StarRocksConnectorException("The property %s must be set.", PAIMON_CATALOG_WAREHOUSE);
         }
         paimonOptions.setString(WAREHOUSE.key(), warehousePath);


### PR DESCRIPTION
## Why I'm doing:
Paimon Table should not require warehouse with hms type.
in many sences such as bigdata platform when query paimon table from SR，we should not need force set warehouse when paimon.catalog.type is hive. Test as it:
CREATE EXTERNAL CATALOG paimon_catalog
PROPERTIES
(
"type" = "paimon",
"paimon.catalog.type"="hive",
"paimon.catalog.warehouse"="hdfs://region01/region01-01/17/warehouse",
"hive.metastore.uris"="thrift://metastore.lan:9083"
)
from paimon_catalog we can query data success.
CREATE EXTERNAL CATALOG paimon_catalog_01
PROPERTIES
(
"type" = "paimon",
"paimon.catalog.type"="hive",
"paimon.catalog.warehouse"="hdfs://region01/region01-01/17/warehouseXXX",
"hive.metastore.uris"="thrift://metastore.lan:9083"
)
paimon_catalog_01 paimon.catalog.warehouse is wrong but also can query paimon table data success，
so do a patch to fix it for unnecessary check
## What I'm doing:
Fix create paimon catalog withnot warehouse options

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
