### PR TITLE
[BugFix] Fix infinite wait in LakeTabletsChannel

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -159,11 +159,13 @@ private:
             return _logs;
         }
 
-        void wait() {
+        // Returns true on notified, false on timeout
+        bool wait(int64_t timeout_ms) {
             std::unique_lock l(_mtx);
             while (!_notified) {
-                _cond.wait(l);
+                return 0 == _cond.wait_for(l, timeout_ms * 1000L);
             }
+            return true;
         }
 
         void notify() {
@@ -539,8 +541,9 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     if (_finish_mode == lake::kDontWriteTxnLog && request.eos() && (request.sender_id() == 0) &&
         response->status().status_code() == TStatusCode::OK) {
         rolk.unlock();
-        _txn_log_collector.wait();
-        auto st = _txn_log_collector.status();
+        auto t = request.timeout_ms() - (int64_t)(watch.elapsed_time() / 1000 / 1000);
+        auto ok = _txn_log_collector.wait(t);
+        auto st = ok ? _txn_log_collector.status() : Status::TimedOut(fmt::format("wait txn log timed out: {}", t));
         if (st.ok()) {
             context->add_txn_logs(_txn_log_collector.logs());
         } else {

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -163,7 +163,9 @@ private:
         bool wait(int64_t timeout_ms) {
             std::unique_lock l(_mtx);
             while (!_notified) {
-                return 0 == _cond.wait_for(l, timeout_ms * 1000L);
+                if (_cond.wait_for(l, timeout_ms * 1000L) == ETIMEDOUT) {
+                    return false;
+                }
             }
             return true;
         }

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -851,6 +851,7 @@ TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
         add_chunk_request.set_sender_id(sender_id);
         add_chunk_request.set_eos(false);
         add_chunk_request.set_packet_seq(0);
+        add_chunk_request.set_timeout_ms(30 * 1000);
 
         for (int i = 0; i < kChunkSize; i++) {
             int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
@@ -873,6 +874,7 @@ TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
         finish_request.set_packet_seq(1);
         finish_request.add_partition_ids(10);
         finish_request.add_partition_ids(11);
+        finish_request.set_timeout_ms(30 * 1000);
 
         _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
 


### PR DESCRIPTION
## Why I'm doing:
LakeTabletsChannel may fail to receive close requests from all senders, causing TxnLogCollector::wait to never return.

## What I'm doing:
Let TxnLogCollector::wait return after timeout

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
