### PR TITLE
[Enhancement] Improve kafka group authorization failed message in routine load

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -64,14 +64,13 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
     auto conf_deleter = [conf]() { delete conf; };
     DeferOp delete_conf([conf_deleter] { return conf_deleter(); });
 
-    std::string group_id;
     auto it = ctx->kafka_info->properties.find("group.id");
     if (it == ctx->kafka_info->properties.end()) {
-        group_id = BackendOptions::get_localhost() + "_" + UniqueId::gen_uid().to_string();
+        _group_id = BackendOptions::get_localhost() + "_" + UniqueId::gen_uid().to_string();
     } else {
-        group_id = it->second;
+        _group_id = it->second;
     }
-    LOG(INFO) << "init kafka consumer with group id: " << group_id;
+    LOG(INFO) << "init kafka consumer with group id: " << _group_id;
 
     std::string errstr;
     auto set_conf = [&conf, &errstr](const std::string& conf_key, const std::string& conf_val) {
@@ -94,7 +93,7 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
     };
 
     RETURN_IF_ERROR(set_conf("metadata.broker.list", ctx->kafka_info->brokers));
-    RETURN_IF_ERROR(set_conf("group.id", group_id));
+    RETURN_IF_ERROR(set_conf("group.id", _group_id));
     // For transaction producer, producer will append one control msg to the group of msgs,
     // but the control msg will not return to consumer,
     // so we can't to judge whether the consumption has been completed by offset comparison.
@@ -270,10 +269,27 @@ Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* q
             }
             break;
         }
+        case RdKafka::ERR_TOPIC_AUTHORIZATION_FAILED: {
+            LOG(WARNING) << "kafka consume failed: " << _id << ", msg: " << msg->errstr();
+            done = true;
+            st = Status::InternalError(fmt::format(
+                    "kafka consume failed, err: {}. You should add READ permission for this topic: {} in topic ACLs",
+                    msg->errstr(), _topic));
+            break;
+        }
+        case RdKafka::ERR_GROUP_AUTHORIZATION_FAILED: {
+            LOG(WARNING) << "kafka consume failed: " << _id << ", msg: " << msg->errstr();
+            done = true;
+            st = Status::InternalError(fmt::format(
+                    "kafka consume failed, err: {}. You should add or modify the consumer group '{}' with READ "
+                    "permission for this topic: {} in consumer group ACLs and set the routine load job with "
+                    "`property.group.id` property", msg->errstr(), _group_id, _topic));
+            break;
+        }
         default:
             LOG(WARNING) << "kafka consume failed: " << _id << ", msg: " << msg->errstr();
             done = true;
-            st = Status::InternalError(msg->errstr());
+            st = Status::InternalError(fmt::format("kafka consume failed, err: {}", msg->errstr()));
             break;
         }
 
@@ -360,13 +376,20 @@ Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids
             continue;
         }
 
-        if ((*it)->err() == RdKafka::ERR_UNKNOWN_TOPIC_OR_PART) {
+        err = (*it)->err();
+        if (err == RdKafka::ERR_UNKNOWN_TOPIC_OR_PART) {
             LOG(WARNING) << "unknown topic: " << _topic;
             return Status::InternalError(fmt::format("unknown topic: {}", _topic));
-        } else if ((*it)->err() != RdKafka::ERR_NO_ERROR) {
+        } else if (err == RdKafka::ERR_TOPIC_AUTHORIZATION_FAILED) {
             std::stringstream ss;
-            ss << "err: " << err2str((*it)->err());
-            if ((*it)->err() == RdKafka::ERR_LEADER_NOT_AVAILABLE) {
+            ss << "failed to get kafka topic meta, err: " << RdKafka::err2str(err)
+               << ". You should add READ permission for this topic: " << _topic << " in topic ACLs";
+            LOG(WARNING) << ss.str();
+            return Status::InternalError(ss.str());
+        } else if (err != RdKafka::ERR_NO_ERROR) {
+            std::stringstream ss;
+            ss << "err: " << err2str(err);
+            if (err == RdKafka::ERR_LEADER_NOT_AVAILABLE) {
                 ss << ", try again";
             }
             LOG(WARNING) << ss.str();
@@ -424,7 +447,8 @@ Status KafkaDataConsumer::commit(const std::string& topic, const std::map<int32_
     RdKafka::ErrorCode err = _k_consumer->commitSync(topic_partitions);
     if (err != RdKafka::ERR_NO_ERROR) {
         std::stringstream ss;
-        ss << "failed to commit kafka offset : " << RdKafka::err2str(err);
+        ss << "failed to commit kafka offset, topic: " << topic << ", group id: " << _group_id << ", err: "
+           << RdKafka::err2str(err);
         return Status::InternalError(ss.str());
     }
     return Status::OK();

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -283,7 +283,8 @@ Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* q
             st = Status::InternalError(fmt::format(
                     "kafka consume failed, err: {}. You should add or modify the consumer group '{}' with READ "
                     "permission for this topic: {} in consumer group ACLs and set the routine load job with "
-                    "`property.group.id` property", msg->errstr(), _group_id, _topic));
+                    "`property.group.id` property",
+                    msg->errstr(), _group_id, _topic));
             break;
         }
         default:
@@ -447,8 +448,8 @@ Status KafkaDataConsumer::commit(const std::string& topic, const std::map<int32_
     RdKafka::ErrorCode err = _k_consumer->commitSync(topic_partitions);
     if (err != RdKafka::ERR_NO_ERROR) {
         std::stringstream ss;
-        ss << "failed to commit kafka offset, topic: " << topic << ", group id: " << _group_id << ", err: "
-           << RdKafka::err2str(err);
+        ss << "failed to commit kafka offset, topic: " << topic << ", group id: " << _group_id
+           << ", err: " << RdKafka::err2str(err);
         return Status::InternalError(ss.str());
     }
     return Status::OK();

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -181,6 +181,7 @@ public:
 private:
     std::string _brokers;
     std::string _topic;
+    std::string _group_id;
     std::unordered_map<std::string, std::string> _custom_properties;
 
     size_t _non_eof_partition_count = 0;


### PR DESCRIPTION
## Why I'm doing:
```
ErrorReason{errCode = 4, msg='Job failed to fetch all current partition with error [err: Broker: Topic authorization failed, BE: TNetworkAddress(hostname:10.0.7.100, port:8060)]'}

[2024-05-23 16:19:37] [task id: cc6fc6c9-e9e6-4a3f-ad3a-190a1f10a633] [txn id: -1] previous task aborted because of FindCoordinator response error: Group authorization failed.
```

## What I'm doing:
```
ErrorReason{errCode = 4, msg='Job failed to fetch all current partition with error [failed to get kafka topic meta, err: Broker: Topic authorization failed. You should add READ permission for this topic: users in topic ACLs, BE: TNetworkAddress(hostname:10.0.7.100, port:8060)]'}

[2024-07-11 02:53:30] [task id: 364c7947-c884-446f-9d1e-b1eeafb1325f] [txn id: -1] previous task aborted because of kafka consume failed, err: Fetch from broker 1 failed: Broker: Topic authorization failed. You should add READ permission for this topic: users in topic ACLs

[2024-07-11 02:55:41] [task id: bee6bf6f-9606-411f-b341-2611ee943c00] [txn id: -1] previous task aborted because of kafka consume failed, err: FindCoordinator response error: Group authorization failed.. You should add or modify the consumer group 'wyb_consume_group_3' with READ permission for this topic: users in consumer group ACLs and set the routine load job with `property.group.id` property
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
