### PR TITLE
[BugFix] Fix Paimon DLF catalog can not use custom dlf catalog id (backport #46072)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -44,6 +44,7 @@ public class PaimonConnector implements Connector {
     private static final String PAIMON_CATALOG_TYPE = "paimon.catalog.type";
     private static final String PAIMON_CATALOG_WAREHOUSE = "paimon.catalog.warehouse";
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
+    private static final String DLF_CATGALOG_ID = "dlf.catalog.id";
     private final HdfsEnvironment hdfsEnvironment;
     private Catalog paimonNativeCatalog;
     private final String catalogType;
@@ -73,8 +74,15 @@ public class PaimonConnector implements Connector {
                 throw new StarRocksConnectorException("The property %s must be set if paimon catalog is hive.",
                         HIVE_METASTORE_URIS);
             }
+        } else if (catalogType.equalsIgnoreCase("dlf")) {
+            String dlfCatalogId = properties.get(DLF_CATGALOG_ID);
+            if (null != dlfCatalogId && !dlfCatalogId.isEmpty()) {
+                paimonOptions.setString(DLF_CATGALOG_ID, dlfCatalogId);
+            }
         }
-        if (Strings.isNullOrEmpty(warehousePath)) {
+        if (Strings.isNullOrEmpty(warehousePath)
+                && !catalogType.equals("hive")
+                && !catalogType.equalsIgnoreCase("dlf")) {
             throw new StarRocksConnectorException("The property %s must be set.", PAIMON_CATALOG_WAREHOUSE);
         }
         paimonOptions.setString(WAREHOUSE.key(), warehousePath);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
@@ -75,6 +75,15 @@ public class PaimonConnectorTest {
     }
 
     @Test
+    public void testCreateDLFPaimonConnector() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("paimon.catalog.type", "dlf");
+        properties.put("dlf.catalog.id", "dlf_test");
+
+        new PaimonConnector(new ConnectorContext("paimon_catalog", "paimon", properties));
+    }
+
+    @Test
     public void testCreatePaimonTable(@Mocked Catalog paimonNativeCatalog,
                                       @Mocked AbstractFileStoreTable paimonNativeTable) throws Catalog.TableNotExistException {
         Map<String, String> properties = new HashMap<>();


### PR DESCRIPTION
## Why I'm doing:
Backport #45942 #46072

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

