### PR TITLE
[BugFix] Fix task run state in multi FEs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -59,8 +59,8 @@ public class Constants {
         PENDING,    // The task run is created and in the pending queue waiting to be scheduled
         RUNNING,    // The task run is scheduled into running queue and is running
         FAILED,     // The task run is failed
-        MERGED,     // The task run is merged into another task run
         SUCCESS,    // The task run is finished successfully
+        MERGED,     // The task run is merged
     }
 
     public static boolean isFinishState(TaskRunState state) {


### PR DESCRIPTION
## Why I'm doing:

- Leader's state should be updated at last, otherwise follower's state will not be updated(MERGED -> MERGED is not supported)
```
       // update the state of the old TaskRun to MERGED in LEADER
                    oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
