### PR TITLE
[BugFix] Fix query scheduler for pruned right local bucket shuffle join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.UserException;
 import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.PlanNodeId;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
@@ -64,6 +65,8 @@ public class ColocatedBackendSelector implements BackendSelector {
 
     @Override
     public void computeScanRangeAssignment() throws UserException {
+        colocatedAssignment.assignedScanNodeIds.add(scanNode.getId());
+
         Map<Integer, Long> bucketSeqToWorkerId = colocatedAssignment.seqToWorkerId;
         ColocatedBackendSelector.BucketSeqToScanRange bucketSeqToScanRange = colocatedAssignment.seqToScanRange;
 
@@ -82,9 +85,11 @@ public class ColocatedBackendSelector implements BackendSelector {
                     .map(location -> new TScanRangeParams(location.scan_range))
                     .forEach(scanRangeParamsList::add);
         }
-        // Because of the right table will not send data to the bucket which has been pruned, the right join or full join will get wrong result.
-        // So if this bucket shuffle is right join or full join, we need to add empty bucket scan range which is pruned by predicate.
-        if (isRightOrFullBucketShuffleFragment) {
+        // Because the right table will not send data to the bucket which has been pruned, the right join or full join will get wrong result.
+        // Therefore, if this bucket shuffle is right join or full join, we need to add empty bucket scan range which is pruned by predicate,
+        // after the last scan node of this fragment is assigned.
+        if (isRightOrFullBucketShuffleFragment &&
+                colocatedAssignment.assignedScanNodeIds.size() == colocatedAssignment.numOlapScanNodes) {
             int bucketNum = colocatedAssignment.bucketNum;
 
             for (int bucketSeq = 0; bucketSeq < bucketNum; ++bucketSeq) {
@@ -170,14 +175,18 @@ public class ColocatedBackendSelector implements BackendSelector {
         private final Map<Long, Integer> backendIdToBucketCount = Maps.newHashMap();
         private final int bucketNum;
 
-        public Assignment(OlapScanNode scanNode) {
+        private final int numOlapScanNodes;
+        private final Set<PlanNodeId> assignedScanNodeIds = Sets.newHashSet();
+
+        public Assignment(OlapScanNode scanNode, int numOlapScanNodes) {
+            this.numOlapScanNodes = numOlapScanNodes;
+
             int curBucketNum = scanNode.getOlapTable().getDefaultDistributionInfo().getBucketNum();
             if (scanNode.getSelectedPartitionIds().size() <= 1) {
                 for (Long pid : scanNode.getSelectedPartitionIds()) {
                     curBucketNum = scanNode.getOlapTable().getPartition(pid).getDistributionInfo().getBucketNum();
                 }
             }
-
             this.bucketNum = curBucketNum;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
@@ -65,7 +65,7 @@ public class ColocatedBackendSelector implements BackendSelector {
 
     @Override
     public void computeScanRangeAssignment() throws UserException {
-        colocatedAssignment.assignedScanNodeIds.add(scanNode.getId());
+        colocatedAssignment.recordAssignedScanNode(scanNode);
 
         Map<Integer, Long> bucketSeqToWorkerId = colocatedAssignment.seqToWorkerId;
         ColocatedBackendSelector.BucketSeqToScanRange bucketSeqToScanRange = colocatedAssignment.seqToScanRange;
@@ -88,8 +88,7 @@ public class ColocatedBackendSelector implements BackendSelector {
         // Because the right table will not send data to the bucket which has been pruned, the right join or full join will get wrong result.
         // Therefore, if this bucket shuffle is right join or full join, we need to add empty bucket scan range which is pruned by predicate,
         // after the last scan node of this fragment is assigned.
-        if (isRightOrFullBucketShuffleFragment &&
-                colocatedAssignment.assignedScanNodeIds.size() == colocatedAssignment.numOlapScanNodes) {
+        if (isRightOrFullBucketShuffleFragment && colocatedAssignment.isAllScanNodesAssigned()) {
             int bucketNum = colocatedAssignment.bucketNum;
 
             for (int bucketSeq = 0; bucketSeq < bucketNum; ++bucketSeq) {
@@ -200,6 +199,14 @@ public class ColocatedBackendSelector implements BackendSelector {
 
         public int getBucketNum() {
             return bucketNum;
+        }
+
+        public void recordAssignedScanNode(OlapScanNode scanNode) {
+            assignedScanNodeIds.add(scanNode.getId());
+        }
+
+        public boolean isAllScanNodesAssigned() {
+            return assignedScanNodeIds.size() == numOlapScanNodes;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
@@ -163,7 +163,8 @@ public class ExecutionFragment {
 
     public ColocatedBackendSelector.Assignment getOrCreateColocatedAssignment(OlapScanNode scanNode) {
         if (colocatedAssignment == null) {
-            colocatedAssignment = new ColocatedBackendSelector.Assignment(scanNode);
+            final int numOlapScanNodes = scanNodes.values().stream().mapToInt(node -> node instanceof OlapScanNode ? 1 : 0).sum();
+            colocatedAssignment = new ColocatedBackendSelector.Assignment(scanNode, numOlapScanNodes);
         }
         return colocatedAssignment;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -132,7 +132,7 @@ public class DefaultSharedDataWorkerProviderTest {
     private WorkerProvider newWorkerProvider() {
         return factory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), true,
-                -1, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
+                -1, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
                 WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
@@ -598,7 +598,7 @@ public class DefaultSharedDataWorkerProviderTest {
 
         { // normal case
             FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
-            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode);
+            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode, 1);
             ColocatedBackendSelector selector =
                     new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, provider, 1);
             // the computation will not fail even though there are non-available locations
@@ -616,7 +616,7 @@ public class DefaultSharedDataWorkerProviderTest {
                     ImmutableMap.of(availNode.getId(), availNode));
 
             FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
-            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode);
+            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode, 1);
             ColocatedBackendSelector selector =
                     new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, provider1, 1);
             // the computation will not fail even though there are non-available locations
@@ -633,7 +633,7 @@ public class DefaultSharedDataWorkerProviderTest {
             WorkerProvider providerNoAvailNode = new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes),
                     ImmutableMap.of());
             FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
-            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode);
+            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode, 1);
             ColocatedBackendSelector selector =
                     new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, providerNoAvailNode, 1);
             Assert.assertThrows(NonRecoverableException.class, selector::computeScanRangeAssignment);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
@@ -269,7 +269,8 @@ public class ColocatedBackendSelectorTest {
                                           Map<Integer, Long> expectedSeqToBackendId)
             throws UserException {
         FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
-        ColocatedBackendSelector.Assignment colocatedAssignemnt = new ColocatedBackendSelector.Assignment(scanNodes.get(0));
+        ColocatedBackendSelector.Assignment colocatedAssignemnt =
+                new ColocatedBackendSelector.Assignment(scanNodes.get(0), scanNodes.size());
 
         for (OlapScanNode scanNode : scanNodes) {
             ColocatedBackendSelector backendSelector =

--- a/test/sql/test_join/R/test_pruned_right_outer_local_bucket_shuffle_join
+++ b/test/sql/test_join/R/test_pruned_right_outer_local_bucket_shuffle_join
@@ -8,30 +8,40 @@ DISTRIBUTED BY HASH(`k1`) BUCKETS 6
 PROPERTIES (
     "replication_num" = "1"
 );
-
+-- result:
+-- !result
 insert into t1 select generate_series, generate_series from TABLE(generate_series(0, 10000 - 1));
-
--- Repeat the same query multiple times.
+-- result:
+-- !result
 with 
   w1 as (select k1 from t1 where k1 = 10),
   w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
   w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
 select count(1) from w3;
-
+-- result:
+10000
+-- !result
 with 
   w1 as (select k1 from t1 where k1 = 10),
   w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
   w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
 select count(1) from w3;
-
+-- result:
+10000
+-- !result
 with 
   w1 as (select k1 from t1 where k1 = 10),
   w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
   w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
 select count(1) from w3;
-
+-- result:
+10000
+-- !result
 with 
   w1 as (select k1 from t1 where k1 = 10),
   w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
   w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
 select count(1) from w3;
+-- result:
+10000
+-- !result

--- a/test/sql/test_join/T/test_pruned_right_outer_local_bucket_shuffle_join
+++ b/test/sql/test_join/T/test_pruned_right_outer_local_bucket_shuffle_join
@@ -1,0 +1,37 @@
+-- name: test_pruned_right_outer_local_bucket_shuffle_join
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 6
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 select generate_series, generate_series from TABLE(generate_series(0, 10000 - 1));
+
+-- Repeat the same query multiple times.
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select * from w3;
+
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select * from w3;
+
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select * from w3;
+
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select * from w3;


### PR DESCRIPTION
## Why I'm doing:
Fix query scheduler for pruned right local bucket shuffle join. #46098 has an example.


## What I'm doing:

As for local bucket shuffle right outer join, we add empty bucket scan range which is pruned by predicate and assign this bucket to arbitrary BE. 
- The reason is that, if we do not assign a BE to the pruned bucket of the left table, the right table will not send data to the bucket which has been pruned, and then the right join or full join will get wrong result. 

The code is as follows:
```java
        if (isRightOrFullBucketShuffleFragment && colocatedAssignment.isAllScanNodesAssigned()) {
            int bucketNum = colocatedAssignment.bucketNum;

            for (int bucketSeq = 0; bucketSeq < bucketNum; ++bucketSeq) {
                if (!bucketSeqToWorkerId.containsKey(bucketSeq)) { 
                    long workerId = workerProvider.selectNextWorker(); // --------------------- here ------------------
                    bucketSeqToWorkerId.put(bucketSeq, workerId);
                }
                if (!bucketSeqToScanRange.containsKey(bucketSeq)) {
                    bucketSeqToScanRange.put(bucketSeq, Maps.newHashMap());
                    bucketSeqToScanRange.get(bucketSeq).put(scanNode.getId().asInt(), Lists.newArrayList());
                }
            }
        }
```

This code assigns the pruned buckets to arbitrary BE after processing the **first** olap scan node of a fragment.

However, we should do this after processing the **last** instead of **first** scan node, because only after all OLAP scan nodes have been processed can it be determined whether a bucket has been pruned.
    
Fixes #46098.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
