### PR TITLE
[BugFix] Fix query a view with MATCH got exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -136,7 +136,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     }
 
     public boolean isValidMatchChildren() {
-        if (matchChildren.size() == 0) {
+        if (matchChildren.isEmpty()) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/LowCardinalityRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/LowCardinalityRewriteRule.java
@@ -34,6 +34,9 @@ public class LowCardinalityRewriteRule implements TreeRewriteRule {
         {
             DecodeCollector collector = new DecodeCollector(session);
             collector.collect(root, context);
+            if (!collector.isValidMatchChildren()) {
+                return root;
+            }
         }
         DecodeRewriter rewriter = new DecodeRewriter(factory, context);
         return rewriter.rewrite(root);

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1504,3 +1504,137 @@ SELECT count(*) FROM t_gin_match_empty WHERE v3 MATCH "";
 DROP TABLE t_gin_match_empty;
 -- result:
 -- !result
+-- name: test_gin_view
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE `t_gin_view` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_gin_view VALUES (1, "abd bcd");
+-- result:
+-- !result
+SELECT * FROM t_gin_view;
+-- result:
+1	abd bcd
+-- !result
+CREATE VIEW test_view1 (column1, column2) AS SELECT * FROM t_gin_view;
+-- result:
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+-- result:
+1	abd bcd
+-- !result
+DROP TABLE t_gin_view;
+-- result:
+-- !result
+CREATE TABLE duplicate_table_demo_datatype_not_replicated_all_varchar ( AAA DATETIME not NULL COMMENT "", BBB VARCHAR(200) not NULL COMMENT "", CCC VARCHAR(200) not NULL COMMENT "", DDD VARCHAR(20000) COMMENT "", EEE LARGEINT  NULL COMMENT "", FFF DECIMAL(20,10) NULL COMMENT "", GGG VARCHAR(200)  NULL COMMENT "", HHH FLOAT  NULL COMMENT "", III BOOLEAN  NULL COMMENT "", KKK CHAR(20)   NULL COMMENT "", LLL STRING   NULL COMMENT "", MMM VARCHAR(20)   NULL COMMENT "", NNN BINARY  NULL COMMENT "", OOO TINYINT NULL COMMENT "", PPP DATETIME NULL COMMENT "", QQQ ARRAY<INT> NULL COMMENT "", RRR JSON NULL COMMENT "", SSS MAP<INT,INT> NULL COMMENT "", TTT STRUCT<a INT, b INT> NULL COMMENT "", INDEX init_bitmap_index (KKK) USING BITMAP ) duplicate KEY(AAA, BBB, CCC) PARTITION BY RANGE (`AAA`) ( START ("1970-01-01") END ("2030-01-01") EVERY (INTERVAL 30 YEAR) ) DISTRIBUTED BY HASH(`AAA`, `BBB`) BUCKETS 3 ORDER BY(`AAA`,`BBB`,`CCC`,`DDD`) PROPERTIES ( "replicated_storage"="false", "replication_num" = "1", "storage_format" = "v2", "enable_persistent_index" = "true", "bloom_filter_columns" = "MMM", "unique_constraints" = "GGG" );
+-- result:
+-- !result
+create view test_view (AAA, DDD) as select AAA, max(DDD) from duplicate_table_demo_datatype_not_replicated_all_varchar group by AAA;
+-- result:
+-- !result
+CREATE INDEX idx ON duplicate_table_demo_datatype_not_replicated_all_varchar(DDD) USING GIN('parser' = 'english');
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into duplicate_table_demo_datatype_not_replicated_all_varchar values ('1974-08-20 23:13:25', 'xIjfSXnegdnZiZGQMaxo', 'syHwIOMctmDLDGCibEun', 'hIbilUEGdLbCnaZASCVL', 6299, 25361.52081, 'QuTsacRyxiIkBjEmjhNu', -11.4812925061712, True, 'QcLRdQJMhtPXojJUjkUd', 'yUeFlbzomaPDwKeaHylx', 'WqQyGEjEYpvLzfBXYUCB', '', 8, '2015-11-03 16:31:47', [2621, 5950, 13171], '{"job": "Administrator, Civil Service", "company": "Morris-Anderson", "ssn": "823-67-5554", "residence": "59688 Hanna Shoal Apt. 586\nWest Waynefort, CO 69652", "current_location": ["-64.3777465", "21.079566"], "blood_group": "O-", "website": ["http://young.biz/", "https://cobb-bell.com/", "http://www.roberts-garrison.com/", "http://jones.com/"], "username": "howardarcher", "name": "John Mccullough", "sex": "M", "address": "1361 Susan Mountain\nJasonbury, MI 85084", "mail": "lovejennifer@gmail.com", "birthdate": "1928-06-25"}', null, null);
+-- result:
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+-- result:
+E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+-- !result
+DROP VIEW test_view;
+-- result:
+-- !result
+DROP TABLE duplicate_table_demo_datatype_not_replicated_all_varchar;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -843,3 +843,54 @@ SELECT count(*) FROM t_gin_match_empty WHERE v2 MATCH "";
 SELECT count(*) FROM t_gin_match_empty WHERE v3 MATCH "";
 
 DROP TABLE t_gin_match_empty;
+
+-- name: test_gin_view
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+CREATE TABLE `t_gin_view` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_gin_view VALUES (1, "abd bcd");
+SELECT * FROM t_gin_view;
+CREATE VIEW test_view1 (column1, column2) AS SELECT * FROM t_gin_view;
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+SELECT * FROM test_view1 WHERE column2 MATCH "abd" AND column2 MATCH "bcd";
+DROP TABLE t_gin_view;
+
+CREATE TABLE duplicate_table_demo_datatype_not_replicated_all_varchar ( AAA DATETIME not NULL COMMENT "", BBB VARCHAR(200) not NULL COMMENT "", CCC VARCHAR(200) not NULL COMMENT "", DDD VARCHAR(20000) COMMENT "", EEE LARGEINT  NULL COMMENT "", FFF DECIMAL(20,10) NULL COMMENT "", GGG VARCHAR(200)  NULL COMMENT "", HHH FLOAT  NULL COMMENT "", III BOOLEAN  NULL COMMENT "", KKK CHAR(20)   NULL COMMENT "", LLL STRING   NULL COMMENT "", MMM VARCHAR(20)   NULL COMMENT "", NNN BINARY  NULL COMMENT "", OOO TINYINT NULL COMMENT "", PPP DATETIME NULL COMMENT "", QQQ ARRAY<INT> NULL COMMENT "", RRR JSON NULL COMMENT "", SSS MAP<INT,INT> NULL COMMENT "", TTT STRUCT<a INT, b INT> NULL COMMENT "", INDEX init_bitmap_index (KKK) USING BITMAP ) duplicate KEY(AAA, BBB, CCC) PARTITION BY RANGE (`AAA`) ( START ("1970-01-01") END ("2030-01-01") EVERY (INTERVAL 30 YEAR) ) DISTRIBUTED BY HASH(`AAA`, `BBB`) BUCKETS 3 ORDER BY(`AAA`,`BBB`,`CCC`,`DDD`) PROPERTIES ( "replicated_storage"="false", "replication_num" = "1", "storage_format" = "v2", "enable_persistent_index" = "true", "bloom_filter_columns" = "MMM", "unique_constraints" = "GGG" );
+create view test_view (AAA, DDD) as select AAA, max(DDD) from duplicate_table_demo_datatype_not_replicated_all_varchar group by AAA;
+CREATE INDEX idx ON duplicate_table_demo_datatype_not_replicated_all_varchar(DDD) USING GIN('parser' = 'english');
+function: wait_alter_table_finish()
+
+insert into duplicate_table_demo_datatype_not_replicated_all_varchar values ('1974-08-20 23:13:25', 'xIjfSXnegdnZiZGQMaxo', 'syHwIOMctmDLDGCibEun', 'hIbilUEGdLbCnaZASCVL', 6299, 25361.52081, 'QuTsacRyxiIkBjEmjhNu', -11.4812925061712, True, 'QcLRdQJMhtPXojJUjkUd', 'yUeFlbzomaPDwKeaHylx', 'WqQyGEjEYpvLzfBXYUCB', '', 8, '2015-11-03 16:31:47', [2621, 5950, 13171], '{"job": "Administrator, Civil Service", "company": "Morris-Anderson", "ssn": "823-67-5554", "residence": "59688 Hanna Shoal Apt. 586\nWest Waynefort, CO 69652", "current_location": ["-64.3777465", "21.079566"], "blood_group": "O-", "website": ["http://young.biz/", "https://cobb-bell.com/", "http://www.roberts-garrison.com/", "http://jones.com/"], "username": "howardarcher", "name": "John Mccullough", "sex": "M", "address": "1361 Susan Mountain\nJasonbury, MI 85084", "mail": "lovejennifer@gmail.com", "birthdate": "1928-06-25"}', null, null);
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
+
+DROP VIEW test_view;
+DROP TABLE duplicate_table_demo_datatype_not_replicated_all_varchar;


### PR DESCRIPTION
Background:
In this pr #44514, we disbale the global dict rewrite for the left child of the MATCH expression. We record the left child operator Id of the MATCH expression, and skip the rewrite if we meet this id again.

But the problem is that, if we query a view with
MATCH expression, the left child of the MATCH expression may not represent a physical column(which should be appear in PhysicalOlapScan). And we will still try to rewrite the corrponding column and got exception.

Solution:
Check all matchChildren id before the rewrite. If there is a child id is not contained in the physical columns set in PhysicalOlapScan, it mean that the left child of match expression may be a non-column Ref expression and we should stop the rewrite immediately.

Fixes https://github.com/StarRocks/starrocks/issues/44894

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
