### PR TITLE
[Enhancement] Bump FE's thrift to 0.20.0

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -725,6 +725,34 @@ under the License.
             </exclusions>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-hadoop -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-avro -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-column -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-common -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-common</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-bundle</artifactId>

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -18,9 +18,9 @@ package com.starrocks.catalog;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.server.CatalogMgr;
-import org.apache.parquet.Strings;
 
 /**
  * BaseTableInfo is used for MaterializedView persisted as a base table's meta info which can be an olap

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.annotations.SerializedName;
@@ -38,7 +39,6 @@ import com.starrocks.sql.parser.SqlParser;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.parquet.Strings;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Strings;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -24,7 +25,6 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.parquet.Strings;
 
 import java.util.List;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerContext.java
@@ -50,4 +50,15 @@ public class ThriftServerContext implements ServerContext {
     public TNetworkAddress getClient() {
         return client;
     }
+
+
+    @Override
+    public <T> T unwrap(Class<T> aClass) {
+        throw new UnsupportedOperationException("Unimplemented method 'unwrap'");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> aClass) {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -313,9 +313,9 @@ public class TableQueryPlanAction extends RestBaseAction {
         tQueryPlanInfo.tablet_info = tabletInfo;
 
         // serialize TQueryPlanInfo and encode plan with Base64 to string in order to translate by json format
-        TSerializer serializer = new TSerializer();
         String opaquedQueryPlan;
         try {
+            TSerializer serializer = new TSerializer();
             byte[] queryPlanStream = serializer.serialize(tQueryPlanInfo);
             opaquedQueryPlan = Base64.getEncoder().encodeToString(queryPlanStream);
         } catch (TException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -231,9 +231,8 @@ public class FragmentNormalizer {
     public ByteBuffer normalizeExpr(Expr expr) {
         uncacheable = uncacheable || hasNonDeterministicFunctions(expr);
         TExpr texpr = expr.normalize(this);
-        //TSerializer ser = new TSerializer(new TCompactProtocol.Factory());
-        TSerializer ser = new TSerializer(new TSimpleJSONProtocol.Factory());
         try {
+            TSerializer ser = new TSerializer(new TSimpleJSONProtocol.Factory());
             return ByteBuffer.wrap(ser.serialize(texpr));
         } catch (Exception ignored) {
             Preconditions.checkArgument(false);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/FragmentScanRangeAssignment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/FragmentScanRangeAssignment.java
@@ -57,10 +57,10 @@ public class FragmentScanRangeAssignment extends
             for (Integer scanNodeId : placement.keySet()) {
                 ArrayList<TScanRangeParams> scanRangeParams = new ArrayList<>(placement.get(scanNodeId));
                 Collections.sort(scanRangeParams);
-                TMemoryBuffer transport = new TMemoryBuffer(1024 * 1024);
-                TBinaryProtocol protocol = new TBinaryProtocol(transport);
                 String output;
                 try {
+                    TMemoryBuffer transport = new TMemoryBuffer(1024 * 1024);
+                    TBinaryProtocol protocol = new TBinaryProtocol(transport);
                     for (TScanRangeParams param : scanRangeParams) {
                         param.write(protocol);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -156,8 +156,8 @@ public class FragmentInstanceExecState {
     }
 
     public void serializeRequest() {
-        TSerializer serializer = AttachmentRequest.getSerializer(jobSpec.getPlanProtocol());
         try {
+            TSerializer serializer = AttachmentRequest.getSerializer(jobSpec.getPlanProtocol());
             serializedRequest = serializer.serialize(requestToDeploy);
         } catch (TException ignore) {
             // throw exception means serializedRequest will be empty, and then we will treat it as not serialized

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
@@ -29,6 +29,7 @@ import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TJSONProtocol;
+import org.apache.thrift.transport.TTransportException;
 
 // used to compatible with our older thrift protocol
 public class AttachmentRequest {
@@ -37,7 +38,7 @@ public class AttachmentRequest {
     @Ignore
     protected byte[] serializedResult;
 
-    public static TSerializer getSerializer(String protocol) {
+    public static TSerializer getSerializer(String protocol) throws TTransportException {
         TSerializer serializer;
         if (StringUtils.equalsIgnoreCase(protocol, "compact")) {
             serializer = new TSerializer(TCompactProtocol::new);

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -157,10 +157,10 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.layered.TFramedTransport;
 
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
@@ -571,7 +571,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
                                     + "Continuing without it.", e);
                         }
                     }
-                } catch (MetaException e) {
+                } catch (MetaException | TTransportException e) {
                     LOG.error("Unable to connect to metastore with URI " + store
                             + " in attempt " + attempt, e);
                 }

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/security/TFilterTransport.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/security/TFilterTransport.java
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package org.apache.hadoop.hive.metastore.security;
 

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/security/TFilterTransport.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/security/TFilterTransport.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.hadoop.hive.metastore.security;
+
+import org.apache.thrift.TConfiguration;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+// Used to replace TFilterTransport in apache-hive
+// Fix problem introduced by https://github.com/StarRocks/starrocks/pull/995
+public class TFilterTransport extends TTransport {
+    protected final TTransport wrapped;
+
+    public TFilterTransport(TTransport wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void open() throws TTransportException {
+        wrapped.open();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return wrapped.isOpen();
+    }
+
+    @Override
+    public boolean peek() {
+        return wrapped.peek();
+    }
+
+    @Override
+    public void close() {
+        wrapped.close();
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) throws TTransportException {
+        return wrapped.read(buf, off, len);
+    }
+
+    @Override
+    public int readAll(byte[] buf, int off, int len) throws TTransportException {
+        return wrapped.readAll(buf, off, len);
+    }
+
+    @Override
+    public void write(byte[] buf) throws TTransportException {
+        wrapped.write(buf);
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) throws TTransportException {
+        wrapped.write(buf, off, len);
+    }
+
+    @Override
+    public void flush() throws TTransportException {
+        wrapped.flush();
+    }
+
+    @Override
+    public byte[] getBuffer() {
+        return wrapped.getBuffer();
+    }
+
+    @Override
+    public int getBufferPosition() {
+        return wrapped.getBufferPosition();
+    }
+
+    @Override
+    public int getBytesRemainingInBuffer() {
+        return wrapped.getBytesRemainingInBuffer();
+    }
+
+    @Override
+    public void consumeBuffer(int len) {
+        wrapped.consumeBuffer(len);
+    }
+
+    @Override
+    public TConfiguration getConfiguration() {
+        return wrapped.getConfiguration();
+    }
+
+    @Override
+    public void updateKnownMessageSize(long size) throws TTransportException {
+        wrapped.updateKnownMessageSize(size);
+    }
+
+    @Override
+    public void checkReadBytesAvailable(long numBytes) throws TTransportException {
+        wrapped.checkReadBytesAvailable(numBytes);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -151,7 +152,7 @@ public class MetadataParser {
         metrics.skippedDataFiles().increment(liveFilesCount - metrics.resultDataFiles().value());
     }
 
-    private List<FileScanTask> parse(TResultBatch resultBatch) {
+    private List<FileScanTask> parse(TResultBatch resultBatch) throws TTransportException {
         List<DataFile> dataFiles = buildIcebergDataFile(resultBatch);
         return dataFiles.stream().map(this::createFileScanTasks).collect(Collectors.toList());
     }
@@ -173,7 +174,7 @@ public class MetadataParser {
                 residuals);
     }
 
-    private List<DataFile> buildIcebergDataFile(TResultBatch resultBatch) {
+    private List<DataFile> buildIcebergDataFile(TResultBatch resultBatch) throws TTransportException {
         List<DataFile> dataFiles = new ArrayList<>();
         TDeserializer deserializer = new TDeserializer();
         for (ByteBuffer bb : resultBatch.rows) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.planner;
 
 import com.google.api.client.util.Lists;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
@@ -27,7 +28,6 @@ import com.starrocks.common.Pair;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
-import org.apache.parquet.Strings;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -914,9 +914,9 @@ public class PseudoBackend {
             if (shutdown) {
                 throw new RuntimeException("backend " + getId() + " shutdown");
             }
-            TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
             final TExecPlanFragmentParams params = new TExecPlanFragmentParams();
             try {
+                TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
                 deserializer.deserialize(params, request.getSerializedRequest());
             } catch (TException e) {
                 LOG.warn("error deserialize request", e);
@@ -947,9 +947,9 @@ public class PseudoBackend {
             if (shutdown) {
                 throw new RuntimeException("backend " + getId() + " shutdown");
             }
-            TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
             final TExecBatchPlanFragmentsParams params = new TExecBatchPlanFragmentsParams();
             try {
+                TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
                 deserializer.deserialize(params, request.getSerializedRequest());
             } catch (TException e) {
                 LOG.warn("error deserialize request", e);

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -551,6 +551,10 @@ under the License.
                         <groupId>org.apache.parquet</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -53,7 +53,7 @@ under the License.
         <gcs.connector.version>hadoop3-2.2.11</gcs.connector.version>
         <skip.plugin>false</skip.plugin>
         <hudi.version>0.14.1</hudi.version>
-        <hive-apache.version>3.1.2-13</hive-apache.version>
+        <hive-apache.version>3.1.2-22</hive-apache.version>
         <dlf-metastore-client.version>0.2.14</dlf-metastore-client.version>
         <sonar.organization>starrocks</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -375,7 +375,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.13.0</version>
+                <version>0.20.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -48,7 +48,7 @@ under the License.
         <jackson.version>2.15.2</jackson.version>
         <spark.version>3.4.1</spark.version>
         <tomcat.version>8.5.70</tomcat.version>
-        <parquet.version>1.10.1</parquet.version>
+        <parquet.version>1.14.0</parquet.version>
         <hadoop.version>3.4.0</hadoop.version>
         <gcs.connector.version>hadoop3-2.2.11</gcs.connector.version>
         <skip.plugin>false</skip.plugin>
@@ -603,6 +603,22 @@ under the License.
             <dependency>
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-common</artifactId>
+                <version>${parquet.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-column -->
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-column</artifactId>
+                <version>${parquet.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-avro -->
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-avro</artifactId>
                 <version>${parquet.version}</version>
                 <scope>provided</scope>
             </dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -546,6 +546,12 @@ under the License.
                 <groupId>io.trino.hive</groupId>
                 <artifactId>hive-apache</artifactId>
                 <version>${hive-apache.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.parquet</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.aliyun.datalake/metastore-client-hive3 -->


### PR DESCRIPTION
## Why I'm doing:
Bump thrift for cve problem

## What I'm doing:
* Fix kerberos connection issue https://github.com/StarRocks/starrocks/pull/995 by `TFilterTransport`
* Bump thrift
* introduce parquet because parquet module was removed in latest `apache-hive`


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
