### PR TITLE
[BugFix] fix broker load fail to get tablet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -350,7 +350,9 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                 RangeUtils.checkRangeIntersect(reservePartitionKeyRange, checkDropPartitionKey);
                 if (checkDropPartitionKey.upperEndpoint().compareTo(reservePartitionKeyRange.lowerEndpoint()) <= 0) {
                     String dropPartitionName = olapTable.getPartition(checkDropPartitionId).getName();
-                    dropPartitionClauses.add(new DropPartitionClause(false, dropPartitionName, false, true));
+                    boolean isExistPrepareTxns = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().
+                            existPrepareTxns(db.getId(), olapTable.getId(), checkDropPartitionId);
+                    dropPartitionClauses.add(new DropPartitionClause(false, dropPartitionName, false, !isExistPrepareTxns));
                 }
             } catch (DdlException e) {
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -762,6 +762,20 @@ public class DatabaseTransactionMgr {
         }
     }
 
+    public List<TransactionState> getPrepareTxnList() {
+        readLock();
+        try {
+            // only send task to prepare transaction
+            return idToRunningTransactionState.values().stream()
+                    .filter(transactionState -> (transactionState.getTransactionStatus() ==
+                            TransactionStatus.PREPARE))
+                    .sorted(Comparator.comparing(TransactionState::getCommitTime))
+                    .collect(Collectors.toList());
+        } finally {
+            readUnlock();
+        }
+    }
+
     public List<TransactionState> getCommittedTxnList() {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -514,6 +514,19 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         return transactionStateList;
     }
 
+    public boolean existPrepareTxns(Long dbId, Long tableId, Long partitionId) {
+        DatabaseTransactionMgr dbTransactionMgr = dbIdToDatabaseTransactionMgrs.get(dbId);
+        if (tableId == null && partitionId == null) {
+            return !dbTransactionMgr.getPrepareTxnList().isEmpty();
+        }
+        for (TransactionState transactionState : dbTransactionMgr.getPrepareTxnList()) {
+            if (transactionState.getTableIdList().contains(tableId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean existCommittedTxns(Long dbId, Long tableId, Long partitionId) {
         DatabaseTransactionMgr dbTransactionMgr = dbIdToDatabaseTransactionMgrs.get(dbId);
         if (tableId == null && partitionId == null) {


### PR DESCRIPTION
## Why I'm doing:
using broker load to import data into a table,
when the number of broker load jobs > max_broker_load_job_concurrency, some jobs state is queueing.  At this point,if the dynamic partition expires, the partition will be deleted with force.
when the state of these jobs state changes from queueing to loading, broker load failed to "fail to get tablet, tablet id = xxx"
 
## What I'm doing:
Optimized the dynamic partition expiration deletion logic

Fixes #issue
https://forum.mirrorship.cn/t/topic/3462

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5