### PR TITLE
[BugFix] fix follower image size is 0 when follower abnormal exit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -122,6 +122,7 @@ public class MetaHelper {
                 conn.disconnect();
             }
             if (out != null) {
+                out.flush();
                 out.close();
             }
         }


### PR DESCRIPTION
## Why I'm doing:
When a follower is in the process of receiving the leader's image file, restarting the leader at this point may probabilistically trigger a restart of the follower, resulting in an image file of size 0, which in turn prevents the follower from being able to start.

## What I'm doing:
flush the image output stream before rename the image file

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
