### PR TITLE
[Refactor] remove some unused intrinsics

### DIFF
--- a/be/src/exec/arrow_to_starrocks_converter.h
+++ b/be/src/exec/arrow_to_starrocks_converter.h
@@ -33,8 +33,6 @@ namespace starrocks {
 class RuntimeState;
 class SlotDescriptor;
 struct ConvertFuncTree;
-} // namespace starrocks
-namespace starrocks {
 
 struct ArrowConvertContext {
     class RuntimeState* state;
@@ -77,7 +75,7 @@ LogicalType get_strict_type(ArrowTypeId at);
 
 struct ConvertFuncTree {
     ConvertFuncTree(ConvertFunc f) : func(f){};
-    ConvertFuncTree() : func(nullptr){};
+    ConvertFuncTree() = default;
     ConvertFunc func = nullptr;
     std::vector<std::string> field_names; // used in struct
     std::vector<std::unique_ptr<ConvertFuncTree>> children;


### PR DESCRIPTION
in GCC-11.4 all of the code in offsets_copy will be auto-vectorized. so we could remove them
```
.L4:
        vpaddd  ymm0, ymm1, YMMWORD PTR [rdi+rax]
        vmovdqu YMMWORD PTR [rdx+rax], ymm0
        add     rax, 32
        cmp     rcx, rax
        jne     .L4
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
