### PR TITLE
[BugFix] Fix down_cast failed in adaptive io task

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -610,12 +610,14 @@ void ConnectorScanOperator::append_morsels(std::vector<MorselPtr>&& morsels) {
 
 // ==================== ConnectorChunkSource ====================
 ConnectorChunkSource::ConnectorChunkSource(ScanOperator* op, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
-                                           ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer)
+                                           ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer,
+                                           bool enable_adaptive_io_tasks)
         : ChunkSource(op, runtime_profile, std::move(morsel), chunk_buffer),
           _scan_node(scan_node),
           _limit(scan_node->limit()),
           _runtime_in_filters(op->runtime_in_filters()),
-          _runtime_bloom_filters(op->runtime_bloom_filters()) {
+          _runtime_bloom_filters(op->runtime_bloom_filters()),
+          _enable_adaptive_io_tasks(enable_adaptive_io_tasks) {
     _conjunct_ctxs = scan_node->conjunct_ctxs();
     _conjunct_ctxs.insert(_conjunct_ctxs.end(), _runtime_in_filters.begin(), _runtime_in_filters.end());
     auto* scan_morsel = (ScanMorsel*)_morsel.get();
@@ -662,8 +664,7 @@ ConnectorScanOperatorIOTasksMemLimiter* ConnectorChunkSource::_get_io_tasks_mem_
 void ConnectorChunkSource::close(RuntimeState* state) {
     if (_closed) return;
 
-    ConnectorScanOperator* scan_op = down_cast<ConnectorScanOperator*>(_scan_op);
-    if (scan_op->enable_adaptive_io_tasks()) {
+    if (_enable_adaptive_io_tasks) {
         MemTracker* mem_tracker = state->query_ctx()->connector_scan_mem_tracker();
         mem_tracker->release(_request_mem_tracker_bytes);
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -296,7 +296,8 @@ ChunkSourcePtr ConnectorScanOperator::create_chunk_source(MorselPtr morsel, int3
     }
 
     return std::make_shared<ConnectorChunkSource>(this, _chunk_source_profiles[chunk_source_index].get(),
-                                                  std::move(morsel), scan_node, factory->get_chunk_buffer());
+                                                  std::move(morsel), scan_node, factory->get_chunk_buffer(),
+                                                  _enable_adaptive_io_tasks);
 }
 
 void ConnectorScanOperator::attach_chunk_source(int32_t source_index) {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -126,7 +126,8 @@ private:
 class ConnectorChunkSource : public ChunkSource {
 public:
     ConnectorChunkSource(ScanOperator* op, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
-                         ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer);
+                         ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer,
+                         bool enable_adaptive_io_tasks);
 
     ~ConnectorChunkSource() override;
 
@@ -168,6 +169,7 @@ private:
     uint64_t _chunk_mem_bytes = 0;
     int64_t _request_mem_tracker_bytes = 0;
     int64_t _mem_alloc_failed_count = 0;
+    bool _enable_adaptive_io_tasks = true;
 };
 
 } // namespace pipeline

--- a/be/src/exec/stream/scan/stream_scan_operator.cpp
+++ b/be/src/exec/stream/scan/stream_scan_operator.cpp
@@ -119,7 +119,8 @@ ChunkSourcePtr StreamScanOperator::create_chunk_source(MorselPtr morsel, int32_t
     auto* scan_node = down_cast<ConnectorScanNode*>(_scan_node);
     auto* factory = down_cast<StreamScanOperatorFactory*>(_factory);
     return std::make_shared<StreamChunkSource>(this, _chunk_source_profiles[chunk_source_index].get(),
-                                               std::move(morsel), scan_node, factory->get_chunk_buffer());
+                                               std::move(morsel), scan_node, factory->get_chunk_buffer(),
+                                               enable_adaptive_io_tasks());
 }
 
 bool StreamScanOperator::is_finished() const {
@@ -334,8 +335,10 @@ void StreamScanOperator::_close_chunk_source_unlocked(RuntimeState* state, int c
 }
 
 StreamChunkSource::StreamChunkSource(ScanOperator* op, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
-                                     ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer)
-        : ConnectorChunkSource(op, runtime_profile, std::move(morsel), scan_node, chunk_buffer) {}
+                                     ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer,
+                                     bool enable_adaptive_io_tasks)
+        : ConnectorChunkSource(op, runtime_profile, std::move(morsel), scan_node, chunk_buffer,
+                               enable_adaptive_io_tasks) {}
 
 Status StreamChunkSource::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ConnectorChunkSource::prepare(state));

--- a/be/src/exec/stream/scan/stream_scan_operator.h
+++ b/be/src/exec/stream/scan/stream_scan_operator.h
@@ -103,7 +103,7 @@ private:
 class StreamChunkSource : public ConnectorChunkSource {
 public:
     StreamChunkSource(ScanOperator* op, RuntimeProfile* runtime_profile, MorselPtr&& morsel,
-                      ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer);
+                      ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer, bool enable_adaptive_io_task);
 
     [[nodiscard]] Status prepare(RuntimeState* state) override;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
```bash
Crash Log: 
starrocks_be: be/src/gutil/casts.h:79: To down_cast(From*) [with To = starrocks::pipeline::ConnectorScanOperator*; From = starrocks::pipeline::ScanOperator]: Assertion `f == __null || dynamic_cast<To>(f) != __null' failed.
branch-3.3 ASAN (build c3fa025)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
tracker:process consumption: 0
tracker:query_pool consumption: 0
tracker:query_pool/connector_scan consumption: 304217520
tracker:load consumption: 0
tracker:metadata consumption: 30869302
tracker:tablet_metadata consumption: 2416046
tracker:rowset_metadata consumption: 7052314
tracker:segment_metadata consumption: 5125074
tracker:column_metadata consumption: 16275868
tracker:tablet_schema consumption: 116438
tracker:segment_zonemap consumption: 3631280
tracker:short_key_index consumption: 311115
tracker:column_zonemap_index consumption: 6211220
tracker:ordinal_index consumption: 2767384
tracker:bitmap_index consumption: 0
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 29082432
tracker:jit_cache consumption: 0
tracker:update consumption: 1318058
tracker:chunk_allocator consumption: 0
tracker:clone consumption: 0
tracker:consistency consumption: 0
tracker:datacache consumption: 9304360
tracker:replication consumption: 0
*** Aborted at 1716836461 (unix time) try "date -d @1716836461" if you are using GNU date ***
PC: @     0x7f34a871e387 __GI_raise
*** SIGABRT (@0x3e800000a79) received by PID 2681 (TID 0x7f336e945700) from PID 2681; stack trace: ***
   @         0x18862962 google::(anonymous namespace)::FailureSignalHandler()
   @     0x7f34a93ed630 (unknown)
   @     0x7f34a871e387 __GI_raise
   @     0x7f34a871fa78 __GI_abort
   @     0x7f34a87171a6 __assert_fail_base
   @     0x7f34a8717252 __GI___assert_fail
   @          0xe650f64 down_cast<>()
   @          0xe645b28 starrocks::pipeline::ConnectorChunkSource::close()
   @          0xe5dbafc starrocks::pipeline::ScanOperator::_close_chunk_source_unlocked()
   @          0xe5dbcf2 starrocks::pipeline::ScanOperator::_close_chunk_source()
   @          0xe5d5460 starrocks::pipeline::ScanOperator::~ScanOperator()
   @          0xe6541b3 starrocks::pipeline::ConnectorScanOperator::~ConnectorScanOperator()
   @          0xe6547e2 std::destroy_at<>()
   @          0xe654700 std::allocator_traits<>::destroy<>()
   @          0xe6544eb std::_Sp_counted_ptr_inplace<>::_M_dispose()
   @          0xb66c3bf std::_Sp_counted_base<>::_M_release()
   @          0xb6656aa std::__shared_count<>::~__shared_count()
   @          0xe91643a std::__shared_ptr<>::~__shared_ptr()
   @          0xe916456 std::shared_ptr<>::~shared_ptr()
   @          0xe920f30 std::destroy_at<>()
   @          0xe92236e std::_Destroy<>()
   @          0xe920f0e std::_Destroy_aux<>::__destroy<>()
   @          0xe91ed7a std::_Destroy<>()
   @          0xe91a7a5 std::_Destroy<>()
   @          0xe918740 std::vector<>::~vector()
   @          0xe8f950c starrocks::pipeline::PipelineDriver::~PipelineDriver()
   @          0xeb688ee std::destroy_at<>()
   @          0xeb68854 std::allocator_traits<>::destroy<>()
   @          0xeb6863f std::_Sp_counted_ptr_inplace<>::_M_dispose()
   @          0xb66c3bf std::_Sp_counted_base<>::_M_release()
   @          0xb6656aa std::__shared_count<>::~__shared_count()
   @          0xd465102 std::__shared_ptr<>::~__shared_ptr()

```

[https://github.com/StarRocks/StarRocksTest/issues/7635](https://github.com/StarRocks/StarRocksTest/issues/7635)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
