### PR TITLE
[BugFix] Support force cancel refresh materialized view & optimize some task run strategies

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2830,6 +2830,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The default try lock timeout for mv refresh to try base table/mv dbs' lock")
     public static int mv_refresh_try_lock_timeout_ms = 30 * 1000;
 
+    @ConfField(mutable = true, comment = "Whether enable to refresh materialized view in sync mode mergeable or not")
+    public static boolean enable_mv_refresh_sync_refresh_mergeable = false;
+
+    @ConfField(mutable = true, comment = "The max length for mv task run extra message's values(set/map) to avoid " +
+            "occupying too much meta memory")
+    public static int max_mv_task_run_meta_message_values_length = 16;
+
     /**
      * The refresh partition number when refreshing materialized view at once by default.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
+import com.starrocks.sql.ast.CancelRefreshMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
@@ -314,8 +315,9 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void cancelRefreshMaterializedView(String dbName, String mvName) throws DdlException, MetaNotFoundException {
-        normal.cancelRefreshMaterializedView(dbName, mvName);
+    public void cancelRefreshMaterializedView(
+            CancelRefreshMaterializedViewStmt stmt) throws DdlException, MetaNotFoundException {
+        normal.cancelRefreshMaterializedView(stmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
+import com.starrocks.sql.ast.CancelRefreshMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
@@ -321,7 +322,7 @@ public interface ConnectorMetadata {
         return null;
     }
 
-    default void cancelRefreshMaterializedView(String dbName, String mvName)
+    default void cancelRefreshMaterializedView(CancelRefreshMaterializedViewStmt stmt)
             throws DdlException, MetaNotFoundException {
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -385,10 +385,7 @@ public class DDLStmtExecutor {
         public ShowResultSet visitCancelRefreshMaterializedViewStatement(CancelRefreshMaterializedViewStmt stmt,
                                                                          ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getLocalMetastore()
-                        .cancelRefreshMaterializedView(
-                                stmt.getMvName().getDb(),
-                                stmt.getMvName().getTbl());
+                context.getGlobalStateMgr().getLocalMetastore().cancelRefreshMaterializedView(stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -39,6 +39,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
 import com.google.gson.Gson;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.HintNode;
@@ -2002,7 +2003,8 @@ public class StmtExecutor {
         long createTime = System.currentTimeMillis();
 
         long loadedRows = 0;
-        int filteredRows = 0;
+        // filteredRows is stored in int64_t in the backend, so use long here.
+        long filteredRows = 0;
         long loadedBytes = 0;
         long jobId = -1;
         long estimateScanRows = -1;
@@ -2124,7 +2126,7 @@ public class StmtExecutor {
                 loadedRows = Long.parseLong(coord.getLoadCounters().get(LoadEtlTask.DPP_NORMAL_ALL));
             }
             if (coord.getLoadCounters().get(LoadEtlTask.DPP_ABNORMAL_ALL) != null) {
-                filteredRows = Integer.parseInt(coord.getLoadCounters().get(LoadEtlTask.DPP_ABNORMAL_ALL));
+                filteredRows = Long.parseLong(coord.getLoadCounters().get(LoadEtlTask.DPP_ABNORMAL_ALL));
             }
 
             if (coord.getLoadCounters().get(LoadJob.LOADED_BYTES) != null) {
@@ -2392,7 +2394,8 @@ public class StmtExecutor {
             sb.append("}");
         }
 
-        context.getState().setOk(loadedRows, filteredRows, sb.toString());
+        // filterRows may be overflow when to convert it into int, use `saturatedCast` to avoid overflow
+        context.getState().setOk(loadedRows, Ints.saturatedCast(filteredRows), sb.toString());
     }
 
     public String getOriginStmtInString() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -65,7 +65,14 @@ public class Constants {
         RUNNING,    // The task run is scheduled into running queue and is running
         FAILED,     // The task run is failed
         SUCCESS,    // The task run is finished successfully
-        MERGED,     // The task run is merged
+        MERGED;     // The task run is merged
+
+        /**
+         * Whether the task run state is a success state
+         */
+        public boolean isSuccessState() {
+            return this.equals(TaskRunState.SUCCESS) || this.equals(TaskRunState.MERGED);
+        }
     }
 
     public static boolean isFinishState(TaskRunState state) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -17,6 +17,7 @@ package com.starrocks.scheduler;
 
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.util.Map;
@@ -67,7 +68,11 @@ public class ExecuteOption {
     public boolean isMergeRedundant() {
         // If old task run is a sync-mode task, skip to merge it to avoid sync-mode task
         // hanging after removing it.
-        return !isSync && isMergeRedundant;
+        if (Config.enable_mv_refresh_sync_refresh_mergeable) {
+            return isMergeRedundant;
+        } else {
+            return !isSync && isMergeRedundant;
+        }
     }
 
     public Map<String, String> getTaskRunProperties() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -541,6 +541,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         if (!mvProperty.getProperties().containsKey(MV_SESSION_TIMEOUT)) {
             mvSessionVariable.setQueryTimeoutS(MV_DEFAULT_QUERY_TIMEOUT);
         }
+
+        // set enable_insert_strict by default
+        if (!isMVPropertyContains(SessionVariable.ENABLE_INSERT_STRICT)) {
+            mvSessionVariable.setEnableInsertStrict(false);
+        }
+        // enable profile by default for mv refresh task
+        if (!isMVPropertyContains(SessionVariable.ENABLE_PROFILE)) {
+            mvSessionVariable.setEnableProfile(true);
+        }
+    }
+
+    private boolean isMVPropertyContains(String key) {
+        String mvKey = PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + key;
+        return materializedView.getTableProperty().getProperties().containsKey(mvKey);
     }
 
     private void postProcess() {
@@ -1231,9 +1245,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             parentStmtExecutor.registerSubStmtExecutor(executor);
         }
         ctx.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
-        ctx.getSessionVariable().setEnableInsertStrict(false);
-        // enable profile by default for mv refresh task
-        ctx.getSessionVariable().setEnableProfile(true);
         LOG.info("[QueryId:{}] start to refresh materialized view {}", ctx.getQueryId(), materializedView.getName());
         try {
             executor.handleDMLStmtWithProfile(execPlan, insertStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -188,7 +188,7 @@ public class TaskManager implements MemoryTrackable {
                 GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
 
                 // remove pending task run
-                taskRunScheduler.removePendingTaskRun(taskRun);
+                taskRunScheduler.removePendingTaskRun(taskRun, Constants.TaskRunState.FAILED);
             }
 
             // clear running task runs
@@ -270,24 +270,22 @@ public class TaskManager implements MemoryTrackable {
         return isCancel;
     }
 
-    public boolean killTask(String taskName, boolean clearPending) {
+    public boolean killTask(String taskName, boolean force) {
         Task task = nameToTaskMap.get(taskName);
         if (task == null) {
             return false;
         }
-        if (clearPending) {
-            if (!taskRunManager.tryTaskRunLock()) {
-                return false;
-            }
-            try {
-                taskRunScheduler.removePendingTask(task);
-            } catch (Exception ex) {
-                LOG.warn("failed to kill task.", ex);
-            } finally {
-                taskRunManager.taskRunUnlock();
-            }
+        if (!taskRunManager.tryTaskRunLock()) {
+            return false;
         }
-        return taskRunManager.killTaskRun(task.getId());
+        try {
+            taskRunScheduler.removePendingTask(task);
+        } catch (Exception ex) {
+            LOG.warn("failed to kill task.", ex);
+        } finally {
+            taskRunManager.taskRunUnlock();
+        }
+        return taskRunManager.killTaskRun(task.getId(), force);
     }
 
     public SubmitResult executeTask(String taskName) {
@@ -338,7 +336,7 @@ public class TaskManager implements MemoryTrackable {
         try {
             taskRunScheduler.addSyncRunningTaskRun(taskRun);
             Constants.TaskRunState taskRunState = taskRun.getFuture().get();
-            if (taskRunState != Constants.TaskRunState.SUCCESS) {
+            if (!taskRunState.isSuccessState()) {
                 String msg = taskRun.getStatus().getErrorMessage();
                 throw new DmlException("execute task %s failed: %s", task.getName(), msg);
             }
@@ -378,7 +376,7 @@ public class TaskManager implements MemoryTrackable {
                     }
                     periodFutureMap.remove(task.getId());
                 }
-                if (!killTask(task.getName(), true)) {
+                if (!killTask(task.getName(), false)) {
                     LOG.error("kill task failed: " + task.getName());
                 }
                 idToTaskMap.remove(task.getId());
@@ -818,7 +816,7 @@ public class TaskManager implements MemoryTrackable {
                 return;
             }
             // remove it from pending task queue
-            taskRunScheduler.removePendingTaskRun(pendingTaskRun);
+            taskRunScheduler.removePendingTaskRun(pendingTaskRun, toStatus);
 
             TaskRunStatus status = pendingTaskRun.getStatus();
             if (toStatus == Constants.TaskRunState.RUNNING) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -82,12 +82,12 @@ public class TaskRunScheduler {
         return pendingTaskRunQueue.add(taskRun);
     }
 
-    public void removePendingTaskRun(TaskRun taskRun) {
+    public void removePendingTaskRun(TaskRun taskRun, Constants.TaskRunState state) {
         if (taskRun == null) {
             return;
         }
         LOG.info("remove pending task run: {}", taskRun);
-        pendingTaskRunQueue.remove(taskRun);
+        pendingTaskRunQueue.remove(taskRun, state);
     }
 
     public void removePendingTask(Task task) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -19,10 +19,12 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.ExecuteOption;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.DataInput;
@@ -32,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class MVTaskRunExtraMessage implements Writable {
+
     @SerializedName("forceRefresh")
     private boolean forceRefresh;
     @SerializedName("partitionStart")
@@ -53,6 +56,11 @@ public class MVTaskRunExtraMessage implements Writable {
     private String nextPartitionStart;
     @SerializedName("nextPartitionEnd")
     private String nextPartitionEnd;
+
+    // task run starts to process time
+    // NOTE: finishTime - processStartTime = process task run time(exclude pending time)
+    @SerializedName("processStartTime")
+    private long processStartTime = 0;
 
     @SerializedName("executeOption")
     private ExecuteOption executeOption = new ExecuteOption(true);
@@ -89,7 +97,8 @@ public class MVTaskRunExtraMessage implements Writable {
     }
 
     public void setMvPartitionsToRefresh(Set<String> mvPartitionsToRefresh) {
-        this.mvPartitionsToRefresh = mvPartitionsToRefresh;
+        this.mvPartitionsToRefresh = MvUtils.shrinkToSize(mvPartitionsToRefresh,
+                Config.max_mv_task_run_meta_message_values_length);
     }
 
     public Map<String, Set<String>> getBasePartitionsToRefreshMap() {
@@ -100,9 +109,10 @@ public class MVTaskRunExtraMessage implements Writable {
         return refBasePartitionsToRefreshMap;
     }
 
-    public void setRefBasePartitionsToRefreshMap(
-            Map<String, Set<String>> refBasePartitionsToRefreshMap) {
-        this.refBasePartitionsToRefreshMap = refBasePartitionsToRefreshMap;
+
+    public void setRefBasePartitionsToRefreshMap(Map<String, Set<String>> refBasePartitionsToRefreshMap) {
+        this.refBasePartitionsToRefreshMap = MvUtils.shrinkToSize(refBasePartitionsToRefreshMap,
+                Config.max_mv_task_run_meta_message_values_length);
     }
 
     public String getMvPartitionsToRefreshString() {
@@ -123,9 +133,9 @@ public class MVTaskRunExtraMessage implements Writable {
         }
     }
 
-    public void setBasePartitionsToRefreshMap(
-            Map<String, Set<String>> basePartitionsToRefreshMap) {
-        this.basePartitionsToRefreshMap = basePartitionsToRefreshMap;
+    public void setBasePartitionsToRefreshMap(Map<String, Set<String>> basePartitionsToRefreshMap) {
+        this.basePartitionsToRefreshMap = MvUtils.shrinkToSize(basePartitionsToRefreshMap,
+                Config.max_mv_task_run_meta_message_values_length);
     }
 
     public static MVTaskRunExtraMessage read(DataInput in) throws IOException {
@@ -155,6 +165,14 @@ public class MVTaskRunExtraMessage implements Writable {
 
     public void setNextPartitionEnd(String nextPartitionEnd) {
         this.nextPartitionEnd = nextPartitionEnd;
+    }
+
+    public long getProcessStartTime() {
+        return processStartTime;
+    }
+
+    public void setProcessStartTime(long processStartTime) {
+        this.processStartTime = processStartTime;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -299,6 +299,10 @@ public class TaskRunStatus implements Writable {
 
     public void setProcessStartTime(long processStartTime) {
         this.processStartTime = processStartTime;
+        // update process start time in mvTaskRunExtraMessage to display in the web page
+        if (mvTaskRunExtraMessage != null) {
+            mvTaskRunExtraMessage.setProcessStartTime(processStartTime);
+        }
     }
 
     public Map<String, String> getProperties() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelRefreshMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelRefreshMaterializedViewStmt.java
@@ -19,20 +19,25 @@ import com.starrocks.sql.parser.NodePosition;
 
 public class CancelRefreshMaterializedViewStmt extends DdlStmt {
     private final TableName mvName;
+    private final boolean force;
 
-    public CancelRefreshMaterializedViewStmt(TableName mvName) {
-        this(mvName, NodePosition.ZERO);
+    public CancelRefreshMaterializedViewStmt(TableName mvName, boolean force) {
+        this(mvName, force, NodePosition.ZERO);
     }
 
-    public CancelRefreshMaterializedViewStmt(TableName mvName, NodePosition pos) {
+    public CancelRefreshMaterializedViewStmt(TableName mvName, boolean force, NodePosition pos) {
         super(pos);
         this.mvName = mvName;
+        this.force = force;
     }
 
     public TableName getMvName() {
         return mvName;
     }
 
+    public boolean isForce() {
+        return force;
+    }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1413,4 +1413,26 @@ public class MvUtils {
             return new RandomDistributionDesc();
         }
     }
+
+    /**
+     * Trim the input set if its size is larger than maxLength.
+     * @return the trimmed set.
+     */
+    public static Set<String> shrinkToSize(Set<String> set, int maxLength) {
+        if (set != null && set.size() > maxLength) {
+            return set.stream().limit(maxLength).collect(Collectors.toSet());
+        }
+        return set;
+    }
+
+    /**
+     * Trim the input map if its size is larger than maxLength.
+     * @return the trimmed map.
+     */
+    public static Map<String, Set<String>> shrinkToSize(Map<String, Set<String>> map, int maxLength) {
+        if (map != null && map.size() > maxLength) {
+            return map.entrySet().stream().limit(maxLength).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+        return map;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1865,7 +1865,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             StarRocksParser.CancelRefreshMaterializedViewStatementContext context) {
         QualifiedName mvQualifiedName = getQualifiedName(context.qualifiedName());
         TableName mvName = qualifiedNameToTableName(mvQualifiedName);
-        return new CancelRefreshMaterializedViewStmt(mvName, createPos(context));
+        boolean force = context.FORCE() != null;
+        return new CancelRefreshMaterializedViewStmt(mvName, force, createPos(context));
     }
 
     // ------------------------------------------- Catalog Statement ---------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -643,7 +643,7 @@ refreshMaterializedViewStatement
     ;
 
 cancelRefreshMaterializedViewStatement
-    : CANCEL REFRESH MATERIALIZED VIEW mvName=qualifiedName
+    : CANCEL REFRESH MATERIALIZED VIEW mvName=qualifiedName FORCE?
     ;
 
 // ------------------------------------------- Admin Statement ---------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -320,9 +320,7 @@ public class AlterTest {
         CancelRefreshMaterializedViewStmt cancelRefresh =
                 (CancelRefreshMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .cancelRefreshMaterializedView(cancelRefresh.getMvName().getDb(),
-                            cancelRefresh.getMvName().getTbl());
+            GlobalStateMgr.getCurrentState().getLocalMetastore().cancelRefreshMaterializedView(cancelRefresh);
             if (expectedException) {
                 Assert.fail();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CancelRefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CancelRefreshMaterializedViewTest.java
@@ -40,5 +40,18 @@ public class CancelRefreshMaterializedViewTest {
         String mvName = cancelRefresh.getMvName().getTbl();
         Assert.assertEquals("test1", dbName);
         Assert.assertEquals("mv1", mvName);
+        Assert.assertFalse(cancelRefresh.isForce());
+    }
+
+    @Test
+    public void testForceRefreshMaterializedView() throws Exception {
+        String refreshMvSql = "cancel refresh materialized view test1.mv1 force";
+        CancelRefreshMaterializedViewStmt cancelRefresh =
+                (CancelRefreshMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(refreshMvSql, connectContext);
+        String dbName = cancelRefresh.getMvName().getDb();
+        String mvName = cancelRefresh.getMvName().getTbl();
+        Assert.assertEquals("test1", dbName);
+        Assert.assertEquals("mv1", mvName);
+        Assert.assertTrue(cancelRefresh.isForce());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -184,7 +184,7 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.dropMaterializedView(null);
                 connectorMetadata.alterMaterializedView(null);
                 connectorMetadata.refreshMaterializedView(null);
-                connectorMetadata.cancelRefreshMaterializedView("test_db", "test_mv");
+                connectorMetadata.cancelRefreshMaterializedView(null);
                 connectorMetadata.createView(null);
                 connectorMetadata.alterView(null);
                 connectorMetadata.truncateTable(null, null);
@@ -221,7 +221,7 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.dropMaterializedView(null);
         catalogConnectorMetadata.alterMaterializedView(null);
         catalogConnectorMetadata.refreshMaterializedView(null);
-        catalogConnectorMetadata.cancelRefreshMaterializedView("test_db", "test_mv");
+        catalogConnectorMetadata.cancelRefreshMaterializedView(null);
         catalogConnectorMetadata.createView(null);
         catalogConnectorMetadata.alterView(null);
         catalogConnectorMetadata.truncateTable(null, null);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
@@ -22,9 +22,21 @@ import java.time.LocalDateTime;
 
 public class MockTaskRunProcessor implements TaskRunProcessor {
     private static final Logger LOG = LogManager.getLogger(TaskManagerTest.class);
+    private final long sleepTimeMs;
+
+    public MockTaskRunProcessor() {
+        this.sleepTimeMs = 0;
+    }
+
+    public MockTaskRunProcessor(long sleepTime) {
+        this.sleepTimeMs = sleepTime;
+    }
 
     @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
+        if (sleepTimeMs > 0) {
+            Thread.sleep(sleepTimeMs);
+        }
         LOG.info("running a task. currentTime:" + LocalDateTime.now());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessageTest.java
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.scheduler.persist;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
+import org.assertj.core.util.Sets;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+public class MVTaskRunExtraMessageTest {
+    @Test
+    public void testMessageWithNormalMVPartitionsToRefresh() {
+        MVTaskRunExtraMessage extraMessage = new MVTaskRunExtraMessage();
+        Set<String> mvPartitionsToRefresh = Sets.newHashSet();
+        for (int i = 0; i < 10; i++) {
+            mvPartitionsToRefresh.add("partition" + i);
+        }
+        extraMessage.setMvPartitionsToRefresh(mvPartitionsToRefresh);
+        Assert.assertTrue(extraMessage.getMvPartitionsToRefresh().size() ==
+                10);
+    }
+
+    @Test
+    public void testMessageWithTooLongMVPartitionsToRefresh() {
+        MVTaskRunExtraMessage extraMessage = new MVTaskRunExtraMessage();
+        Set<String> mvPartitionsToRefresh = Sets.newHashSet();
+        for (int i = 0; i < 100; i++) {
+            mvPartitionsToRefresh.add("partition" + i);
+        }
+        extraMessage.setMvPartitionsToRefresh(mvPartitionsToRefresh);
+        Assert.assertTrue(extraMessage.getMvPartitionsToRefresh().size() ==
+                Config.max_mv_task_run_meta_message_values_length);
+    }
+
+    @Test
+    public void testMessageWithNormalRefBasePartitionsToRefreshMap() {
+        Map<String, Set<String>> refBasePartitionsToRefreshMap = Maps.newHashMap();
+        for (int i = 0; i < 15; i++) {
+            Set<String> partitions = Sets.newHashSet();
+            for (int j = 0; j < 10; j++) {
+                partitions.add("partition" + j);
+            }
+            refBasePartitionsToRefreshMap.put("table" + i, partitions);
+        }
+        MVTaskRunExtraMessage message = new MVTaskRunExtraMessage();
+        message.setRefBasePartitionsToRefreshMap(refBasePartitionsToRefreshMap);
+        Assert.assertTrue(message.getRefBasePartitionsToRefreshMap().size() == 15);
+    }
+
+    @Test
+    public void testMessageWithTooLongRefBasePartitionsToRefreshMap() {
+        Map<String, Set<String>> refBasePartitionsToRefreshMap = Maps.newHashMap();
+        for (int i = 0; i < 100; i++) {
+            Set<String> partitions = Sets.newHashSet();
+            for (int j = 0; j < 10; j++) {
+                partitions.add("partition" + j);
+            }
+            refBasePartitionsToRefreshMap.put("table" + i, partitions);
+        }
+        MVTaskRunExtraMessage message = new MVTaskRunExtraMessage();
+        message.setRefBasePartitionsToRefreshMap(refBasePartitionsToRefreshMap);
+        Assert.assertTrue(message.getRefBasePartitionsToRefreshMap().size() ==
+                Config.max_mv_task_run_meta_message_values_length);
+    }
+
+    @Test
+    public void testMessageWithNormalBasePartitionsToRefreshMap() {
+        Map<String, Set<String>> basePartitionsToRefreshMap = Maps.newHashMap();
+        for (int i = 0; i < 15; i++) {
+            Set<String> partitions = Sets.newHashSet();
+            for (int j = 0; j < 10; j++) {
+                partitions.add("partition" + j);
+            }
+            basePartitionsToRefreshMap.put("table" + i, partitions);
+        }
+        MVTaskRunExtraMessage message = new MVTaskRunExtraMessage();
+        message.setBasePartitionsToRefreshMap(basePartitionsToRefreshMap);
+        Assert.assertTrue(message.getBasePartitionsToRefreshMap().size() == 15);
+    }
+
+    @Test
+    public void testMessageWithTooLongBasePartitionsToRefreshMap() {
+        Map<String, Set<String>> basePartitionsToRefreshMap = Maps.newHashMap();
+        for (int i = 0; i < 100; i++) {
+            Set<String> partitions = Sets.newHashSet();
+            for (int j = 0; j < 10; j++) {
+                partitions.add("partition" + j);
+            }
+            basePartitionsToRefreshMap.put("table" + i, partitions);
+        }
+        MVTaskRunExtraMessage message = new MVTaskRunExtraMessage();
+        message.setBasePartitionsToRefreshMap(basePartitionsToRefreshMap);
+        Assert.assertTrue(message.getBasePartitionsToRefreshMap().size() ==
+                Config.max_mv_task_run_meta_message_values_length);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
- Little bugs in mv refreshing.

## What I'm doing:
- Support force cancel refresh materialized view which can ensure the running task run can be removed from running queue to avoid occupying resources too long.
- Add `Config. enable_mv_refresh_sync_refresh_mergeable` to support merge sync refresh mv task;
- Add `Config. max_mv_task_run_meta_message_values_length` to limit the mv task run extra message's size;
-  Make `ENABLE_INSERT_STRICT` and `ENABLE_PROFILE` configurage in mv refresh.
- Change `filterRows` to long since be's type is `int64_t` and it may be overflow .

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
