### PR TITLE
[BugFix] Fix ObjectType equal

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ObjectType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ObjectType.java
@@ -119,7 +119,7 @@ public class ObjectType {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ObjectType)) {
             return false;
         }
         ObjectType that = (ObjectType) o;


### PR DESCRIPTION
## Why I'm doing:

The behavior is to grant usage on warehouse xxx to user_x. Only the master can show the grant for user_x, and if the follower attempts to show the grant for user_x, an error will occur. Then, only the user on the master has the permission, and the follower does not have permission either. After restarting the master, the master's show grant for user_x will also result in an error and no permission. 

Currently, debugging the code reveals that during the serialization of typeToPrivilegeEntryList in the PrivilegeCollectionV2 class, the Key is of the ObjectTypeEPack type, but during deserialization, it is only serialized into the ObjectType type, which leads to the warehouse's objectType being unrecognizable, hence returning unknown when retrieving the name. Then, in the privilegeCollection, an attempt to retrieve the warehouse's permission will result in an error.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
