### PR TITLE
[BugFix] fix lake pk crash because invalid rowset meta ptr access

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -78,7 +78,7 @@ Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateSt
                                        bool need_resolve_conflict, bool need_lock) {
     TRACE_COUNTER_SCOPE_LATENCY_US("load_segment_us");
     if (_rowset_ptr == nullptr) {
-        _rowset_meta_ptr = std::make_shared<const RowsetMetadata>(params.op_write.rowset());
+        _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
         _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
                                                -1 /*unused*/, params.tablet_schema);
     }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -78,8 +78,9 @@ Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateSt
                                        bool need_resolve_conflict, bool need_lock) {
     TRACE_COUNTER_SCOPE_LATENCY_US("load_segment_us");
     if (_rowset_ptr == nullptr) {
-        _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(),
-                                               &params.op_write.rowset(), -1 /*unused*/, params.tablet_schema);
+        _rowset_meta_ptr = std::make_shared<const RowsetMetadata>(params.op_write.rowset());
+        _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
+                                               -1 /*unused*/, params.tablet_schema);
     }
     _upserts.resize(_rowset_ptr->num_segments());
     _base_versions.resize(_rowset_ptr->num_segments());

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -183,6 +183,8 @@ private:
 
     std::vector<std::unique_ptr<Column>> _auto_increment_delete_pks;
 
+    // `_rowset_meta_ptr` contains full life cycle rowset meta in `_rowset_ptr`.
+    RowsetMetadataPtr _rowset_meta_ptr;
     std::unique_ptr<Rowset> _rowset_ptr;
 
     // to be destructed after segment iters

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -139,7 +139,7 @@ public:
                                    std::map<uint32_t, std::vector<uint32_t>>* rowids_by_rssid,
                                    std::vector<uint32_t>* idxes);
 
-    const std::unique_ptr<Column>& auto_increment_deletes(uint32_t segment_id) const;
+    const ColumnUniquePtr& auto_increment_deletes(uint32_t segment_id) const;
 
     static StatusOr<bool> file_exist(const std::string& full_path);
 
@@ -181,10 +181,10 @@ private:
 
     std::vector<AutoIncrementPartialUpdateState> _auto_increment_partial_update_states;
 
-    std::vector<std::unique_ptr<Column>> _auto_increment_delete_pks;
+    std::vector<ColumnUniquePtr> _auto_increment_delete_pks;
 
     // `_rowset_meta_ptr` contains full life cycle rowset meta in `_rowset_ptr`.
-    RowsetMetadataPtr _rowset_meta_ptr;
+    RowsetMetadataUniquePtr _rowset_meta_ptr;
     std::unique_ptr<Rowset> _rowset_ptr;
 
     // to be destructed after segment iters

--- a/be/src/storage/lake/types_fwd.h
+++ b/be/src/storage/lake/types_fwd.h
@@ -30,6 +30,7 @@ class RowsetMetadataPB;
 using ChunkIteratorPtr = std::shared_ptr<ChunkIterator>;
 using RowsetMetadata = RowsetMetadataPB;
 using RowsetMetadataPtr = std::shared_ptr<const RowsetMetadata>;
+using RowsetMetadataUniquePtr = std::unique_ptr<const RowsetMetadata>;
 
 namespace lake {
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -961,6 +961,36 @@ TEST_P(LakePrimaryKeyPublishTest, test_mem_tracker) {
               _update_mgr->update_state_mem_tracker()->limit());
 }
 
+TEST_P(LakePrimaryKeyPublishTest, test_write_with_clear_txnlog) {
+    auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+        auto txn_log_st = delta_writer->finish();
+        ASSERT_OK(txn_log_st);
+        _tablet_mgr->prune_metacache();
+        std::const_pointer_cast<TxnLogPB>(txn_log_st.value())->Clear();
+        delta_writer->close();
+        EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() > 0);
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_absent(tablet_id, txn_id));
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+}
+
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,
                          ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
                                            PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE}));


### PR DESCRIPTION
## Why I'm doing:
In `lake::Rowset`, it contains `RowsetMetadataPB` native pointer and user need to make sure this pointer can't be free before `lake::Rowset` itself.
```
namespace starrocks::lake {

class Rowset : public BaseRowset {
...
private:
    TabletManager* _tablet_mgr;
    int64_t _tablet_id;
    const RowsetMetadataPB* _metadata; <-- this is a native pointer
    int _index;
    TabletSchemaPtr _tablet_schema;
    TabletMetadataPtr _tablet_metadata;
    std::vector<SegmentSharedPtr> _segments;
}
```
Now, we meet a BE crash because `lake::Rowset` in `RowsetUpdateState` will be create in preload, and continue use this `lake::Rowset` in publish transaction. And  `RowsetMetadataPB` pointer in `lake::Rowset` had already been free.

```
tracker:replication consumption: 0
*** Aborted at 1717079393 (unix time) try "date -d @1717079393" if you are using GNU date ***
PC: @          0x5aa1c72 starrocks::PrimaryIndex::upsert()
*** SIGSEGV (@0xa8) received by PID 13365 (TID 0x7f79e1fa7700) from PID 168; stack trace: ***
    @          0x7462dd2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f7f156a554f os::Linux::chained_handler()
    @     0x7f7f156ab3b8 JVM_handle_linux_signal
    @     0x7f7f1569cdb8 signalHandler()
    @     0x7f7f14835630 (unknown)
    @          0x5aa1c72 starrocks::PrimaryIndex::upsert()
    @          0x5dd397e starrocks::lake::UpdateManager::_do_update()
    @          0x5ddc01f starrocks::lake::UpdateManager::publish_primary_key_tablet()
    @          0x5e1b3e4 starrocks::lake::PrimaryKeyTxnLogApplier::apply()
    @          0x5dcc100 starrocks::lake::publish_version()
    @          0x351d60f _ZZN9starrocks15LakeServiceImpl15publish_versionEPN6google8protobuf13RpcControllerEPKNS_21PublishVersionRequestEPNS_22PublishVersionResponseEPNS2_7ClosureEENKUlvE_clEv
    @          0x351f65a _ZNSt17_Function_handlerIFvvEZN9starrocks33ConcurrencyLimitedThreadPoolToken11submit_funcESt8functionIS0_ENSt6chrono10time_pointINS5_3_V212system_clockENS5_8durationIlSt5ratioILl1ELl1000000000EEEEEEEUlvE_E9_M_invokeERKSt9_Any_data
terminate called after throwing an instance of 'std::length_error'
  what():  vector::_M_default_append
    @          0x35ca1bc starrocks::ThreadPool::dispatch_thread()
    @          0x35c3e4a starrocks::Thread::supervise_thread()
    @     0x7f7f1482dea5 start_thread
    @     0x7f7f13c2eb0d __clone
    @                0x0 (unknown)
```

## What I'm doing:

Fix this issue by maintain `RowsetMetadataPB` in `RowsetUpdateState`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
