### PR TITLE
[Enhancement] add dynamic partition force

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -650,7 +650,8 @@ public class AlterJobMgr {
             Preconditions.checkState(alterClauses.size() == 1);
             AlterClause alterClause = alterClauses.get(0);
             if (alterClause instanceof AddPartitionClause) {
-                if (!((AddPartitionClause) alterClause).isTempPartition()) {
+                if (!((AddPartitionClause) alterClause).isTempPartition()
+                        && !((AddPartitionClause) alterClause).isForce()) {
                     DynamicPartitionUtil.checkAlterAllowed((OlapTable) db.getTable(tableName));
                 }
                 GlobalStateMgr.getCurrentState().getLocalMetastore()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionClause.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 // clause which is used to add partition
 public class AddPartitionClause extends AlterTableClause {
-
+    private final boolean force;
     private final PartitionDesc partitionDesc;
     private final DistributionDesc distributionDesc;
     private final Map<String, String> properties;
@@ -41,22 +41,51 @@ public class AddPartitionClause extends AlterTableClause {
         return isTempPartition;
     }
 
-    public AddPartitionClause(PartitionDesc partitionDesc,
-                              DistributionDesc distributionDesc,
-                              Map<String, String> properties,
-                              boolean isTempPartition) {
-        this(partitionDesc, distributionDesc, properties, isTempPartition, NodePosition.ZERO);
+    public boolean isForce() {
+        return force;
     }
 
     public AddPartitionClause(PartitionDesc partitionDesc,
                               DistributionDesc distributionDesc,
                               Map<String, String> properties,
-                              boolean isTempPartition, NodePosition pos) {
+                              boolean isTempPartition) {
+        this(partitionDesc, distributionDesc, properties, isTempPartition, false, NodePosition.ZERO);
+    }
+
+    public AddPartitionClause(PartitionDesc partitionDesc,
+                              DistributionDesc distributionDesc,
+                              Map<String, String> properties,
+                              boolean isTempPartition,
+                              boolean force) {
+        this(partitionDesc, distributionDesc, properties, isTempPartition, force, NodePosition.ZERO);
+    }
+
+    public AddPartitionClause(PartitionDesc partitionDesc,
+                              DistributionDesc distributionDesc,
+                              Map<String, String> properties,
+                              boolean isTempPartition,
+                              NodePosition pos) {
         super(AlterOpType.ADD_PARTITION, pos);
         this.partitionDesc = partitionDesc;
         this.distributionDesc = distributionDesc;
         this.properties = properties;
         this.isTempPartition = isTempPartition;
+        this.force = false;
+        this.needTableStable = false;
+    }
+
+    public AddPartitionClause(PartitionDesc partitionDesc,
+                              DistributionDesc distributionDesc,
+                              Map<String, String> properties,
+                              boolean isTempPartition,
+                              boolean force,
+                              NodePosition pos) {
+        super(AlterOpType.ADD_PARTITION, pos);
+        this.partitionDesc = partitionDesc;
+        this.distributionDesc = distributionDesc;
+        this.properties = properties;
+        this.isTempPartition = isTempPartition;
+        this.force = force;
         this.needTableStable = false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4155,6 +4155,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitAddPartitionClause(StarRocksParser.AddPartitionClauseContext context) {
         boolean temporary = context.TEMPORARY() != null;
+        boolean force = context.FORCE() != null;
         PartitionDesc partitionDesc = null;
         if (context.singleRangePartition() != null) {
             partitionDesc = (PartitionDesc) visitSingleRangePartition(context.singleRangePartition());
@@ -4176,7 +4177,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 properties.put(property.getKey(), property.getValue());
             }
         }
-        return new AddPartitionClause(partitionDesc, distributionDesc, properties, temporary, createPos(context));
+        return new AddPartitionClause(partitionDesc, distributionDesc, properties, temporary, force, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1009,7 +1009,7 @@ compactionClause
 // ---------Alter partition clause---------
 
 addPartitionClause
-    : ADD TEMPORARY? (singleRangePartition | PARTITIONS multiRangePartition) distributionDesc? properties?
+    : ADD TEMPORARY? (singleRangePartition | PARTITIONS multiRangePartition) distributionDesc? properties? FORCE?
     | ADD TEMPORARY? (singleItemListPartitionDesc | multiItemListPartitionDesc) distributionDesc? properties?
     ;
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -2551,4 +2551,44 @@ public class AlterTest {
             }
         }
     }
+
+    @Test
+    public void testCatalogAddPartitionsForce() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test_partition_exception (\n" +
+                "      k1 DATE,\n" +
+                "      k2 SMALLINT,\n" +
+                "      v1 VARCHAR(2048),\n" +
+                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(k1, k2)\n" +
+                "PARTITION BY RANGE (k1) (\n" +
+                "    START (\"2024-05-20\") END (\"2024-05-24\") EVERY (INTERVAL 1 DAY)\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"dynamic_partition.enable\" = \"true\",\n" +
+                "\"dynamic_partition.start\" = \"-30\",\n" +
+                "\"dynamic_partition.end\" = \"1\",\n" +
+                "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                "\"dynamic_partition.prefix\" = \"p\",\n" +
+                "\"dynamic_partition.buckets\" = \"1\"\n" +
+                ");";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+
+        String alterSQL =
+                "ALTER TABLE test_partition_exception ADD PARTITION p20240501 VALUES [(\"2024-05-01\"), (\"2024-05-02\")) FORCE";
+        AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
+        AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getOps().get(0);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(db, "test_partition_exception", addPartitionClause);
+
+        Table table = db.getTable("test_partition_exception");
+
+        Assert.assertEquals(5, ((OlapTable) table).getPartitions().size());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

### dynamic partition like below
```
CREATE TABLE `test_db`.`add_partition_force` (
  `id` int(11) NOT NULL DEFAULT "0" COMMENT "",
  `price` decimal64(1, 1) NOT NULL DEFAULT "0.0" COMMENT "",
  `dt` date NOT NULL DEFAULT "2022-01-01" COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`id`)
COMMENT "aa"
PARTITION BY RANGE(`dt`)
(START("2024-05-20")END("2024-05-24")EVERY(INTERVAL 1 DAY))
DISTRIBUTED BY HASH(`id`) BUCKETS 10
PROPERTIES (
"replication_num" = "1",
"dynamic_partition.enable" = "true",
"dynamic_partition.time_unit" = "DAY",
"dynamic_partition.time_zone" = "Asia/Shanghai",
"dynamic_partition.start" = "-30",
"dynamic_partition.end" = "1",
"dynamic_partition.prefix" = "p",
"dynamic_partition.buckets" = "10",
"in_memory" = "false"
);
```

### a dynamic partition table add a new partition need do 3 steps
+ step 1. close the dynamic_partiton.enable
```
alter table `test_db`.`add_partition_force` set ("dynamic_partition.enable" = "false");
```

+ step 2. add a new partition
```
alter table `test_db`.`add_partition_force` add partition p20240520 VALUES [("2024-05-20"), ("2024-05-21"));
```

+ step 3. open the dynamic_partition.enable
```
alter table `test_db`.`add_partition_force` set ("dynamic_partition.enable" = "true");
```

### Multiple threads operate concurrently while adding partitions
+ 1. Thread 1 has completed step 3, turning on the dynamic partition identifier
+ 2 Thread 2 is doing the second step, adding a partition, and receives an error message
```
Cannot add/drop partition on a Dynamic Partition Table, Use command `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false")` firstly.
``` 


## What I'm doing:
add a clause to add partition force
```
ALTER TABLE test_partition_force_dup_sr ADD PARTITION p20240501 VALUES [("2024-05-01"), ("2024-05-02")) FORCE
```

Fixes #46227

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5