### PR TITLE
[BugFix] Fix query scheduler for pruned right local bucket shuffle join (backport #46097)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -706,8 +706,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.cacheParam = cacheParam;
     }
 
-    public List<OlapScanNode> collectOlapScanNodes() {
-        List<OlapScanNode> olapScanNodes = Lists.newArrayList();
+    public int getNumOlapScanNodes() {
+        int numOlapScanNodes = 0;
         Queue<PlanNode> queue = Lists.newLinkedList();
         queue.add(planRoot);
         while (!queue.isEmpty()) {
@@ -717,13 +717,13 @@ public class PlanFragment extends TreeNode<PlanFragment> {
                 continue;
             }
             if (node instanceof OlapScanNode) {
-                olapScanNodes.add((OlapScanNode) node);
+                numOlapScanNodes++;
             }
 
             queue.addAll(node.getChildren());
         }
 
-        return olapScanNodes;
+        return numOlapScanNodes;
     }
 
     public PlanNode getLeftMostNode() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -155,6 +155,7 @@ public class CoordinatorPreprocessor {
     // fragment_id -> < be_id -> bucket_count >
     private final Map<PlanFragmentId, Map<Long, Integer>> fragmentIdToBackendIdBucketCountMap = Maps.newHashMap();
     private final Map<PlanFragmentId, List<Integer>> fragmentIdToSeqToInstanceMap = Maps.newHashMap();
+    private final Map<PlanFragmentId, ColocatedBackendSelector.Assignment> fragmentIdToColocatedAssignment = Maps.newHashMap();
 
     // used only by channel stream load, records the mapping from channel id to target BE's address
     private final Map<Integer, TNetworkAddress> channelIdToBEHTTP = Maps.newHashMap();
@@ -2213,10 +2214,17 @@ public class CoordinatorPreprocessor {
                                 scanNode.getOlapTable().getPartition(pid).getDistributionInfo().getBucketNum());
                     }
                 }
+
+                PlanFragment fragment = scanNode.getFragment();
+                fragmentIdToColocatedAssignment.put(fragmentId,
+                        new ColocatedBackendSelector.Assignment(fragment.getNumOlapScanNodes()));
             }
             Map<Integer, TNetworkAddress> bucketSeqToAddress =
                     fragmentIdToSeqToAddressMap.get(fragmentId);
             BucketSeqToScanRange bucketSeqToScanRange = fragmentIdBucketSeqToScanRangeMap.get(scanNode.getFragmentId());
+            Assignment colocatedAssignment = fragmentIdToColocatedAssignment.get(fragmentId);
+
+            colocatedAssignment.recordAssignedScanNode(scanNode);
 
             for (Integer bucketSeq : scanNode.bucketSeq2locations.keySet()) {
                 //fill scanRangeParamsList
@@ -2239,9 +2247,11 @@ public class CoordinatorPreprocessor {
                     scanRangeParamsList.add(scanRangeParams);
                 }
             }
-            // Because of the right table will not send data to the bucket which has been pruned, the right join or full join will get wrong result.
-            // So if this bucket shuffle is right join or full join, we need to add empty bucket scan range which is pruned by predicate.
-            if (rightOrFullBucketShuffleFragmentIds.contains(fragmentId.asInt())) {
+            // Because the right table will not send data to the bucket which has been pruned, the right join or full join will get wrong result.
+            // Therefore, if this bucket shuffle is right join or full join, we need to add empty bucket scan range which is pruned by predicate,
+            // after the last scan node of this fragment is assigned.
+            if (rightOrFullBucketShuffleFragmentIds.contains(fragmentId.asInt()) &&
+                    colocatedAssignment.isAllScanNodesAssigned()) {
                 int bucketNum = getFragmentBucketNum(fragmentId);
 
                 for (int bucketSeq = 0; bucketSeq < bucketNum; ++bucketSeq) {
@@ -2308,6 +2318,23 @@ public class CoordinatorPreprocessor {
 
             recordUsedBackend(execHostPort, backendIdRef.getRef());
             fragmentIdToSeqToAddressMap.get(fragmentId).put(bucketSeq, execHostPort);
+        }
+
+        public class Assignment {
+            private final int numOlapScanNodes;
+            private final Set<PlanNodeId> assignedScanNodeIds = Sets.newHashSet();
+
+            public Assignment(int numOlapScanNodes) {
+                this.numOlapScanNodes = numOlapScanNodes;
+            }
+
+            public void recordAssignedScanNode(OlapScanNode scanNode) {
+                assignedScanNodeIds.add(scanNode.getId());
+            }
+
+            public boolean isAllScanNodesAssigned() {
+                return assignedScanNodeIds.size() == numOlapScanNodes;
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -372,18 +372,6 @@ public class PlanFragmentBuilder {
         return execPlan;
     }
 
-    private static void maybeClearOlapScanNodePartitions(PlanFragment fragment) {
-        List<OlapScanNode> olapScanNodes = fragment.collectOlapScanNodes();
-        long numNodesWithBucketColumns =
-                olapScanNodes.stream().filter(node -> !node.getBucketColumns().isEmpty()).count();
-        // Either all OlapScanNode use bucketColumns for local shuffle, or none of them do.
-        // Therefore, clear bucketColumns if only some of them contain bucketColumns.
-        boolean needClear = numNodesWithBucketColumns > 0 && numNodesWithBucketColumns < olapScanNodes.size();
-        if (needClear) {
-            clearOlapScanNodePartitions(fragment.getPlanRoot());
-        }
-    }
-
     /**
      * Clear partitionExprs of OlapScanNode (the bucket keys to pass to BE).
      * <p>

--- a/test/sql/test_join/R/test_pruned_right_outer_local_bucket_shuffle_join
+++ b/test/sql/test_join/R/test_pruned_right_outer_local_bucket_shuffle_join
@@ -1,0 +1,47 @@
+-- name: test_pruned_right_outer_local_bucket_shuffle_join
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 6
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;
+-- result:
+10000
+-- !result
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;
+-- result:
+10000
+-- !result
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;
+-- result:
+10000
+-- !result
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;
+-- result:
+10000
+-- !result

--- a/test/sql/test_join/T/test_pruned_right_outer_local_bucket_shuffle_join
+++ b/test/sql/test_join/T/test_pruned_right_outer_local_bucket_shuffle_join
@@ -1,0 +1,37 @@
+-- name: test_pruned_right_outer_local_bucket_shuffle_join
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 6
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 select generate_series, generate_series from TABLE(generate_series(0, 10000 - 1));
+
+-- Repeat the same query multiple times.
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;
+
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;
+
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;
+
+with 
+  w1 as (select k1 from t1 where k1 = 10),
+  w2 as (select tt1.k1 from t1 tt1 right outer join [bucket] t1 tt2 using(k1)),
+  w3 as (select w1.k1 from w1 right outer join [colocate] w2 using(k1))
+select count(1) from w3;


### PR DESCRIPTION
CP from #46097.

## Why I'm doing:
Fix query scheduler for pruned right local bucket shuffle join. #46098 has an example.


## What I'm doing:

As for local bucket shuffle right outer join, we add empty bucket scan range which is pruned by predicate and assign this bucket to arbitrary BE. 
- The reason is that, if we do not assign a BE to the pruned bucket of the left table, the right table will not send data to the bucket which has been pruned, and then the right join or full join will get wrong result. 

The code is as follows:
```java
        if (isRightOrFullBucketShuffleFragment && colocatedAssignment.isAllScanNodesAssigned()) {
            int bucketNum = colocatedAssignment.bucketNum;

            for (int bucketSeq = 0; bucketSeq < bucketNum; ++bucketSeq) {
                if (!bucketSeqToWorkerId.containsKey(bucketSeq)) { 
                    long workerId = workerProvider.selectNextWorker(); // --------------------- here ------------------
                    bucketSeqToWorkerId.put(bucketSeq, workerId);
                }
                if (!bucketSeqToScanRange.containsKey(bucketSeq)) {
                    bucketSeqToScanRange.put(bucketSeq, Maps.newHashMap());
                    bucketSeqToScanRange.get(bucketSeq).put(scanNode.getId().asInt(), Lists.newArrayList());
                }
            }
        }
```

This code assigns the pruned buckets to arbitrary BE after processing the **first** olap scan node of a fragment.

However, we should do this after processing the **last** instead of **first** scan node, because only after all OLAP scan nodes have been processed can it be determined whether a bucket has been pruned.
    
Fixes #46098.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5


