### PR TITLE
[Enhancement] Update pk index major compaction thread count in cloud native table

### DIFF
--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -140,10 +140,9 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                     config::update_compaction_num_threads_per_disk);
         });
         _config_callback.emplace("pindex_major_compaction_num_threads", [&]() {
-            PersistentIndexCompactionManager* mgr =
-                    StorageEngine::instance()->update_manager()->get_pindex_compaction_mgr();
             const int max_pk_index_compaction_thread_cnt = std::max(1, config::pindex_major_compaction_num_threads);
-            (void)mgr->update_max_threads(max_pk_index_compaction_thread_cnt);
+            (void)StorageEngine::instance()->update_manager()->get_pindex_compaction_mgr()->update_max_threads(
+                    max_pk_index_compaction_thread_cnt);
 #ifdef USE_STAROS
             (void)StorageEngine::instance()->local_pk_index_manager()->update_max_threads(
                     max_pk_index_compaction_thread_cnt);

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -143,9 +143,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             PersistentIndexCompactionManager* mgr =
                     StorageEngine::instance()->update_manager()->get_pindex_compaction_mgr();
             const int max_pk_index_compaction_thread_cnt = std::max(1, config::pindex_major_compaction_num_threads);
-            if (mgr != nullptr) {
-                (void)mgr->update_max_threads(max_pk_index_compaction_thread_cnt);
-            }
+            (void)mgr->update_max_threads(max_pk_index_compaction_thread_cnt);
 #ifdef USE_STAROS
             (void)StorageEngine::instance()->local_pk_index_manager()->update_max_threads(
                     max_pk_index_compaction_thread_cnt);

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -70,6 +70,7 @@
 #ifdef USE_STAROS
 #include "common/gflags_utils.h"
 #include "service/staros_worker.h"
+#include "storage/lake/local_pk_index_manager.h"
 #endif // USE_STAROS
 
 namespace starrocks {
@@ -141,10 +142,14 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         _config_callback.emplace("pindex_major_compaction_num_threads", [&]() {
             PersistentIndexCompactionManager* mgr =
                     StorageEngine::instance()->update_manager()->get_pindex_compaction_mgr();
+            const int max_pk_index_compaction_thread_cnt = std::max(1, config::pindex_major_compaction_num_threads);
             if (mgr != nullptr) {
-                const int max_pk_index_compaction_thread_cnt = std::max(1, config::pindex_major_compaction_num_threads);
                 (void)mgr->update_max_threads(max_pk_index_compaction_thread_cnt);
             }
+#ifdef USE_STAROS
+            (void)StorageEngine::instance()->local_pk_index_manager()->update_max_threads(
+                    max_pk_index_compaction_thread_cnt);
+#endif
         });
         _config_callback.emplace("update_memory_limit_percent", [&]() {
             (void)StorageEngine::instance()->update_manager()->update_primary_index_memory_limit(


### PR DESCRIPTION
## Why I'm doing:
In #41737, pk index major compaction has been supported in cloud native table. But pk index major compaction thread count can not be updated dynamically.
## What I'm doing:
Update pk index major compaction thread count in cloud native table dynamically.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
