### PR TITLE
[BugFix] fix lake pk auto increment column crash

### DIFF
--- a/be/test/storage/lake/auto_increment_partial_update_test.cpp
+++ b/be/test/storage/lake/auto_increment_partial_update_test.cpp
@@ -39,12 +39,16 @@ namespace starrocks::lake {
 
 class LakeAutoIncrementPartialUpdateTest : public TestBase {
 public:
-    LakeAutoIncrementPartialUpdateTest() : TestBase(kTestDirectory) {
+    LakeAutoIncrementPartialUpdateTest() : TestBase(kTestDirectory) {}
+
+    void recreate_schema(int auto_column) {
         _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
         _tablet_metadata->set_next_rowset_id(1);
-
+        _slots.clear();
+        _slot_pointers.clear();
+        _slot_cid_map.clear();
         //
         //  | column | type | KEY | NULL | isAutoIncrement |
         //  +--------+------+-----+------+-----------------+
@@ -71,16 +75,21 @@ public:
             c1->set_type("BIGINT");
             c1->set_is_key(false);
             c1->set_is_nullable(false);
-            c1->set_is_auto_increment(true);
+            if (auto_column == 1) {
+                c1->set_is_auto_increment(true);
+            }
             c1->set_aggregation("REPLACE");
         }
         auto c2 = schema->add_column();
         {
             c2->set_unique_id(next_id());
             c2->set_name("c2");
-            c2->set_type("INT");
+            c2->set_type("BIGINT");
             c2->set_is_key(false);
             c2->set_is_nullable(false);
+            if (auto_column == 2) {
+                c1->set_is_auto_increment(true);
+            }
             c2->set_aggregation("REPLACE");
         }
 
@@ -95,12 +104,10 @@ public:
 
         _tablet_schema = TabletSchema::create(*schema);
         _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
-    }
-
-    void SetUp() override {
-        clear_and_init_test_dir();
         CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
     }
+
+    void SetUp() override { clear_and_init_test_dir(); }
 
     void TearDown() override {
         // check primary index cache's ref
@@ -111,7 +118,7 @@ public:
     Chunk generate_data(int chunk_size, bool partial) {
         std::vector<int> v0(chunk_size);
         std::vector<int64_t> v1(chunk_size);
-        std::vector<int> v2(chunk_size);
+        std::vector<int64_t> v2(chunk_size);
 
         if (partial) {
             v1.assign(chunk_size, 0);
@@ -133,8 +140,8 @@ public:
             for (int i = 0; i < chunk_size; i++) {
                 v2[i] = i;
             }
-            auto c2 = Int32Column::create();
-            c2->append_numbers(v2.data(), v2.size() * sizeof(int));
+            auto c2 = Int64Column::create();
+            c2->append_numbers(v2.data(), v2.size() * sizeof(int64_t));
             return Chunk({c0, c1, c2}, _slot_cid_map);
         } else {
             return Chunk({c0, c1}, _slot_cid_map);
@@ -158,9 +165,9 @@ public:
             auto cols = chunk->columns();
             for (int i = 0; i < chunk->num_rows(); i++) {
                 EXPECT_TRUE(
-                        check_fn(cols[0]->get(i).get_int32(), cols[1]->get(i).get_int64(), cols[2]->get(i).get_int32()))
+                        check_fn(cols[0]->get(i).get_int32(), cols[1]->get(i).get_int64(), cols[2]->get(i).get_int64()))
                         << "c0=" << cols[0]->get(i).get_int32() << "c1=" << cols[1]->get(i).get_int64()
-                        << "c2=" << cols[2]->get(i).get_int32();
+                        << "c2=" << cols[2]->get(i).get_int64();
             }
             chunk->reset();
         }
@@ -181,6 +188,7 @@ protected:
 };
 
 TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
+    recreate_schema(1);
     auto chunk0 = generate_data(kChunkSize, false);
     auto chunk1 = generate_data(kChunkSize, true);
     auto indexes = std::vector<uint32_t>(kChunkSize);
@@ -255,7 +263,84 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
     SyncPoint::GetInstance()->DisableProcessing();
 }
 
+TEST_F(LakeAutoIncrementPartialUpdateTest, test_write2) {
+    recreate_schema(2);
+    auto chunk0 = generate_data(kChunkSize, false);
+    auto chunk1 = generate_data(kChunkSize, true);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("StorageEngine::get_next_increment_id_interval.1", [](void* arg) {
+        auto& meta = *(std::shared_ptr<AutoIncrementMeta>*)(arg);
+        meta->min = 1;
+        meta->max = kChunkSize * 2;
+    });
+
+    // partial update with auto increment column only
+    const int64_t old_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_miss_auto_increment_column(true)
+                                                   .set_table_id(next_id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        // multi segment
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    config::write_buffer_size = old_size;
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+    SyncPoint::GetInstance()->DisableProcessing();
+}
+
 TEST_F(LakeAutoIncrementPartialUpdateTest, test_resolve_conflict) {
+    recreate_schema(1);
     auto chunk0 = generate_data(kChunkSize, false);
     auto chunk1 = generate_data(kChunkSize, true);
     auto indexes = std::vector<uint32_t>(kChunkSize);


### PR DESCRIPTION
## Why I'm doing:
`txn_meta.partial_rowset_footers` will be empty when `_partial_update_states.size() > 0` while handle auto increment column, it will cause BE crash.
```
*** Aborted at 1716756863 (unix time) try "date -d @1716756863" if you are using GNU date ***
PC: @          0x5ed025f starrocks::lake::RowsetUpdateState::rewrite_segment()
*** SIGSEGV (@0x8) received by PID 44053 (TID 0x7fa7646c8700) from PID 8; stack trace: ***
    @          0x755b172 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fa86aaaa630 (unknown)
    @          0x5ed025f starrocks::lake::RowsetUpdateState::rewrite_segment()
    @          0x5ec5820 starrocks::lake::UpdateManager::publish_primary_key_tablet()
    @          0x5f05194 starrocks::lake::PrimaryKeyTxnLogApplier::apply()
    @          0x5eb5362 starrocks::lake::publish_version()
    @          0x35977fb _ZZN9starrocks15LakeServiceImpl15publish_versionEPN6google8protobuf13RpcControllerEPKNS_21PublishVersionRequestEPNS_22PublishVersionResponseEPNS2_7ClosureEENKUlvE_clEv
    @          0x359967a _ZNSt17_Function_handlerIFvvEZN9starrocks33ConcurrencyLimitedThreadPoolToken11submit_funcESt8functionIS0_ENSt6chrono10time_pointINS5_3_V212system_clockENS5_8durationIlSt5ratioILl1ELl1000000000EEEEEEEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x3644f7c starrocks::ThreadPool::dispatch_thread()
    @          0x363ec0a starrocks::Thread::supervise_thread()
    @     0x7fa86aaa2ea5 start_thread
    @     0x7fa869ea3b0d __clone
    @                0x0 (unknown)
```

## What I'm doing:
we should use this function to decide whether need to rewrite segment:
```
static bool has_partial_update_state(const RowsetUpdateStateParams& params) {
    return !params.op_write.txn_meta().partial_update_column_unique_ids().empty();
}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
