### PR TITLE
[Enhancement] support function percentile_disc_lc

### DIFF
--- a/be/src/column/column_hash.h
+++ b/be/src/column/column_hash.h
@@ -15,6 +15,10 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
+
+#include "column/vectorized_fwd.h"
+#include "storage/uint24.h"
 
 #ifdef __SSE4_2__
 #include <nmmintrin.h>
@@ -329,6 +333,14 @@ struct Hash128WithSeed {
     std::size_t operator()(int128_t value) const {
         return phmap_mix_with_seed<sizeof(size_t), seed>()(hash_128(seed, value));
     }
+};
+template <typename T>
+struct HashTypeTraits {
+    using HashFunc = StdHashWithSeed<T, PhmapSeed2>;
+};
+template <>
+struct HashTypeTraits<int128_t> {
+    using HashFunc = Hash128WithSeed<PhmapSeed2>;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -198,6 +198,12 @@ public:
     template <LogicalType PT>
     static AggregateFunctionPtr MakePercentileDiscAggregateFunction();
 
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeLowCardPercentileBinAggregateFunction();
+
+    template <LogicalType PT>
+    static AggregateFunctionPtr MakeLowCardPercentileCntAggregateFunction();
+
     // Windows functions:
     static AggregateFunctionPtr MakeDenseRankWindowFunction();
 
@@ -396,6 +402,16 @@ AggregateFunctionPtr AggregateFactory::MakePercentileContAggregateFunction() {
 template <LogicalType PT>
 AggregateFunctionPtr AggregateFactory::MakePercentileDiscAggregateFunction() {
     return std::make_shared<PercentileDiscAggregateFunction<PT>>();
+}
+
+template <LogicalType PT>
+AggregateFunctionPtr AggregateFactory::MakeLowCardPercentileBinAggregateFunction() {
+    return std::make_shared<LowCardPercentileBinAggregateFunction<PT>>();
+}
+
+template <LogicalType PT>
+AggregateFunctionPtr AggregateFactory::MakeLowCardPercentileCntAggregateFunction() {
+    return std::make_shared<LowCardPercentileCntAggregateFunction<PT>>();
 }
 
 template <LogicalType LT>

--- a/be/src/exprs/percentile_functions.cpp
+++ b/be/src/exprs/percentile_functions.cpp
@@ -17,7 +17,10 @@
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/agg/percentile_cont.h"
 #include "gutil/strings/substitute.h"
+#include "types/logical_type.h"
 #include "util/percentile_value.h"
 #include "util/string_parser.hpp"
 
@@ -63,5 +66,34 @@ StatusOr<ColumnPtr> PercentileFunctions::percentile_approx_raw(FunctionContext* 
     }
     return builder.build(columns[0]->is_constant());
 }
+
+struct LCPercentileExtracter {
+    template <LogicalType Type>
+    ColumnPtr operator()(const FunctionContext::TypeDesc& type_desc, const ColumnPtr& lc_percentile, double rate) {
+        if constexpr (lt_is_decimal<Type> || lt_is_float<Type> || lt_is_integer<Type> || lt_is_date_or_datetime<Type>) {
+            ColumnBuilder<Type> builder(lc_percentile->size(), type_desc.precision, type_desc.scale);
+            ColumnViewer<TYPE_VARCHAR> viewer(lc_percentile);
+            for (size_t i = 0; i < viewer.size(); ++i) {
+                // process null
+                if (viewer.is_null(i)) {
+                    builder.append_null();
+                    continue;
+                }
+                LowCardPercentileState<Type> state;
+                state.merge(viewer.value(i));
+                if (state.items.empty()) {
+                    builder.append_null();
+                    continue;
+                }
+                auto res = state.build_result(rate);
+                builder.append(res);
+            }
+            return builder.build(lc_percentile->is_constant());
+        } else {
+            throw std::runtime_error(fmt::format("Unsupported column type {}", Type));
+        }
+        return nullptr;
+    }
+};
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -254,6 +254,7 @@ public class FunctionSet {
     public static final String PERCENTILE_APPROX = "percentile_approx";
     public static final String PERCENTILE_CONT = "percentile_cont";
     public static final String PERCENTILE_DISC = "percentile_disc";
+    public static final String LC_PERCENTILE_DISC = "percentile_disc_lc";
     public static final String RETENTION = "retention";
     public static final String STDDEV = "stddev";
     public static final String STDDEV_POP = "stddev_pop";
@@ -1405,6 +1406,11 @@ public class FunctionSet {
 
         for (Type type : SORTABLE_TYPES) {
             addBuiltin(AggregateFunction.createBuiltin(FunctionSet.PERCENTILE_DISC,
+                    Lists.newArrayList(type, Type.DOUBLE), type, Type.VARBINARY,
+                    false, false, false));
+        }
+        for (Type type : SORTABLE_TYPES) {
+            addBuiltin(AggregateFunction.createBuiltin(FunctionSet.LC_PERCENTILE_DISC,
                     Lists.newArrayList(type, Type.DOUBLE), type, Type.VARBINARY,
                     false, false, false));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1093,7 +1093,7 @@ public class ExpressionAnalyzer {
                 // need to distinct output columns in finalize phase
                 ((AggregateFunction) fn).setIsDistinct(node.getParams().isDistinct() &&
                         (!isAscOrder.isEmpty() || outputConst));
-            } else if (FunctionSet.PERCENTILE_DISC.equals(fnName)) {
+            } else if (FunctionSet.PERCENTILE_DISC.equals(fnName) || FunctionSet.LC_PERCENTILE_DISC.equals(fnName)) {
                 argumentTypes[1] = Type.DOUBLE;
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_IDENTICAL);
                 // correct decimal's precision and scale

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -133,7 +133,8 @@ public class FunctionAnalyzer {
                         functionCallExpr.getPos());
             }
 
-            int sepPos = functionCallExpr.getParams().exprs().size() - functionCallExpr.getParams().getOrderByElemNum() - 1;
+            int sepPos =
+                    functionCallExpr.getParams().exprs().size() - functionCallExpr.getParams().getOrderByElemNum() - 1;
             Expr arg1 = functionCallExpr.getChild(sepPos);
             if (!arg1.getType().isStringType() && !arg1.getType().isNull()) {
                 throw new SemanticException(
@@ -146,7 +147,8 @@ public class FunctionAnalyzer {
         if (fnName.getFunction().equals(FunctionSet.LAG)
                 || fnName.getFunction().equals(FunctionSet.LEAD)) {
             if (!functionCallExpr.isAnalyticFnCall()) {
-                throw new SemanticException(fnName.getFunction() + " only used in analytic function", functionCallExpr.getPos());
+                throw new SemanticException(fnName.getFunction() + " only used in analytic function",
+                        functionCallExpr.getPos());
             } else {
                 if (functionCallExpr.getChildren().size() > 2) {
                     if (!functionCallExpr.getChild(2).isConstant()) {
@@ -169,7 +171,8 @@ public class FunctionAnalyzer {
 
         if (FunctionSet.onlyAnalyticUsedFunctions.contains(fnName.getFunction())) {
             if (!functionCallExpr.isAnalyticFnCall()) {
-                throw new SemanticException(fnName.getFunction() + " only used in analytic function", functionCallExpr.getPos());
+                throw new SemanticException(fnName.getFunction() + " only used in analytic function",
+                        functionCallExpr.getPos());
             }
         }
 
@@ -395,7 +398,8 @@ public class FunctionAnalyzer {
                 Preconditions.checkNotNull(k);
                 if (counterNum > FeConstants.MAX_COUNTER_NUM_OF_TOP_K) {
                     throw new SemanticException("The maximum number of the third parameter is "
-                            + FeConstants.MAX_COUNTER_NUM_OF_TOP_K + ", " + functionCallExpr.toSql(), counterNumExpr.getPos());
+                            + FeConstants.MAX_COUNTER_NUM_OF_TOP_K + ", " + functionCallExpr.toSql(),
+                            counterNumExpr.getPos());
                 }
                 if (k > counterNum) {
                     throw new SemanticException(
@@ -414,7 +418,8 @@ public class FunctionAnalyzer {
         }
 
         if (fnName.getFunction().equals(FunctionSet.PERCENTILE_DISC) ||
-                fnName.getFunction().equals(FunctionSet.PERCENTILE_CONT)) {
+                fnName.getFunction().equals(FunctionSet.PERCENTILE_CONT) ||
+                fnName.getFunction().equals(FunctionSet.LC_PERCENTILE_DISC)) {
             if (functionCallExpr.getChildren().size() != 2) {
                 throw new SemanticException(fnName + " requires two parameters");
             }

--- a/test/sql/test_agg_function/R/test_lc_percentile
+++ b/test/sql/test_agg_function/R/test_lc_percentile
@@ -1,0 +1,149 @@
+-- name: test_lc_percentile
+CREATE TABLE `test_pc` (
+  `date` date NULL COMMENT "",
+  `datetime` datetime NULL COMMENT "",
+  `db` double NULL COMMENT "",
+  `id` int(11) NULL COMMENT "",
+  `name` varchar(255) NULL COMMENT "",
+  `subject` varchar(255) NULL COMMENT "",
+  `score` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`date`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into test_pc values ("2018-01-01","2018-01-01 00:00:01",11.1,1,"Tom","English",90);
+-- result:
+-- !result
+insert into test_pc values ("2019-01-01","2019-01-01 00:00:01",11.2,1,"Tom","English",91);
+-- result:
+-- !result
+insert into test_pc values ("2020-01-01","2020-01-01 00:00:01",11.3,1,"Tom","English",92);
+-- result:
+-- !result
+insert into test_pc values ("2021-01-01","2021-01-01 00:00:01",11.4,1,"Tom","English",93);
+-- result:
+-- !result
+insert into test_pc values ("2022-01-01","2022-01-01 00:00:01",11.5,1,"Tom","English",94);
+-- result:
+-- !result
+insert into test_pc values (NULL,NULL,NULL,NULL,"Tom","English",NULL);
+-- result:
+-- !result
+select percentile_disc_lc(score, 0) from test_pc;
+-- result:
+90
+-- !result
+select percentile_disc_lc(score, 0.25) from test_pc;
+-- result:
+91
+-- !result
+select percentile_disc_lc(score, 0.5) from test_pc;
+-- result:
+92
+-- !result
+select percentile_disc_lc(score, 0.75) from test_pc;
+-- result:
+93
+-- !result
+select percentile_disc_lc(score, 1) from test_pc;
+-- result:
+94
+-- !result
+select percentile_disc_lc(date, 0) from test_pc;
+-- result:
+2018-01-01
+-- !result
+select percentile_disc_lc(date, 0.25) from test_pc;
+-- result:
+2019-01-01
+-- !result
+select percentile_disc_lc(date, 0.5) from test_pc;
+-- result:
+2020-01-01
+-- !result
+select percentile_disc_lc(date, 0.75) from test_pc;
+-- result:
+2021-01-01
+-- !result
+select percentile_disc_lc(date, 1) from test_pc;
+-- result:
+2022-01-01
+-- !result
+select percentile_disc_lc(datetime, 0) from test_pc;
+-- result:
+2018-01-01 00:00:01
+-- !result
+select percentile_disc_lc(datetime, 0.25) from test_pc;
+-- result:
+2019-01-01 00:00:01
+-- !result
+select percentile_disc_lc(datetime, 0.5) from test_pc;
+-- result:
+2020-01-01 00:00:01
+-- !result
+select percentile_disc_lc(datetime, 0.75) from test_pc;
+-- result:
+2021-01-01 00:00:01
+-- !result
+select percentile_disc_lc(datetime, 1) from test_pc;
+-- result:
+2022-01-01 00:00:01
+-- !result
+select percentile_disc_lc(db, 0) from test_pc;
+-- result:
+11.1
+-- !result
+select percentile_disc_lc(db, 0.25) from test_pc;
+-- result:
+11.2
+-- !result
+select percentile_disc_lc(db, 0.5) from test_pc;
+-- result:
+11.3
+-- !result
+select percentile_disc_lc(db, 0.75) from test_pc;
+-- result:
+11.4
+-- !result
+select percentile_disc_lc(db, 1) from test_pc;
+-- result:
+11.5
+-- !result
+set new_planner_agg_stage=2;
+-- result:
+-- !result
+set streaming_preaggregation_mode="force_streaming";
+-- result:
+-- !result
+select `date`, percentile_disc_lc(score, 0) from test_pc group by `date` order by 1,2;
+-- result:
+None	None
+2018-01-01	90
+2019-01-01	91
+2020-01-01	92
+2021-01-01	93
+2022-01-01	94
+-- !result
+set streaming_preaggregation_mode="force_preaggregation";
+-- result:
+-- !result
+select `date`, percentile_disc_lc(score, 0) from test_pc group by `date` order by 1,2;
+-- result:
+None	None
+2018-01-01	90
+2019-01-01	91
+2020-01-01	92
+2021-01-01	93
+2022-01-01	94
+-- !result
+select percentile_disc_lc(score, 1.1) from test_pc;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_disc_lc second parameter'value should be between 0 and 1.")
+-- !result

--- a/test/sql/test_agg_function/T/test_lc_percentile
+++ b/test/sql/test_agg_function/T/test_lc_percentile
@@ -1,0 +1,57 @@
+-- name: test_lc_percentile
+
+CREATE TABLE `test_pc` (
+  `date` date NULL COMMENT "",
+  `datetime` datetime NULL COMMENT "",
+  `db` double NULL COMMENT "",
+  `id` int(11) NULL COMMENT "",
+  `name` varchar(255) NULL COMMENT "",
+  `subject` varchar(255) NULL COMMENT "",
+  `score` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`date`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into test_pc values ("2018-01-01","2018-01-01 00:00:01",11.1,1,"Tom","English",90);
+insert into test_pc values ("2019-01-01","2019-01-01 00:00:01",11.2,1,"Tom","English",91);
+insert into test_pc values ("2020-01-01","2020-01-01 00:00:01",11.3,1,"Tom","English",92);
+insert into test_pc values ("2021-01-01","2021-01-01 00:00:01",11.4,1,"Tom","English",93);
+insert into test_pc values ("2022-01-01","2022-01-01 00:00:01",11.5,1,"Tom","English",94);
+insert into test_pc values (NULL,NULL,NULL,NULL,"Tom","English",NULL);
+
+
+select percentile_disc_lc(score, 0) from test_pc;
+select percentile_disc_lc(score, 0.25) from test_pc;
+select percentile_disc_lc(score, 0.5) from test_pc;
+select percentile_disc_lc(score, 0.75) from test_pc;
+select percentile_disc_lc(score, 1) from test_pc;
+select percentile_disc_lc(date, 0) from test_pc;
+select percentile_disc_lc(date, 0.25) from test_pc;
+select percentile_disc_lc(date, 0.5) from test_pc;
+select percentile_disc_lc(date, 0.75) from test_pc;
+select percentile_disc_lc(date, 1) from test_pc;
+select percentile_disc_lc(datetime, 0) from test_pc;
+select percentile_disc_lc(datetime, 0.25) from test_pc;
+select percentile_disc_lc(datetime, 0.5) from test_pc;
+select percentile_disc_lc(datetime, 0.75) from test_pc;
+select percentile_disc_lc(datetime, 1) from test_pc;
+select percentile_disc_lc(db, 0) from test_pc;
+select percentile_disc_lc(db, 0.25) from test_pc;
+select percentile_disc_lc(db, 0.5) from test_pc;
+select percentile_disc_lc(db, 0.75) from test_pc;
+select percentile_disc_lc(db, 1) from test_pc;
+
+-- test streaming agg and merge
+set new_planner_agg_stage=2;
+set streaming_preaggregation_mode="force_streaming";
+select `date`, percentile_disc_lc(score, 0) from test_pc group by `date` order by 1,2;
+set streaming_preaggregation_mode="force_preaggregation";
+select `date`, percentile_disc_lc(score, 0) from test_pc group by `date` order by 1,2;
+-- test wrong arguments
+select percentile_disc_lc(score, 1.1) from test_pc;


### PR DESCRIPTION
## Why I'm doing:
With a lower cardinality, lc_percentile_xx performs better and uses less memory than the normal implementation (percentile_disc/percentile_cnt). The use case for most users is to deal with lower cardinality, e.g. interface elapsed time (usually within 1s, the cardinality is probably within 1,000). In such cases there is a significant reduction in memory usage.

In the normal implementation, percentile_xxx needs to collect all inputs to construct an array. In lc_percentile we use map (value->count) to collect the same values. If the base of inputs is low, lc_percentile will use less memory and will perform better.

## What I'm doing:
support below functions:
```
percentile_disc_lc(input_type, rate) lowcardinality implements for percentile_disc
```
example:
```
select percentile_disc_lc(lo_linenumber, 0.01) from lineorder;
```

performance:
cardinality = 7
```
mysql> select count(distinct lo_linenumber) from lineorder;
+-------------------------------+
| count(DISTINCT lo_linenumber) |
+-------------------------------+
|                             7 |
+-------------------------------+
1 row in set (7.20 sec)
```

```
mysql> select percentile_disc_lc(lo_linenumber, 0.01) from lineorder;
+-----------------------------------------+
| lc_percentile_disc(lo_linenumber, 0.01) |
+-----------------------------------------+
|                                       1 |
+-----------------------------------------+
1 row in set (0.71 sec)
cost: 15.001 MB

mysql> select percentile_disc(lo_linenumber, 0.01) from lineorder;
+--------------------------------------+
| percentile_disc(lo_linenumber, 0.01) |
+--------------------------------------+
|                                    1 |
+--------------------------------------+
1 row in set (11.64 sec)
cost: 9.127 GB

```


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
