### PR TITLE
[BugFix] use same jdk opt variable in be.conf and start_backend.sh

### DIFF
--- a/conf/be.conf
+++ b/conf/be.conf
@@ -57,4 +57,4 @@ starlet_port = 9070
 # eg:
 # JAVA_OPTS="-Djava.security.krb5.conf=/etc/krb5.conf"
 # For jdk 9+, this JAVA_OPTS will be used as default JVM options
-# JAVA_OPTS_FOR_JDK_9="-Djava.security.krb5.conf=/etc/krb5.conf"
+# JAVA_OPTS_FOR_JDK_9_AND_LATER="-Djava.security.krb5.conf=/etc/krb5.conf"


### PR DESCRIPTION
## Why I'm doing:
In start_backend.sh,  we use JAVA_OPTS_FOR_JDK_9_AND_LATER
![image](https://github.com/StarRocks/starrocks/assets/9495145/4e34d229-4c26-474f-919f-d35cfddba14c)

## What I'm doing:
modify JAVA_OPTS_FOR_JDK_9 to JAVA_OPTS_FOR_JDK_9_AND_LATER in be.conf
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
