### PR TITLE
[BugFix] Fix push down decimal window function error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
@@ -345,6 +345,10 @@ public class PushDownDistinctAggregateRewriter {
                 Type[] argTypes = newArgs.stream().map(ScalarOperator::getType).toArray(Type[]::new);
                 Function newFunc = Expr.getBuiltinFunction(funcName, argTypes,
                         Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                if (FunctionSet.SUM.equals(funcName) && argTypes[0].isDecimalOfAnyVersion()) {
+                    newFunc = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) newFunc,
+                            argTypes[0], rewriteCallOp.getType());
+                }
                 CallOperator newWindowCall = new CallOperator(funcName, newFunc.getReturnType(), newArgs, newFunc);
                 newWindowCalls.put(entry.getKey(), newWindowCall);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -221,4 +221,18 @@ public class AggregatePushDownTest extends PlanTestBase {
                         "  |  \n" +
                         "  2:EXCHANGE");
     }
+
+    @Test
+    public void testPruneDistinctWindow() throws Exception {
+        String sql = "select distinct t1c, t1d, t1g, amount " +
+                " from (" +
+                " select  t1b, t1c, t1d, t1g, id_date, \n" +
+                "     sum(id_decimal)over(partition by t1c) as amount\n" +
+                "from test_all_type_not_null) tt";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  5:ANALYTIC\n" +
+                "  |  functions: [, sum[([12: sum, DECIMAL128(38,2), true]);" +
+                " args: DECIMAL128; result: DECIMAL128(38,2); args nullable: true; result nullable: true], ]");
+        assertContains(plan, "2:AGGREGATE (update finalize)");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

push down aggregate function on window, lose deicmal's scale and precision

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
