### PR TITLE
[Enhancement] Add warehouse name to the result of show proc "/current _queries" (backport #45990)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
@@ -67,6 +67,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             .add("DiskSpillSize")
             .add("CPUTime")
             .add("ExecTime")
+            .add("Warehouse")
             .build();
 
     @Override
@@ -119,6 +120,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             values.add(QueryStatisticsFormatter.getBytes(statistics.getSpillBytes()));
             values.add(QueryStatisticsFormatter.getSecondsFromNano(statistics.getCpuCostNs()));
             values.add(QueryStatisticsFormatter.getSecondsFromMilli(item.getQueryExecTime()));
+            values.add(item.getWarehouseName());
             sortedRowData.add(values);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1115,6 +1115,14 @@ public class DefaultCoordinator extends Coordinator {
         return this.queryProfile.isProfileAlreadyReported();
     }
 
+    @Override
+    public String getWarehouseName() {
+        if (connectContext == null) {
+            return "";
+        }
+        return connectContext.getCurrentWarehouse();
+    }
+
     private void execShortCircuit() {
         shortCircuitExecutor.exec();
         Optional<RuntimeProfile> runtimeProfile = shortCircuitExecutor.getRuntimeProfile();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -171,7 +171,9 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                     .connId(String.valueOf(context.getConnectionId()))
                     .db(context.getDatabase())
                     .fragmentInstanceInfos(info.getCoord().getFragmentInstanceInfos())
-                    .profile(info.getCoord().getQueryProfile()).build();
+                    .profile(info.getCoord().getQueryProfile())
+                    .warehouseName(info.coord.getWarehouseName()).build();
+
             querySet.put(queryIdStr, item);
         }
         return querySet;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
@@ -36,6 +36,7 @@ public final class QueryStatisticsItem {
     // root query profile
     private final RuntimeProfile queryProfile;
     private final TUniqueId executionId;
+    private final String warehouseName;
 
     private QueryStatisticsItem(Builder builder) {
         this.queryId = builder.queryId;
@@ -47,6 +48,7 @@ public final class QueryStatisticsItem {
         this.fragmentInstanceInfos = builder.fragmentInstanceInfos;
         this.queryProfile = builder.queryProfile;
         this.executionId = builder.executionId;
+        this.warehouseName = builder.warehouseName;
     }
 
     public String getDb() {
@@ -90,6 +92,10 @@ public final class QueryStatisticsItem {
         return executionId;
     }
 
+    public String getWarehouseName() {
+        return warehouseName;
+    }
+
     public static final class Builder {
         private String queryId;
         private String db;
@@ -100,6 +106,7 @@ public final class QueryStatisticsItem {
         private List<FragmentInstanceInfo> fragmentInstanceInfos;
         private RuntimeProfile queryProfile;
         private TUniqueId executionId;
+        private String warehouseName;
 
         public Builder() {
             fragmentInstanceInfos = Lists.newArrayList();
@@ -147,6 +154,11 @@ public final class QueryStatisticsItem {
 
         public Builder executionId(TUniqueId executionId) {
             this.executionId = executionId;
+            return this;
+        }
+
+        public Builder warehouseName(String warehouseName) {
+            this.warehouseName = warehouseName;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -220,4 +220,6 @@ public abstract class Coordinator {
     public abstract void setTimeoutSecond(int timeoutSecond);
 
     public abstract boolean isProfileAlreadyReported();
+
+    public abstract String getWarehouseName();
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsItemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsItemTest.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+class QueryStatisticsItemTest {
+
+    @Test
+    void testQueryStatisticsItem() {
+        String queryId = "123";
+        String warehouseName = "wh1";
+
+        final QueryStatisticsItem item = new QueryStatisticsItem.Builder()
+                .queryId("123")
+                .warehouseName("wh1").build();
+
+        Assert.assertEquals("wh1", item.getWarehouseName());
+        Assert.assertEquals("123", item.getQueryId());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

There is add `warehouse` column when execute `show proc '/current_queries';`
```
mysql> show proc '/current_queries';
+---------------------+--------------------------------------+--------------+----------+------+-----------+----------+-------------+---------------+---------+----------+-----------------+
| StartTime           | QueryId                              | ConnectionId | Database | User | ScanBytes | ScanRows | MemoryUsage | DiskSpillSize | CPUTime | ExecTime | Warehouse       |
+---------------------+--------------------------------------+--------------+----------+------+-----------+----------+-------------+---------------+---------+----------+-----------------+
| 2024-05-21 14:52:10 | a5b52ca1-173e-11ef-af07-469314b28ba2 | 2            |          | root | 0.000 B   | 0 rows   | 45.109 KB   | 0.000 B       | 0.000 s | 2.106 s  | daily_warehouse |
+---------------------+--------------------------------------+--------------+----------+------+-----------+----------+-------------+---------------+---------+----------+-----------------+
1 row in set (0.00 sec)
```

## What I'm doing:

add a method in `Coordinator` 
```
public abstract String getWarehouseName()
```

In its implementation, we try to get the warehouse name from session variable.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

