### PR TITLE
[BugFix] correlation in plan should not be null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -247,7 +247,8 @@ public class MaterializedViewAnalyzer {
             // check query relation is select relation
             if (!(queryStatement.getQueryRelation() instanceof SelectRelation) &&
                     !(queryStatement.getQueryRelation() instanceof SetOperationRelation)) {
-                throw new SemanticException("Materialized view query statement only support select or set operation",
+                throw new SemanticException("Materialized view query statement only supports a single query block or " +
+                        "multiple query blocks in set operations",
                         queryStatement.getQueryRelation().getPos());
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -301,12 +301,12 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         }
 
         if (!(queryStatement.getQueryRelation() instanceof SelectRelation)) {
-            throw new SemanticException("Materialized view query statement only support a single query blocks");
+            throw new SemanticException("Materialized view query statement only supports a single query blocks");
         }
 
         Map<TableName, Table> tables = AnalyzerUtils.collectAllTableAndViewWithAlias(queryStatement);
         if (tables.size() != 1) {
-            throw new UnsupportedMVException("The materialized view only support one table in from clause.");
+            throw new UnsupportedMVException("The materialized view only supports one table in from clause.");
         }
         Map.Entry<TableName, Table> entry = tables.entrySet().iterator().next();
         Table table = entry.getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -301,7 +301,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         }
 
         if (!(queryStatement.getQueryRelation() instanceof SelectRelation)) {
-            throw new SemanticException("Materialized view query statement only support select");
+            throw new SemanticException("Materialized view query statement only support a single query blocks");
         }
 
         Map<TableName, Table> tables = AnalyzerUtils.collectAllTableAndViewWithAlias(queryStatement);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -28,8 +28,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryRelation;
-import com.starrocks.sql.ast.SelectRelation;
-import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -101,7 +99,7 @@ public class SubqueryUtils {
     public static LogicalPlan getLogicalPlan(ConnectContext session, CTETransformerContext cteContext,
                                              ColumnRefFactory columnRefFactory, QueryRelation relation,
                                              ExpressionMapping outer) {
-        if (!(relation instanceof SelectRelation) && !(relation instanceof SubqueryRelation)) {
+        if (relation instanceof QueryRelation) {
             throw new SemanticException("Currently only subquery of the Select type are supported");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -26,7 +26,6 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -99,10 +98,6 @@ public class SubqueryUtils {
     public static LogicalPlan getLogicalPlan(ConnectContext session, CTETransformerContext cteContext,
                                              ColumnRefFactory columnRefFactory, QueryRelation relation,
                                              ExpressionMapping outer) {
-        if (!(relation instanceof QueryRelation)) {
-            throw new SemanticException("Currently only subquery of the Select type are supported");
-        }
-
         // For in subQuery, the order by is meaningless
         if (!relation.hasLimit()) {
             relation.getOrderBy().clear();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -99,7 +99,7 @@ public class SubqueryUtils {
     public static LogicalPlan getLogicalPlan(ConnectContext session, CTETransformerContext cteContext,
                                              ColumnRefFactory columnRefFactory, QueryRelation relation,
                                              ExpressionMapping outer) {
-        if (relation instanceof QueryRelation) {
+        if (!(relation instanceof QueryRelation)) {
             throw new SemanticException("Currently only subquery of the Select type are supported");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/LogicalPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/LogicalPlan.java
@@ -18,10 +18,12 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.List;
+import javax.validation.constraints.NotNull;
 
 public class LogicalPlan {
     private final OptExprBuilder root;
     private final List<ColumnRefOperator> outputColumn;
+    @NotNull
     private final List<ColumnRefOperator> correlation;
 
     public LogicalPlan(OptExprBuilder root, List<ColumnRefOperator> outputColumns,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -394,7 +394,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
         }
 
         root = addOrderByLimit(root, setOperationRelation);
-        return new LogicalPlan(root, outputColumns, null);
+        return new LogicalPlan(root, outputColumns, List.of());
     }
 
     private OptExprBuilder addOrderByLimit(OptExprBuilder root, QueryRelation relation) {
@@ -460,7 +460,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
         OptExprBuilder valuesOpt = new OptExprBuilder(new LogicalValuesOperator(valuesOutputColumns, values),
                 Collections.emptyList(),
                 new ExpressionMapping(new Scope(RelationId.of(node), node.getRelationFields()), valuesOutputColumns));
-        return new LogicalPlan(valuesOpt, valuesOutputColumns, null);
+        return new LogicalPlan(valuesOpt, valuesOutputColumns, List.of());
     }
 
     private DistributionSpec getTableDistributionSpec(TableRelation node,
@@ -645,7 +645,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                 new LogicalProjectOperator(outputVariables.stream().distinct()
                         .collect(Collectors.toMap(Function.identity(), Function.identity())));
 
-        return new LogicalPlan(scanBuilder.withNewRoot(projectOperator), outputVariables, null);
+        return new LogicalPlan(scanBuilder.withNewRoot(projectOperator), outputVariables, List.of());
     }
 
     @Override
@@ -667,7 +667,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
         OptExprBuilder consumeBuilder = new OptExprBuilder(consume, Lists.newArrayList(childPlan.getRootBuilder()),
                 new ExpressionMapping(node.getScope(), childPlan.getOutputColumn()));
 
-        return new LogicalPlan(consumeBuilder, childPlan.getOutputColumn(), null);
+        return new LogicalPlan(consumeBuilder, childPlan.getOutputColumn(), List.of());
     }
 
     @Override
@@ -711,7 +711,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
             LogicalViewScanOperator viewScanOperator = buildViewScan(logicalPlan, node, newOutputColumns);
             OptExprBuilder scanBuilder = new OptExprBuilder(viewScanOperator, Collections.emptyList(),
                     new ExpressionMapping(node.getScope(), newOutputColumns));
-            return new LogicalPlan(scanBuilder, newOutputColumns, null);
+            return new LogicalPlan(scanBuilder, newOutputColumns, List.of());
         }
     }
 
@@ -798,7 +798,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                     .setNeedOutputRightChildColumns(true).build();
             return new LogicalPlan(
                     new OptExprBuilder(root, Lists.newArrayList(leftPlan.getRootBuilder(), rightPlan.getRootBuilder()),
-                            expressionMapping), expressionMapping.getFieldMappings(), null);
+                            expressionMapping), expressionMapping.getFieldMappings(), List.of());
         }
 
         LogicalPlan leftPlan = visit(node.getLeft());
@@ -839,7 +839,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                     new LogicalProjectOperator(expressionMapping.getFieldMappings().stream().distinct()
                             .collect(Collectors.toMap(Function.identity(), Function.identity())));
             return new LogicalPlan(joinOptExprBuilder.withNewRoot(projectOperator),
-                    expressionMapping.getFieldMappings(), null);
+                    expressionMapping.getFieldMappings(), List.of());
         }
 
         ExpressionMapping outputExpressionMapping;
@@ -885,7 +885,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                 new LogicalProjectOperator(outputExpressionMapping.getFieldMappings().stream().distinct()
                         .collect(Collectors.toMap(Function.identity(), Function.identity())));
         return new LogicalPlan(joinOptExprBuilder.withNewRoot(projectOperator),
-                outputExpressionMapping.getFieldMappings(), null);
+                outputExpressionMapping.getFieldMappings(), List.of());
     }
 
     @Override
@@ -926,7 +926,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
         Operator root = new LogicalTableFunctionOperator(outputColumns, node.getTableFunction(), projectMap);
         return new LogicalPlan(new OptExprBuilder(root, Collections.emptyList(),
                 new ExpressionMapping(new Scope(RelationId.of(node), node.getRelationFields()), outputColumns)),
-                null, null);
+                null, List.of());
     }
 
     @Override
@@ -959,7 +959,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
 
         ExpressionMapping mapping = new ExpressionMapping(node.getScope(), output);
         builder.setExpressionMapping(mapping);
-        return new LogicalPlan(builder, output, null);
+        return new LogicalPlan(builder, output, List.of());
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1489,7 +1489,7 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view query statement only support select"));
+            Assert.assertTrue(e.getMessage().contains("Materialized view query statement only support a single query blocks"));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1489,7 +1489,7 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view query statement only support a single query blocks"));
+            Assert.assertTrue(e.getMessage().contains("Materialized view query statement only supports a single query blocks"));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1903,7 +1903,7 @@ public class SubqueryTest extends PlanTestBase {
     }
 
     @Test
-    public void testComplexCorrelationPredicateNotInSubquery2() throws Exception {
+    public void testComplexCorrelationPredicateNotInSubquery2() {
         String sql = "select v2 not in (select v5 from t1 where t0.v1 = t1.v4 + t0.v1) from t0";
         Assert.assertThrows("IN subquery not supported the correlation predicate of the" +
                         " WHERE clause that used multiple outer-table columns at the same time.\n", SemanticException.class,
@@ -1938,5 +1938,22 @@ public class SubqueryTest extends PlanTestBase {
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage(), e.getMessage().contains("referencing columns from more than one table"));
         }
+    }
+
+    @Test
+    public void testUnionRelationSubquery() throws Exception {
+        String sql = "select * from t0 where v2 = 1 and v1 not in (select v4 from t1 union all select v7 from t2);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "7:HASH JOIN\n" +
+                "  |  join op: NULL AWARE LEFT ANTI JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 10: v4");
+
+        sql = "select * from t0 where v2 = 1 and v1 not in ((select v4 from t1 union all select v7 from t2));";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "7:HASH JOIN\n" +
+                "  |  join op: NULL AWARE LEFT ANTI JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 10: v4");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
- correlation in plan should not be null


## What I'm doing:
- set a immutable empty list when there is not exist correlation cols.
- Relax the check on relations in the subquery.

Fixes #issue
fix
![image](https://github.com/StarRocks/starrocks/assets/110370499/ef4a4b3c-edd6-4823-bf63-b0d32702d99f)


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
