### PR TITLE
[Enhancement] add more profile and metrics to measure runtime bloom filter size

### DIFF
--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -50,6 +50,8 @@ void HashJoinBuildMetrics::prepare(RuntimeProfile* runtime_profile) {
     runtime_filter_num = ADD_COUNTER(runtime_profile, "RuntimeFilterNum", TUnit::UNIT);
     build_keys_per_bucket = ADD_COUNTER(runtime_profile, "BuildKeysPerBucket%", TUnit::UNIT);
     hash_table_memory_usage = ADD_COUNTER(runtime_profile, "HashTableMemoryUsage", TUnit::BYTES);
+
+    partial_runtime_bloom_filter_bytes = ADD_COUNTER(runtime_profile, "PartialRuntimeBloomFilterBytes", TUnit::BYTES);
 }
 
 HashJoiner::HashJoiner(const HashJoinerParam& param)

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -156,6 +156,8 @@ struct HashJoinBuildMetrics {
     RuntimeProfile::Counter* build_keys_per_bucket = nullptr;
     RuntimeProfile::Counter* hash_table_memory_usage = nullptr;
 
+    RuntimeProfile::Counter* partial_runtime_bloom_filter_bytes = nullptr;
+
     void prepare(RuntimeProfile* runtime_profile);
 };
 

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -218,6 +218,7 @@ void RuntimeFilterPort::receive_shared_runtime_filter(int32_t filter_id,
         rf_desc->set_shared_runtime_filter(rf);
     }
 }
+
 RuntimeFilterMerger::RuntimeFilterMerger(ExecEnv* env, const UniqueId& query_id, const TQueryOptions& query_options,
                                          bool is_pipeline)
         : _exec_env(env), _query_id(query_id), _query_options(query_options), _is_pipeline(is_pipeline) {}
@@ -496,15 +497,6 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
     pool->clear();
 }
 
-enum EventType {
-    RECEIVE_TOTAL_RF = 0,
-    CLOSE_QUERY = 1,
-    OPEN_QUERY = 2,
-    RECEIVE_PART_RF = 3,
-    SEND_PART_RF = 4,
-    SEND_BROADCAST_GRF = 5,
-};
-
 struct RuntimeFilterWorkerEvent {
 public:
     RuntimeFilterWorkerEvent() = default;
@@ -532,9 +524,14 @@ static_assert(std::is_move_assignable<RuntimeFilterWorkerEvent>::value);
 
 RuntimeFilterWorker::RuntimeFilterWorker(ExecEnv* env) : _exec_env(env), _thread([this] { execute(); }) {
     Thread::set_thread_name(_thread, "runtime_filter");
+    _metrics = new RuntimeFilterWorkerMetrics();
 }
 
-RuntimeFilterWorker::~RuntimeFilterWorker() = default;
+RuntimeFilterWorker::~RuntimeFilterWorker() {
+    if (_metrics) {
+        delete _metrics;
+    }
+}
 
 void RuntimeFilterWorker::close() {
     _queue.shutdown();
@@ -550,6 +547,7 @@ void RuntimeFilterWorker::open_query(const TUniqueId& query_id, const TQueryOpti
     ev.query_options = query_options;
     ev.create_rf_merger_request = params;
     ev.is_opened_by_pipeline = is_pipeline;
+    _metrics->update_event_nums(ev.type, 1);
     _queue.put(std::move(ev));
 }
 
@@ -558,6 +556,7 @@ void RuntimeFilterWorker::close_query(const TUniqueId& query_id) {
     RuntimeFilterWorkerEvent ev;
     ev.type = CLOSE_QUERY;
     ev.query_id = query_id;
+    _metrics->update_event_nums(ev.type, 1);
     _queue.put(std::move(ev));
 }
 
@@ -571,6 +570,8 @@ void RuntimeFilterWorker::send_part_runtime_filter(PTransmitRuntimeFilterParams&
     ev.transmit_via_http_min_size = rpc_http_min_size;
     ev.transmit_addrs = addrs;
     ev.transmit_rf_request = std::move(params);
+    _metrics->update_event_nums(ev.type, 1);
+    _metrics->update_rf_bytes(ev.type, ev.transmit_rf_request.data().size());
     _queue.put(std::move(ev));
 }
 
@@ -584,6 +585,8 @@ void RuntimeFilterWorker::send_broadcast_runtime_filter(PTransmitRuntimeFilterPa
     ev.transmit_via_http_min_size = rpc_http_min_size;
     ev.destinations = destinations;
     ev.transmit_rf_request = std::move(params);
+    _metrics->update_event_nums(ev.type, 1);
+    _metrics->update_rf_bytes(ev.type, ev.transmit_rf_request.data().size());
     _queue.put(std::move(ev));
 }
 
@@ -604,8 +607,11 @@ void RuntimeFilterWorker::receive_runtime_filter(const PTransmitRuntimeFilterPar
     ev.query_id.hi = params.query_id().hi();
     ev.query_id.lo = params.query_id().lo();
     ev.transmit_rf_request = params;
+    _metrics->update_event_nums(ev.type, 1);
+    _metrics->update_rf_bytes(ev.type, ev.transmit_rf_request.data().size());
     _queue.put(std::move(ev));
 }
+
 // receive total runtime filter in pipeline engine.
 static inline void receive_total_runtime_filter_pipeline(PTransmitRuntimeFilterParams& params,
                                                          const std::shared_ptr<JoinRuntimeFilter>& shared_rf) {
@@ -876,6 +882,7 @@ void RuntimeFilterWorker::_deliver_part_runtime_filter(std::vector<TNetworkAddre
 void RuntimeFilterWorker::execute() {
     LOG(INFO) << "RuntimeFilterWorker start working.";
     for (;;) {
+        // @TODO pending queue size, total rf size
         RuntimeFilterWorkerEvent ev;
         if (!_queue.blocking_get(&ev)) {
             break;
@@ -884,8 +891,10 @@ void RuntimeFilterWorker::execute() {
         LOG_IF_EVERY_N(INFO, _queue.get_size() > CpuInfo::num_cores() * 10, 10)
                 << "runtime filter worker queue may be too large, size: " << _queue.get_size();
 
+        _metrics->update_event_nums(ev.type, -1);
         switch (ev.type) {
         case RECEIVE_TOTAL_RF: {
+            _metrics->update_rf_bytes(ev.type, -ev.transmit_rf_request.data().size());
             _receive_total_runtime_filter(ev.transmit_rf_request);
             break;
         }
@@ -915,6 +924,7 @@ void RuntimeFilterWorker::execute() {
         }
 
         case RECEIVE_PART_RF: {
+            _metrics->update_rf_bytes(ev.type, -ev.transmit_rf_request.data().size());
             auto it = _mergers.find(ev.query_id);
             if (it == _mergers.end()) {
                 VLOG_QUERY << "receive part rf: rf merger not existed. query_id = " << ev.query_id;
@@ -928,11 +938,13 @@ void RuntimeFilterWorker::execute() {
         }
 
         case SEND_PART_RF: {
+            _metrics->update_rf_bytes(ev.type, -ev.transmit_rf_request.data().size());
             _deliver_part_runtime_filter(std::move(ev.transmit_addrs), std::move(ev.transmit_rf_request),
                                          ev.transmit_timeout_ms, ev.transmit_via_http_min_size);
             break;
         }
         case SEND_BROADCAST_GRF: {
+            _metrics->update_rf_bytes(ev.type, -ev.transmit_rf_request.data().size());
             _process_send_broadcast_runtime_filter_event(std::move(ev.transmit_rf_request), std::move(ev.destinations),
                                                          ev.transmit_timeout_ms, ev.transmit_via_http_min_size);
             break;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -882,7 +882,6 @@ void RuntimeFilterWorker::_deliver_part_runtime_filter(std::vector<TNetworkAddre
 void RuntimeFilterWorker::execute() {
     LOG(INFO) << "RuntimeFilterWorker start working.";
     for (;;) {
-        // @TODO pending queue size, total rf size
         RuntimeFilterWorkerEvent ev;
         if (!_queue.blocking_get(&ev)) {
             break;

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -29,6 +29,7 @@
 #include "gen_cpp/internal_service.pb.h"
 #include "util/blocking_queue.hpp"
 #include "util/ref_count_closure.h"
+#include "util/system_metrics.h"
 #include "util/uid_util.h"
 namespace starrocks {
 
@@ -113,6 +114,35 @@ private:
     const bool _is_pipeline;
 };
 
+enum EventType {
+    RECEIVE_TOTAL_RF = 0,
+    CLOSE_QUERY = 1,
+    OPEN_QUERY = 2,
+    RECEIVE_PART_RF = 3,
+    SEND_PART_RF = 4,
+    SEND_BROADCAST_GRF = 5,
+    MAX_COUNT,
+};
+
+inline std::string EventTypeToString(EventType type) {
+    switch (type) {
+    case RECEIVE_TOTAL_RF:
+        return "RECEIVE_TOTAL_RF";
+    case CLOSE_QUERY:
+        return "CLOSE_QUERY";
+    case OPEN_QUERY:
+        return "OPEN_QUERY";
+    case RECEIVE_PART_RF:
+        return "RECEIVE_PART_RF";
+    case SEND_PART_RF:
+        return "SEND_PART_RF";
+    case SEND_BROADCAST_GRF:
+        return "SEND_BROADCAST_GRF";
+    default:
+        break;
+    }
+    __builtin_unreachable();
+}
 // RuntimeFilterWorker works in a separated thread, and does following jobs:
 // 1. deserialize runtime filters.
 // 2. merge runtime filters.
@@ -124,6 +154,24 @@ private:
 // - send partitioned RF(for hash join node)
 // - close a query(delete runtime filter merger)
 struct RuntimeFilterWorkerEvent;
+
+struct RuntimeFilterWorkerMetrics {
+    void update_event_nums(EventType event_type, int64_t delta) {
+        LOG(INFO) << "update event num, type: " << EventTypeToString(event_type)
+                  << ", old: " << runtime_filter_bytes[event_type] << ", delta:" << delta;
+        event_nums[event_type] += delta;
+    }
+
+    void update_rf_bytes(EventType event_type, int64_t delta) {
+        LOG(INFO) << "update rf bytes, type: " << EventTypeToString(event_type)
+                  << ", old: " << runtime_filter_bytes[event_type] << ", delta:" << delta;
+        runtime_filter_bytes[event_type] += delta;
+    }
+
+    std::array<std::atomic_int64_t, EventType::MAX_COUNT> event_nums{};
+    std::array<std::atomic_int64_t, EventType::MAX_COUNT> runtime_filter_bytes{};
+};
+
 class RuntimeFilterWorker {
 public:
     RuntimeFilterWorker(ExecEnv* env);
@@ -143,6 +191,7 @@ public:
                                        int64_t rpc_http_min_size);
 
     size_t queue_size() const;
+    const RuntimeFilterWorkerMetrics* metrics() const { return _metrics; }
 
 private:
     void _receive_total_runtime_filter(PTransmitRuntimeFilterParams& params);
@@ -166,6 +215,7 @@ private:
     std::unordered_map<TUniqueId, RuntimeFilterMerger> _mergers;
     ExecEnv* _exec_env;
     std::thread _thread;
+    RuntimeFilterWorkerMetrics* _metrics = nullptr;
 };
 
 }; // namespace starrocks

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -156,13 +156,9 @@ inline std::string EventTypeToString(EventType type) {
 struct RuntimeFilterWorkerEvent;
 
 struct RuntimeFilterWorkerMetrics {
-    void update_event_nums(EventType event_type, int64_t delta) {
-        event_nums[event_type] += delta;
-    }
+    void update_event_nums(EventType event_type, int64_t delta) { event_nums[event_type] += delta; }
 
-    void update_rf_bytes(EventType event_type, int64_t delta) {
-        runtime_filter_bytes[event_type] += delta;
-    }
+    void update_rf_bytes(EventType event_type, int64_t delta) { runtime_filter_bytes[event_type] += delta; }
 
     std::array<std::atomic_int64_t, EventType::MAX_COUNT> event_nums{};
     std::array<std::atomic_int64_t, EventType::MAX_COUNT> runtime_filter_bytes{};

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -157,14 +157,10 @@ struct RuntimeFilterWorkerEvent;
 
 struct RuntimeFilterWorkerMetrics {
     void update_event_nums(EventType event_type, int64_t delta) {
-        LOG(INFO) << "update event num, type: " << EventTypeToString(event_type)
-                  << ", old: " << runtime_filter_bytes[event_type] << ", delta:" << delta;
         event_nums[event_type] += delta;
     }
 
     void update_rf_bytes(EventType event_type, int64_t delta) {
-        LOG(INFO) << "update rf bytes, type: " << EventTypeToString(event_type)
-                  << ", old: " << runtime_filter_bytes[event_type] << ", delta:" << delta;
         runtime_filter_bytes[event_type] += delta;
     }
 

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -30,6 +30,7 @@ class NetMetrics;
 class FileDescriptorMetrics;
 class SnmpMetrics;
 class QueryCacheMetrics;
+class RuntimeFilterMetrics;
 
 class MemoryMetrics {
 public:
@@ -134,6 +135,10 @@ private:
 
     void _update_query_cache_metrics();
 
+    void _install_runtime_filter_metrics(MetricRegistry* registry);
+
+    void _update_runtime_filter_metrics();
+
 private:
     static const char* const _s_hook_name;
 
@@ -143,6 +148,7 @@ private:
     std::map<std::string, NetMetrics*> _net_metrics;
     std::unique_ptr<FileDescriptorMetrics> _fd_metrics;
     std::unique_ptr<QueryCacheMetrics> _query_cache_metrics;
+    std::map<std::string, RuntimeFilterMetrics*> _runtime_filter_metrics;
     int _proc_net_dev_version = 0;
     std::unique_ptr<SnmpMetrics> _snmp_metrics;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Major changes:
1. add new metrics to query profile to observe the memory occupied by partial runtime bloom filter.
2. add new be system metrics to  observe the number of rf events in the queue and the bloom filter memory consumption  in the queue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
