### PR TITLE
[Enhancement] Make the user in FE & BE as a variable

### DIFF
--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -10,6 +10,8 @@
 #   image: copy the artifacts from a artifact docker image.
 #   local: copy the artifacts from a local repo. Mainly used for local development and test.
 ARG ARTIFACT_SOURCE=image
+# The user to run the container. Run as root by default
+ARG RUN_USER=root
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
 FROM ${ARTIFACTIMAGE} as artifacts-from-image
@@ -26,6 +28,7 @@ RUN rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo
 
 FROM ubuntu:22.04
 ARG STARROCKS_ROOT=/opt/starrocks
+ARG RUN_USER
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         binutils-dev default-jdk mysql-client curl vim tree net-tools less tzdata locales pigz inotify-tools rclone gdb && \
@@ -56,5 +59,4 @@ COPY --chown=starrocks:starrocks docker/dockerfiles/be/*.sh $STARROCKS_ROOT/
 # Create directory for BE storage, create cn symbolic link to be
 RUN mkdir -p $STARROCKS_ROOT/be/storage && ln -sfT be $STARROCKS_ROOT/cn
 
-# run as root by default
-USER root
+USER $RUN_USER

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -43,8 +43,10 @@ RUN touch /.dockerenv
 
 WORKDIR $STARROCKS_ROOT
 
-RUN groupadd --gid 1000 $GROUP && useradd --no-create-home --uid 1000 --gid 1000 \
-             --shell /usr/sbin/nologin $USER  && \
+RUN groupadd --gid 1000 $GROUP && \
+    if [ "$USER" != "root" ]; then \
+        useradd --no-create-home --uid 1000 --gid 1000 --shell /usr/sbin/nologin $USER; \
+    fi && \
     chown -R $USER:$GROUP $STARROCKS_ROOT
 USER $USER
 

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -10,6 +10,9 @@
 #   image: copy the artifacts from a artifact docker image.
 #   local: copy the artifacts from a local repo. Mainly used for local development and test.
 ARG ARTIFACT_SOURCE=image
+# The USER and GROUP for $STARROCKS_ROOT. Use starrocks by default.
+ARG USER=starrocks
+ARG GROUP=starrocks
 # The user to run the container. Run as root by default
 ARG RUN_USER=root
 
@@ -28,6 +31,8 @@ RUN rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo
 
 FROM ubuntu:22.04
 ARG STARROCKS_ROOT=/opt/starrocks
+ARG USER
+ARG GROUP
 ARG RUN_USER
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
@@ -42,19 +47,16 @@ RUN touch /.dockerenv
 
 WORKDIR $STARROCKS_ROOT
 
-# Run as starrocks user
-ARG USER=starrocks
-ARG GROUP=starrocks
 RUN groupadd --gid 1000 $GROUP && useradd --no-create-home --uid 1000 --gid 1000 \
              --shell /usr/sbin/nologin $USER  && \
     chown -R $USER:$GROUP $STARROCKS_ROOT
 USER $USER
 
 # Copy all artifacts to the runtime container image
-COPY --from=artifacts --chown=starrocks:starrocks /release/be_artifacts/ $STARROCKS_ROOT/
+COPY --from=artifacts --chown=$USER:$GROUP /release/be_artifacts/ $STARROCKS_ROOT/
 
 # Copy be k8s scripts to the runtime container image
-COPY --chown=starrocks:starrocks docker/dockerfiles/be/*.sh $STARROCKS_ROOT/
+COPY --chown=$USER:$GROUP docker/dockerfiles/be/*.sh $STARROCKS_ROOT/
 
 # Create directory for BE storage, create cn symbolic link to be
 RUN mkdir -p $STARROCKS_ROOT/be/storage && ln -sfT be $STARROCKS_ROOT/cn

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -10,11 +10,8 @@
 #   image: copy the artifacts from a artifact docker image.
 #   local: copy the artifacts from a local repo. Mainly used for local development and test.
 ARG ARTIFACT_SOURCE=image
-# The USER and GROUP for $STARROCKS_ROOT. Use starrocks by default.
-ARG USER=starrocks
-ARG GROUP=starrocks
-# The user to run the container. Run as root by default
-ARG RUN_USER=root
+# The user for $STARROCKS_ROOT and to run the container. Run as root by default
+ARG USER=root
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
 FROM ${ARTIFACTIMAGE} as artifacts-from-image
@@ -32,8 +29,7 @@ RUN rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo
 FROM ubuntu:22.04
 ARG STARROCKS_ROOT=/opt/starrocks
 ARG USER
-ARG GROUP
-ARG RUN_USER
+ARG GROUP=starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         binutils-dev default-jdk mysql-client curl vim tree net-tools less tzdata locales pigz inotify-tools rclone gdb && \
@@ -61,4 +57,4 @@ COPY --chown=$USER:$GROUP docker/dockerfiles/be/*.sh $STARROCKS_ROOT/
 # Create directory for BE storage, create cn symbolic link to be
 RUN mkdir -p $STARROCKS_ROOT/be/storage && ln -sfT be $STARROCKS_ROOT/cn
 
-USER $RUN_USER
+USER $USER

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -40,8 +40,10 @@ ENV JAVA_HOME=/lib/jvm/default-java
 
 WORKDIR $STARROCKS_ROOT
 
-RUN groupadd --gid 1000 $GROUP && useradd --no-create-home --uid 1000 --gid 1000 \
-             --shell /usr/sbin/nologin $USER && \
+RUN groupadd --gid 1000 $GROUP && \
+    if [ "$USER" != "root" ]; then \
+        useradd --no-create-home --uid 1000 --gid 1000 --shell /usr/sbin/nologin $USER; \
+    fi && \
     chown -R $USER:$GROUP $STARROCKS_ROOT
 USER $USER
 

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -9,11 +9,8 @@
 #   image: copy the artifacts from a artifact docker image.
 #   local: copy the artifacts from a local repo. Mainly used for local development and test.
 ARG ARTIFACT_SOURCE=image
-# The USER and GROUP for $STARROCKS_ROOT. Use starrocks by default.
-ARG USER=starrocks
-ARG GROUP=starrocks
-# The user to run the container. Run as root by default
-ARG RUN_USER=root
+# The user for $STARROCKS_ROOT and to run the container. Run as root by default
+ARG USER=root
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
 FROM ${ARTIFACTIMAGE} as artifacts-from-image
@@ -30,8 +27,7 @@ FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
 FROM ubuntu:22.04
 ARG STARROCKS_ROOT=/opt/starrocks
 ARG USER
-ARG GROUP
-ARG RUN_USER
+ARG GROUP=starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         default-jdk mysql-client curl vim tree net-tools less tzdata locales netcat && \
@@ -58,4 +54,4 @@ COPY --chown=$USER:$GROUP docker/dockerfiles/fe/*.sh $STARROCKS_ROOT/
 # Create directory for FE metadata
 RUN mkdir -p /opt/starrocks/fe/meta
 
-USER $RUN_USER
+USER $USER

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -9,6 +9,8 @@
 #   image: copy the artifacts from a artifact docker image.
 #   local: copy the artifacts from a local repo. Mainly used for local development and test.
 ARG ARTIFACT_SOURCE=image
+# The user to run the container. Run as root by default
+ARG RUN_USER=root
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
 FROM ${ARTIFACTIMAGE} as artifacts-from-image
@@ -24,6 +26,7 @@ FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
 
 FROM ubuntu:22.04
 ARG STARROCKS_ROOT=/opt/starrocks
+ARG RUN_USER
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         default-jdk mysql-client curl vim tree net-tools less tzdata locales netcat && \
@@ -53,5 +56,4 @@ COPY --chown=starrocks:starrocks docker/dockerfiles/fe/*.sh $STARROCKS_ROOT/
 # Create directory for FE metadata
 RUN mkdir -p /opt/starrocks/fe/meta
 
-# run as root by default
-USER root
+USER $RUN_USER


### PR DESCRIPTION
## Why I'm doing:
We want to non-root user to run the docker container for security reason.

## What I'm doing:
Make the user to run FE & BE as a variable which can be set during docker build.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
