### PR TITLE
[Enhancement] refine profile for short-cricuit point query

### DIFF
--- a/be/src/exec/short_circuit.cpp
+++ b/be/src/exec/short_circuit.cpp
@@ -234,8 +234,7 @@ Status ShortCircuitExecutor::build_source_exec_node(starrocks::ObjectPool* pool,
                                                     starrocks::ExecNode** node) {
     switch (t_node.node_type) {
     case TPlanNodeType::OLAP_SCAN_NODE: {
-        *node = pool->add(
-                new ShortCircuitHybridScanNode(pool, t_node, descs, scan_range, _runtime_profile, *_common_request));
+        *node = pool->add(new ShortCircuitHybridScanNode(pool, t_node, descs, scan_range, *_common_request));
         break;
     }
     case TPlanNodeType::PROJECT_NODE:

--- a/be/src/exec/short_circuit_hybrid.h
+++ b/be/src/exec/short_circuit_hybrid.h
@@ -38,17 +38,17 @@ class TabletManager;
 class ShortCircuitHybridScanNode : public ScanNode {
 public:
     ShortCircuitHybridScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
-                               const TScanRange& scan_range, RuntimeProfile* runtime_profile,
-                               TExecShortCircuitParams& common_request)
+                               const TScanRange& scan_range, TExecShortCircuitParams& common_request)
             : ScanNode(pool, tnode, descs),
               _tnode(tnode),
-              _runtime_profile(runtime_profile),
               _common_request(common_request),
               _tuple_id(tnode.olap_scan_node.tuple_id) {}
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
-    Status open(RuntimeState* state);
-    Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos);
+    // do not call ScanNode::prepare which will register some useless profile counters
+    Status prepare(RuntimeState* state) override;
+    Status open(RuntimeState* state) override;
+    Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 
     Status _process_key_chunk();
     Status _process_value_chunk(std::vector<bool>& found);
@@ -56,7 +56,6 @@ public:
 private:
     const TPlanNode& _tnode;
     TableReaderPtr _table_reader;
-    RuntimeProfile* _runtime_profile;
     TExecShortCircuitParams& _common_request;
     TDescriptorTable* _t_desc_tbl;
     ChunkPtr _key_chunk;

--- a/be/src/exec/short_circuit_hybrid.h
+++ b/be/src/exec/short_circuit_hybrid.h
@@ -40,7 +40,6 @@ public:
     ShortCircuitHybridScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
                                const TScanRange& scan_range, TExecShortCircuitParams& common_request)
             : ScanNode(pool, tnode, descs),
-              _tnode(tnode),
               _common_request(common_request),
               _tuple_id(tnode.olap_scan_node.tuple_id) {}
 
@@ -54,7 +53,6 @@ public:
     Status _process_value_chunk(std::vector<bool>& found);
 
 private:
-    const TPlanNode& _tnode;
     TableReaderPtr _table_reader;
     TExecShortCircuitParams& _common_request;
     TDescriptorTable* _t_desc_tbl;

--- a/be/src/exec/short_circuit_hybrid.h
+++ b/be/src/exec/short_circuit_hybrid.h
@@ -39,9 +39,7 @@ class ShortCircuitHybridScanNode : public ScanNode {
 public:
     ShortCircuitHybridScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
                                const TScanRange& scan_range, TExecShortCircuitParams& common_request)
-            : ScanNode(pool, tnode, descs),
-              _common_request(common_request),
-              _tuple_id(tnode.olap_scan_node.tuple_id) {}
+            : ScanNode(pool, tnode, descs), _common_request(common_request), _tuple_id(tnode.olap_scan_node.tuple_id) {}
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     // do not call ScanNode::prepare which will register some useless profile counters

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -102,7 +102,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -261,7 +260,7 @@ public class DefaultCoordinator extends Coordinator {
         FragmentInstanceExecState execState = FragmentInstanceExecState.createFakeExecution(queryId, address);
         executionDAG.addExecution(execState);
 
-        this.queryProfile = new QueryRuntimeProfile(connectContext, jobSpec, 1);
+        this.queryProfile = new QueryRuntimeProfile(connectContext, jobSpec, 1, false);
         queryProfile.attachInstances(Collections.singletonList(queryId));
         queryProfile.attachExecutionProfiles(executionDAG.getExecutions());
 
@@ -276,7 +275,6 @@ public class DefaultCoordinator extends Coordinator {
         this.coordinatorPreprocessor = new CoordinatorPreprocessor(context, jobSpec);
         this.executionDAG = coordinatorPreprocessor.getExecutionDAG();
 
-        this.queryProfile = new QueryRuntimeProfile(connectContext, jobSpec, executionDAG.getFragmentsInCreatedOrder().size());
         List<PlanFragment> fragments = jobSpec.getFragments();
         List<ScanNode> scanNodes = jobSpec.getScanNodes();
         TDescriptorTable descTable = jobSpec.getDescTable();
@@ -291,6 +289,10 @@ public class DefaultCoordinator extends Coordinator {
         if (null != shortCircuitExecutor) {
             isShortCircuit = true;
         }
+
+        this.queryProfile =
+                new QueryRuntimeProfile(connectContext, jobSpec, executionDAG.getFragmentsInCreatedOrder().size(),
+                        isShortCircuit);
     }
 
     @Override
@@ -416,6 +418,11 @@ public class DefaultCoordinator extends Coordinator {
     @Override
     public boolean isUsingBackend(Long backendID) {
         return coordinatorPreprocessor.getWorkerProvider().isWorkerSelected(backendID);
+    }
+
+    @Override
+    public boolean isShortCircuit() {
+        return isShortCircuit;
     }
 
     private void lock() {
@@ -1017,7 +1024,7 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     public boolean tryProcessProfileAsync(Consumer<Boolean> task) {
-        if (executionDAG.getExecutions().isEmpty()) {
+        if (executionDAG.getExecutions().isEmpty() && (!isShortCircuit)) {
             return false;
         }
         if (!jobSpec.isNeedReport()) {
@@ -1083,8 +1090,12 @@ public class DefaultCoordinator extends Coordinator {
         return false;
     }
 
+    // build execution profile  from every BE's report
     @Override
     public RuntimeProfile buildQueryProfile(boolean needMerge) {
+        if (isShortCircuit) {
+            return shortCircuitExecutor.buildQueryProfile(needMerge);
+        }
         return queryProfile.buildQueryProfile(needMerge);
     }
 
@@ -1154,11 +1165,5 @@ public class DefaultCoordinator extends Coordinator {
 
     private void execShortCircuit() {
         shortCircuitExecutor.exec();
-        Optional<RuntimeProfile> runtimeProfile = shortCircuitExecutor.getRuntimeProfile();
-        if (jobSpec.isNeedReport() && runtimeProfile.isPresent()) {
-            RuntimeProfile profile = runtimeProfile.get();
-            profile.setName("Short Circuit Executor");
-            queryProfile.getQueryProfile().addChild(profile);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
@@ -28,7 +28,9 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TScanRangeLocations;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Random;
@@ -51,6 +53,8 @@ public class ShortCircuitExecutor {
 
     protected ShortCircuitResult result = null;
 
+    protected Map<String, RuntimeProfile> perBeExecutionProfile;
+
     private static final Random RANDOM = new Random(); // NOSONAR
 
     protected ShortCircuitExecutor(ConnectContext context, PlanFragment planFragment,
@@ -63,6 +67,9 @@ public class ShortCircuitExecutor {
         this.isBinaryRow = isBinaryRow;
         this.enableProfile = enableProfile;
         this.protocol = protocol;
+        if (enableProfile) {
+            this.perBeExecutionProfile = new HashMap<>();
+        }
     }
 
     public static ShortCircuitExecutor create(ConnectContext context, List<PlanFragment> fragments,
@@ -98,6 +105,16 @@ public class ShortCircuitExecutor {
     public RowBatch getNext() {
         Preconditions.checkNotNull(result);
         return result.getRowBatches().poll();
+    }
+
+    public RuntimeProfile buildQueryProfile(boolean needMerge) {
+        RuntimeProfile executionProfile = new RuntimeProfile("Short Circuit Executor");
+        perBeExecutionProfile.forEach((key, beProfile) -> {
+            // compute localTimePercent for each backend profile
+            beProfile.computeTimeInProfile();
+            executionProfile.addChild(beProfile);
+        });
+        return executionProfile;
     }
 
     public Optional<RuntimeProfile> getRuntimeProfile() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
@@ -28,6 +28,7 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TScanRangeLocations;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,8 @@ public class ShortCircuitExecutor {
         this.protocol = protocol;
         if (enableProfile) {
             this.perBeExecutionProfile = new HashMap<>();
+        } else {
+            this.perBeExecutionProfile = Collections.emptyMap();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -133,8 +133,9 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
                     TDeserializer deserializer = new TDeserializer();
                     TRuntimeProfileTree runtimeProfileTree = new TRuntimeProfileTree();
                     deserializer.deserialize(runtimeProfileTree, shortCircuitResult.profile);
-                    runtimeProfile.set(new RuntimeProfile());
-                    runtimeProfile.get().update(runtimeProfileTree);
+                    RuntimeProfile beProfile = new RuntimeProfile(beAddress.toString());
+                    beProfile.update(runtimeProfileTree);
+                    perBeExecutionProfile.put(beAddress.toString(), beProfile);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -135,7 +135,9 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
                     deserializer.deserialize(runtimeProfileTree, shortCircuitResult.profile);
                     RuntimeProfile beProfile = new RuntimeProfile(beAddress.toString());
                     beProfile.update(runtimeProfileTree);
-                    perBeExecutionProfile.put(beAddress.toString(), beProfile);
+                    if (enableProfile) {
+                        perBeExecutionProfile.put(beAddress.toString(), beProfile);
+                    }
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -896,7 +896,12 @@ public class StmtExecutor {
                 summaryProfile.addInfoString(ProfileManager.RETRY_TIMES, Integer.toString(retryIndex + 1));
             }
 
-            ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
+            ProfilingExecPlan profilingPlan;
+            if (coord.isShortCircuit()) {
+                profilingPlan = null;
+            } else {
+                profilingPlan = plan == null ? null : plan.getProfilingPlan();
+            }
             String profileContent = ProfileManager.getInstance().pushProfile(profilingPlan, profile);
             if (queryDetail != null) {
                 queryDetail.setProfile(profileContent);
@@ -1212,12 +1217,17 @@ public class StmtExecutor {
         sendShowResult(resultSet);
     }
 
-    private void handleAnalyzeProfileStmt() throws IOException {
+    private void handleAnalyzeProfileStmt() throws IOException, UserException {
         AnalyzeProfileStmt analyzeProfileStmt = (AnalyzeProfileStmt) parsedStmt;
         String queryId = analyzeProfileStmt.getQueryId();
         List<Integer> planNodeIds = analyzeProfileStmt.getPlanNodeIds();
         ProfileManager.ProfileElement profileElement = ProfileManager.getInstance().getProfileElement(queryId);
         Preconditions.checkNotNull(profileElement, "query not exists");
+        if (coord.isShortCircuit()) {
+            throw new UserException(
+                    "short circuit point query doesn't suppot analyze profile stmt, " +
+                            "you can set it off by using  set enable_short_circuit=false");
+        }
         handleExplainStmt(ExplainAnalyzer.analyze(profileElement.plan,
                 RuntimeProfileParser.parseFrom(CompressionUtils.gzipDecompressString(profileElement.profileContent)),
                 planNodeIds));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -618,6 +618,11 @@ public class StmtExecutor {
                             isAsync = tryProcessProfileAsync(execPlan, i);
                             if (parsedStmt.isExplain() &&
                                     StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
+                                if (coord.isShortCircuit()) {
+                                    throw new UserException(
+                                            "short circuit point query doesn't suppot explain analyze stmt, " +
+                                                    "you can set it off by using  set enable_short_circuit=false");
+                                }
                                 handleExplainStmt(ExplainAnalyzer.analyze(
                                         ProfilingExecPlan.buildFrom(execPlan), profile, null));
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -231,4 +231,6 @@ public abstract class Coordinator {
     public abstract boolean isProfileAlreadyReported();
 
     public abstract String getWarehouseName();
+
+    public abstract boolean isShortCircuit();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -303,6 +303,10 @@ public class FeExecuteCoordinator extends Coordinator {
         return connectContext.getSessionVariable().getWarehouseName();
     }
 
+    public boolean isShortCircuit() {
+        return false;
+    }
+
     private List<ByteBuffer> covertToMySQLRowBuffer() {
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         PhysicalValuesOperator valuesOperator = (PhysicalValuesOperator) execPlan.getPhysicalPlan().getOp();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -112,6 +112,8 @@ public class QueryRuntimeProfile {
     private Supplier<RuntimeProfile> topProfileSupplier;
     private ExecPlan execPlan;
     private final AtomicLong lastRuntimeProfileUpdateTime = new AtomicLong(System.currentTimeMillis());
+    // whether this profile is belong to short-circuit query
+    private boolean isShortCircuit;
 
     // ------------------------------------------------------------------------------------
     // Fields for load.
@@ -138,9 +140,11 @@ public class QueryRuntimeProfile {
 
     public QueryRuntimeProfile(ConnectContext connectContext,
                                JobSpec jobSpec,
-                               int numFragments) {
+                               int numFragments,
+                               boolean isShortCircuit) {
         this.connectContext = connectContext;
         this.jobSpec = jobSpec;
+        this.isShortCircuit = isShortCircuit;
 
         this.queryProfile = new RuntimeProfile("Execution");
         this.fragmentProfiles = new ArrayList<>(numFragments);
@@ -244,6 +248,15 @@ public class QueryRuntimeProfile {
         if (EXECUTOR.getQueue().size() > Config.profile_process_blocking_queue_size) {
             return false;
         }
+
+        // short circuit point query will get profile from be synchronously, so just submit task here
+        if (isShortCircuit) {
+            EXECUTOR.submit(() -> {
+                task.accept(true);
+            });
+            return true;
+        }
+
         // We need to make sure this submission won't be rejected by set the queue size to Integer.MAX_VALUE
         profileDoneSignal.addListener(() -> EXECUTOR.submit(() -> {
             task.accept(true);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -113,7 +113,7 @@ public class QueryRuntimeProfile {
     private ExecPlan execPlan;
     private final AtomicLong lastRuntimeProfileUpdateTime = new AtomicLong(System.currentTimeMillis());
     // whether this profile is belong to short-circuit query
-    private boolean isShortCircuit;
+    private final boolean isShortCircuit;
 
     // ------------------------------------------------------------------------------------
     // Fields for load.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -69,7 +69,7 @@ public class QueryRuntimeProfileTest {
             }
         };
 
-        QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, 1);
+        QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, 1, false);
         TReportExecStatusParams reportExecStatusParams = buildReportStatus();
         profile.updateLoadChannelProfile(reportExecStatusParams);
         Optional<RuntimeProfile> optional = profile.mergeLoadChannelProfile();

--- a/test/sql/test_short_circuit/R/test_short_circuit
+++ b/test/sql/test_short_circuit/R/test_short_circuit
@@ -72,6 +72,10 @@ select * from short_circuit_bool where k1 = 6 and k2=true;
 -- result:
 6	1	6
 -- !result
+explain analyze select * from short_circuit_bool where k1 = 6 and k2=true;
+-- result:
+E: (1064, "short circuit point query doesn't suppot explain analyze stmt, you can set it off by using  set enable_short_circuit=false")
+-- !result
 set enable_short_circuit=false;
 -- result:
 -- !result

--- a/test/sql/test_short_circuit/R/test_short_circuit
+++ b/test/sql/test_short_circuit/R/test_short_circuit
@@ -2,6 +2,9 @@
 set enable_short_circuit=true;
 -- result:
 -- !result
+set enable_profile=true;
+-- result:
+-- !result
 CREATE TABLE short_circuit
     (c1 int,
     c2  int)
@@ -40,7 +43,7 @@ select * from short_circuit where c1 in (10);
 -- !result
 select c1||c2 from short_circuit where c1 = 6;
 -- result:
-66
+1
 -- !result
 CREATE TABLE short_circuit_bool
     (k1 int,
@@ -70,5 +73,8 @@ select * from short_circuit_bool where k1 = 6 and k2=true;
 6	1	6
 -- !result
 set enable_short_circuit=false;
+-- result:
+-- !result
+set enable_profile=false;
 -- result:
 -- !result

--- a/test/sql/test_short_circuit/R/test_short_circuit
+++ b/test/sql/test_short_circuit/R/test_short_circuit
@@ -43,7 +43,7 @@ select * from short_circuit where c1 in (10);
 -- !result
 select c1||c2 from short_circuit where c1 = 6;
 -- result:
-1
+66
 -- !result
 CREATE TABLE short_circuit_bool
     (k1 int,

--- a/test/sql/test_short_circuit/T/test_short_circuit
+++ b/test/sql/test_short_circuit/T/test_short_circuit
@@ -1,5 +1,6 @@
 -- name: testShortCircuit
 set enable_short_circuit=true;
+set enable_profile=true;
 
 CREATE TABLE short_circuit
     (c1 int,
@@ -48,3 +49,4 @@ insert into short_circuit_bool values
 select * from short_circuit_bool where k1 = 6 and k2=true;
 
 set enable_short_circuit=false;
+set enable_profile=false;

--- a/test/sql/test_short_circuit/T/test_short_circuit
+++ b/test/sql/test_short_circuit/T/test_short_circuit
@@ -47,6 +47,7 @@ insert into short_circuit_bool values
 (9, true, 9),
 (10, true, 10);
 select * from short_circuit_bool where k1 = 6 and k2=true;
+explain analyze select * from short_circuit_bool where k1 = 6 and k2=true;
 
 set enable_short_circuit=false;
 set enable_profile=false;


### PR DESCRIPTION
## Why I'm doing:
short-circuit point query  doesn't have any profile information, which is very confused for dba. 

## What I'm doing:
so add basic profile for short-circuit point query like below:
```
Query:
  Summary:
     - Query ID: 4a53651d-1d6b-11ef-87a4-2277c624d19e
     - Start Time: 2024-05-29 11:26:51
     - End Time: 2024-05-29 11:26:51
     - Total: 11ms
     - Query Type: Query
     - Query State: Finished
     - StarRocks Version: short_circuit_profile-4bf48f9
     - User: root
     - Default Db: test
     - Sql Statement: select abs(c0) from t2 where c0 = 1
     - Variables: parallel_fragment_exec_instance_num=1,max_parallel_scan_instance_num=-1,pipeline_dop=0,enable_adaptive_sink_dop=true,enable_runtime_adaptive_dop=false,runtime_profile_report_interval=10
     - NonDefaultSessionVariables: {"enable_adaptive_sink_dop":{"defaultValue":false,"actualValue":true},"enable_short_circuit":{"defaultValue":false,"actualValue":true},"enable_profile":{"defaultValue":false,"actualValue":true}}
     - Collect Profile Time: 1ms
     - IsProfileAsync: true
  Planner:
     - -- Total[1] 3ms
     -     -- Analyzer[1] 0
     -     -- Transformer[1] 0
     -     -- Optimizer[1] 1ms
     -         -- preprocessMvs[1] 0
     -             -- chooseCandidates[1] 0
     -             -- generateMvPlan[1] 0
     -             -- validateMv[1] 0
     -             -- mvWithView[1] 0
     -         -- RuleBaseOptimize[1] 0
     -     -- ExecPlanBuild[1] 0
     - -- Pending[1] 0
     - -- DeploySerializeTime[1] 0
  Short Circuit Executor:
    TNetworkAddress(hostname:172.26.92.227, port:18060):(Active: 2.696ms[2696730ns], % non-child: 3.35%)
       - CloseTime: 18.677us
       - ExecuteTime: 1.311ms
       - PrepareTime: 1.295ms
      PROJECT_NODE (id=1):(Active: 1.459ms[1459085ns], % non-child: 54.11%)
         - CommonSubExprComputeTime: 2.163us
         - ExprComputeTime: 37.010us
         - PeakMemoryUsage: 0.000 B
         - RowsReturned: 1
         - RowsReturnedRate: 685 /sec
      OLAP_SCAN_NODE (id=0):(Active: 1.147ms[1147338ns], % non-child: 42.55%)
         - PeakMemoryUsage: 0.000 B
         - RowsReturned: 1
         - RowsReturnedRate: 871 /sec
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
