### PR TITLE
[Enhancement] Add broker address in broker rpc error message

### DIFF
--- a/be/src/fs/fs_broker.cpp
+++ b/be/src/fs/fs_broker.cpp
@@ -60,7 +60,7 @@ static Status to_status(const TBrokerOperationStatus& st, const TNetworkAddress&
     case TBrokerOperationStatusCode::OK:
         return Status::OK();
     case TBrokerOperationStatusCode::END_OF_FILE:
-        return Status::EndOfFile(st.message);
+        return Status::EndOfFile(fmt::format("error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::NOT_AUTHORIZED:
         return Status::IOError(fmt::format("No broker permission, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::DUPLICATE_REQUEST:

--- a/be/src/fs/fs_broker.cpp
+++ b/be/src/fs/fs_broker.cpp
@@ -24,7 +24,6 @@
 #include "fs/fs.h"
 #include "gen_cpp/FileBrokerService_types.h"
 #include "gen_cpp/TFileBrokerService.h"
-#include "gutil/strings/substitute.h"
 #include "runtime/broker_mgr.h"
 #include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
@@ -56,30 +55,36 @@ inline BrokerServiceClientCache* client_cache() {
     return ExecEnv::GetInstance()->broker_client_cache();
 }
 
-static Status to_status(const TBrokerOperationStatus& st) {
+static Status to_status(const TBrokerOperationStatus& st, const TNetworkAddress& broker) {
     switch (st.statusCode) {
     case TBrokerOperationStatusCode::OK:
         return Status::OK();
     case TBrokerOperationStatusCode::END_OF_FILE:
         return Status::EndOfFile(st.message);
     case TBrokerOperationStatusCode::NOT_AUTHORIZED:
-        return Status::IOError("No broker permission, " + st.message);
+        return Status::IOError(fmt::format("No broker permission, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::DUPLICATE_REQUEST:
-        return Status::InternalError("Duplicate broker request, " + st.message);
+        return Status::InternalError(
+                fmt::format("Duplicate broker request, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::INVALID_INPUT_OFFSET:
-        return Status::InvalidArgument("Invalid broker offset, " + st.message);
+        return Status::InvalidArgument(
+                fmt::format("Invalid broker offset, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::INVALID_ARGUMENT:
-        return Status::InvalidArgument("Invalid broker argument, " + st.message);
+        return Status::InvalidArgument(
+                fmt::format("Invalid broker argument, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::INVALID_INPUT_FILE_PATH:
-        return Status::NotFound("Invalid broker file path, " + st.message);
+        return Status::NotFound(
+                fmt::format("Invalid broker file path, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::FILE_NOT_FOUND:
-        return Status::NotFound("Broker file not found, " + st.message);
+        return Status::NotFound(fmt::format("Broker file not found, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::TARGET_STORAGE_SERVICE_ERROR:
-        return Status::InternalError("Broker storage service error, " + st.message);
+        return Status::InternalError(
+                fmt::format("Broker storage service error, error={}, broker={}", st.message, broker.hostname));
     case TBrokerOperationStatusCode::OPERATION_NOT_SUPPORTED:
-        return Status::NotSupported("Broker operation not supported, " + st.message);
+        return Status::NotSupported(
+                fmt::format("Broker operation not supported, error={}, broker={}", st.message, broker.hostname));
     }
-    return Status::InternalError("Unknown broker error, " + st.message);
+    return Status::InternalError(fmt::format("Unknown broker error, error={}, broker={}", st.message, broker.hostname));
 }
 
 template <typename Method, typename Request, typename Response>
@@ -90,8 +95,8 @@ static Status call_method(const TNetworkAddress& broker, Method method, const Re
     Status status;
     BrokerServiceConnection conn(client_cache(), broker, timeout_ms, &status);
     if (!status.ok()) {
-        LOG(WARNING) << "Fail to get broker client: " << status;
-        return status;
+        LOG(WARNING) << "Fail to get broker client, error=" << status << ", broker=" << broker.hostname;
+        return status.clone_and_append(fmt::format("broker={}", broker.hostname));
     }
     client = conn.get();
 #else
@@ -110,10 +115,12 @@ static Status call_method(const TNetworkAddress& broker, Method method, const Re
             if (retry_count-- > 0) {
                 std::this_thread::sleep_for(std::chrono::seconds(1));
             } else {
-                return Status::ThriftRpcError(e.what());
+                return Status::ThriftRpcError(
+                        fmt::format("Fail to call broker, error={}, broker={}", e.what(), broker.hostname));
             }
         } catch (apache::thrift::TException& e) {
-            return Status::ThriftRpcError(e.what());
+            return Status::ThriftRpcError(
+                    fmt::format("Fail to call broker, error={}, broker={}", e.what(), broker.hostname));
         }
     }
 }
@@ -136,7 +143,7 @@ static Status broker_pread(void* buff, const TNetworkAddress& broker, const TBro
         if (response.opStatus.statusCode == TBrokerOperationStatusCode::END_OF_FILE) {
             break;
         } else if (response.opStatus.statusCode != TBrokerOperationStatusCode::OK) {
-            return to_status(response.opStatus);
+            return to_status(response.opStatus, broker);
         } else if (response.data.empty()) {
             break;
         }
@@ -155,7 +162,7 @@ static void broker_close_reader(const TNetworkAddress& broker, const TBrokerFD& 
     request.__set_fd(fd);
 
     Status st = call_method(broker, &BrokerServiceClient::closeReader, request, &response);
-    LOG_IF(WARNING, !st.ok()) << "Fail to close broker reader, " << st.to_string();
+    LOG_IF(WARNING, !st.ok()) << "Fail to close broker reader, error=" << st.to_string();
 }
 
 static Status broker_close_writer(const TNetworkAddress& broker, const TBrokerFD& fd, int timeout_ms) {
@@ -167,12 +174,12 @@ static Status broker_close_writer(const TNetworkAddress& broker, const TBrokerFD
 
     Status st = call_method(broker, &BrokerServiceClient::closeWriter, request, &response, 1, timeout_ms);
     if (!st.ok()) {
-        LOG(WARNING) << "Fail to close broker writer: " << st;
+        LOG(WARNING) << "Fail to close broker writer, error=" << st;
         return st;
     }
     if (response.statusCode != TBrokerOperationStatusCode::OK) {
-        LOG(WARNING) << "Fail to close broker writer: " << response.message;
-        return to_status(response);
+        LOG(WARNING) << "Fail to close broker writer, error=" << response.message << ", broker=" << broker.hostname;
+        return to_status(response, broker);
     }
     return Status::OK();
 }
@@ -226,12 +233,13 @@ public:
 
         Status st = call_method(_broker, &BrokerServiceClient::pwrite, request, &response, 0, _timeout_ms);
         if (!st.ok()) {
-            LOG(WARNING) << "Fail to append " << _path << ": " << st;
+            LOG(WARNING) << "Fail to append " << _path << ", error=" << st;
             return st;
         }
         if (response.statusCode != TBrokerOperationStatusCode::OK) {
-            LOG(WARNING) << "Fail to append " << _path << ": " << response.message;
-            return to_status(response);
+            LOG(WARNING) << "Fail to append " << _path << ", error=" << response.message
+                         << ", broker=" << _broker.hostname;
+            return to_status(response, _broker);
         }
         _offset += data.size;
         return Status::OK();
@@ -289,12 +297,13 @@ StatusOr<std::unique_ptr<SequentialFile>> BrokerFileSystem::new_sequential_file(
 
     Status st = call_method(_broker_addr, &BrokerServiceClient::openReader, request, &response);
     if (!st.ok()) {
-        LOG(WARNING) << "Fail to open " << path << ": " << st;
+        LOG(WARNING) << "Fail to open " << path << ", error=" << st;
         return st;
     }
     if (response.opStatus.statusCode != TBrokerOperationStatusCode::OK) {
-        LOG(WARNING) << "Fail to open " << path << ": " << response.opStatus.message;
-        return to_status(response.opStatus);
+        LOG(WARNING) << "Fail to open " << path << ", error=" << response.opStatus.message
+                     << ", broker=" << _broker_addr.hostname;
+        return to_status(response.opStatus, _broker_addr);
     }
 
     // Get file size.
@@ -317,12 +326,13 @@ StatusOr<std::unique_ptr<RandomAccessFile>> BrokerFileSystem::new_random_access_
 
     Status st = call_method(_broker_addr, &BrokerServiceClient::openReader, request, &response);
     if (!st.ok()) {
-        LOG(WARNING) << "Fail to open " << path << ": " << st;
+        LOG(WARNING) << "Fail to open " << path << ", error=" << st;
         return st;
     }
     if (response.opStatus.statusCode != TBrokerOperationStatusCode::OK) {
-        LOG(WARNING) << "Fail to open " << path << ": " << response.opStatus.message;
-        return to_status(response.opStatus);
+        LOG(WARNING) << "Fail to open " << path << ", error=" << response.opStatus.message
+                     << ", broker=" << _broker_addr.hostname;
+        return to_status(response.opStatus, _broker_addr);
     }
 
     // Get file size.
@@ -354,8 +364,7 @@ StatusOr<std::unique_ptr<WritableFile>> BrokerFileSystem::new_writable_file(cons
                     fmt::format("Cannot open an already exists file through broker, path={}", path));
         }
     } else {
-        auto msg = strings::Substitute("Unsupported open mode $0", opts.mode);
-        return Status::NotSupported(msg);
+        return Status::NotSupported(fmt::format("Unsupported open mode {}", opts.mode));
     }
 
     TBrokerOpenWriterRequest request;
@@ -369,13 +378,14 @@ StatusOr<std::unique_ptr<WritableFile>> BrokerFileSystem::new_writable_file(cons
 
     Status st = call_method(_broker_addr, &BrokerServiceClient::openWriter, request, &response, 1, _timeout_ms);
     if (!st.ok()) {
-        LOG(WARNING) << "Fail to open " << path << ": " << st;
+        LOG(WARNING) << "Fail to open " << path << ", error=" << st;
         return st;
     }
 
     if (response.opStatus.statusCode != TBrokerOperationStatusCode::OK) {
-        LOG(WARNING) << "Fail to open " << path << ": " << response.opStatus.message;
-        return to_status(response.opStatus);
+        LOG(WARNING) << "Fail to open " << path << ", error=" << response.opStatus.message
+                     << ", broker=" << _broker_addr.hostname;
+        return to_status(response.opStatus, _broker_addr);
     }
 
     return std::make_unique<BrokerWritableFile>(_broker_addr, path, response.fd, 0, _timeout_ms);
@@ -393,7 +403,7 @@ Status BrokerFileSystem::_path_exists(const std::string& path) {
     request.__set_version(TBrokerVersion::VERSION_ONE);
     RETURN_IF_ERROR(call_method(_broker_addr, &BrokerServiceClient::checkPathExist, request, &response));
     if (response.opStatus.statusCode != TBrokerOperationStatusCode::OK) {
-        return to_status(response.opStatus);
+        return to_status(response.opStatus, _broker_addr);
     }
     return response.isPathExist ? Status::OK() : Status::NotFound(path);
 }
@@ -430,14 +440,14 @@ Status BrokerFileSystem::_delete_file(const std::string& path) {
 
     Status st = call_method(_broker_addr, &BrokerServiceClient::deletePath, request, &response);
     if (!st.ok()) {
-        LOG(WARNING) << "Fail to delete " << path << ": " << st.message();
+        LOG(WARNING) << "Fail to delete " << path << ", error=" << st.message() << ", broker=" << _broker_addr.hostname;
         return st;
     }
-    st = to_status(response);
+    st = to_status(response, _broker_addr);
     if (st.ok()) {
         LOG(INFO) << "Deleted " << path;
     } else {
-        LOG(WARNING) << "Fail to delete " << path << ": " << st.message();
+        LOG(WARNING) << "Fail to delete " << path << ", error=" << st.message();
     }
     return st;
 }
@@ -508,12 +518,12 @@ Status BrokerFileSystem::_list_file(const std::string& path, TBrokerFileStatus* 
         return Status::NotFound(path);
     } else if (response.opStatus.statusCode == TBrokerOperationStatusCode::OK) {
         if (response.files.size() != 1) {
-            return Status::InternalError(strings::Substitute("unexpected file list size=$0", response.files.size()));
+            return Status::InternalError(fmt::format("unexpected file list size={}", response.files.size()));
         }
         swap(*stat, response.files[0]);
         return Status::OK();
     } else {
-        return to_status(response.opStatus);
+        return to_status(response.opStatus, _broker_addr);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
```
*************************** 3. row ***************************
         JobId: 10149
         Label: label01
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:LOAD_RUN_FAIL; msg:No broker permission, java.io.IOException: ERROR: not found login secrets, please configure the accessKeyId and accessKeySecret., cause by: ERROR: not found login secrets, please configure the accessKeyId and accessKeySecret.
    CreateTime: 2024-05-22 20:18:58
  EtlStartTime: 2024-05-22 20:18:59
 EtlFinishTime: 2024-05-22 20:18:59
 LoadStartTime: 2024-05-22 20:18:59
LoadFinishTime: 2024-05-22 20:18:59
   TrackingSQL:
    JobDetails: {"All backends":{"b32340bf-9a2f-4848-993f-27d35250b519":[10002]},"FileNumber":1,"FileSize":96,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":1,"Unfinished backends":{"b32340bf-9a2f-4848-993f-27d35250b519":[]}}
```

## What I'm doing:
```
*************************** 5. row ***************************
         JobId: 10157
         Label: label01
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:LOAD_RUN_FAIL; msg:No broker permission, error=java.io.IOException: ERROR: not found login secrets, please configure the accessKeyId and accessKeySecret., cause by: ERROR: not found login secrets, please configure the accessKeyId and accessKeySecret., broker=127.0.0.1
    CreateTime: 2024-05-23 00:24:00
  EtlStartTime: 2024-05-23 00:24:03
 EtlFinishTime: 2024-05-23 00:24:03
 LoadStartTime: 2024-05-23 00:24:03
LoadFinishTime: 2024-05-23 00:24:04
   TrackingSQL:
    JobDetails: {"All backends":{"624698f5-f335-455e-a6d9-03ab7b532bd2":[10002]},"FileNumber":1,"FileSize":96,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":1,"Unfinished backends":{"624698f5-f335-455e-a6d9-03ab7b532bd2":[]}}

```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
