### PR TITLE
[Enhancement] pushdown or predicate (8): support unused_columns_in_scan_stage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -286,14 +286,16 @@ public class OlapScanNode extends ScanNode {
         }
     }
 
-    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds,
-                                             Set<String> aggOrPrimaryKeyTableValueColumnNames) {
+    public List<SlotDescriptor> getSlots() {
+        return desc.getSlots();
+    }
+
+    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds) {
         for (SlotDescriptor slot : desc.getSlots()) {
             if (!slot.isMaterialized()) {
                 continue;
             }
-            if (unUsedOutputColumnIds.contains(slot.getId().asInt()) &&
-                    !aggOrPrimaryKeyTableValueColumnNames.contains(slot.getColumn().getName())) {
+            if (unUsedOutputColumnIds.contains(slot.getId().asInt())) {
                 unUsedOutputStringColumns.add(slot.getColumn().getName());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -470,71 +470,93 @@ public class PlanFragmentBuilder {
             return fragment;
         }
 
+        /**
+         * Set the columns that do not need to be output by ScanNode. They are columns that are only used in predicates
+         * that can be pushed down, rather than columns that are not pushable predicates and outputs.
+         *
+         * <p> The columns that can be pushed down need to meet:
+         * <ul>
+         * <li> All the columns of duplicate-key model.
+         * <li> Keys of primary-key model.
+         * <li> Keys of agg-key model (aggregation/unique_key model) in the skip-aggr scan stage.
+         * </ul>
+         *
+         * <p> The predicates that can be pushed down need to meet:
+         * <ul>
+         * <li> Simple single-column predicates, and the column can be pushed down, such as a = v1.
+         * <li> AND and OR predicates, and the sub-predicates are all pushable, such as a = v1 OR (b = v2 AND c = v3).
+         * <li> The other predicates are not pushable, such as a + b = v1, a = v1 OR a + b = v2.
+         * </ul>
+         *
+         * <p> The columns in the predicates that cannot be pushed down need to be retained, because these columns are
+         * used in the stage after scan.
+         */
         private void setUnUsedOutputColumns(PhysicalOlapScanOperator node, OlapScanNode scanNode,
                                             List<ScalarOperator> predicates, OlapTable referenceTable) {
-            if (!ConnectContext.get().getSessionVariable().isEnableFilterUnusedColumnsInScanStage()) {
+            SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
+            if (!sessionVariable.isEnableFilterUnusedColumnsInScanStage()) {
                 return;
             }
 
             // Key columns and value columns cannot be pruned in the non-skip-aggr scan stage.
             // - All the keys columns must be retained to merge and aggregate rows.
             // - Value columns can only be used after merging and aggregating.
-            MaterializedIndexMeta materializedIndexMeta =
-                    referenceTable.getIndexMetaByIndexId(node.getSelectedIndexId());
+            MaterializedIndexMeta materializedIndexMeta = referenceTable.getIndexMetaByIndexId(node.getSelectedIndexId());
             if (materializedIndexMeta.getKeysType().isAggregationFamily() && !node.isPreAggregation()) {
                 return;
             }
 
-            List<ColumnRefOperator> outputColumns = node.getOutputColumns();
-            // if outputColumns is empty, skip this optimization
-            if (outputColumns.isEmpty()) {
-                return;
-            }
-            Set<Integer> outputColumnIds = new HashSet<Integer>();
-            for (ColumnRefOperator colref : outputColumns) {
-                outputColumnIds.add(colref.getId());
+            Set<Integer> outputColumnIds = node.getOutputColumns().stream()
+                    .map(ColumnRefOperator::getId)
+                    .collect(Collectors.toSet());
+            // Empty outputColumnIds means that the expression after ScanNode does not need any column from ScanNode.
+            // However, at least one column needs to be output, so choose any column as the output column.
+            if (outputColumnIds.isEmpty()) {
+                if (!scanNode.getSlots().isEmpty()) {
+                    outputColumnIds.add(scanNode.getSlots().get(0).getId().asInt());
+                }
             }
 
-            // NOTE:
-            // - only support push down single predicate(eg, a = xx) to scan node.
-            // - only keys in agg-key model (aggregation/unique_key model) and primary-key model can be included in
-            // the unused
-            // columns.
-            // - complex pred(eg, a + b = xx) can not be pushed down to scan node yet.
-            // so the columns in complex predicate are useful for the stage after scan.
-            Set<Integer> singlePredColumnIds = new HashSet<Integer>();
-            Set<Integer> complexPredColumnIds = new HashSet<Integer>();
-            Set<String> aggOrPrimaryKeyTableValueColumnNames = new HashSet<String>();
+            Set<Integer> nonPushdownColumnIds = Collections.emptySet();
             if (materializedIndexMeta.getKeysType().isAggregationFamily() ||
                     materializedIndexMeta.getKeysType() == KeysType.PRIMARY_KEYS) {
-                aggOrPrimaryKeyTableValueColumnNames =
-                        materializedIndexMeta.getSchema().stream()
-                                .filter(col -> !col.isKey())
-                                .map(Column::getName)
-                                .collect(Collectors.toSet());
+                Map<String, Integer> columnNameToId = scanNode.getSlots().stream().collect(Collectors.toMap(
+                        slot -> slot.getColumn().getName(),
+                        slot -> slot.getId().asInt()
+                ));
+                nonPushdownColumnIds = materializedIndexMeta.getSchema().stream()
+                        .filter(col -> !col.isKey())
+                        .map(Column::getName)
+                        .map(columnNameToId::get)
+                        .collect(Collectors.toSet());
             }
 
+            Set<Integer> pushdownPredColumnIds = new HashSet<>();
+            Set<Integer> nonPushdownPredColumnIds = new HashSet<>();
             for (ScalarOperator predicate : predicates) {
                 ColumnRefSet usedColumns = predicate.getUsedColumns();
-                if (DecodeVisitor.isSimpleStrictPredicate(predicate)) {
+                boolean isPushdown =
+                        DecodeVisitor.isSimpleStrictPredicate(predicate, sessionVariable.isEnablePushdownOrPredicate())
+                                && Arrays.stream(usedColumns.getColumnIds()).noneMatch(nonPushdownColumnIds::contains);
+                if (isPushdown) {
                     for (int cid : usedColumns.getColumnIds()) {
-                        singlePredColumnIds.add(cid);
+                        pushdownPredColumnIds.add(cid);
                     }
                 } else {
                     for (int cid : usedColumns.getColumnIds()) {
-                        complexPredColumnIds.add(cid);
+                        nonPushdownPredColumnIds.add(cid);
                     }
                 }
             }
 
             Set<Integer> unUsedOutputColumnIds = new HashSet<>();
-            for (Integer newCid : singlePredColumnIds) {
-                if (!complexPredColumnIds.contains(newCid) && !outputColumnIds.contains(newCid)) {
+            for (Integer newCid : pushdownPredColumnIds) {
+                if (!nonPushdownPredColumnIds.contains(newCid) && !outputColumnIds.contains(newCid)) {
                     unUsedOutputColumnIds.add(newCid);
                 }
             }
 
-            scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds, aggOrPrimaryKeyTableValueColumnNames);
+            scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds);
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.utframe.StarRocksAssert;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -79,7 +77,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
                 "            ref_0.d_dow as c1 from tpcds_100g_date_dim as ref_0 \n" +
                 "            where ref_0.d_day_name = ref_0.d_day_name limit 137;\n";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        assertContains(plan, "unused_output_column_name:[]");
     }
 
     @Test
@@ -88,7 +86,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
                 "            ref_0.d_dow as c1 from tpcds_100g_date_dim as ref_0 \n" +
                 "            where ref_0.d_day_name = \"dd\" limit 137;\n";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[d_day_name]"));
+        assertContains(plan, "unused_output_column_name:[d_day_name]");
     }
 
     @Test
@@ -96,7 +94,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
         String sql = "select 1 from tpcds_100g_date_dim as ref_0 where ref_0.d_day_name=\"dd\" limit 137";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        assertContains(plan, "unused_output_column_name:[]");
     }
 
     @Test
@@ -105,7 +103,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
                 "            ref_0.d_dow as c1, year(d_date) as year from tpcds_100g_date_dim as ref_0 \n" +
                 "            where ref_0.d_date = \'1997-12-31\' limit 137;\n";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        assertContains(plan, "unused_output_column_name:[]");
     }
 
     @Test
@@ -118,21 +116,21 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             // Key columns cannot be pruned in the non-skip-aggr scan stage.
             String sql = "select timestamp from metrics_detail where tags_id > 1";
             String plan = getThriftPlan(sql);
-            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+            assertContains(plan, "unused_output_column_name:[]");
 
             sql = "select max(value) from metrics_detail where tags_id > 1";
             plan = getThriftPlan(sql);
-            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+            assertContains(plan, "unused_output_column_name:[]");
 
             // Key columns can be pruned in the skip-aggr scan stage.
             sql = "select sum(value) from metrics_detail where tags_id > 1";
             plan = getThriftPlan(sql);
-            Assert.assertTrue(plan.contains("unused_output_column_name:[tags_id]"));
+            assertContains(plan, "unused_output_column_name:[tags_id]");
 
             // Value columns cannot be pruned in the non-skip-aggr scan stage.
             sql = "select timestamp from metrics_detail where value is NULL limit 10;";
             plan = getThriftPlan(sql);
-            Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+            assertContains(plan, "unused_output_column_name:[]");
         } finally {
             connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(prevEnable);
         }
@@ -186,21 +184,117 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         String sql = "select timestamp\n" +
                 "               from primary_table where k3 = \"test\" limit 10;";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        assertContains(plan, "unused_output_column_name:[]");
     }
 
     @Test
     public void testFilterDoublePredicateColumn() throws Exception {
         String sql = "select t1a from test_all_type where t1f > 1";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        assertContains(plan, "unused_output_column_name:[]");
 
         sql = "select t1a from test_all_type where t1f is null";
         plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        assertContains(plan, "unused_output_column_name:[]");
 
         sql = "select t1a from test_all_type where t1f in (1.0, 2.0)";
         plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        assertContains(plan, "unused_output_column_name:[]");
+    }
+
+    @Test
+    public void testEmptyOutputColumns() throws Exception {
+        {
+            String sql = "select count(1) from test_all_type";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select count(1) from test_all_type where t1a='a'";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select count(1) from test_all_type where t1a='a' and t1b=1 and t1c=2";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+        }
+
+        {
+            String sql = "select 1 from test_all_type";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select 1 from test_all_type where t1a='a'";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select 1 from test_all_type where t1a='a' and t1b=1 and t1c=2";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+        }
+    }
+
+    @Test
+    public void tesOrPredicate() throws Exception {
+        {
+            String sql = "select count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2)";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+        }
+        {
+            String sql = "select count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2 and t1a='b')";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+        }
+        {
+            String sql = "select count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2 and t1d+t1a=3)";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+
+        // Aggregate-key mode.
+        {
+            String sql = "select sum(value) from metrics_detail " +
+                    "where tags_id=1 or value=1 ";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select sum(value) from metrics_detail " +
+                    "where tags_id=1 or timestamp=1 ";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[tags_id, timestamp]");
+        }
+
+        // Primary-key mode.
+        {
+            String sql = "select k3 from primary_table " +
+                    "where tags_id=1 or k3=1 ";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select k3 from primary_table " +
+                    "where tags_id=1 or timestamp=1 ";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[tags_id, timestamp]");
+        }
+
+        // Disable pushdown or predicate.
+        {
+            String sql = "select /*+SET_VAR(enable_pushdown_or_predicate=false)*/ " +
+                    "count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2)";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select /*+SET_VAR(enable_pushdown_or_predicate=false)*/ " +
+                    "count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2 and t1a='b')";
+            String plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

The optimization of _unused columns in scan stage_ is to drop the columns which have already been pushed down to storage.

Since OR predicates are able to be pushed down now, the logic of _unused columns in scan stage_ also need to be adjusted.
 

## What I'm doing:

1. `DecodeVisitor.isSimpleStrictPredicate` returns true for OR predicates if the session variable`enable_pushdown_or_predicates` is true.
2. Change the strategy about empty output columns.
    When the output columns of `OlapScanNode` are empty, we disable this optimization before this PR. 
    But instead, we could just choose any column as the output column, because empty `outputColumnIds` means that the expression after `ScanNode` does not need any column from `ScanNode` and at least one column needs to be output.
3. Refactor the logic of this optimization to these steps:
    1. Get the output columns `outputColumnIds`.
    2. Get the columns that can not be pushed down `nonPushdownColumnIds`. 
    The columns that can be pushed down need to meet:    
         - All the columns of duplicate-key model.
         - Keys of primary-key model.
         - Keys of agg-key model (aggregation/unique_key model) in the skip-aggr scan stage.
    3. Get the columns `pushdownPredUsedColumnIds` which are used by pushdownable predicates and the columns `nonPushdownPredUsedColumnIds` which are used by non-pushdownable predicate.
    The predicates that can be pushed down need to meet:
         - Simple single-column predicates, and the column **can be pushed down**, such as `a = v1`.
         - AND and OR predicates, and the sub-predicates are all pushable, such as `a = v1 OR (b = v2 AND c = v3)`.
         - The other predicates are not pushable, such as `a + b = v1, a = v1 OR a + b = v2`.
    4. Get `unUsedOutputColumnIds` which are in `pushdownPredUsedColumnIds`  but not in `nonPushdownPredUsedColumnIds` and `outputColumnIds`.


Close #43801.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
