### PR TITLE
[BugFix] Use correct warehouse in information_schema.task when mv is created

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3448,9 +3448,9 @@ public class LocalMetastore implements ConnectorMetadata {
                         storageInfo == null ? null : storageInfo.getDataCacheInfo());
                 Long version = Partition.PARTITION_INIT_VERSION;
                 Partition partition = createPartition(db, materializedView, partitionId, mvName, version, tabletIdSet,
-                        ConnectContext.get().getCurrentWarehouseId());
+                        materializedView.getWarehouseId());
                 buildPartitions(db, materializedView, new ArrayList<>(partition.getSubPartitions()),
-                        ConnectContext.get().getCurrentWarehouseId());
+                        materializedView.getWarehouseId());
                 materializedView.addPartition(partition);
             } else {
                 Expr partitionExpr = stmt.getPartitionExpDesc().getExpr();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
@@ -16,13 +16,32 @@ package com.starrocks.scheduler;
 
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.epack.warehouse.LocalWarehouse;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.Warehouse;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TaskBuilderTest {
 
     @Test
-    public void testTaskBuilderForMv() {
+    public void testTaskBuilderForMv(@Mocked WarehouseManager warehouseManager) {
+        // mock the warehouse of MaterializedView for creating task
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Warehouse getWarehouse(long warehouseId) {
+                return new LocalWarehouse();
+            }
+
+            @Mock
+            public Warehouse getWarehouse(String warehouse) {
+                return new LocalWarehouse();
+            }
+        };
+
         MaterializedView mv = new MaterializedView();
         mv.setName("aa.bb.cc");
         mv.setViewDefineSql("select * from table1");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
@@ -16,29 +16,30 @@ package com.starrocks.scheduler;
 
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.TableProperty;
-import com.starrocks.epack.warehouse.LocalWarehouse;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.Warehouse;
 import mockit.Mock;
 import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TaskBuilderTest {
 
     @Test
-    public void testTaskBuilderForMv(@Mocked WarehouseManager warehouseManager) {
+    public void testTaskBuilderForMv() {
         // mock the warehouse of MaterializedView for creating task
         new MockUp<WarehouseManager>() {
             @Mock
             public Warehouse getWarehouse(long warehouseId) {
-                return new LocalWarehouse();
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                        WarehouseManager.DEFAULT_WAREHOUSE_NAME);
             }
 
             @Mock
             public Warehouse getWarehouse(String warehouse) {
-                return new LocalWarehouse();
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                        WarehouseManager.DEFAULT_WAREHOUSE_NAME);
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:

After creating the MV, the warehouse displayed by `SHOW MATERIALIZED VIEWS` and `select * from information_schema.tasks` is inconsistent.

```
mysql> select * from information_schema.tasks \G;
*************************** 1. row ***************************
  TASK_NAME: mv-10138
CREATE_TIME: 2024-05-27 19:37:23
   SCHEDULE: PERIODICAL START(2022-09-01T10:00) EVERY(1 DAYS)
    CATALOG: default_catalog
  WAREHOUSE: default_warehouse
   DATABASE: test_db
 DEFINITION: insert overwrite `order_mv` SELECT `test_db`.`order_list`.`order_id`, sum(`test_db`.`goods`.`price`) AS `total`
FROM `test_db`.`order_list` INNER JOIN `test_db`.`goods` ON `test_db`.`goods`.`item_id1` = `test_db`.`order_list`.`item_id2`
GROUP BY `test_db`.`order_list`.`order_id`
EXPIRE_TIME: NULL
 PROPERTIES: ('datacache.enable'='true','replicated_storage'='true','mvId'='10138','enable_async_write_back'='false','replication_num'='1','compression'='LZ4')
```

This is 
```
mysql> SHOW MATERIALIZED VIEWS \G;
*************************** 1. row ***************************
                                  id: 10152
                       database_name: test_db
                                name: order_mv2
                        refresh_type: ASYNC
                           is_active: true
                     inactive_reason:
                      partition_type: UNPARTITIONED
                             task_id: 10157
                           task_name: mv-10152
             last_refresh_start_time: 2024-05-27 19:53:16
          last_refresh_finished_time: 2024-05-27 19:53:17
               last_refresh_duration: 0.178
                  last_refresh_state: SUCCESS
          last_refresh_force_refresh: false
        last_refresh_start_partition: NULL
          last_refresh_end_partition: NULL
last_refresh_base_refresh_partitions: {goods=[goods], order_list=[order_list]}
  last_refresh_mv_refresh_partitions: [order_mv2]
             last_refresh_error_code: 0
          last_refresh_error_message:
                                rows: 0
                                text: CREATE MATERIALIZED VIEW `order_mv2` (`order_id`, `total`)
COMMENT "MATERIALIZED_VIEW"
DISTRIBUTED BY HASH(`order_id`)
REFRESH ASYNC START("2022-09-01 10:00:00") EVERY(INTERVAL 1 DAY)
PROPERTIES (
"replicated_storage" = "true",
"replication_num" = "1",
"datacache.enable" = "true",
"enable_async_write_back" = "false",
"storage_volume" = "builtin_storage_volume",
"warehouse" = "daily_warehouse"
)
AS SELECT `order_list`.`order_id`, sum(`goods`.`price`) AS `total`
FROM `test_db`.`order_list` INNER JOIN `test_db`.`goods` ON `goods`.`item_id1` = `order_list`.`item_id2`
GROUP BY `order_list`.`order_id`;
                       extra_message: {"queryIds":["b40eafc2-1c1f-11ef-81e3-00163e2918b8"],"isManual":true,"isSync":false,"isReplay":false,"priority":0,"lastTaskRunSt
ate":"SUCCESS"}
```
The reason is that In PropertyAnalyzer.analyzeMVProperties, it removed the warehouse property.

## What I'm doing:

Add the warehouse property the task.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
