### PR TITLE
[BugFix] Fix validation failure of aggregation analyzer analyzing subfields

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -208,6 +208,10 @@ public class SlotRef extends Expr {
         col = colStr.toString();
     }
 
+    public Boolean isSubField() {
+        return getOriginType().isStructType() && getUsedStructFieldPos() != null && !getUsedStructFieldPos().isEmpty();
+    }
+
     @Override
     public Expr clone() {
         return new SlotRef(this);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
@@ -95,8 +96,9 @@ public class AggregationAnalyzer {
         this.orderByScope = orderByScope;
         this.analyzeState = analyzeState;
         this.groupingExpressions = groupingExpressions;
+        // We need to filter out subfields of struct type SlotRef here.
         this.groupingFields = groupingExpressions.stream()
-                .filter(analyzeState.getColumnReferences()::containsKey)
+                .filter(filterSubfieldsFromColumnReference(analyzeState.getColumnReferences())::containsKey)
                 .map(analyzeState.getColumnReferences()::get)
                 .collect(toImmutableSet());
     }
@@ -105,6 +107,20 @@ public class AggregationAnalyzer {
         if (!new VerifyExpressionVisitor().visit(expression)) {
             throw new SemanticException(PARSER_ERROR_MSG.shouldBeAggFunc(expression.toSql()), expression.getPos());
         }
+    }
+
+    /**
+     * subfields (a.b, a.c) with the same SlotRef (a) as parent share the same FieldId, which allows subfields to pass
+     * the check in isGroupingKey function, even though they might not be actually grouping keys. This could result into
+     * BE crash. The following SQL is an example.
+     * Select a.b, a.c, count(1) from tbl group by 1.
+     * @param columnReferences
+     * @return
+     */
+    private Map<Expr, FieldId> filterSubfieldsFromColumnReference(Map<Expr, FieldId> columnReferences) {
+        return columnReferences.entrySet().stream()
+                .filter(entry -> entry.getKey() instanceof SlotRef && !((SlotRef) entry.getKey()).isSubField())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -79,6 +79,11 @@ public class AnalyzeAggregateTest {
                 "No matching function with signature: min_by(bigint(20), bigint(20), bigint(20)).");
         analyzeFail("select min_by(v1,1) from t0", "min_by function args must be column");
         analyzeFail("select min_by(1,v1) from t0", "min_by function args must be column");
+
+        analyzeSuccess("select vs.a, vs.b from ttypes group by vs.a, vs.b");
+        analyzeSuccess("select vs.a, vs.b from ttypes group by vs");
+        analyzeFail("select vs.a, vs.b from ttypes group by vs.a",
+                "must be an aggregate expression or appear in GROUP BY clause");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Select a.b, a.c, count(1) from tbl group by 1

Missing one subfield grouping expression may cause be crash when it comes to struct-type SlotRef.

## What I'm doing:
Fix the check of this very case in AggregationAnalyzer to prevent incorrect plan being generated. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5