### PR TITLE
[Enhancement] Cache segment footer after loading it during query cardinality

### DIFF
--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -107,7 +107,7 @@ Status LakeMetaReader::_init_seg_meta_collecters(const lake::VersionedTablet& ta
 Status LakeMetaReader::_get_segments(const lake::VersionedTablet& tablet, std::vector<SegmentSharedPtr>* segments) {
     auto rowsets = tablet.get_rowsets();
     for (const auto& rowset : rowsets) {
-        ASSIGN_OR_RETURN(auto rowset_segs, rowset->segments(false));
+        ASSIGN_OR_RETURN(auto rowset_segs, rowset->segments(true));
         segments->insert(segments->end(), rowset_segs.begin(), rowset_segs.end());
     }
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:

Currently, during global dictionary loading, cardinality information is queried for all BE nodes in the planning phase. At this point, the BE loads the Segment Footer. However, the issue lies in the fact that these segment footers are not placed into the meta cache. Consequently, when accessed again, they are reloaded from the underlying storage, potentially leading to disk cache misses and subsequent access to S3, thus impacting query efficiency.

## What I'm doing:
Put segment footer into metadata cache after loaded

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
