### PR TITLE
[BugFix] Fix an issue When connection failed, CloseListener was not executed.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/AcceptListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/AcceptListener.java
@@ -95,9 +95,9 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                         }
                         Pair<Boolean, String> registerResult = connectScheduler.registerConnection(context);
                         if (registerResult.first) {
-                            MysqlProto.sendResponsePacket(context);
                             connection.setCloseListener(
                                     streamConnection -> connectScheduler.unregisterConnection(context));
+                            MysqlProto.sendResponsePacket(context);
                         } else {
                             context.getState().setError(registerResult.second);
                             MysqlProto.sendResponsePacket(context);


### PR DESCRIPTION
## Why I'm doing:
When MysqlProto. SendResponsePacket executed failed,  CloseListener is not registered, then connectionMap unable to remove the connection
## What I'm doing:
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
