### PR TITLE
[BugFix] Fix inconsistent tablet schema during data ingestion

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -625,12 +625,14 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
         if (ptable_schema_param.indexes_size() > 0 && ptable_schema_param.indexes(i).has_column_param() &&
             ptable_schema_param.indexes(i).column_param().columns_desc_size() != 0 &&
             ptable_schema_param.indexes(i).column_param().columns_desc(0).unique_id() >= 0 &&
-            ptable_schema_param.version() > ori_tablet_schema->schema_version()) {
+            ptable_schema_param.version() != ori_tablet_schema->schema_version()) {
             ASSIGN_OR_RETURN(
-                    auto tablet_schema,
+                    _tablet_schema,
                     TabletSchema::create(*ori_tablet_schema, ptable_schema_param.indexes(i).schema_id(),
                                          ptable_schema_param.version(), ptable_schema_param.indexes(i).column_param()));
-            _tablet_schema = _tablet->update_max_version_schema(tablet_schema);
+            if (_tablet_schema->schema_version() > ori_tablet_schema->schema_version()) {
+                _tablet->update_max_version_schema(_tablet_schema);
+            }
             return Status::OK();
         }
     }

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1792,7 +1792,6 @@ void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
         }
         _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
     }
-    return;
 }
 
 const TabletSchema& Tablet::unsafe_tablet_schema_ref() const {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1780,7 +1780,7 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
     return _max_version_schema;
 }
 
-TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
+void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
     std::lock_guard l0(_meta_lock);
     std::lock_guard l1(_schema_lock);
     // Double Check for concurrent update
@@ -1790,10 +1790,9 @@ TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tab
         } else {
             _max_version_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_schema).first;
         }
+        _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
     }
-
-    _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
-    return _max_version_schema;
+    return;
 }
 
 const TabletSchema& Tablet::unsafe_tablet_schema_ref() const {

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -309,7 +309,7 @@ public:
 
     const TabletSchemaCSPtr thread_safe_get_tablet_schema() const;
 
-    TabletSchemaCSPtr update_max_version_schema(const TabletSchemaCSPtr& tablet_schema);
+    void update_max_version_schema(const TabletSchemaCSPtr& tablet_schema);
 
     int64_t data_size();
 


### PR DESCRIPTION
## Why I'm doing:
If the tablet_schema on the BE (Backend) is updated when data import is initiated, the tablet_schema on the BE during the import process may be newer than the tablet_schema at the time of import initiation. This may lead to a BE crash. And the reproduce steps are following:
1. Submit a data ingestion task and the current tablet schema version is x
2. Finish a fast schema evolution task and update the tablet schema in BE, the current tablet schema version in BE is x+1
3. Start to do data ingestion task, and we will use the version x+1 tablet schema handle this ingestion task

https://github.com/StarRocks/StarRocksTest/issues/7585

## What I'm doing:
Keep the tablet schema inconsistent during data ingestion.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
