### PR TITLE
[Enhancement] Support more mode for window_funnel aggregation.

### DIFF
--- a/docs/en/sql-reference/sql-functions/aggregate-functions/window_funnel.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/window_funnel.md
@@ -28,11 +28,11 @@ BIGINT window_funnel(BIGINT window, DATE|DATETIME time, INT mode, array[cond1, c
 
 - `time`: The column containing timestamps. DATE and DATETIME types are supported.
 
-- `mode`: The mode in which the event chain is filtered. The supported data type is INT. Value range: 0, 1, 2.
+- `mode`: The mode in which the event chain is filtered. The supported data type is INT. Value range: 0-7.
   - `0` is the default value, which indicates common funnel calculation.
-  - `1` indicates the `DEDUPLICATION` mode, that is, the filtered event chain cannot have repeated events. Suppose the `array` parameter is `[event_type = 'A', event_type = 'B', event_type = 'C', event_type = 'D']` and the original event chain is "A-B-C-B-D". Event B is repeated and the filtered event chain is "A-B-C".
-  - `2` indicates the `FIXED` mode, that is, the filtered event chain cannot have events that disrupt the specified sequence. Suppose the previous `array` parameter is used and the original event chain is "A-B-D-C". Event D interrupts the sequence and the filtered event chain is "A-B".
-  - `4` indicates the `INCREASE` mode, which means the filtered events must have strictly increasing timestamps. Duplicate timestamp disrupts the event chain. This mode is supported since version 2.5.
+  - `1` (Set the 1st bit of mode) indicates the `DEDUPLICATION` mode, that is, the filtered event chain cannot have repeated events. Suppose the `array` parameter is `[event_type = 'A', event_type = 'B', event_type = 'C', event_type = 'D']` and the original event chain is "A-B-C-B-D". Event B is repeated and the filtered event chain is "A-B-C".
+  - `2` (Set the 2nd bit of mode) indicates the `FIXED` mode, that is, the filtered event chain cannot have events that disrupt the specified sequence. Suppose the previous `array` parameter is used and the original event chain is "A-B-D-C". Event D interrupts the sequence and the filtered event chain is "A-B".
+  - `4` (Set the 3rd bit of mode) indicates the `INCREASE` mode, which means the filtered events must have strictly increasing timestamps. Duplicate timestamp disrupts the event chain. This mode is supported since version 2.5.
 
 - `array`: The defined event chain. It must be an array.
 

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/window_funnel.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/window_funnel.md
@@ -30,11 +30,11 @@ BIGINT window_funnel(BIGINT window, DATE|DATETIME time, INT mode, array[cond1, c
 
 - `time`：包含时间戳的列。目前支持 DATE 和 DATETIME 类型。
 
-- `mode`：事件链的筛选模式，类型为 INT。取值范围：0，1，2，4。
+- `mode`：事件链的筛选模式，类型为 INT。取值范围：0-7。
   - 默认值为 `0`，表示执行最一般的漏斗计算。
   - 模式为 `1` 时（bits 设置第 1 位）表示 `DEDUPLICATION` 模式，即筛选出的事件链不能有重复的事件。假设 `array` 参数为 `[event_type='A', event_type='B', event_type='C', event_type='D']`，原事件链为 "A-B-C-B-D"。由于事件 B 重复，那么筛选出的事件链只能是 "A-B-C"。
   - 模式为 `2` 时（bits 设置第 2 位）表示 `FIXED` 模式，即筛选出的事件链不能有跳跃的事件，假设 `array` 参数如上不变，原事件链为 "A-B-D-C"，由于事件 D 跳跃，那么筛选出的事件链只能是 "A-B"。
-  - 模式为 `4` 时（bits 设置第3位）表示 `INCREASE` 模式，即筛选出的事件链中，连续事件的时间戳必须严格递增。**此模式自 2.5 版本开始支持。**
+  - 模式为 `4` 时（bits 设置第 3 位）表示 `INCREASE` 模式，即筛选出的事件链中，连续事件的时间戳必须严格递增。**此模式自 2.5 版本开始支持。**
 
 - `array`：定义的事件链，类型为 ARRAY 。
 


### PR DESCRIPTION
## Why I'm doing:
The current range of mode parameter values for the window_funnel function is 0, 1, 2, 4, which correspond to DEFAULT, DEDUPLICATION, FIXED, and INCREASE, respectively. However, these modes are actually orthogonal to each other and can be superimposed. Therefore, the range of values for the mode parameter of the window_funnel function should actually be 0-7.

## What I'm doing:
Change the mode parameter of window_funnel to support 0-7.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
