### PR TITLE
[BugFix] analyze warehouse property for pipe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
@@ -31,6 +31,7 @@ import com.starrocks.load.pipe.FilePipeSource;
 import com.starrocks.load.pipe.Pipe;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
@@ -155,7 +156,8 @@ public class PipeAnalyzer {
     }
 
     public static void analyzeWarehouseProperty(String warehouseName) {
-        ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, warehouseName);
+        // If the warehouse does not exist, will report a runtime exception
+        GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseName);
     }
 
     public static void analyze(CreatePipeStmt stmt, ConnectContext context) {


### PR DESCRIPTION
## Why I'm doing:

Failed to create pipe when there are warehouse property

```
mysql> CREATE PIPE user_behavior_pipe
    -> PROPERTIES
    -> (
    ->     "AUTO_INGEST" = "TRUE",
    ->     'warehouse'='xxx'
    -> )
    -> AS
    -> INSERT INTO user_behavior_from_pipe
    -> SELECT * FROM FILES
    -> (
    ->     "path" = "s3://starrocks-examples/user-behavior-10-million-rows/*",
    ->     "format" = "parquet",
    ->     "aws.s3.region" = "us-east-1",
    ->     "aws.s3.access_key" = "xxx",
    ->     "aws.s3.secret_key" = "xxx"
    -> );
ERROR 6013 (42000): Getting analyzing error. Detail message: Invalid parameter daily_warehouse.
```

## What I'm doing:

Fix analyze logic

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
