### PR TITLE
[BugFix] Add cast type for mv union rewrite to avoid type not match

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -270,6 +270,7 @@ public class MvRewritePreprocessor {
 
                 // initialize mv rewrite strategy finally
                 MvRewriteStrategy.prepareRewriteStrategy(context, connectContext, queryOptExpression, strategy);
+                logMVPrepare(connectContext, "Mv rewrite strategy: {}", strategy);
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
                 logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}", tableNames, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -628,13 +628,13 @@ public class Optimizer {
             OptExpression treeWithView = queryMaterializationContext.getLogicalTreeWithView();
             // should add a LogicalTreeAnchorOperator for rewrite
             treeWithView = OptExpression.create(new LogicalTreeAnchorOperator(), treeWithView);
-            deriveLogicalProperty(treeWithView);
             if (mvRewriteStrategy.enableMultiTableRewrite) {
-                ruleRewriteIterative(tree, rootTaskContext, RuleSetType.MULTI_TABLE_MV_REWRITE);
+                ruleRewriteIterative(treeWithView, rootTaskContext, RuleSetType.MULTI_TABLE_MV_REWRITE);
             }
             if (mvRewriteStrategy.enableSingleTableRewrite) {
-                ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
+                ruleRewriteIterative(treeWithView, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
             }
+            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.ALL_MV_REWRITE);
             List<Operator> viewScanOperators = Lists.newArrayList();
             MvUtils.collectViewScanOperator(treeWithView, viewScanOperators);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -148,6 +148,11 @@ public class Optimizer {
         return context;
     }
 
+    @VisibleForTesting
+    public MvRewriteStrategy getMvRewriteStrategy() {
+        return mvRewriteStrategy;
+    }
+
     public OptExpression optimize(ConnectContext connectContext,
                                   OptExpression logicOperatorTree,
                                   PhysicalPropertySet requiredProperty,
@@ -378,14 +383,19 @@ public class Optimizer {
         if (!mvRewriteStrategy.enableMaterializedViewRewrite || context.getQueryMaterializationContext() == null) {
             return;
         }
-        if (mvRewriteStrategy.enableRBOViewBasedRewrite) {
+        if (mvRewriteStrategy.enableViewBasedRewrite) {
             // try view based mv rewrite first, then try normal mv rewrite rules
             viewBasedMvRuleRewrite(tree, rootTaskContext);
         }
         if (mvRewriteStrategy.enableForceRBORewrite) {
             // use rule based mv rewrite strategy to do mv rewrite for multi tables query
-            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.ALL_MV_REWRITE);
-        } else if (mvRewriteStrategy.enableRBOSingleTableRewrite) {
+            if (mvRewriteStrategy.enableMultiTableRewrite) {
+                ruleRewriteIterative(tree, rootTaskContext, RuleSetType.MULTI_TABLE_MV_REWRITE);
+            }
+            if (mvRewriteStrategy.enableSingleTableRewrite) {
+                ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
+            }
+        } else if (mvRewriteStrategy.enableSingleTableRewrite) {
             // now add single table materialized view rewrite rules in rule based rewrite phase to boost optimization
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
         }
@@ -619,7 +629,12 @@ public class Optimizer {
             // should add a LogicalTreeAnchorOperator for rewrite
             treeWithView = OptExpression.create(new LogicalTreeAnchorOperator(), treeWithView);
             deriveLogicalProperty(treeWithView);
-            ruleRewriteIterative(treeWithView, rootTaskContext, RuleSetType.ALL_MV_REWRITE);
+            if (mvRewriteStrategy.enableMultiTableRewrite) {
+                ruleRewriteIterative(tree, rootTaskContext, RuleSetType.MULTI_TABLE_MV_REWRITE);
+            }
+            if (mvRewriteStrategy.enableSingleTableRewrite) {
+                ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
+            }
             List<Operator> viewScanOperators = Lists.newArrayList();
             MvUtils.collectViewScanOperator(treeWithView, viewScanOperators);
 
@@ -775,7 +790,7 @@ public class Optimizer {
             context.getRuleSet().addRealtimeMVRules();
         }
 
-        if (mvRewriteStrategy.enableCBORewrite) {
+        if (mvRewriteStrategy.enableMultiTableRewrite) {
             context.getRuleSet().addSingleTableMvRewriteRule();
             context.getRuleSet().addMultiTableMvRewriteRule();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -813,7 +813,7 @@ public class Utils {
             return input;
         }
         Operator newOp = input.getOp();
-        if (newOp.getProjection() == null) {
+        if (newOp.getProjection() == null || newOp.getProjection().getColumnRefMap().isEmpty()) {
             newOp.setProjection(new Projection(newProjectionMap));
         } else {
             // merge two projections

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -33,6 +33,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.base.LogicalProperty;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHudiScanOperator;
@@ -798,5 +799,32 @@ public class Utils {
         }
 
         expr.setStatistics(expressionContext.getStatistics());
+    }
+
+    /**
+     * Add new project into input, merge input's existing project if input has one.
+     * @param input input expression
+     * @param newProjectionMap new project map to be pushed down into input
+     * @return a new expression with new project
+     */
+    public static OptExpression mergeProjection(OptExpression input,
+                                                Map<ColumnRefOperator, ScalarOperator> newProjectionMap) {
+        if (newProjectionMap == null || newProjectionMap.isEmpty()) {
+            return input;
+        }
+        Operator newOp = input.getOp();
+        if (newOp.getProjection() == null) {
+            newOp.setProjection(new Projection(newProjectionMap));
+        } else {
+            // merge two projections
+            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(newOp.getProjection().getColumnRefMap());
+            Map<ColumnRefOperator, ScalarOperator> resultMap = Maps.newHashMap();
+            for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : newProjectionMap.entrySet()) {
+                ScalarOperator result = rewriter.rewrite(entry.getValue());
+                resultMap.put(entry.getKey(), result);
+            }
+            newOp.setProjection(new Projection(resultMap));
+        }
+        return input;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -37,19 +37,17 @@ import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
-import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensation;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MVPartitionPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTransparentState;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -117,7 +115,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         // merge projection
         Map<ColumnRefOperator, ScalarOperator> originalProjectionMap =
                 olapScanOperator.getProjection() == null ? null : olapScanOperator.getProjection().getColumnRefMap();
-        OptExpression result = mergeProjection(mvTransparentPlan, originalProjectionMap);
+        OptExpression result = Utils.mergeProjection(mvTransparentPlan, originalProjectionMap);
 
         // merge predicate
         if (olapScanOperator.getPredicate() != null) {
@@ -329,8 +327,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                                                 MaterializationContext mvContext,
                                                 List<ColumnRefOperator> originalOutputColumns) {
         OptExpressionDuplicator duplicator = new OptExpressionDuplicator(mvContext);
-        OptExpression newMvQueryPlan = duplicator.duplicate(mvPlan);
-        newMvQueryPlan = MVPartitionPruner.resetSelectedPartitions(newMvQueryPlan, true);
+        OptExpression newMvQueryPlan = duplicator.duplicate(mvPlan, true, true);
 
         List<ColumnRefOperator> orgMvQueryOutputColumnRefs = mvContext.getMvOutputColumnRefs();
         List<ColumnRefOperator> newQueryOutputColumns = duplicator.getMappedColumns(orgMvQueryOutputColumnRefs);
@@ -338,26 +335,6 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         for (int i = 0; i < originalOutputColumns.size(); i++) {
             newProjectionMap.put(originalOutputColumns.get(i), newQueryOutputColumns.get(i));
         }
-        return mergeProjection(newMvQueryPlan, newProjectionMap);
-    }
-
-    private OptExpression mergeProjection(OptExpression input, Map<ColumnRefOperator, ScalarOperator> newProjectionMap) {
-        if (newProjectionMap == null || newProjectionMap.isEmpty()) {
-            return input;
-        }
-        Operator newOp = input.getOp();
-        if (newOp.getProjection() == null) {
-            newOp.setProjection(new Projection(newProjectionMap));
-        } else {
-            // merge two projections
-            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(newOp.getProjection().getColumnRefMap());
-            Map<ColumnRefOperator, ScalarOperator> resultMap = Maps.newHashMap();
-            for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : newProjectionMap.entrySet()) {
-                ScalarOperator result = rewriter.rewrite(entry.getValue());
-                resultMap.put(entry.getKey(), result);
-            }
-            newOp.setProjection(new Projection(resultMap));
-        }
-        return input;
+        return Utils.mergeProjection(newMvQueryPlan, newProjectionMap);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -427,9 +427,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         List<ColumnRefOperator> originalOutputColumns = new ArrayList<>(queryColumnRefMap.keySet());
         // rewrite query
         OptExpressionDuplicator duplicator = new OptExpressionDuplicator(materializationContext);
-        OptExpression newQueryInput = duplicator.duplicate(queryInput);
         // reset original partition predicates to prune partitions/tablets again
-        newQueryInput = MVPartitionPruner.resetSelectedPartitions(newQueryInput, false);
+        OptExpression newQueryInput = duplicator.duplicate(queryInput, true);
         List<ColumnRefOperator> newQueryOutputColumns = duplicator.getMappedColumns(originalOutputColumns);
 
         Projection projection = getMvOptExprProjection(viewInput);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -29,7 +28,6 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
-import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFileScanOperator;
@@ -63,13 +61,7 @@ public class MVPartitionPruner {
 
     /**
      * For input query expression, reset/clear pruned partitions and return new query expression to be pruned again.
-     * @param optExpression: optExpression of input query
-     * @return: a new query expression with pruned partitions cleared
      */
-    public static OptExpression resetSelectedPartitions(OptExpression optExpression, boolean refreshTableMetadata) {
-        return optExpression.getOp().accept(new SelectedPartitionCleanerVisitor(refreshTableMetadata), optExpression, null);
-    }
-
     public static LogicalOlapScanOperator resetSelectedPartitions(LogicalOlapScanOperator olapScanOperator) {
         final LogicalOlapScanOperator.Builder mvScanBuilder = OperatorBuilderFactory.build(olapScanOperator);
         // reset original partition predicates to prune partitions/tablets again
@@ -78,63 +70,6 @@ public class MVPartitionPruner {
                 .setPrunedPartitionPredicates(Lists.newArrayList())
                 .setSelectedTabletId(Lists.newArrayList());
         return mvScanBuilder.build();
-    }
-
-    private static class SelectedPartitionCleanerVisitor extends OptExpressionVisitor<OptExpression, Void> {
-        private final boolean refreshTableMetadata;
-        public SelectedPartitionCleanerVisitor(boolean refreshTableMetadata) {
-            this.refreshTableMetadata = refreshTableMetadata;
-        }
-
-        @Override
-        public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
-            LogicalScanOperator scanOperator = optExpression.getOp().cast();
-
-            if (scanOperator instanceof LogicalOlapScanOperator) {
-                // NOTE: need clear original partition predicates before,
-                // original partition predicates if cannot be rewritten may contain wrong slot refs.
-                // MV   : select c1, c3, c2 from test_base_part where c2 < 2000
-                // Query: select c1, c3, c2 from test_base_part where c2 < 3000 and c3 < 3000
-                LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) (scanOperator);
-                LogicalScanOperator newOlapScanOperator = resetSelectedPartitions(olapScanOperator);
-                return OptExpression.create(newOlapScanOperator);
-            } else {
-                try {
-                    ScanOperatorPredicates operatorPredicates = scanOperator.getScanOperatorPredicates();
-                    operatorPredicates.clear();
-                } catch (AnalysisException e) {
-                    // ignore
-                }
-
-                final LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(scanOperator);
-                // reset original partition predicates to prune partitions/tablets again
-                builder.withOperator(scanOperator);
-                if (refreshTableMetadata && scanOperator.getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN) {
-                    // refresh iceberg table's metadata
-                    Table refBaseTable = scanOperator.getTable();
-                    IcebergTable cachedIcebergTable = (IcebergTable) refBaseTable;
-                    String catalogName = cachedIcebergTable.getCatalogName();
-                    String dbName = cachedIcebergTable.getRemoteDbName();
-                    TableName tableName = new TableName(catalogName, dbName, cachedIcebergTable.getName());
-                    Table currentTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName).orElse(null);
-                    if (currentTable == null) {
-                        return null;
-                    }
-                    // Iceberg table's snapshot is cached in the mv's plan cache, need to reset it to get the latest snapshot
-                    builder.setTable(currentTable);
-                }
-                LogicalScanOperator newScanOperator = builder.build();
-                return OptExpression.create(newScanOperator);
-            }
-        }
-
-        public OptExpression visit(OptExpression optExpression, Void context) {
-            List<OptExpression> children = Lists.newArrayList();
-            for (int i = 0; i < optExpression.arity(); ++i) {
-                children.add(optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), null));
-            }
-            return OptExpression.create(optExpression.getOp(), children);
-        }
     }
 
     private class MVPartitionPrunerVisitor extends OptExpressionVisitor<OptExpression, Void> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -2198,9 +2198,8 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
 
         // rewrite query
         OptExpressionDuplicator duplicator = new OptExpressionDuplicator(materializationContext);
-        OptExpression newQueryInput = duplicator.duplicate(queryInput);
         // NOTE: selected partitions and tablets should be deduced again.
-        newQueryInput = MVPartitionPruner.resetSelectedPartitions(newQueryInput, false);
+        OptExpression newQueryInput = duplicator.duplicate(queryInput, true);
         List<ColumnRefOperator> newQueryOutputColumns = duplicator.getMappedColumns(originalOutputColumns);
 
         // rewrite viewInput

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -500,9 +500,7 @@ public class MvPartitionCompensator {
             OptExpression optExpression,
             List<ColumnRefOperator> outputColumns,
             List<ColumnRefOperator> expectOutputColumns) {
-        if (outputColumns.size() != expectOutputColumns.size()) {
-            return null;
-        }
+        Preconditions.checkState(outputColumns.size() == expectOutputColumns.size());
         int len = outputColumns.size();
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
         List<ColumnRefOperator> newChildOutputs = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -38,6 +38,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
@@ -48,6 +49,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
@@ -59,6 +61,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
@@ -69,6 +72,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -187,21 +191,21 @@ public class MvPartitionCompensator {
         }
 
         if (refScanOperator instanceof LogicalOlapScanOperator) {
-            return getMvCompensationForOlap(sessionVariable, refBaseTable, refTablePartitionNameToRefresh,
+            return getMvCompensationForOlap(mvContext, refBaseTable, refTablePartitionNameToRefresh,
                     (LogicalOlapScanOperator) refScanOperator);
         } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(refScanOperator.getOpType())) {
-            return getMvCompensationForExternal(sessionVariable, refTablePartitionNameToRefresh, refScanOperator);
+            return getMvCompensationForExternal(mvContext, refTablePartitionNameToRefresh, refScanOperator);
         } else {
             return MVCompensation.createUnkownState(sessionVariable);
         }
     }
 
-    private static MVCompensation getMvCompensationForOlap(SessionVariable sessionVariable,
+    private static MVCompensation getMvCompensationForOlap(MaterializationContext mvContext,
                                                            Table refBaseTable,
                                                            Set<String> refTablePartitionNameToRefresh,
                                                            LogicalOlapScanOperator olapScanOperator) {
         OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
-
+        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
         List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
         if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
             return MVCompensation.createNoCompensateState(sessionVariable);
@@ -222,6 +226,8 @@ public class MvPartitionCompensator {
         }
 
         if (Sets.newHashSet(toRefreshRefTablePartitions).containsAll(selectPartitionIds)) {
+            logMVRewrite(mvContext, "All table {}'s selected partitions {} need to refresh, no rewrite",
+                    refBaseTable.getName(), selectPartitionIds);
             return MVCompensation.createNoRewriteState(sessionVariable);
         }
 
@@ -229,9 +235,10 @@ public class MvPartitionCompensator {
                 toRefreshRefTablePartitions, null);
     }
 
-    private static MVCompensation getMvCompensationForExternal(SessionVariable sessionVariable,
+    private static MVCompensation getMvCompensationForExternal(MaterializationContext mvContext,
                                                                Set<String> refTablePartitionNamesToRefresh,
                                                                LogicalScanOperator refScanOperator) {
+        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
         try {
             ScanOperatorPredicates scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
             Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
@@ -256,7 +263,10 @@ public class MvPartitionCompensator {
             if (toRefreshRefTablePartitions == null) {
                 return MVCompensation.createUnkownState(sessionVariable);
             }
+            Table table = refScanOperator.getTable();
             if (Sets.newHashSet(toRefreshRefTablePartitions).containsAll(selectPartitionKeys)) {
+                logMVRewrite(mvContext, "All table {}'s selected partitions {} need to refresh, no rewrite",
+                        table.getName(), selectPartitionIds);
                 return MVCompensation.createNoRewriteState(sessionVariable);
             }
             return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE, null,
@@ -448,11 +458,17 @@ public class MvPartitionCompensator {
             logMVRewrite(mvContext, "Get mv scan transparent plan failed");
             return null;
         }
+        mvScanPlans = addCastProjectIfNeeded(mvContext.getQueryRefFactory(),
+                mvScanPlans.first, mvScanPlans.second, originalOutputColumns);
+
         Pair<OptExpression, List<ColumnRefOperator>> mvQueryPlans = getMvQueryPlan(mvContext, mvCompensation);
         if (mvQueryPlans == null) {
             logMVRewrite(mvContext, "Get mv query transparent plan failed");
             return null;
         }
+        mvQueryPlans = addCastProjectIfNeeded(mvContext.getQueryRefFactory(),
+                mvQueryPlans.first, mvQueryPlans.second, originalOutputColumns);
+
         LogicalUnionOperator unionOperator = new LogicalUnionOperator.Builder()
                 .setOutputColumnRefOp(originalOutputColumns)
                 .setChildOutputColumns(Lists.newArrayList(mvScanPlans.second, mvQueryPlans.second))
@@ -461,6 +477,58 @@ public class MvPartitionCompensator {
         OptExpression result = OptExpression.create(unionOperator, mvScanPlans.first, mvQueryPlans.first);
         deriveLogicalProperty(result);
         return result;
+    }
+
+    /**
+     * In some cases, need add cast project to make sure the output columns are the same as expectOutputColumns.
+     * <p>
+     * eg: table t1: k1 date, v1 int, v2 char(20)
+     * mv: create mv mv1 as select k1, v1, v2 from t1.
+     * mv's schema will be: k1 date, v1 int, v2 varchar(20)
+     * </p>
+     * It needs to add a cast project in generating the union operator, which is the same as
+     * {@link com.starrocks.sql.optimizer.transformer.RelationTransformer#processSetOperation(SetOperationRelation)}
+     * </p>
+     * @param columnRefFactory column ref factory to generate the new query column ref
+     * @param optExpression the original opt expression
+     * @param outputColumns the original output columns of the opt expression
+     * @param expectOutputColumns the expected output columns
+     * @return the new opt expression and the new output columns if it needs to cast, otherwise return the original
+     */
+    private static Pair<OptExpression, List<ColumnRefOperator>> addCastProjectIfNeeded(
+            ColumnRefFactory columnRefFactory,
+            OptExpression optExpression,
+            List<ColumnRefOperator> outputColumns,
+            List<ColumnRefOperator> expectOutputColumns) {
+        if (outputColumns.size() != expectOutputColumns.size()) {
+            return null;
+        }
+        int len = outputColumns.size();
+        Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
+        List<ColumnRefOperator> newChildOutputs = new ArrayList<>();
+        boolean isNeedCast = false;
+        for (int i = 0; i < len; i++) {
+            ColumnRefOperator outOp = outputColumns.get(i);
+            Type outputType = outOp.getType();
+            ColumnRefOperator expectOp = expectOutputColumns.get(i);
+            Type expectType = expectOp.getType();
+            if (!outputType.equals(expectType)) {
+                isNeedCast = true;
+                ColumnRefOperator newColRef = columnRefFactory.create("cast", expectType, expectOp.isNullable());
+                ScalarOperator cast = new CastOperator(outputType, outOp, true);
+                projections.put(newColRef, cast);
+                newChildOutputs.add(newColRef);
+            } else {
+                projections.put(outOp, outOp);
+                newChildOutputs.add(outOp);
+            }
+        }
+        if (isNeedCast) {
+            OptExpression newOptExpression = Utils.mergeProjection(optExpression, projections);
+            return Pair.create(newOptExpression, newChildOutputs);
+        } else {
+            return Pair.create(optExpression, outputColumns);
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
@@ -131,4 +131,15 @@ public class MvRewriteStrategy {
         // cbo strategies
         strategy.enableMultiTableRewrite = arbitrator.isEnableCBOMultiTableRewrite(queryPlan);
     }
+
+    @Override
+    public String toString() {
+        return "MvRewriteStrategy{" +
+                "enableMaterializedViewRewrite=" + enableMaterializedViewRewrite +
+                ", enableForceRBORewrite=" + enableForceRBORewrite +
+                ", enableViewBasedRewrite=" + enableViewBasedRewrite +
+                ", enableSingleTableRewrite=" + enableSingleTableRewrite +
+                ", enableMultiTableRewrite=" + enableMultiTableRewrite +
+                '}';
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
@@ -31,12 +31,9 @@ public class MvRewriteStrategy {
     // Whether enable force rewrite for query plans with join operator by rule based mv rewrite
     public boolean enableForceRBORewrite = false;
 
-    // rbo config
-    public boolean enableRBOViewBasedRewrite = false;
-    public boolean enableRBOSingleTableRewrite = false;
-
-    // cbo config
-    public boolean enableCBORewrite = false;
+    public boolean enableViewBasedRewrite = false;
+    public boolean enableSingleTableRewrite = false;
+    public boolean enableMultiTableRewrite = false;
 
     static class MvStrategyArbitrator {
         private final OptimizerConfig optimizerConfig;
@@ -128,10 +125,10 @@ public class MvRewriteStrategy {
         strategy.enableForceRBORewrite = sessionVariable.isEnableForceRuleBasedMvRewrite();
 
         // rbo strategies
-        strategy.enableRBOViewBasedRewrite = arbitrator.isEnableRBOViewBasedRewrite();
-        strategy.enableRBOSingleTableRewrite = arbitrator.isEnableRBOSingleTableRewrite(queryPlan);
+        strategy.enableViewBasedRewrite = arbitrator.isEnableRBOViewBasedRewrite();
+        strategy.enableSingleTableRewrite = arbitrator.isEnableRBOSingleTableRewrite(queryPlan);
 
         // cbo strategies
-        strategy.enableCBORewrite = arbitrator.isEnableCBOMultiTableRewrite(queryPlan);
+        strategy.enableMultiTableRewrite = arbitrator.isEnableCBOMultiTableRewrite(queryPlan);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategyTest.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Optimizer;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
+import com.starrocks.sql.optimizer.transformer.RelationTransformer;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MvRewriteStrategyTest extends MvRewriteTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+        starRocksAssert.withTable(cluster, "test_base_part");
+        starRocksAssert.withTable(cluster, "table_with_partition");
+    }
+
+    private OptExpression optimize(Optimizer optimizer, String sql) {
+        try {
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+            ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+            LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, connectContext)
+                    .transformWithSelectLimit(queryStatement.getQueryRelation());
+            return optimizer.optimize(connectContext, logicalPlan.getRoot(), new PhysicalPropertySet(),
+                    new ColumnRefSet(logicalPlan.getOutputColumn()), columnRefFactory);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+            return null;
+        }
+    }
+
+    @Test
+    public void testSingleTableRewriteStrategy() throws Exception {
+        createAndRefreshMv("create materialized view mv1 " +
+                " partition by id_date" +
+                " distributed by random " +
+                " as" +
+                " select t1a, id_date, t1b from table_with_partition");
+        String sql =  "select t1a, id_date, t1b from table_with_partition";
+        Optimizer optimizer = new Optimizer();
+        OptExpression optExpression = optimize(optimizer, sql);
+        Assert.assertTrue(optExpression != null);
+        MvRewriteStrategy mvRewriteStrategy = optimizer.getMvRewriteStrategy();
+        Assert.assertTrue(mvRewriteStrategy.enableMultiTableRewrite == false);
+        Assert.assertTrue(mvRewriteStrategy.enableSingleTableRewrite == true);
+        Assert.assertTrue(mvRewriteStrategy.enableMaterializedViewRewrite == true);
+        Assert.assertTrue(mvRewriteStrategy.enableForceRBORewrite == true);
+        Assert.assertTrue(mvRewriteStrategy.enableViewBasedRewrite == false);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 public class MvTransparentRewriteWithOlapTableTest extends MvRewriteTestBase {
     private static MTable m1;
     private static MTable m2;
+    private static MTable m3;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -59,6 +60,22 @@ public class MvTransparentRewriteWithOlapTableTest extends MvRewriteTestBase {
                         "v1 INT",
                         "v2 INT",
                         "v3 string"
+                ),
+                "k1",
+                ImmutableList.of(
+                        "PARTITION `p1` VALUES LESS THAN ('3')",
+                        "PARTITION `p2` VALUES LESS THAN ('6')",
+                        "PARTITION `p3` VALUES LESS THAN ('9')"
+                )
+        );
+        m3 = new MTable("m3", "k1",
+                ImmutableList.of(
+                        "k1 INT",
+                        "k2 string",
+                        "v1 INT",
+                        "v2 TINYINT",
+                        "v3 char(20)",
+                        "v4 varchar(20)"
                 ),
                 "k1",
                 ImmutableList.of(
@@ -584,7 +601,7 @@ public class MvTransparentRewriteWithOlapTableTest extends MvRewriteTestBase {
                             String plan = getFragmentPlan(query, "MV");
                             PlanTestBase.assertContains(plan, ":UNION");
                             PlanTestBase.assertContains(plan, "mv0");
-                        }
+                       }
                     });
         });
     }
@@ -614,6 +631,67 @@ public class MvTransparentRewriteWithOlapTableTest extends MvRewriteTestBase {
                             String plan = getFragmentPlan(query, "MV");
                             PlanTestBase.assertContains(plan, ":UNION");
                             PlanTestBase.assertContains(plan, "mv0");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithCharType() {
+        starRocksAssert.withTable(m3, () -> {
+            cluster.runSql("test", "insert into m3 values (1,1,1,1,1,2), (4,2,1,1,1,1), (10,10,10,10,10,10);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (k1) " +
+                            " DISTRIBUTED BY HASH(k1) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " PROPERTIES (\n" +
+                            " 'transparent_mv_rewrite_mode' = 'true'" +
+                            " ) " +
+                            " AS select * from m3;",
+                    () -> {
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        MaterializedView mv1 = getMv("test", "mv0");
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1]", mvNames.toString());
+                        String[] sqls = {
+                                "SELECT * from mv0",
+                                "SELECT * from mv0 where k1=1",
+                        };
+                        String[] expects = {
+                                "  4:Project\n" +
+                                        "  |  <slot 19> : 19: k1\n" +
+                                        "  |  <slot 20> : 20: k2\n" +
+                                        "  |  <slot 21> : 21: v1\n" +
+                                        "  |  <slot 22> : 22: v2\n" +
+                                        "  |  <slot 24> : 24: v4\n" +
+                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  \n" +
+                                        "  3:OlapScanNode\n" +
+                                        "     TABLE: m3\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     partitions=2/3",
+                                "  4:Project\n" +
+                                        "  |  <slot 19> : 19: k1\n" +
+                                        "  |  <slot 20> : 20: k2\n" +
+                                        "  |  <slot 21> : 21: v1\n" +
+                                        "  |  <slot 22> : 22: v2\n" +
+                                        "  |  <slot 24> : 24: v4\n" +
+                                        "  |  <slot 25> : CAST(23: v3 AS CHAR(20))\n" +
+                                        "  |  \n" +
+                                        "  3:OlapScanNode\n" +
+                                        "     TABLE: m3\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     PREDICATES: 19: k1 = 1"
+                        };
+                        int len = sqls.length;
+                        for (int i = 0; i < len; i++) {
+                            String query = sqls[i];
+                            String plan = getFragmentPlan(query, "MV");
+                            System.out.println(plan);
+                            PlanTestBase.assertContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "mv0");
+                            PlanTestBase.assertContains(plan, expects[i]);
                         }
                     });
         });

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -601,7 +601,7 @@ public class MvTransparentRewriteWithOlapTableTest extends MvRewriteTestBase {
                             String plan = getFragmentPlan(query, "MV");
                             PlanTestBase.assertContains(plan, ":UNION");
                             PlanTestBase.assertContains(plan, "mv0");
-                       }
+                        }
                     });
         });
     }

--- a/test/sql/test_materialized_view/R/test_materialized_view_union_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union_rewrite
@@ -58,9 +58,8 @@ select * from t1 order by k1;
 -- result:
 2020-01-01	2020-01-01 01:00:00	1	1	1	1	1	1	1	1	1.0	1.0	1.000000000
 -- !result
-insert into unique_par_table_with_null values ('2023-01-02', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
+insert into t1 values ('2023-01-02', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table unique_par_table_with_null is not found.')
 -- !result
 function: check_hit_materialized_view("select count(*) from t1", "test_mv0")
 -- result:
@@ -72,11 +71,12 @@ None
 -- !result
 select count(*) from t1;
 -- result:
-1
+2
 -- !result
 select * from t1 order by k1;
 -- result:
 2020-01-01	2020-01-01 01:00:00	1	1	1	1	1	1	1	1	1.0	1.0	1.000000000
+2023-01-02	2020-01-01 01:00:00	1	1	1	1	1	1	1	1	1.0	1.0	1.000000000
 -- !result
 drop materialized view test_mv0;
 -- result:

--- a/test/sql/test_materialized_view/R/test_materialized_view_union_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union_rewrite
@@ -1,0 +1,86 @@
+-- name: test_materialized_view_union_rewrite
+CREATE TABLE `t1` (
+  `k1` date NULL COMMENT "",
+  `k2` datetime NULL COMMENT "",
+  `k3` char(20) NULL COMMENT "",
+  `k4` varchar(20) NULL COMMENT "",
+  `k5` boolean NULL COMMENT "",
+  `v1` tinyint(4) NULL COMMENT "",
+  `v2` smallint(6) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `v4` bigint(20) NULL COMMENT "",
+  `v5` largeint(40) NULL COMMENT "",
+  `v6` float NULL COMMENT "",
+  `v7` double NULL COMMENT "",
+  `v8` decimal(27, 9) NULL COMMENT ""
+) ENGINE=OLAP
+UNIQUE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION p1 VALUES [("0000-01-01"), ("2020-01-01")),
+  PARTITION p2 VALUES [("2020-01-01"), ("2023-01-01")),
+  PARTITION p3 VALUES [("2023-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`)
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 values ('2020-01-01', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv0
+PARTITION BY (`k1`)
+DISTRIBUTED BY random
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "replication_num" = "1"
+)
+AS SELECT * FROM t1; 
+REFRESH MATERIALIZED VIEW test_mv0 WITH SYNC MODE;
+-- result:
+-- !result
+function: check_hit_materialized_view("select count(*) from t1", "test_mv0")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select * from t1", "test_mv0")
+-- result:
+None
+-- !result
+select count(*) from t1;
+-- result:
+1
+-- !result
+select * from t1 order by k1;
+-- result:
+2020-01-01	2020-01-01 01:00:00	1	1	1	1	1	1	1	1	1.0	1.0	1.000000000
+-- !result
+insert into unique_par_table_with_null values ('2023-01-02', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table unique_par_table_with_null is not found.')
+-- !result
+function: check_hit_materialized_view("select count(*) from t1", "test_mv0")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select * from t1", "test_mv0")
+-- result:
+None
+-- !result
+select count(*) from t1;
+-- result:
+1
+-- !result
+select * from t1 order by k1;
+-- result:
+2020-01-01	2020-01-01 01:00:00	1	1	1	1	1	1	1	1	1.0	1.0	1.000000000
+-- !result
+drop materialized view test_mv0;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_reasoning
+++ b/test/sql/test_materialized_view/R/test_mv_reasoning
@@ -69,8 +69,6 @@ TRACE REASON MV
 -- result:
     MV rewrite fail for mv1: Rewrite group by key failed: 4: c4 
     MV rewrite fail for mv1: Rewrite rollup aggregate failed, cannot rewrite group by keys: [4: c4] 
-    MV rewrite fail for mv1: Rewrite group by key failed: 4: c4 
-    MV rewrite fail for mv1: Rewrite rollup aggregate failed, cannot rewrite group by keys: [4: c4] 
 -- !result
 TRACE REASON MV
     SELECT c1, sum(c3), count(c3)
@@ -78,7 +76,6 @@ TRACE REASON MV
     WHERE c4 > 'a'
     GROUP BY c1;
 -- result:
-    MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 > a cannot be rewritten 
     MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 > a cannot be rewritten 
 -- !result
 DROP MATERIALIZED VIEW mv1;
@@ -105,13 +102,11 @@ TRACE REASON MV
     GROUP BY c1, c2, c4;
 -- result:
     MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
-    MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
 -- !result
 TRACE REASON MV
     SELECT c1, c2, c4
     FROM t1;
 -- result:
-    MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
     MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
 -- !result
 TRACE REASON MV
@@ -119,7 +114,6 @@ TRACE REASON MV
     FROM t1
     WHERE c4='a';
 -- result:
-    MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 = a cannot be rewritten 
     MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 = a cannot be rewritten 
 -- !result
 ALTER MATERIALIZED VIEW mv1 INACTIVE;

--- a/test/sql/test_materialized_view/T/test_materialized_view_union_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_union_rewrite
@@ -1,0 +1,55 @@
+-- name: test_materialized_view_union_rewrite
+CREATE TABLE `t1` (
+  `k1` date NULL COMMENT "",
+  `k2` datetime NULL COMMENT "",
+  `k3` char(20) NULL COMMENT "",
+  `k4` varchar(20) NULL COMMENT "",
+  `k5` boolean NULL COMMENT "",
+  `v1` tinyint(4) NULL COMMENT "",
+  `v2` smallint(6) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `v4` bigint(20) NULL COMMENT "",
+  `v5` largeint(40) NULL COMMENT "",
+  `v6` float NULL COMMENT "",
+  `v7` double NULL COMMENT "",
+  `v8` decimal(27, 9) NULL COMMENT ""
+) ENGINE=OLAP
+UNIQUE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION p1 VALUES [("0000-01-01"), ("2020-01-01")),
+  PARTITION p2 VALUES [("2020-01-01"), ("2023-01-01")),
+  PARTITION p3 VALUES [("2023-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`)
+PROPERTIES (
+  "replication_num" = "1"
+);
+insert into t1 values ('2020-01-01', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
+
+CREATE MATERIALIZED VIEW test_mv0
+PARTITION BY (`k1`)
+DISTRIBUTED BY random
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "replication_num" = "1"
+)
+AS SELECT * FROM t1; 
+REFRESH MATERIALIZED VIEW test_mv0 WITH SYNC MODE;
+
+-- complete rewrite
+function: check_hit_materialized_view("select count(*) from t1", "test_mv0")
+function: check_hit_materialized_view("select * from t1", "test_mv0")
+select count(*) from t1;
+select * from t1 order by k1;
+
+-- union rewrite
+insert into unique_par_table_with_null values ('2023-01-02', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
+function: check_hit_materialized_view("select count(*) from t1", "test_mv0")
+function: check_hit_materialized_view("select * from t1", "test_mv0")
+select count(*) from t1;
+select * from t1 order by k1;
+
+drop materialized view test_mv0;
+drop table t1;

--- a/test/sql/test_materialized_view/T/test_materialized_view_union_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_union_rewrite
@@ -45,7 +45,7 @@ select count(*) from t1;
 select * from t1 order by k1;
 
 -- union rewrite
-insert into unique_par_table_with_null values ('2023-01-02', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
+insert into t1 values ('2023-01-02', '2020-01-01 01:00:00', '1', '1', 1, 1, 1, 1, 1, 1, 1, 1, 1.0);
 function: check_hit_materialized_view("select count(*) from t1", "test_mv0")
 function: check_hit_materialized_view("select * from t1", "test_mv0")
 select count(*) from t1;


### PR DESCRIPTION
## Why I'm doing:

```
2024-05-31 05:49:43.614+08:00 WARN (starrocks-mysql-nio-pool-5|548) [StmtExecutor.execute():732] execute Exception, sql select count(*) from `auto_set_bucket_4044db2c_1e7d_11ef_ac68_00163e0e489a`.`unique_par_table_with_null`
com.starrocks.sql.optimizer.validate.ValidateException: Incorrect logical plan found in operator: LOGICAL_UNION child size 2. Invalid reason: input cols type not equal with output cols type
        at com.starrocks.common.ErrorReport.reportValidateException(ErrorReport.java:106) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.visitLogicalUnion(OptExpressionValidator.java:136) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.visitLogicalUnion(OptExpressionValidator.java:42) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator.accept(LogicalUnionOperator.java:69) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.validateChildOpt(OptExpressionValidator.java:203) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.visitLogicalProject(OptExpressionValidator.java:70) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.visitLogicalProject(OptExpressionValidator.java:42) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator.accept(LogicalProjectOperator.java:103) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.validateChildOpt(OptExpressionValidator.java:203) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.commonValidate(OptExpressionValidator.java:196) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.visitLogicalAggregate(OptExpressionValidator.java:91) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.visitLogicalAggregate(OptExpressionValidator.java:42) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator.accept(LogicalAggregationOperator.java:212) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.OptExpressionVisitor.visit(OptExpressionVisitor.java:28) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.validate.OptExpressionValidator.validate(OptExpressionValidator.java:55) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.rewriteAndValidatePlan(Optimizer.java:646) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:227) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:176) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:278) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:131) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:90) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:534) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:427) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:623) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:956) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```
## What I'm doing:
- Add implicit cast if Union operator (mv rewrite union)'s child type is not matched.
- Avoid to rewrite by JOIN Rewrite for single table.
- Refactor  SelectedPartitionCleanerVisitor into duplicator

Fixes [#issue
](https://github.com/StarRocks/StarRocksTest/issues/7689)
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
