### PR TITLE
[BugFix] fix kudu catalog non-required parameter check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduConnector.java
@@ -94,8 +94,7 @@ public class KuduConnector implements Connector {
     @Override
     public ConnectorMetadata getMetadata() {
         Optional<IHiveMetastore> hiveMetastore = Optional.empty();
-        if (HIVE.equals(catalogType) || GLUE.equals(catalogType)) {
-            Util.validateMetastoreUris(metastoreUris);
+        if (isHiveOrGlueCatalogType()) {
             MetastoreType metastoreType = MetastoreType.get(catalogType);
             HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(this.hdfsEnvironment, properties);
             hiveMetastore = Optional.of(new HiveMetastore(metaClient, catalogName, metastoreType));
@@ -103,5 +102,13 @@ public class KuduConnector implements Connector {
         }
         return new KuduMetadata(catalogName, hdfsEnvironment, kuduMaster, schemaEmulationEnabled, schemaEmulationPrefix,
                 hiveMetastore);
+    }
+
+    private boolean isHiveOrGlueCatalogType() {
+        if (HIVE.equals(catalogType)) {
+            Util.validateMetastoreUris(metastoreUris);
+            return true;
+        }
+        return GLUE.equals(catalogType);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduConnectorTest.java
@@ -62,6 +62,17 @@ public class KuduConnectorTest {
     }
 
     @Test
+    public void testCreateGlueKuduConnectorWithoutUris() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("kudu.master", "localhost:7051");
+        properties.put("kudu.catalog.type", "glue");
+        KuduConnector connector = new KuduConnector(new ConnectorContext("kudu_catalog", "kudu", properties));
+
+        ConnectorMetadata metadata = connector.getMetadata();
+        Assert.assertTrue(metadata instanceof KuduMetadata);
+    }
+
+    @Test
     public void testGetMetadata() {
         Map<String, String> properties = new HashMap<>();
         properties.put("kudu.master", "localhost:7051");


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix non-required `hive.metastore.uris` check when `kudu.catalog.type` is `glue`.

Fixes #issue 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
