### PR TITLE
[Enhancement] Fix compile warning in http_client.h

### DIFF
--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -93,7 +93,7 @@ public:
     // used to get content length
     int64_t get_content_length() const {
         double cl = 0.0f;
-        curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
+        curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
         return cl;
     }
 


### PR DESCRIPTION
## Why I'm doing:
```bash
[54/390] Building CXX object src/runtime/CMakeFiles/Runtime.dir/small_file_mgr.cpp.o
In file included from /home/disk1/dingchao/code/starrocks-bak/be/src/http/http_client.h:20,
                 from /home/disk1/dingchao/code/starrocks-bak/be/src/runtime/small_file_mgr.cpp:49:
/home/disk1/dingchao/code/starrocks-bak/be/src/http/http_client.h: In member function ‘int64_t starrocks::HttpClient::get_content_length() const’:
/home/disk1/dingchao/code/starrocks-bak/be/src/http/http_client.h:96:34: warning: ‘CURLINFO_CONTENT_LENGTH_DOWNLOAD’ is deprecated: since 7.55.0. Use CURLINFO_CONTENT_LENGTH_DOWNLOAD_T [-Wdeprecated-declarations]
   96 |         curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/disk1/dingchao/docker-thirdparty/installed/include/curl/curl.h:2883:3: note: declared here
```

## What I'm doing:
fix it


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
