### PR TITLE
[Feature] Support add/drop field for struct column(part1)

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -146,6 +146,9 @@ static Status type_desc_to_pb(const std::vector<TTypeNode>& types, int* index, C
             // All struct fields all nullable now
             RETURN_IF_ERROR(type_desc_to_pb(types, index, field_pb));
             field_pb->set_name(field.name);
+            if (field.__isset.id && field.id >= 0) {
+                field_pb->set_unique_id(field.id);
+            }
         }
         return Status::OK();
     }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -622,7 +622,6 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_create_merge_struct_ite
     DCHECK(_column_type == LogicalType::TYPE_STRUCT);
     DCHECK(column != nullptr);
     auto num_fields = column->subcolumn_count();
-    int cur_sub_reader = 0;
 
     std::unique_ptr<ColumnIterator> null_iter;
     if (is_nullable()) {
@@ -643,7 +642,6 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_create_merge_struct_ite
         if (iter != _sub_reader_pos.end()) {
             ASSIGN_OR_RETURN(auto iter, (*_sub_readers)[iter->second]->new_iterator(child_paths[i], sub_column));
             field_iters.emplace_back(std::move(iter));
-            cur_sub_reader++;
         } else {
             if (!sub_column->has_default_value() && !sub_column->is_nullable()) {
                 return Status::InternalError(

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -94,6 +94,11 @@ public:
     // This method will not take the ownership of |meta|.
     // Note that |meta| is mutable, this method may change its internal state.
     //
+    // The primary purpose of the |column| currently is to obtain the name and unique ID of the sub_column
+    // to support the add/drop field functionality of the struct column.
+    // It is importantthat the |column| needs to be consistent with the tablet schema corresponding to the segment.
+    // If you can ensure that this column does not involve a struct column, the |column| can be set to nullptr.
+    //
     // To developers: keep this method lightweight, should not incur any I/O.
     static StatusOr<std::unique_ptr<ColumnReader>> create(ColumnMetaPB* meta, Segment* segment,
                                                           const TabletColumn* column);

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -96,7 +96,7 @@ public:
     //
     // The primary purpose of the |column| currently is to obtain the name and unique ID of the sub_column
     // to support the add/drop field functionality of the struct column.
-    // It is importantthat the |column| needs to be consistent with the tablet schema corresponding to the segment.
+    // It is important that the |column| needs to be consistent with the tablet schema corresponding to the segment.
     // If you can ensure that this column does not involve a struct column, the |column| can be set to nullptr.
     //
     // To developers: keep this method lightweight, should not incur any I/O.

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -260,7 +260,14 @@ private:
 
     using SubReaderList = std::vector<std::unique_ptr<ColumnReader>>;
     std::unique_ptr<SubReaderList> _sub_readers;
-    // only used for struct column right now
+    // Only used for struct column right now
+    // Use column names and unique IDs to distinguish sub-columns.
+    // The unnique id is always -1 for historical data, so the column name is needed.
+    // After support add/drop field for struct column, the following scenarios might occur:
+    //   1. Drop field v1
+    //   2. Add field v1
+    // The field `v1` in step 2 is different from the `v1` in step 1 and needs to be distinguished,
+    // So we also need to unqiue id.
     struct SubReaderId {
         std::string name;
         int32_t id;

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -397,7 +397,7 @@ Status Segment::_create_column_readers(SegmentFooterPB* footer) {
             continue;
         }
 
-        auto res = ColumnReader::create(footer->mutable_columns(iter->second), this);
+        auto res = ColumnReader::create(footer->mutable_columns(iter->second), this, &column);
         if (!res.ok()) {
             return res.status();
         }
@@ -410,7 +410,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator_or_defaul
                                                                                   ColumnAccessPath* path) {
     auto id = column.unique_id();
     if (_column_readers.contains(id)) {
-        ASSIGN_OR_RETURN(auto source_iter, _column_readers[id]->new_iterator(path));
+        ASSIGN_OR_RETURN(auto source_iter, _column_readers[id]->new_iterator(path, &column));
         if (_column_readers[id]->column_type() == column.type()) {
             return source_iter;
         } else {
@@ -439,7 +439,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(const Tab
     auto id = column.unique_id();
     auto iter = _column_readers.find(id);
     if (iter != _column_readers.end()) {
-        ASSIGN_OR_RETURN(auto source_iter, iter->second->new_iterator(path));
+        ASSIGN_OR_RETURN(auto source_iter, iter->second->new_iterator(path, nullptr));
         if (iter->second->column_type() == column.type()) {
             return source_iter;
         } else {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -163,6 +163,12 @@ public:
     void add_sub_column(TabletColumn&& sub_column);
     uint32_t subcolumn_count() const { return _extra_fields ? _extra_fields->sub_columns.size() : 0; }
     const TabletColumn& subcolumn(uint32_t i) const { return _extra_fields->sub_columns[i]; }
+    const TabletColumn* subcolumn_ptr(uint32_t i) const {
+        if (i >= subcolumn_count()) {
+            return nullptr;
+        }
+        return &(_extra_fields->sub_columns[i]);
+    }
 
     friend bool operator==(const TabletColumn& a, const TabletColumn& b);
     friend bool operator!=(const TabletColumn& a, const TabletColumn& b);

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -162,7 +162,12 @@ public:
     void add_sub_column(const TabletColumn& sub_column);
     void add_sub_column(TabletColumn&& sub_column);
     uint32_t subcolumn_count() const { return _extra_fields ? _extra_fields->sub_columns.size() : 0; }
-    const TabletColumn& subcolumn(uint32_t i) const { return _extra_fields->sub_columns[i]; }
+    const TabletColumn& subcolumn(uint32_t i) const {
+        if (i >= subcolumn_count()) {
+            throw std::out_of_range("Index i is out of range");
+        }
+        return _extra_fields->sub_columns[i];
+    }
     const TabletColumn* subcolumn_ptr(uint32_t i) const {
         if (i >= subcolumn_count()) {
             return nullptr;

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -161,7 +161,7 @@ protected:
         // read and check
         {
             // read and check
-            auto res = ColumnReader::create(&meta, segment.get());
+            auto res = ColumnReader::create(&meta, segment.get(), nullptr);
             ASSERT_TRUE(res.ok());
             auto reader = std::move(res).value();
 
@@ -386,7 +386,7 @@ protected:
 
         // read and check
         {
-            auto res = ColumnReader::create(&meta, segment.get());
+            auto res = ColumnReader::create(&meta, segment.get(), nullptr);
             ASSERT_TRUE(res.ok());
             auto reader = std::move(res).value();
 
@@ -709,7 +709,7 @@ TEST_F(ColumnReaderWriterTest, test_scalar_column_total_mem_footprint) {
     // read and check
     {
         // read and check
-        auto res = ColumnReader::create(&meta, segment.get());
+        auto res = ColumnReader::create(&meta, segment.get(), nullptr);
         ASSERT_TRUE(res.ok());
         auto reader = std::move(res).value();
         ASSERT_EQ(1024, meta.num_rows());
@@ -770,7 +770,7 @@ TEST_F(ColumnReaderWriterTest, test_large_varchar_column_writer) {
             ASSERT_TRUE(wfile->close().ok());
             // read and check result
             auto segment = create_dummy_segment(fs, fname);
-            auto res = ColumnReader::create(&meta, segment.get());
+            auto res = ColumnReader::create(&meta, segment.get(), nullptr);
             ASSERT_TRUE(res.ok());
             auto reader = std::move(res).value();
             ASSIGN_OR_ABORT(auto iter, reader->new_iterator());

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -96,7 +96,7 @@ protected:
         }
         LOG(INFO) << "Finish writing";
 
-        auto res = ColumnReader::create(&meta, segment.get());
+        auto res = ColumnReader::create(&meta, segment.get(), nullptr);
         ASSERT_TRUE(res.ok());
         auto reader = std::move(res).value();
 

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -145,7 +145,7 @@ protected:
         }
 
         // read and check
-        auto res = ColumnReader::create(&meta, segment.get());
+        auto res = ColumnReader::create(&meta, segment.get(), nullptr);
         ASSERT_TRUE(res.ok());
         auto reader = std::move(res).value();
 

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -132,7 +132,6 @@ protected:
 
         LOG(INFO) << "Finish writing";
         // read and check
-        auto res = ColumnReader::create(&meta, segment.get());
         ColumnMetaPB meta2 = meta;
         ColumnMetaPB meta3 = meta;
         auto res = ColumnReader::create(&meta, segment.get(), nullptr);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
@@ -17,27 +17,24 @@ package com.starrocks.catalog;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.thrift.TStructField;
 import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
-
 /**
  * TODO: Support comments for struct fields. The Metastore does not properly store
  * comments of struct fields. We set comment to null to avoid compatibility issues.
  */
-public class StructField implements GsonPostProcessable {
+public class StructField {
     @SerializedName(value = "name")
-    private final String name;
+    private String name;
     @SerializedName(value = "type")
-    private final Type type;
+    private Type type;
 
     // comment is not used now, it's always null.
     @SerializedName(value = "comment")
-    private final String comment;
+    private String comment;
     private int position;  // in struct
 
     @SerializedName(value = "fieldId")
@@ -150,14 +147,7 @@ public class StructField implements GsonPostProcessable {
 
     @Override
     public StructField clone() {
-        return new StructField(name, type.clone(), comment);
-    }
-
-    @Override
-    public void gsonPostProcess() throws IOException {
-        if (fieldId <= 0) {
-            fieldId = -1;
-        }
+        return new StructField(name, fieldId, type.clone(), comment);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
@@ -41,7 +41,9 @@ public class StructField implements GsonPostProcessable {
     private int position;  // in struct
 
     @SerializedName(value = "fieldId")
-    private int fieldId;
+    private int fieldId = -1;
+
+    public StructField() {}
 
     public StructField(String name, int fieldId, Type type, String comment) {
         this.name = name;

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -126,6 +126,7 @@ struct TScalarType {
 struct TStructField {
     1: optional string name
     2: optional string comment
+    3: optional i32 id
 }
 
 struct TTypeNode {


### PR DESCRIPTION
## Why I'm doing:
It is the first pr to support add/drop field for struct column. 

## What I'm doing:
The main changes in this PR are two fold:

1. Adding a unique ID to the fields in the struct column. Each field column can be uniquely identified by its name and ID.
2. When creating a column reader for the struct column, the corresponding reader will be created for each field based on the provided column.

Fixes https://github.com/StarRocks/starrocks/issues/46452

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
