### PR TITLE
[BugFix] Fix BE crash in ASAN mode

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3642,9 +3642,13 @@ struct RowsetLoadInfo {
 Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version, ChunkChanger* chunk_changer,
                                 const TabletSchemaCSPtr& base_tablet_schema, const std::string& err_msg_header) {
     OlapStopWatch watch;
-    DCHECK(_tablet.tablet_state() == TABLET_NOTREADY)
-            << err_msg_header << "tablet state is not TABLET_NOTREADY, link_from is not allowed"
-            << " tablet_id:" << _tablet.tablet_id() << " tablet_state:" << _tablet.tablet_state();
+    if (_tablet.tablet_state() == TABLET_NOTREADY) {
+        string msg = strings::Substitute(
+                "$0 tablet state is not TABLET_NOTREADY, link_from is not allowed tablet_id:$1 tablet_state:$2",
+                err_msg_header, _tablet.tablet_id(), _tablet.tablet_state());
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
     LOG(INFO) << err_msg_header << "link_from start tablet:" << _tablet.tablet_id()
               << " #pending:" << _pending_commits.size() << " base_tablet:" << base_tablet->tablet_id()
               << " request_version:" << request_version;
@@ -3856,9 +3860,13 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
                                    ChunkChanger* chunk_changer, const TabletSchemaCSPtr& base_tablet_schema,
                                    const std::string& err_msg_header) {
     OlapStopWatch watch;
-    DCHECK(_tablet.tablet_state() == TABLET_NOTREADY)
-            << err_msg_header << "tablet state is not TABLET_NOTREADY, convert_from is not allowed"
-            << " tablet_id:" << _tablet.tablet_id() << " tablet_state:" << _tablet.tablet_state();
+    if (_tablet.tablet_state() == TABLET_NOTREADY) {
+        string msg = strings::Substitute(
+                "$0 tablet state is not TABLET_NOTREADY, convert_from is not allowed tablet_id:$1 tablet_state:$2",
+                err_msg_header, _tablet.tablet_id(), _tablet.tablet_state());
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
     LOG(INFO) << err_msg_header << "convert_from start tablet:" << _tablet.tablet_id()
               << " #pending:" << _pending_commits.size() << " base_tablet:" << base_tablet->tablet_id()
               << " request_version:" << request_version;
@@ -4121,9 +4129,13 @@ Status TabletUpdates::reorder_from(const std::shared_ptr<Tablet>& base_tablet, i
                                    ChunkChanger* chunk_changer, const TabletSchemaCSPtr& base_tablet_schema,
                                    const std::string& err_msg_header) {
     OlapStopWatch watch;
-    DCHECK(_tablet.tablet_state() == TABLET_NOTREADY)
-            << err_msg_header << "tablet state is not TABLET_NOTREADY, reorder_from is not allowed"
-            << " tablet_id:" << _tablet.tablet_id() << " tablet_state:" << _tablet.tablet_state();
+    if (_tablet.tablet_state() == TABLET_NOTREADY) {
+        string msg = strings::Substitute(
+                "$0 tablet state is not TABLET_NOTREADY, link_from is not allowed tablet_id:$1 tablet_state:$2",
+                err_msg_header, _tablet.tablet_id(), _tablet.tablet_state());
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
     LOG(INFO) << err_msg_header << "reorder_from start tablet:" << _tablet.tablet_id()
               << " #pending:" << _pending_commits.size() << " base_tablet:" << base_tablet->tablet_id()
               << " request_version:" << request_version;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3642,7 +3642,7 @@ struct RowsetLoadInfo {
 Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version, ChunkChanger* chunk_changer,
                                 const TabletSchemaCSPtr& base_tablet_schema, const std::string& err_msg_header) {
     OlapStopWatch watch;
-    if (_tablet.tablet_state() == TABLET_NOTREADY) {
+    if (_tablet.tablet_state() != TABLET_NOTREADY) {
         string msg = strings::Substitute(
                 "$0 tablet state is not TABLET_NOTREADY, link_from is not allowed tablet_id:$1 tablet_state:$2",
                 err_msg_header, _tablet.tablet_id(), _tablet.tablet_state());
@@ -3860,7 +3860,7 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
                                    ChunkChanger* chunk_changer, const TabletSchemaCSPtr& base_tablet_schema,
                                    const std::string& err_msg_header) {
     OlapStopWatch watch;
-    if (_tablet.tablet_state() == TABLET_NOTREADY) {
+    if (_tablet.tablet_state() != TABLET_NOTREADY) {
         string msg = strings::Substitute(
                 "$0 tablet state is not TABLET_NOTREADY, convert_from is not allowed tablet_id:$1 tablet_state:$2",
                 err_msg_header, _tablet.tablet_id(), _tablet.tablet_state());
@@ -4129,9 +4129,9 @@ Status TabletUpdates::reorder_from(const std::shared_ptr<Tablet>& base_tablet, i
                                    ChunkChanger* chunk_changer, const TabletSchemaCSPtr& base_tablet_schema,
                                    const std::string& err_msg_header) {
     OlapStopWatch watch;
-    if (_tablet.tablet_state() == TABLET_NOTREADY) {
+    if (_tablet.tablet_state() != TABLET_NOTREADY) {
         string msg = strings::Substitute(
-                "$0 tablet state is not TABLET_NOTREADY, link_from is not allowed tablet_id:$1 tablet_state:$2",
+                "$0 tablet state is not TABLET_NOTREADY, reorder_from is not allowed tablet_id:$1 tablet_state:$2",
                 err_msg_header, _tablet.tablet_id(), _tablet.tablet_state());
         LOG(WARNING) << msg;
         return Status::InternalError(msg);

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3461,4 +3461,3 @@ TEST_F(TabletUpdatesTest, test_alter_state_not_correct) {
 }
 
 } // namespace starrocks
-

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3452,4 +3452,14 @@ TEST_F(TabletUpdatesTest, test_apply_concurrent_with_on_rowset_finish) {
     }
 }
 
+TEST_F(TabletUpdatesTest, test_alter_state_not_correct) {
+    _tablet = create_tablet(rand(), rand());
+    _tablet2 = create_tablet(rand(), rand());
+    ASSERT_FALSE(_tablet->updates()->link_from(_tablet2.get(), 1, nullptr, _tablet2->tablet_schema(), "").ok());
+    ASSERT_FALSE(_tablet->updates()->convert_from(_tablet2, 1, nullptr, _tablet2->tablet_schema(), "").ok());
+    ASSERT_FALSE(_tablet->updates()->reorder_from(_tablet2, 1, nullptr, _tablet2->tablet_schema(), "").ok());
+}
+} // namespace starrocks
+}
+
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3459,7 +3459,6 @@ TEST_F(TabletUpdatesTest, test_alter_state_not_correct) {
     ASSERT_FALSE(_tablet->updates()->convert_from(_tablet2, 1, nullptr, _tablet2->tablet_schema(), "").ok());
     ASSERT_FALSE(_tablet->updates()->reorder_from(_tablet2, 1, nullptr, _tablet2->tablet_schema(), "").ok());
 }
-} // namespace starrocks
-}
 
 } // namespace starrocks
+


### PR DESCRIPTION
## Why I'm doing:
If primary key table is dropped during alter, the alter job in BE will fail. However, if we run BE in ASAN mode, BE maybe crash.

## What I'm doing:
Crash is not necessary, return error is enough.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
