### PR TITLE
[BugFix] Skip useless txnlog write when schema change

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -409,6 +409,11 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish(DeltaWriterFinishMode mode) {
     RETURN_IF_ERROR(flush());
     RETURN_IF_ERROR(_tablet_writer->finish());
 
+    if (mode == kSkipTxnLog) {
+        // Not need to create txn log in delta writer finish when handle schema change.
+        return Status::OK();
+    }
+
     if (UNLIKELY(_txn_id < 0)) {
         return Status::InvalidArgument(fmt::format("negative txn id: {}", _txn_id));
     }

--- a/be/src/storage/lake/delta_writer_finish_mode.h
+++ b/be/src/storage/lake/delta_writer_finish_mode.h
@@ -19,6 +19,7 @@ namespace starrocks::lake {
 enum DeltaWriterFinishMode {
     kWriteTxnLog,
     kDontWriteTxnLog,
+    kSkipTxnLog,
 };
 
 }

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -287,7 +287,7 @@ Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
         RETURN_IF_ERROR(writer->write(*_new_chunk, _selective->data(), _new_chunk->num_rows()));
     }
 
-    RETURN_IF_ERROR(writer->finish(DeltaWriterFinishMode::kDontWriteTxnLog));
+    RETURN_IF_ERROR(writer->finish(DeltaWriterFinishMode::kSkipTxnLog));
 
     for (auto& f : writer->files()) {
         new_rowset_metadata->add_segments(std::move(f.path));


### PR DESCRIPTION
## Why I'm doing:
In current implementation, there will be useless txnlog build and put in metatache in `delta_writer->finish()` when handle schema change. 

## What I'm doing:
Add new `DeltaWriterFinishMode` named `kSkipTxnLog` , it can skip build txn log when `kSkipTxnLog` is set.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
