### PR TITLE
[Enhancement] support the CREATE CATALOG xx（IF NOT EXISTS) syntax

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -207,6 +207,8 @@ public enum ErrorCode {
             "Unknown resource group '%s' "),
     ERR_BAD_CATALOG_AND_DB_ERROR(5080, new byte[] {'4', '2', '0', '0', '0'},
             "Unknown catalog.db '%s'"),
+    ERR_CATALOG_EXISTED_ERROR(5607, new byte[] {'4', '2', '0', '0', '0'},
+            "catalog existed '%s'"),
     ERR_UNSUPPORTED_SQL_PATTERN(5081, new byte[] {'4', '2', '0', '0', '0'},
             "Only support like 'function_pattern' syntax."),
     ERR_WRONG_LABEL_NAME(5082, new byte[] {'4', '2', '0', '0', '0'},

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -915,6 +915,15 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitCreateCatalogStatement(CreateCatalogStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
+                String catalogName = stmt.getCatalogName();
+                if (context.getGlobalStateMgr().getCatalogMgr().catalogExists(catalogName)) {
+                    if (stmt.isIfNotExists()) {
+                        LOG.info("create catalog[{}] which already exists", catalogName);
+                        return;
+                    } else {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_CATALOG_EXISTED_ERROR, catalogName);
+                    }
+                }
                 context.getGlobalStateMgr().getCatalogMgr().createCatalog(stmt);
             });
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
@@ -78,7 +78,7 @@ public class CreateCatalogStmt extends DdlStmt {
         sb.append("CREATE EXTERNAL CATALOG '");
         sb.append(catalogName).append("' ");
         if (ifNotExists) {
-            sb.append("IF NOT EXISTS \"");
+            sb.append("IF NOT EXISTS ");
         }
         if (comment != null) {
             sb.append("COMMENT \"").append(comment).append("\" ");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
@@ -27,15 +27,20 @@ public class CreateCatalogStmt extends DdlStmt {
     private final Map<String, String> properties;
     private String catalogType;
 
-    public CreateCatalogStmt(String catalogName, String comment, Map<String, String> properties) {
-        this(catalogName, comment, properties, NodePosition.ZERO);
+    private final boolean ifNotExists;
+
+
+    public CreateCatalogStmt(String catalogName, String comment, Map<String, String> properties, boolean ifNotExists) {
+        this(catalogName, comment, properties, NodePosition.ZERO, ifNotExists);
     }
 
-    public CreateCatalogStmt(String catalogName, String comment, Map<String, String> properties, NodePosition pos) {
+    public CreateCatalogStmt(String catalogName, String comment, Map<String, String> properties,
+                             NodePosition pos, boolean ifNotExists) {
         super(pos);
         this.catalogName = catalogName;
         this.comment = comment;
         this.properties = properties;
+        this.ifNotExists = ifNotExists;
     }
 
     public String getCatalogName() {
@@ -58,6 +63,10 @@ public class CreateCatalogStmt extends DdlStmt {
         this.catalogType = catalogType;
     }
 
+    public boolean isIfNotExists() {
+        return ifNotExists;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitCreateCatalogStatement(this, context);
@@ -68,6 +77,9 @@ public class CreateCatalogStmt extends DdlStmt {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE EXTERNAL CATALOG '");
         sb.append(catalogName).append("' ");
+        if (ifNotExists) {
+            sb.append("IF NOT EXISTS \"");
+        }
         if (comment != null) {
             sb.append("COMMENT \"").append(comment).append("\" ");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1870,6 +1870,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitCreateExternalCatalogStatement(
             StarRocksParser.CreateExternalCatalogStatementContext context) {
+        boolean ifNotExists = context.IF() != null;
         Identifier identifier = (Identifier) visit(context.identifierOrString());
         String catalogName = identifier.getValue();
         String comment = null;
@@ -1883,7 +1884,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 properties.put(property.getKey(), property.getValue());
             }
         }
-        return new CreateCatalogStmt(catalogName, comment, properties, createPos(context));
+
+        return new CreateCatalogStmt(catalogName, comment, properties, createPos(context), ifNotExists);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -707,7 +707,7 @@ showComputeNodesStatement
 // ------------------------------------------- Catalog Statement -------------------------------------------------------
 
 createExternalCatalogStatement
-    : CREATE EXTERNAL CATALOG catalogName=identifierOrString comment? properties
+    : CREATE EXTERNAL CATALOG catalogName=identifierOrString (IF NOT EXISTS)? comment? properties
     ;
 
 showCreateExternalCatalogStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -63,7 +63,7 @@ public class CatalogStmtTest {
         Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_5' PROPERTIES(\"type\"  =  \"hive\")", stmt2.toSql());
         String sql_7 = "CREATE EXTERNAL CATALOG catalog_6 IF NOT EXISTS PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt3 = AnalyzeTestUtil.analyzeSuccess(sql_7);
-        Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_6' IF NOT EXISTS \"PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
+        Assert.assertEquals(sql_7, stmt3.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -63,7 +63,7 @@ public class CatalogStmtTest {
         Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_5' PROPERTIES(\"type\"  =  \"hive\")", stmt2.toSql());
         String sql_7 = "CREATE EXTERNAL CATALOG catalog_6 IF NOT EXISTS PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt3 = AnalyzeTestUtil.analyzeSuccess(sql_7);
-        Assert.assertEquals(sql_7, stmt3.toSql());
+        Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_6' IF NOT EXISTS \"PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -64,6 +64,7 @@ public class CatalogStmtTest {
         String sql_7 = "CREATE EXTERNAL CATALOG catalog_6 IF NOT EXISTS PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt3 = AnalyzeTestUtil.analyzeSuccess(sql_7);
         Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_6' IF NOT EXISTS PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
+        Assert.assertTrue(stmt3 instanceof CreateCatalogStmt);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -64,7 +64,6 @@ public class CatalogStmtTest {
         String sql_7 = "CREATE EXTERNAL CATALOG catalog_6 IF NOT EXISTS PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt3 = AnalyzeTestUtil.analyzeSuccess(sql_7);
         Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_6' IF NOT EXISTS PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
-        Assert.assertTrue(stmt3 instanceof CreateCatalogStmt);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -61,6 +61,9 @@ public class CatalogStmtTest {
         String sql_6 = "CREATE EXTERNAL CATALOG catalog_5 properties(\"type\"=\"hive\")";
         StatementBase stmt2 = AnalyzeTestUtil.analyzeSuccess(sql_6);
         Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_5' PROPERTIES(\"type\"  =  \"hive\")", stmt2.toSql());
+        String sql_7 = "CREATE EXTERNAL CATALOG catalog_6 IF NOT EXISTS PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        StatementBase stmt3 = AnalyzeTestUtil.analyzeSuccess(sql_7);
+        Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_6' IF NOT EXISTS \"PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -63,7 +63,7 @@ public class CatalogStmtTest {
         Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_5' PROPERTIES(\"type\"  =  \"hive\")", stmt2.toSql());
         String sql_7 = "CREATE EXTERNAL CATALOG catalog_6 IF NOT EXISTS PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StatementBase stmt3 = AnalyzeTestUtil.analyzeSuccess(sql_7);
-        Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_6' IF NOT EXISTS \"PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
+        Assert.assertEquals("CREATE EXTERNAL CATALOG 'catalog_6' IF NOT EXISTS PROPERTIES(\"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\", \"type\"  =  \"hive\")", stmt3.toSql());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Currently,  Starrocks does't support the syntax, which  would simplify operations for users by allowing them to create external catalogs more easily and robustly.
## What I'm doing:
make StarRocks support the CREATE EXTERNAL CATALOG xx IF NOT EXISTS syntax
## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
