### PR TITLE
[Enhancement] support specify compression in mv table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -626,7 +626,7 @@ public class PropertyAnalyzer {
         if (properties != null && properties.containsKey(PROPERTIES_VERSION_INFO)) {
             if (RunMode.isSharedDataMode()) {
                 throw new AnalysisException(String.format("Does not support the table property \"%s\" in share data " +
-                                "mode, please remove it from the statement", PROPERTIES_VERSION_INFO));
+                        "mode, please remove it from the statement", PROPERTIES_VERSION_INFO));
             }
             String versionInfoStr = properties.get(PROPERTIES_VERSION_INFO);
             try {
@@ -1505,6 +1505,14 @@ public class PropertyAnalyzer {
                 materializedView.getTableProperty().getProperties().put(
                         PropertyAnalyzer.PROPERTY_TRANSPARENT_MV_REWRITE_MODE, str);
                 properties.remove(PropertyAnalyzer.PROPERTY_TRANSPARENT_MV_REWRITE_MODE);
+            }
+
+            // compression
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPRESSION)) {
+                String str = properties.get(PropertyAnalyzer.PROPERTIES_COMPRESSION);
+                materializedView.getTableProperty().getProperties().put(
+                        PropertyAnalyzer.PROPERTIES_COMPRESSION, str);
+                properties.remove(PropertyAnalyzer.PROPERTIES_COMPRESSION);
             }
 
             // ORDER BY() -> sortKeys

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -257,17 +257,26 @@ public class MaterializedViewAnalyzerTest {
                         "DISTRIBUTED BY HASH(a) BUCKETS 12\n" +
                         "REFRESH ASYNC\n" +
                         "PROPERTIES (\n" +
+                        "\"compression\" = \"zstd\",\n" +
                         "\"replication_num\" = \"1\",\n" +
                         "\"replicated_storage\" = \"true\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
                         "AS SELECT k1, k2, v1 from test.tbl1");
-        ShowResultSet showResultSet = ShowExecutor.execute((ShowStmt) analyzeSuccess("show full columns from mv1"),
-                starRocksAssert.getCtx());
-        Assert.assertEquals("[[a, date, , YES, YES, null, , , a1]," +
-                        " [b, int, , YES, YES, null, , , b2]," +
-                        " [c, int, , YES, YES, null, , , ]]",
-                showResultSet.getResultRows().toString());
+        {
+            ShowResultSet showResultSet = ShowExecutor.execute((ShowStmt) analyzeSuccess("show full columns from mv1"),
+                    starRocksAssert.getCtx());
+            Assert.assertEquals("[[a, date, , YES, YES, null, , , a1]," +
+                            " [b, int, , YES, YES, null, , , b2]," +
+                            " [c, int, , YES, YES, null, , , ]]",
+                    showResultSet.getResultRows().toString());
+        }
+        {
+            ShowResultSet showResultSet = ShowExecutor.execute((ShowStmt) analyzeSuccess("show create table mv1"),
+                    starRocksAssert.getCtx());
+            String result = showResultSet.getResultRows().toString();
+            Assert.assertTrue(result.contains("zstd"));
+        }
     }
 
     @Test
@@ -341,10 +350,11 @@ public class MaterializedViewAnalyzerTest {
                     " should contain the partition column k1 of materialized view");
         }
     }
+
     @Test
     public void testCreateMvBaseOnView() throws Exception {
         starRocksAssert.useDatabase("test")
-                        .withView("create view v1 as select date_trunc('month', k1) as kv1, k2 as kv2 from tbl1");
+                .withView("create view v1 as select date_trunc('month', k1) as kv1, k2 as kv2 from tbl1");
 
         analyzeSuccess("create materialized view mv1 partition by k1 distributed by hash(k2) buckets 3 refresh async " +
                 "as select kv1 as k1, kv2 as k2 from v1");


### PR DESCRIPTION
## Why I'm doing:

To support `compression` when building mv table

```
CREATE MATERIALIZED VIEW `t1_mv2` (`value`)
DISTRIBUTED BY RANDOM
REFRESH MANUAL
PROPERTIES (
"replicated_storage" = "true",
"replication_num" = "1",
"compression" = "zstd",
"storage_medium" = "HDD"
)
AS SELECT `t1`.`value`
FROM `zya`.`t1`;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
