### PR TITLE
[Refactor] Remove buffer_size of DataStreamSender

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -93,11 +93,9 @@ static std::unique_ptr<DataStreamSender> create_data_stream_sink(
             params.__isset.enable_exchange_pass_through && params.enable_exchange_pass_through;
     bool enable_exchange_perf = params.__isset.enable_exchange_perf && params.enable_exchange_perf;
 
-    // TODO: figure out good buffer size based on size of output row
-    auto ret = std::make_unique<DataStreamSender>(state, sender_id, row_desc, data_stream_sink, destinations, 16 * 1024,
-                                                  send_query_statistics_with_every_batch, enable_exchange_pass_through,
-                                                  enable_exchange_perf);
-    return ret;
+    return std::make_unique<DataStreamSender>(state, sender_id, row_desc, data_stream_sink, destinations,
+                                              send_query_statistics_with_every_batch, enable_exchange_pass_through,
+                                              enable_exchange_perf);
 }
 
 Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_sink,

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -80,8 +80,7 @@ public:
     // how much tuple data is getting accumulated before being sent; it only applies
     // when data is added via add_row() and not sent directly via send_batch().
     Channel(DataStreamSender* parent, const TNetworkAddress& brpc_dest, const TUniqueId& fragment_instance_id,
-            PlanNodeId dest_node_id, int buffer_size, bool is_transfer_chain,
-            bool send_query_statistics_with_every_batch)
+            PlanNodeId dest_node_id, bool is_transfer_chain, bool send_query_statistics_with_every_batch)
             : _parent(parent),
               _fragment_instance_id(fragment_instance_id),
               _dest_node_id(dest_node_id),
@@ -364,8 +363,8 @@ void DataStreamSender::Channel::close_wait(RuntimeState* state) {
 DataStreamSender::DataStreamSender(RuntimeState* state, int sender_id, const RowDescriptor& row_desc,
                                    const TDataStreamSink& sink,
                                    const std::vector<TPlanFragmentDestination>& destinations,
-                                   int per_channel_buffer_size, bool send_query_statistics_with_every_batch,
-                                   bool enable_exchange_pass_through, bool enable_exchange_perf)
+                                   bool send_query_statistics_with_every_batch, bool enable_exchange_pass_through,
+                                   bool enable_exchange_perf)
         : _sender_id(sender_id),
           _state(state),
           _pool(state->obj_pool()),
@@ -394,7 +393,7 @@ DataStreamSender::DataStreamSender(RuntimeState* state, int sender_id, const Row
         const auto& fragment_instance_id = destinations[i].fragment_instance_id;
         if (fragment_id_to_channel_index.find(fragment_instance_id.lo) == fragment_id_to_channel_index.end()) {
             _channel_shared_ptrs.emplace_back(new Channel(this, destinations[i].brpc_server, fragment_instance_id,
-                                                          sink.dest_node_id, per_channel_buffer_size, is_transfer_chain,
+                                                          sink.dest_node_id, is_transfer_chain,
                                                           send_query_statistics_with_every_batch));
             fragment_id_to_channel_index.insert({fragment_instance_id.lo, _channel_shared_ptrs.size() - 1});
             _channels.push_back(_channel_shared_ptrs.back().get());

--- a/be/src/runtime/data_stream_sender.h
+++ b/be/src/runtime/data_stream_sender.h
@@ -75,12 +75,10 @@ class DataStreamSender final : public DataSink {
 public:
     // Construct a sender according to the output specification (sink),
     // sending to the given destinations.
-    // Per_channel_buffer_size is the buffer size allocated to each channel
-    // and is specified in bytes.
     // The RowDescriptor must live until close() is called.
     // NOTE: supported partition types are UNPARTITIONED (broadcast) and HASH_PARTITIONED
     DataStreamSender(RuntimeState* state, int sender_id, const RowDescriptor& row_desc, const TDataStreamSink& sink,
-                     const std::vector<TPlanFragmentDestination>& destinations, int per_channel_buffer_size,
+                     const std::vector<TPlanFragmentDestination>& destinations,
                      bool send_query_statistics_with_every_batch, bool enable_exchange_pass_through,
                      bool enable_exchange_perf);
     ~DataStreamSender() override;


### PR DESCRIPTION
## Why I'm doing:

buffer_size of DataStreamSender is useless, so remove it.

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
