### PR TITLE
[Refactor]extract statistics_helper to deal rowgroup stats and columnindex

### DIFF
--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(Formats STATIC
         parquet/level_builder.cpp
         parquet/column_chunk_writer.cpp
         parquet/column_read_order_ctx.cpp
+        parquet/statistics_helper.cpp
         )
 
 add_subdirectory(orc/apache-orc)

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -108,7 +108,7 @@ private:
     // make min/max chunk from stats of row group meta
     // exist=true: group meta contain statistics info
     Status _read_min_max_chunk(const tparquet::RowGroup& row_group, const std::vector<SlotDescriptor*>& slots,
-                               ChunkPtr* min_chunk, ChunkPtr* max_chunk, bool* exist) const;
+                               ChunkPtr* min_chunk, ChunkPtr* max_chunk) const;
 
     // only scan partition column + not exist column
     Status _exec_no_materialized_column_scan(ChunkPtr* chunk);
@@ -128,7 +128,7 @@ private:
     Status _decode_min_max_column(const ParquetField& field, const std::string& timezone, const TypeDescriptor& type,
                                   const tparquet::ColumnMetaData& column_meta,
                                   const tparquet::ColumnOrder* column_order, ColumnPtr* min_column,
-                                  ColumnPtr* max_column, bool* decode_ok) const;
+                                  ColumnPtr* max_column) const;
 
     bool _has_correct_min_max_stats(const tparquet::ColumnMetaData& column_meta, const SortOrder& sort_order) const;
 

--- a/be/src/formats/parquet/page_index_reader.h
+++ b/be/src/formats/parquet/page_index_reader.h
@@ -77,10 +77,6 @@ public:
     void select_column_offset_index();
 
 private:
-    Status _decode_value_into_column(ColumnPtr column, const std::vector<std::string>& values,
-                                     const TypeDescriptor& type, const ParquetField* field,
-                                     const std::string& timezone);
-
     GroupReader* _group_reader = nullptr;
     RandomAccessFile* _file = nullptr;
     // column readers for column chunk in row group

--- a/be/src/formats/parquet/statistics_helper.cpp
+++ b/be/src/formats/parquet/statistics_helper.cpp
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/statistics_helper.h"
+
+#include "formats/parquet/column_converter.h"
+#include "formats/parquet/encoding_plain.h"
+#include "formats/parquet/schema.h"
+
+namespace starrocks::parquet {
+
+Status StatisticsHelper::decode_value_into_column(ColumnPtr column, const std::vector<std::string>& values,
+                                                  const TypeDescriptor& type, const ParquetField* field,
+                                                  const std::string& timezone) {
+    std::unique_ptr<ColumnConverter> converter;
+    RETURN_IF_ERROR(ColumnConverterFactory::create_converter(*field, type, timezone, &converter));
+    bool ret = true;
+    switch (field->physical_type) {
+    case tparquet::Type::type::INT32: {
+        int32_t decode_value = 0;
+        if (!converter->need_convert) {
+            for (size_t i = 0; i < values.size(); i++) {
+                RETURN_IF_ERROR(PlainDecoder<int32_t>::decode(values[i], &decode_value));
+                ret &= (column->append_numbers(&decode_value, sizeof(int32_t)) > 0);
+            }
+        } else {
+            ColumnPtr src_column = converter->create_src_column();
+            for (size_t i = 0; i < values.size(); i++) {
+                RETURN_IF_ERROR(PlainDecoder<int32_t>::decode(values[i], &decode_value));
+                ret &= (src_column->append_numbers(&decode_value, sizeof(int32_t)) > 0);
+            }
+            RETURN_IF_ERROR(converter->convert(src_column, column.get()));
+        }
+        break;
+    }
+    case tparquet::Type::type::INT64: {
+        int64_t decode_value = 0;
+        if (!converter->need_convert) {
+            for (size_t i = 0; i < values.size(); i++) {
+                RETURN_IF_ERROR(PlainDecoder<int64_t>::decode(values[i], &decode_value));
+                ret &= (column->append_numbers(&decode_value, sizeof(int64_t)) > 0);
+            }
+        } else {
+            ColumnPtr src_column = converter->create_src_column();
+            for (size_t i = 0; i < values.size(); i++) {
+                RETURN_IF_ERROR(PlainDecoder<int64_t>::decode(values[i], &decode_value));
+                ret &= (src_column->append_numbers(&decode_value, sizeof(int64_t)) > 0);
+            }
+            RETURN_IF_ERROR(converter->convert(src_column, column.get()));
+        }
+        break;
+    }
+    case tparquet::Type::type::BYTE_ARRAY:
+    // todo: FLBA need more test
+    case tparquet::Type::type::FIXED_LEN_BYTE_ARRAY: {
+        Slice decode_value;
+        if (!converter->need_convert) {
+            for (size_t i = 0; i < values.size(); i++) {
+                RETURN_IF_ERROR(PlainDecoder<Slice>::decode(values[i], &decode_value));
+                ret &= column->append_strings(std::vector<Slice>{decode_value});
+            }
+        } else {
+            ColumnPtr src_column = converter->create_src_column();
+            for (size_t i = 0; i < values.size(); i++) {
+                RETURN_IF_ERROR(PlainDecoder<Slice>::decode(values[i], &decode_value));
+                ret &= src_column->append_strings(std::vector<Slice>{decode_value});
+            }
+            RETURN_IF_ERROR(converter->convert(src_column, column.get()));
+        }
+        break;
+    }
+    default:
+        return Status::Aborted("Not Supported min/max value type");
+    }
+
+    if (UNLIKELY(!ret)) {
+        return Status::InternalError("Decode min-max column failed");
+    }
+    return Status::OK();
+}
+
+} // starrocks::parquet

--- a/be/src/formats/parquet/statistics_helper.cpp
+++ b/be/src/formats/parquet/statistics_helper.cpp
@@ -90,4 +90,4 @@ Status StatisticsHelper::decode_value_into_column(ColumnPtr column, const std::v
     return Status::OK();
 }
 
-} // starrocks::parquet
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/statistics_helper.h
+++ b/be/src/formats/parquet/statistics_helper.h
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "runtime/types.h"
+#include "formats/parquet/schema.h"
+
+namespace starrocks::parquet {
+
+class StatisticsHelper {
+public:
+    static Status decode_value_into_column(ColumnPtr column, const std::vector<std::string>& values,
+                                           const TypeDescriptor& type, const ParquetField* field,
+                                           const std::string& timezone);
+};
+
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/statistics_helper.h
+++ b/be/src/formats/parquet/statistics_helper.h
@@ -16,8 +16,8 @@
 
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
-#include "runtime/types.h"
 #include "formats/parquet/schema.h"
+#include "runtime/types.h"
 
 namespace starrocks::parquet {
 
@@ -27,6 +27,5 @@ public:
                                            const TypeDescriptor& type, const ParquetField* field,
                                            const std::string& timezone);
 };
-
 
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
extreat statistics_helper to deal rowgroup stats and columnindex

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
