### PR TITLE
[Enhancement] Remove CVE jars

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -781,14 +781,6 @@ under the License.
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-protocol-shaded</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.htrace</groupId>
-                    <artifactId>htrace-core4</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -815,14 +807,6 @@ under the License.
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-hdfs</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-protocol-shaded</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.htrace</groupId>
-                    <artifactId>htrace-core4</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -212,6 +212,13 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--Include velocity because we are already using it-->
+        <!-- https://mvnrepository.com/artifact/org.apache.velocity/velocity-engine-core -->
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>2.3</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf -->
         <dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -851,11 +851,70 @@ under the License.
             <scope>compile</scope>
         </dependency>
 
+        <!--Decouple dependencies from paimon-bundle, after paimon-bundle fix cve problems, we can use paimon-bundle instead-->
+        <!--BEGIN-->
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-bundle</artifactId>
+            <artifactId>paimon-common</artifactId>
             <version>${paimon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-core</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
+        <!-- codegen runtime dependencies -->
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-codegen-loader</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
+        <!-- format runtime dependencies -->
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-format</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.8.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.8.0</version>
+        </dependency>
+        <!-- paimon catalogs -->
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-hive-catalog</artifactId>
+            <version>${paimon.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- other runtime dependencies -->
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-shade-jackson-2</artifactId>
+            <version>2.14.2-${paimon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-shade-guava-30</artifactId>
+            <version>30.1.1-jre-${paimon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-shade-caffeine-2</artifactId>
+            <version>2.9.3-${paimon.version}</version>
+        </dependency>
+        <!--END-->
+        <!--Decouple from paimon-bundle-->
 
         <dependency>
             <groupId>org.apache.paimon</groupId>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -39,7 +39,7 @@ under the License.
         <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
         <jacoco.version>0.8.7</jacoco.version>
         <iceberg.version>1.5.0</iceberg.version>
-        <paimon.version>0.7.0-incubating</paimon.version>
+        <paimon.version>0.8.0</paimon.version>
         <delta-kernel.version>3.2.0</delta-kernel.version>
         <staros.version>3.3-rc1</staros.version>
         <python>python</python>
@@ -199,6 +199,18 @@ under the License.
             <artifactId>awaitility</artifactId>
             <version>4.2.0</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf -->
+        <dependency>
+            <groupId>com.baidu</groupId>
+            <artifactId>jprotobuf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.auto.value</groupId>
+                    <artifactId>auto-value</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf -->
@@ -577,7 +589,17 @@ under the License.
                     <groupId>com.aliyun</groupId>
                     <artifactId>tea-util</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.aliyun</groupId>
+                    <artifactId>datalake20200710</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!--Fix CVE from aliyun dlf-->
+        <dependency>
+            <groupId>com.aliyun</groupId>
+            <artifactId>datalake20200710</artifactId>
+            <version>2.0.12</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
@@ -644,6 +666,18 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aliyun</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jdom</groupId>
+                    <artifactId>jdom2</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!--Fix CVF from hadoop-aliyun-->
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom2</artifactId>
+            <version>2.0.6.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.qcloud.cos/hadoop-cos -->
@@ -715,6 +749,73 @@ under the License.
                 <exclusion>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-server</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- For CVE problems -->
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>2.4.18</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-protocol-shaded</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>2.4.18</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tomcat</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-hdfs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-protocol-shaded</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -900,6 +1001,22 @@ under the License.
                     <groupId>com.amazonaws</groupId>
                     <artifactId>aws-java-sdk-bundle</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch.client</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -911,6 +1028,12 @@ under the License.
         <dependency>
             <groupId>com.aliyun.odps</groupId>
             <artifactId>odps-sdk-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
@@ -40,9 +40,6 @@ public abstract class MetadataCollectJob {
         DEFAULT_VELOCITY_ENGINE = new VelocityEngine();
         // close velocity log
         DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_REFERENCE_LOG_INVALID, false);
-        DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_LOGSYSTEM_CLASS,
-                "org.apache.velocity.runtime.log.Log4JLogChute");
-        DEFAULT_VELOCITY_ENGINE.setProperty("runtime.log.logsystem.log4j.logger", "velocity");
     }
 
     private final String catalogName;

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.credential.hdfs;
 
-import autovalue.shaded.com.google.common.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.HDFSFileStoreInfo;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -14,9 +14,9 @@
 
 package com.starrocks.lake;
 
-import autovalue.shaded.com.google.common.common.collect.Lists;
-import autovalue.shaded.com.google.common.common.collect.Sets;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.staros.proto.ShardGroupInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -14,9 +14,9 @@
 
 package com.starrocks.lake.backup;
 
-import autovalue.shaded.com.google.common.common.collect.Maps;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.staros.proto.FilePathInfo;
 import com.starrocks.backup.BackupJobInfo;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.qe;
 
-import autovalue.shaded.com.google.common.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -15,7 +15,7 @@
 
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
-import autovalue.shaded.com.google.common.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.BinaryType;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownTopNBelowUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownTopNBelowUnionRule.java
@@ -14,8 +14,8 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import autovalue.shaded.com.google.common.common.base.Preconditions;
 import com.google.api.client.util.Sets;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.OptExpression;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnEnforcer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnEnforcer.java
@@ -15,7 +15,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
-import autovalue.shaded.com.google.common.common.collect.Lists;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.optimizer.OptExpression;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -84,9 +84,6 @@ public class StatisticSQLBuilder {
         DEFAULT_VELOCITY_ENGINE = new VelocityEngine();
         // close velocity log
         DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_REFERENCE_LOG_INVALID, false);
-        DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_LOGSYSTEM_CLASS,
-                "org.apache.velocity.runtime.log.Log4JLogChute");
-        DEFAULT_VELOCITY_ENGINE.setProperty("runtime.log.logsystem.log4j.logger", "velocity");
     }
 
     public static String buildQueryTableStatisticsSQL(Long tableId) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -89,9 +89,6 @@ public abstract class StatisticsCollectJob {
         DEFAULT_VELOCITY_ENGINE = new VelocityEngine();
         // close velocity log
         DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_REFERENCE_LOG_INVALID, false);
-        DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_LOGSYSTEM_CLASS,
-                "org.apache.velocity.runtime.log.Log4JLogChute");
-        DEFAULT_VELOCITY_ENGINE.setProperty("runtime.log.logsystem.log4j.logger", "velocity");
     }
 
     public abstract void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
@@ -21,12 +21,12 @@ import com.starrocks.sql.ast.CreateDataCacheRuleStmt;
 import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
-import org.elasticsearch.common.collect.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -112,17 +112,17 @@ public class PaimonMetadataTest {
 
         List<DataFileMeta> meta1 = new ArrayList<>();
         meta1.add(new DataFileMeta("file1", 100, 200, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, null,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
         meta1.add(new DataFileMeta("file2", 100, 300, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, null,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
 
         List<DataFileMeta> meta2 = new ArrayList<>();
         meta2.add(new DataFileMeta("file3", 100, 400, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, null,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
         this.splits.add(DataSplit.builder().withSnapshot(1L).withPartition(row1).withBucket(1).withDataFiles(meta1)
-                .isStreaming(false).build());
+                .isStreaming(false).withBucketPath("dummy").build());
         this.splits.add(DataSplit.builder().withSnapshot(1L).withPartition(row2).withBucket(1).withDataFiles(meta2)
-                .isStreaming(false).build());
+                .isStreaming(false).withBucketPath("dummy").build());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheMgrTest.java
@@ -16,10 +16,10 @@ package com.starrocks.datacache;
 
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QualifiedName;
-import org.elasticsearch.common.collect.List;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 public class DataCacheMgrTest {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
@@ -27,6 +27,7 @@ import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.paimon.data.BinaryArray;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.io.DataFileMeta;
@@ -77,12 +78,12 @@ public class PaimonScanNodeTest {
 
         List<DataFileMeta> meta1 = new ArrayList<>();
         meta1.add(new DataFileMeta("file1", 100, 200, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, null,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
         meta1.add(new DataFileMeta("file2", 100, 300, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, null,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
 
         DataSplit split = DataSplit.builder().withSnapshot(1L).withPartition(row1).withBucket(1).withDataFiles(meta1)
-                .isStreaming(false).build();
+                .isStreaming(false).withBucketPath("dummy").build();
 
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
@@ -102,12 +103,12 @@ public class PaimonScanNodeTest {
 
         List<DataFileMeta> meta1 = new ArrayList<>();
         meta1.add(new DataFileMeta("file1", 100, 200, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, null,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
         meta1.add(new DataFileMeta("file2", 100, 300, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, null,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
 
         DataSplit split = DataSplit.builder().withSnapshot(1L).withPartition(row1).withBucket(1).withDataFiles(meta1)
-                .isStreaming(false).build();
+                .isStreaming(false).withBucketPath("dummy").build();
 
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
@@ -132,14 +133,15 @@ public class PaimonScanNodeTest {
 
         List<DataFileMeta> meta1 = new ArrayList<>();
 
-        BinaryTableStats dataTableStats = new BinaryTableStats(BinaryRow.EMPTY_ROW, BinaryRow.EMPTY_ROW, new Long[]{0L});
+        BinaryTableStats dataTableStats = new BinaryTableStats(BinaryRow.EMPTY_ROW, BinaryRow.EMPTY_ROW,
+                BinaryArray.fromLongArray(new Long[] {0L}));
         meta1.add(new DataFileMeta("file1", 100, 200, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, dataTableStats,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
         meta1.add(new DataFileMeta("file2", 100, 300, EMPTY_MIN_KEY, EMPTY_MAX_KEY, EMPTY_KEY_STATS, dataTableStats,
-                1, 1, 1, DUMMY_LEVEL));
+                1, 1, 1, DUMMY_LEVEL, 0L, new byte[] {}));
 
         DataSplit split = DataSplit.builder().withSnapshot(1L).withPartition(row1).withBucket(1).withDataFiles(meta1)
-                .isStreaming(false).build();
+                .isStreaming(false).withBucketPath("dummy").build();
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -55,7 +56,6 @@ import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
-import org.elasticsearch.common.Strings;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
@@ -199,7 +199,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
             GenericRow genericRow = new GenericRow(3);
             genericRow.setField(0, BinaryString.fromString(String.valueOf(i)));
             genericRow.setField(1, BinaryString.fromString("2"));
-            batchTableWrite.write(genericRow);
+            batchTableWrite.write(genericRow, -1);
         }
         batchTableCommit.commit(batchTableWrite.prepareCommit());
     }
@@ -228,7 +228,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
             genericRow.setField(0, BinaryString.fromString("1"));
             genericRow.setField(1, BinaryString.fromString("2"));
             genericRow.setField(2, (int) LocalDate.now().toEpochDay() + i);
-            batchTableWrite.write(genericRow);
+            batchTableWrite.write(genericRow, -1);
         }
         batchTableCommit.commit(batchTableWrite.prepareCommit());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -199,7 +199,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
             GenericRow genericRow = new GenericRow(3);
             genericRow.setField(0, BinaryString.fromString(String.valueOf(i)));
             genericRow.setField(1, BinaryString.fromString("2"));
-            batchTableWrite.write(genericRow, -1);
+            batchTableWrite.write(genericRow, 1);
         }
         batchTableCommit.commit(batchTableWrite.prepareCommit());
     }
@@ -228,7 +228,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
             genericRow.setField(0, BinaryString.fromString("1"));
             genericRow.setField(1, BinaryString.fromString("2"));
             genericRow.setField(2, (int) LocalDate.now().toEpochDay() + i);
-            batchTableWrite.write(genericRow, -1);
+            batchTableWrite.write(genericRow, 1);
         }
         batchTableCommit.commit(batchTableWrite.prepareCommit());
     }

--- a/fe/hive-udf/pom.xml
+++ b/fe/hive-udf/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -43,7 +43,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <jprotobuf.version>2.4.12</jprotobuf.version>
+        <jprotobuf.version>2.4.23</jprotobuf.version>
         <log4j.version>2.19.0</log4j.version>
         <jackson.version>2.15.2</jackson.version>
         <spark.version>3.4.1</spark.version>
@@ -57,7 +57,8 @@ under the License.
         <dlf-metastore-client.version>0.2.14</dlf-metastore-client.version>
         <sonar.organization>starrocks</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <odps.version>0.45.5-public</odps.version>
+        <odps.version>0.48.3-public</odps.version>
+        <kudu.version>1.17.0</kudu.version>
         <hikaricp.version>3.4.5</hikaricp.version>
         <kafka-clients.version>3.4.0</kafka-clients.version>
     </properties>
@@ -220,7 +221,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.kudu</groupId>
                 <artifactId>kudu-client</artifactId>
-                <version>1.16.0</version>
+                <version>${kudu.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.github.seancfoley/ipaddress -->
@@ -327,7 +328,17 @@ under the License.
                 <groupId>com.baidu</groupId>
                 <artifactId>jprotobuf</artifactId>
                 <version>${jprotobuf.version}</version>
+            </dependency>
+
+            <!--Only used to compile protobuf-->
+            <!--jar-with-dependencies contains CVE problems, so set scope with provided to download it.-->
+            <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf -->
+            <dependency>
+                <groupId>com.baidu</groupId>
+                <artifactId>jprotobuf</artifactId>
+                <version>${jprotobuf.version}</version>
                 <classifier>jar-with-dependencies</classifier>
+                <scope>provided</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf-rpc-common -->
@@ -410,7 +421,8 @@ under the License.
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.1.61.Final</version>
+                <!--same with hadoop 3.4.0-->
+                <version>4.1.100.Final</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
@@ -745,12 +757,6 @@ under the License.
                 <groupId>org.apache.hudi</groupId>
                 <artifactId>hudi-common</artifactId>
                 <version>${hudi.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.zookeeper</groupId>
-                        <artifactId>zookeeper</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.hudi/hudi-hadoop-mr -->

--- a/java-extensions/kudu-reader/pom.xml
+++ b/java-extensions/kudu-reader/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <java-extensions.home>${basedir}/../</java-extensions.home>
-        <kudu.version>1.15.0</kudu.version>
+        <kudu.version>1.17.0</kudu.version>
         <slf4j.version>1.7.32</slf4j.version>
         <hive.version>2.3.9</hive.version>
         <hadoop.version>3.4.0</hadoop.version>

--- a/java-extensions/odps-reader/pom.xml
+++ b/java-extensions/odps-reader/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java-extensions.home>${basedir}/../</java-extensions.home>
         <slf4j.version>1.7.32</slf4j.version>
-        <odps.version>0.45.5-public</odps.version>
+        <odps.version>0.48.3-public</odps.version>
     </properties>
 
     <dependencies>

--- a/java-extensions/paimon-reader/pom.xml
+++ b/java-extensions/paimon-reader/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <java-extensions.home>${basedir}/../</java-extensions.home>
-        <paimon.version>0.7.0-incubating</paimon.version>
+        <paimon.version>0.8.0</paimon.version>
         <slf4j.version>1.7.32</slf4j.version>
         <hive.version>2.3.9</hive.version>
         <hadoop.version>3.4.0</hadoop.version>


### PR DESCRIPTION
## Why I'm doing:
rm cve jars

## What I'm doing:
```bash
2024-05-29T15:04:35.828+0800	[33mWARN[0m	OS is not detected and vulnerabilities in OS packages are not detected.
2024-05-29T15:04:35.828+0800	[34mINFO[0m	Detecting jar vulnerabilities...

lib/hbase-protocol-shaded-2.4.18.jar
====================================
Total: 49 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 26, CRITICAL: 20)

+---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------------------------------------------------+
|                   LIBRARY                   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |         FIXED VERSION          |                                      TITLE                                      |
+---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------------------------------------------------+
| com.fasterxml.jackson.core:jackson-databind | CVE-2017-15095   | CRITICAL | 2.4.0             | 2.9.4, 2.8.11                  | jackson-databind: Unsafe                                                        |
|                                             |                  |          |                   |                                | deserialization due to                                                          |
|                                             |                  |          |                   |                                | incomplete black list (incomplete                                               |
|                                             |                  |          |                   |                                | fix for CVE-2017-7525)...                                                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-15095                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2017-17485   |          |                   | 2.8.11, 2.9.4                  | jackson-databind: Unsafe                                                        |
|                                             |                  |          |                   |                                | deserialization due to                                                          |
|                                             |                  |          |                   |                                | incomplete black list (incomplete                                               |
|                                             |                  |          |                   |                                | fix for CVE-2017-15095)...                                                      |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-17485                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2017-7525    |          |                   | 2.7.9.1, 2.6.7.1, 2.8.9        | jackson-databind: Deserialization                                               |
|                                             |                  |          |                   |                                | vulnerability via readValue                                                     |
|                                             |                  |          |                   |                                | method of ObjectMapper                                                          |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-7525                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-11307   |          |                   | 2.8.11.2, 2.7.9.4, 2.9.6       | jackson-databind: Potential                                                     |
|                                             |                  |          |                   |                                | information exfiltration with                                                   |
|                                             |                  |          |                   |                                | default typing, serialization                                                   |
|                                             |                  |          |                   |                                | gadget from MyBatis                                                             |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-11307                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-14718   |          |                   | 2.7.9.5, 2.8.11.3, 2.9.7       | jackson-databind: arbitrary code                                                |
|                                             |                  |          |                   |                                | execution in slf4j-ext class                                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-14718                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2018-14719   |          |                   |                                | jackson-databind: arbitrary                                                     |
|                                             |                  |          |                   |                                | code execution in blaze-ds-opt                                                  |
|                                             |                  |          |                   |                                | and blaze-ds-core classes                                                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-14719                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-7489    |          |                   | 2.8.11.1, 2.9.5                | jackson-databind: incomplete fix                                                |
|                                             |                  |          |                   |                                | for CVE-2017-7525 permits unsafe                                                |
|                                             |                  |          |                   |                                | serialization via c3p0 libraries                                                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-7489                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14379   |          |                   | 2.9.9.2                        | jackson-databind: default                                                       |
|                                             |                  |          |                   |                                | typing mishandling leading                                                      |
|                                             |                  |          |                   |                                | to remote code execution                                                        |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14379                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14540   |          |                   | 2.9.10                         | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | com.zaxxer.hikari.HikariConfig                                                  |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14540                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14892   |          |                   | 2.9.10, 2.8.11.5, 2.6.7.3      | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in classes of the                                                       |
|                                             |                  |          |                   |                                | commons-configuration package                                                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14892                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14893   |          |                   | 2.8.11.5, 2.9.10               | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | classes of the xalan package                                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14893                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-16335   |          |                   | 2.9.10                         | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | com.zaxxer.hikari.HikariDataSource                                              |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-16335                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-16942   |          |                   | 2.9.10.1                       | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp.datasources.*                                           |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-16942                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2019-16943   |          |                   |                                | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | com.p6spy.engine.spy.P6DataSource                                               |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-16943                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-17267   |          |                   | 2.9.10                         | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in classes of                                                           |
|                                             |                  |          |                   |                                | the ehcache package                                                             |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-17267                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-17531   |          |                   | 2.9.10.1                       | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | org.apache.log4j.receivers.db.*                                                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-17531                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-20330   |          |                   | 2.6.7.4, 2.7.9.7, 2.9.10.2,    | jackson-databind: lacks                                                         |
|                                             |                  |          |                   | 2.8.11.5                       | certain net.sf.ehcache blocking                                                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-20330                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-8840    |          |                   | 2.6.7.4, 2.7.9.7, 2.9.10.3,    | jackson-databind: Lacks certain                                                 |
|                                             |                  |          |                   | 2.8.11.5                       | xbean-reflect/JNDI blocking                                                     |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-8840                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-9547    |          |                   | 2.9.10.4                       | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in ibatis-sqlmap                                                        |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-9547                                            |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-9548    |          |                   |                                | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in anteros-core                                                         |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-9548                                            |
+                                             +------------------+----------+                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-12022   | HIGH     |                   | 2.8.11.2, 2.7.9.4, 2.9.6       | jackson-databind: improper                                                      |
|                                             |                  |          |                   |                                | polymorphic deserialization                                                     |
|                                             |                  |          |                   |                                | of types from Jodd-db library                                                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-12022                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-5968    |          |                   | 2.9.4, 2.8.11                  | jackson-databind: unsafe                                                        |
|                                             |                  |          |                   |                                | deserialization due to incomplete                                               |
|                                             |                  |          |                   |                                | blacklist (incomplete fix                                                       |
|                                             |                  |          |                   |                                | for CVE-2017-7525 and...                                                        |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-5968                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-12086   |          |                   | 2.9.9                          | jackson-databind: polymorphic                                                   |
|                                             |                  |          |                   |                                | typing issue allows attacker to                                                 |
|                                             |                  |          |                   |                                | read arbitrary local files on...                                                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-12086                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14439   |          |                   | 2.9.9.2                        | jackson-databind: Polymorphic                                                   |
|                                             |                  |          |                   |                                | typing issue related to logback/JNDI                                            |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14439                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-10650   |          |                   | 2.9.10.4                       | jackson-databind before 2.9.10.4                                                |
|                                             |                  |          |                   |                                | vulnerable to unsafe deserialization                                            |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-10650                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-10673   |          |                   |                                | jackson-databind: mishandles                                                    |
|                                             |                  |          |                   |                                | the interaction between                                                         |
|                                             |                  |          |                   |                                | serialization gadgets and                                                       |
|                                             |                  |          |                   |                                | typing which could result...                                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-10673                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-24616   |          |                   | 2.9.10.6                       | jackson-databind: mishandles the                                                |
|                                             |                  |          |                   |                                | interaction between serialization                                               |
|                                             |                  |          |                   |                                | gadgets and typing, related to                                                  |
|                                             |                  |          |                   |                                | br.com.anteros.dbcp.AnterosDBCPDataSource...                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-24616                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-24750   |          |                   | 2.9.10.6, 2.6.7.5              | jackson-databind: Serialization gadgets in                                      |
|                                             |                  |          |                   |                                | com.pastdev.httpcomponents.configuration.JndiConfiguration                      |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-24750                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-25649   |          |                   | 2.10.5.1, 2.9.10.7, 2.6.7.4    | jackson-databind: FasterXML                                                     |
|                                             |                  |          |                   |                                | DOMDeserializer insecure                                                        |
|                                             |                  |          |                   |                                | entity expansion is vulnerable                                                  |
|                                             |                  |          |                   |                                | to XML external entity...                                                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-25649                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-35490   |          |                   | 2.9.10.8                       | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp2.datasources.PerUserPoolDataSource...                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-35490                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-35491   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp2.datasources.SharedPoolDataSource...                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-35491                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36179   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS...                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36179                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36180   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS...                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36180                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36181   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS...                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36181                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36182   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS...                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36182                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36183   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool...                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36183                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36184   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource...               |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36184                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36185   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource...                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36185                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36186   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource...                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36186                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36187   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource...                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36187                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36188   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource...          |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36188                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36189   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource... |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36189                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-36518   |          |                   | 2.12.6.1, 2.13.2.1             | jackson-databind: denial of service                                             |
|                                             |                  |          |                   |                                | via a large depth of nested objects                                             |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36518                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2021-20190   |          |                   | 2.9.10.7                       | jackson-databind: mishandles                                                    |
|                                             |                  |          |                   |                                | the interaction between                                                         |
|                                             |                  |          |                   |                                | serialization gadgets and                                                       |
|                                             |                  |          |                   |                                | typing, related to javax.swing...                                               |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-20190                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2022-42003   |          |                   | 2.13.4.1, 2.12.7.1             | jackson-databind: deep                                                          |
|                                             |                  |          |                   |                                | wrapper array nesting wrt                                                       |
|                                             |                  |          |                   |                                | UNWRAP_SINGLE_VALUE_ARRAYS                                                      |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2022-42003                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2022-42004   |          |                   | 2.13.4, 2.12.7.1               | jackson-databind: use                                                           |
|                                             |                  |          |                   |                                | of deeply nested arrays                                                         |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2022-42004                                           |
+                                             +------------------+----------+                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-1000873 | MEDIUM   |                   | 2.9.8                          | jackson-modules-java8: DoS due                                                  |
|                                             |                  |          |                   |                                | to an Improper Input Validation                                                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-1000873                                         |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-12384   |          |                   | 2.9.9.1                        | jackson-databind: failure                                                       |
|                                             |                  |          |                   |                                | to block the logback-core                                                       |
|                                             |                  |          |                   |                                | class from polymorphic                                                          |
|                                             |                  |          |                   |                                | deserialization leading to...                                                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-12384                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2019-12814   |          |                   |                                | jackson-databind: polymorphic                                                   |
|                                             |                  |          |                   |                                | typing issue allows attacker to                                                 |
|                                             |                  |          |                   |                                | read arbitrary local files on...                                                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-12814                                           |
+---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------------------------------------------------+

lib/htrace-core4-4.2.0-incubating.jar
=====================================
Total: 49 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 26, CRITICAL: 20)

+---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------------------------------------------------+
|                   LIBRARY                   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |         FIXED VERSION          |                                      TITLE                                      |
+---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------------------------------------------------+
| com.fasterxml.jackson.core:jackson-databind | CVE-2017-15095   | CRITICAL | 2.4.0             | 2.9.4, 2.8.11                  | jackson-databind: Unsafe                                                        |
|                                             |                  |          |                   |                                | deserialization due to                                                          |
|                                             |                  |          |                   |                                | incomplete black list (incomplete                                               |
|                                             |                  |          |                   |                                | fix for CVE-2017-7525)...                                                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-15095                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2017-17485   |          |                   | 2.8.11, 2.9.4                  | jackson-databind: Unsafe                                                        |
|                                             |                  |          |                   |                                | deserialization due to                                                          |
|                                             |                  |          |                   |                                | incomplete black list (incomplete                                               |
|                                             |                  |          |                   |                                | fix for CVE-2017-15095)...                                                      |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-17485                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2017-7525    |          |                   | 2.7.9.1, 2.6.7.1, 2.8.9        | jackson-databind: Deserialization                                               |
|                                             |                  |          |                   |                                | vulnerability via readValue                                                     |
|                                             |                  |          |                   |                                | method of ObjectMapper                                                          |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-7525                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-11307   |          |                   | 2.8.11.2, 2.7.9.4, 2.9.6       | jackson-databind: Potential                                                     |
|                                             |                  |          |                   |                                | information exfiltration with                                                   |
|                                             |                  |          |                   |                                | default typing, serialization                                                   |
|                                             |                  |          |                   |                                | gadget from MyBatis                                                             |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-11307                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-14718   |          |                   | 2.7.9.5, 2.8.11.3, 2.9.7       | jackson-databind: arbitrary code                                                |
|                                             |                  |          |                   |                                | execution in slf4j-ext class                                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-14718                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2018-14719   |          |                   |                                | jackson-databind: arbitrary                                                     |
|                                             |                  |          |                   |                                | code execution in blaze-ds-opt                                                  |
|                                             |                  |          |                   |                                | and blaze-ds-core classes                                                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-14719                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-7489    |          |                   | 2.8.11.1, 2.9.5                | jackson-databind: incomplete fix                                                |
|                                             |                  |          |                   |                                | for CVE-2017-7525 permits unsafe                                                |
|                                             |                  |          |                   |                                | serialization via c3p0 libraries                                                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-7489                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14379   |          |                   | 2.9.9.2                        | jackson-databind: default                                                       |
|                                             |                  |          |                   |                                | typing mishandling leading                                                      |
|                                             |                  |          |                   |                                | to remote code execution                                                        |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14379                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14540   |          |                   | 2.9.10                         | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | com.zaxxer.hikari.HikariConfig                                                  |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14540                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14892   |          |                   | 2.9.10, 2.8.11.5, 2.6.7.3      | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in classes of the                                                       |
|                                             |                  |          |                   |                                | commons-configuration package                                                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14892                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14893   |          |                   | 2.8.11.5, 2.9.10               | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | classes of the xalan package                                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14893                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-16335   |          |                   | 2.9.10                         | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | com.zaxxer.hikari.HikariDataSource                                              |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-16335                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-16942   |          |                   | 2.9.10.1                       | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp.datasources.*                                           |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-16942                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2019-16943   |          |                   |                                | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | com.p6spy.engine.spy.P6DataSource                                               |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-16943                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-17267   |          |                   | 2.9.10                         | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in classes of                                                           |
|                                             |                  |          |                   |                                | the ehcache package                                                             |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-17267                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-17531   |          |                   | 2.9.10.1                       | jackson-databind:                                                               |
|                                             |                  |          |                   |                                | Serialization gadgets in                                                        |
|                                             |                  |          |                   |                                | org.apache.log4j.receivers.db.*                                                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-17531                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-20330   |          |                   | 2.6.7.4, 2.7.9.7, 2.9.10.2,    | jackson-databind: lacks                                                         |
|                                             |                  |          |                   | 2.8.11.5                       | certain net.sf.ehcache blocking                                                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-20330                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-8840    |          |                   | 2.6.7.4, 2.7.9.7, 2.9.10.3,    | jackson-databind: Lacks certain                                                 |
|                                             |                  |          |                   | 2.8.11.5                       | xbean-reflect/JNDI blocking                                                     |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-8840                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-9547    |          |                   | 2.9.10.4                       | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in ibatis-sqlmap                                                        |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-9547                                            |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-9548    |          |                   |                                | jackson-databind: Serialization                                                 |
|                                             |                  |          |                   |                                | gadgets in anteros-core                                                         |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-9548                                            |
+                                             +------------------+----------+                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-12022   | HIGH     |                   | 2.8.11.2, 2.7.9.4, 2.9.6       | jackson-databind: improper                                                      |
|                                             |                  |          |                   |                                | polymorphic deserialization                                                     |
|                                             |                  |          |                   |                                | of types from Jodd-db library                                                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-12022                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-5968    |          |                   | 2.9.4, 2.8.11                  | jackson-databind: unsafe                                                        |
|                                             |                  |          |                   |                                | deserialization due to incomplete                                               |
|                                             |                  |          |                   |                                | blacklist (incomplete fix                                                       |
|                                             |                  |          |                   |                                | for CVE-2017-7525 and...                                                        |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-5968                                            |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-12086   |          |                   | 2.9.9                          | jackson-databind: polymorphic                                                   |
|                                             |                  |          |                   |                                | typing issue allows attacker to                                                 |
|                                             |                  |          |                   |                                | read arbitrary local files on...                                                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-12086                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-14439   |          |                   | 2.9.9.2                        | jackson-databind: Polymorphic                                                   |
|                                             |                  |          |                   |                                | typing issue related to logback/JNDI                                            |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-14439                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-10650   |          |                   | 2.9.10.4                       | jackson-databind before 2.9.10.4                                                |
|                                             |                  |          |                   |                                | vulnerable to unsafe deserialization                                            |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-10650                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-10673   |          |                   |                                | jackson-databind: mishandles                                                    |
|                                             |                  |          |                   |                                | the interaction between                                                         |
|                                             |                  |          |                   |                                | serialization gadgets and                                                       |
|                                             |                  |          |                   |                                | typing which could result...                                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-10673                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-24616   |          |                   | 2.9.10.6                       | jackson-databind: mishandles the                                                |
|                                             |                  |          |                   |                                | interaction between serialization                                               |
|                                             |                  |          |                   |                                | gadgets and typing, related to                                                  |
|                                             |                  |          |                   |                                | br.com.anteros.dbcp.AnterosDBCPDataSource...                                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-24616                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-24750   |          |                   | 2.9.10.6, 2.6.7.5              | jackson-databind: Serialization gadgets in                                      |
|                                             |                  |          |                   |                                | com.pastdev.httpcomponents.configuration.JndiConfiguration                      |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-24750                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-25649   |          |                   | 2.10.5.1, 2.9.10.7, 2.6.7.4    | jackson-databind: FasterXML                                                     |
|                                             |                  |          |                   |                                | DOMDeserializer insecure                                                        |
|                                             |                  |          |                   |                                | entity expansion is vulnerable                                                  |
|                                             |                  |          |                   |                                | to XML external entity...                                                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-25649                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-35490   |          |                   | 2.9.10.8                       | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp2.datasources.PerUserPoolDataSource...                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-35490                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-35491   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp2.datasources.SharedPoolDataSource...                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-35491                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36179   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS...                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36179                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36180   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS...                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36180                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36181   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS...                    |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36181                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36182   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS...                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36182                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36183   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool...                       |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36183                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36184   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource...               |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36184                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36185   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource...                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36185                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36186   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource...                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36186                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36187   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource...                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36187                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36188   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource...          |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36188                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2020-36189   |          |                   |                                | jackson-databind: mishandles the interaction                                    |
|                                             |                  |          |                   |                                | between serialization gadgets and typing, related to                            |
|                                             |                  |          |                   |                                | com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource... |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36189                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2020-36518   |          |                   | 2.12.6.1, 2.13.2.1             | jackson-databind: denial of service                                             |
|                                             |                  |          |                   |                                | via a large depth of nested objects                                             |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36518                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2021-20190   |          |                   | 2.9.10.7                       | jackson-databind: mishandles                                                    |
|                                             |                  |          |                   |                                | the interaction between                                                         |
|                                             |                  |          |                   |                                | serialization gadgets and                                                       |
|                                             |                  |          |                   |                                | typing, related to javax.swing...                                               |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-20190                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2022-42003   |          |                   | 2.13.4.1, 2.12.7.1             | jackson-databind: deep                                                          |
|                                             |                  |          |                   |                                | wrapper array nesting wrt                                                       |
|                                             |                  |          |                   |                                | UNWRAP_SINGLE_VALUE_ARRAYS                                                      |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2022-42003                                           |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2022-42004   |          |                   | 2.13.4, 2.12.7.1               | jackson-databind: use                                                           |
|                                             |                  |          |                   |                                | of deeply nested arrays                                                         |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2022-42004                                           |
+                                             +------------------+----------+                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2018-1000873 | MEDIUM   |                   | 2.9.8                          | jackson-modules-java8: DoS due                                                  |
|                                             |                  |          |                   |                                | to an Improper Input Validation                                                 |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-1000873                                         |
+                                             +------------------+          +                   +--------------------------------+---------------------------------------------------------------------------------+
|                                             | CVE-2019-12384   |          |                   | 2.9.9.1                        | jackson-databind: failure                                                       |
|                                             |                  |          |                   |                                | to block the logback-core                                                       |
|                                             |                  |          |                   |                                | class from polymorphic                                                          |
|                                             |                  |          |                   |                                | deserialization leading to...                                                   |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-12384                                           |
+                                             +------------------+          +                   +                                +---------------------------------------------------------------------------------+
|                                             | CVE-2019-12814   |          |                   |                                | jackson-databind: polymorphic                                                   |
|                                             |                  |          |                   |                                | typing issue allows attacker to                                                 |
|                                             |                  |          |                   |                                | read arbitrary local files on...                                                |
|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2019-12814                                           |
+---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------------------------------------------------+

lib/paimon-format-0.8.0.jar
===========================
Total: 8 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 7, CRITICAL: 0)

+-------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
|               LIBRARY               | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |         FIXED VERSION          |                 TITLE                 |
+-------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
| com.google.protobuf:protobuf-java   | CVE-2022-3171    | HIGH     | 3.17.3            | 3.16.3, 3.19.6, 3.20.3, 3.21.7 | protobuf-java: timeout                |
|                                     |                  |          |                   |                                | in parser leads to DoS                |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2022-3171  |
+                                     +------------------+          +                   +--------------------------------+---------------------------------------+
|                                     | CVE-2022-3509    |          |                   | 3.21.7, 3.20.3, 3.19.6, 3.16.3 | Protobuf Java vulnerable to           |
|                                     |                  |          |                   |                                | Uncontrolled Resource Consumption     |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2022-3509  |
+                                     +------------------+          +                   +                                +---------------------------------------+
|                                     | CVE-2022-3510    |          |                   |                                | Protobuf Java vulnerable to           |
|                                     |                  |          |                   |                                | Uncontrolled Resource Consumption     |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2022-3510  |
+-------------------------------------+------------------+          +-------------------+--------------------------------+---------------------------------------+
| org.apache.commons:commons-compress | CVE-2021-35515   |          | 1.4.1             |                           1.21 | apache-commons-compress:              |
|                                     |                  |          |                   |                                | infinite loop when reading a          |
|                                     |                  |          |                   |                                | specially crafted 7Z archive          |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-35515 |
+                                     +------------------+          +                   +                                +---------------------------------------+
|                                     | CVE-2021-35516   |          |                   |                                | apache-commons-compress: excessive    |
|                                     |                  |          |                   |                                | memory allocation when reading        |
|                                     |                  |          |                   |                                | a specially crafted 7Z archive        |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-35516 |
+                                     +------------------+          +                   +                                +---------------------------------------+
|                                     | CVE-2021-35517   |          |                   |                                | apache-commons-compress: excessive    |
|                                     |                  |          |                   |                                | memory allocation when reading        |
|                                     |                  |          |                   |                                | a specially crafted TAR archive       |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-35517 |
+                                     +------------------+          +                   +                                +---------------------------------------+
|                                     | CVE-2021-36090   |          |                   |                                | apache-commons-compress: excessive    |
|                                     |                  |          |                   |                                | memory allocation when reading        |
|                                     |                  |          |                   |                                | a specially crafted ZIP archive       |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-36090 |
+                                     +------------------+----------+                   +--------------------------------+---------------------------------------+
|                                     | CVE-2018-11771   | MEDIUM   |                   |                           1.18 | apache-commons-compress:              |
|                                     |                  |          |                   |                                | ZipArchiveInputStream.read()          |
|                                     |                  |          |                   |                                | fails to identify correct EOF         |
|                                     |                  |          |                   |                                | allowing for DoS via crafted...       |
|                                     |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2018-11771 |
+-------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+

lib/spark-network-common_2.12-3.4.1.jar
=======================================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

+------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|        LIBRARY         | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| com.google.guava:guava | CVE-2018-10237   | MEDIUM   | 14.0.1            | 24.1.1        | guava: Unbounded memory               |
|                        |                  |          |                   |               | allocation in AtomicDoubleArray       |
|                        |                  |          |                   |               | and CompoundOrdering classes          |
|                        |                  |          |                   |               | allow remote attackers...             |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-10237 |
+                        +------------------+----------+                   +---------------+---------------------------------------+
|                        | CVE-2020-8908    | LOW      |                   |               | guava: local information              |
|                        |                  |          |                   |               | disclosure via temporary directory    |
|                        |                  |          |                   |               | created with unsafe permissions       |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-8908  |
+------------------------+------------------+----------+-------------------+---------------+---------------------------------------+

```
hudi-common->hbase server/client->hbase-protocol-shaded-2.4.18.jar/htrace-core4-4.2.0-incubating.jar
hbase-protocol-shaded-2.4.18.jar (affect hudi using) (but trino didn't require hbase server/client)
htrace-core4-4.2.0-incubating.jar  (affect hudi using) (but trino didn't require hbase server/client)
paimon-format-0.8.0.jar (affect paimon using)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
