### PR TITLE
[Enhancement] Introduce dataVersion, versionEpoch and versionTxnType to partition

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -34,6 +34,9 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"VISIBLE_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"VISIBLE_VERSION_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"NEXT_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"DATA_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"VERSION_EPOCH", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"VERSION_TXN_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"PARTITION_KEY", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"PARTITION_VALUE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"DISTRIBUTION_KEY", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
@@ -51,9 +54,6 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"P50_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"MAX_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"STORAGE_PATH", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"DATA_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
-        {"VERSION_EPOCH", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
-        {"VERSION_TXN_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -165,40 +165,56 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
             break;
         }
         case 9: {
+            // DATA_VERSION
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.data_version);
+            break;
+        }
+        case 10: {
+            // VERSION_EPOCH
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.version_epoch);
+            break;
+        }
+        case 11: {
+            // VERSION_TXN_TYPE
+            Slice version_txn_type = Slice(to_string(info.version_txn_type));
+            fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&version_txn_type);
+            break;
+        }
+        case 12: {
             // PARTITION_KEY
             Slice partition_key = Slice(info.partition_key);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&partition_key);
             break;
         }
-        case 10: {
+        case 13: {
             // PARTITION_VALUE
             Slice partition_value = Slice(info.partition_value);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&partition_value);
             break;
         }
-        case 11: {
+        case 14: {
             // DISTRIBUTION_KEY
             Slice distribution_key = Slice(info.distribution_key);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&distribution_key);
             break;
         }
-        case 12: {
+        case 15: {
             // BUCKETS
             fill_column_with_slot<TYPE_INT>(column.get(), (void*)&info.buckets);
             break;
         }
-        case 13: {
+        case 16: {
             // REPLICATION_NUM
             fill_column_with_slot<TYPE_INT>(column.get(), (void*)&info.replication_num);
             break;
         }
-        case 14: {
+        case 17: {
             // STORAGE_MEDIUM
             Slice storage_medium = Slice(info.storage_medium);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&storage_medium);
             break;
         }
-        case 15: {
+        case 18: {
             // COOLDOWN_TIME
             if (info.cooldown_time > 0) {
                 DateTimeValue ts;
@@ -209,7 +225,7 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 16: {
+        case 19: {
             // LAST_CONSISTENCY_CHECK_TIME
             if (info.last_consistency_check_time > 0) {
                 DateTimeValue ts;
@@ -220,67 +236,51 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 17: {
+        case 20: {
             // IS_IN_MEMORY
             fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.is_in_memory);
             break;
         }
-        case 18: {
+        case 21: {
             // IS_TEMP
             fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.is_temp);
             break;
         }
-        case 19: {
+        case 22: {
             // DATA_SIZE
             Slice data_size = Slice(info.data_size);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&data_size);
             break;
         }
-        case 20: {
+        case 23: {
             // ROW_COUNT
             fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.row_count);
             break;
         }
-        case 21: {
+        case 24: {
             // ENABLE_DATACACHE
             fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.enable_datacache);
             break;
         }
-        case 22: {
+        case 25: {
             // AVG_CS
             fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&info.avg_cs);
             break;
         }
-        case 23: {
+        case 26: {
             // P50_CS
             fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&info.p50_cs);
             break;
         }
-        case 24: {
+        case 27: {
             // MAX_CS
             fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&info.max_cs);
             break;
         }
-        case 25: {
+        case 28: {
             // STORAGE_PATH
             Slice storage_path = Slice(info.storage_path);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&storage_path);
-            break;
-        }
-        case 26: {
-            // DATA_VERSION
-            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.data_version);
-            break;
-        }
-        case 27: {
-            // VERSION_EPOCH
-            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.version_epoch);
-            break;
-        }
-        case 28: {
-            // VERSION_TXN_TYPE
-            Slice version_txn_type = Slice(to_string(info.version_txn_type));
-            fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&version_txn_type);
             break;
         }
         default:

--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -106,7 +106,7 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
     const TPartitionMetaInfo& info = _partitions_meta_response.partitions_meta_infos[_partitions_meta_index];
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
     for (const auto& [slot_id, index] : slot_id_to_index_map) {
-        if (slot_id < 1 || slot_id > 25) {
+        if (slot_id < 1 || slot_id > 28) {
             return Status::InternalError(fmt::format("invalid slot id:{}", slot_id));
         }
         ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
@@ -262,6 +262,22 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
             // STORAGE_PATH
             Slice storage_path = Slice(info.storage_path);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&storage_path);
+            break;
+        }
+        case 26: {
+            // DATA_VERSION
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.data_version);
+            break;
+        }
+        case 27: {
+            // VERSION_EPOCH
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.version_epoch);
+            break;
+        }
+        case 28: {
+            // VERSION_TXN_TYPE
+            Slice version_txn_type = Slice(to_string(info.version_txn_type));
+            fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&version_txn_type);
             break;
         }
         default:

--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -51,6 +51,9 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"P50_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"MAX_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"STORAGE_PATH", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"DATA_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"VERSION_EPOCH", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"VERSION_TXN_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -106,7 +109,7 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
     const TPartitionMetaInfo& info = _partitions_meta_response.partitions_meta_infos[_partitions_meta_index];
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
     for (const auto& [slot_id, index] : slot_id_to_index_map) {
-        if (slot_id < 1 || slot_id > 28) {
+        if (slot_id < 1 || slot_id > _column_num) {
             return Status::InternalError(fmt::format("invalid slot id:{}", slot_id));
         }
         ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.transaction.TransactionType;
 
 import java.util.List;
 
@@ -55,6 +56,16 @@ public interface PhysicalPartition {
     public long getNextVersion();
     public void setNextVersion(long nextVersion);
     public long getCommittedVersion();
+    public long getDataVersion();
+    public void setDataVersion(long dataVersion);
+    public long getNextDataVersion();
+    public void setNextDataVersion(long nextDataVersion);
+    public long getCommittedDataVersion();
+    public long getVersionEpoch();
+    public void setVersionEpoch(long versionEpoch);
+    public long nextVersionEpoch();
+    public TransactionType getVersionTxnType();
+    public void setVersionTxnType(TransactionType versionTxnType);
     public long getVisibleTxnId();
 
     // materialized index interface

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartitionImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartitionImpl.java
@@ -22,9 +22,13 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.TransactionType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -33,7 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Physical Partition implementation
  */
-public class PhysicalPartitionImpl extends MetaObject implements PhysicalPartition {
+public class PhysicalPartitionImpl extends MetaObject implements PhysicalPartition, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(PhysicalPartitionImpl.class);
 
     public static final long PARTITION_INIT_VERSION = 1L;
@@ -85,6 +89,16 @@ public class PhysicalPartitionImpl extends MetaObject implements PhysicalPartiti
     private long visibleVersionTime;
     @SerializedName(value = "nextVersion")
     private long nextVersion;
+
+    @SerializedName(value = "dataVersion")
+    private long dataVersion;
+    @SerializedName(value = "nextDataVersion")
+    private long nextDataVersion;
+
+    @SerializedName(value = "versionEpoch")
+    private long versionEpoch;
+    @SerializedName(value = "versionTxnType")
+    private TransactionType versionTxnType;
     /**
      * ID of the transaction that has committed current visible version.
      * Just for tracing the txn log, no need to persist.
@@ -102,7 +116,11 @@ public class PhysicalPartitionImpl extends MetaObject implements PhysicalPartiti
         this.baseIndex = baseIndex;
         this.visibleVersion = PARTITION_INIT_VERSION;
         this.visibleVersionTime = System.currentTimeMillis();
-        this.nextVersion = PARTITION_INIT_VERSION + 1;
+        this.nextVersion = this.visibleVersion + 1;
+        this.dataVersion = this.visibleVersion;
+        this.nextDataVersion = this.nextVersion;
+        this.versionEpoch = this.nextVersionEpoch();
+        this.versionTxnType = TransactionType.TXN_NORMAL;
         this.shardGroupId = sharedGroupId;
     }
 
@@ -267,6 +285,54 @@ public class PhysicalPartitionImpl extends MetaObject implements PhysicalPartiti
     @Override
     public long getCommittedVersion() {
         return this.nextVersion - 1;
+    }
+
+    @Override
+    public long getDataVersion() {
+        return dataVersion;
+    }
+
+    @Override
+    public void setDataVersion(long dataVersion) {
+        this.dataVersion = dataVersion;
+    }
+
+    @Override
+    public long getNextDataVersion() {
+        return nextDataVersion;
+    }
+
+    @Override
+    public void setNextDataVersion(long nextDataVersion) {
+        this.nextDataVersion = nextDataVersion;
+    }
+
+    @Override
+    public long getCommittedDataVersion() {
+        return this.nextDataVersion - 1;
+    }
+
+    @Override
+    public long getVersionEpoch() {
+        return versionEpoch;
+    }
+
+    @Override
+    public void setVersionEpoch(long versionEpoch) {
+        this.versionEpoch = versionEpoch;
+    }
+
+    @Override
+    public long nextVersionEpoch() {
+        return GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid();
+    }
+
+    public TransactionType getVersionTxnType() {
+        return versionTxnType;
+    }
+
+    public void setVersionTxnType(TransactionType versionTxnType) {
+        this.versionTxnType = versionTxnType;
     }
 
     @Override
@@ -436,10 +502,32 @@ public class PhysicalPartitionImpl extends MetaObject implements PhysicalPartiti
         buffer.append("visibleVersionTime: ").append(visibleVersionTime).append("; ");
         buffer.append("committedVersion: ").append(getCommittedVersion()).append("; ");
 
+        buffer.append("dataVersion: ").append(dataVersion).append("; ");
+        buffer.append("committedDataVersion: ").append(getCommittedDataVersion()).append("; ");
+
+        buffer.append("versionEpoch: ").append(versionEpoch).append("; ");
+        buffer.append("versionTxnType: ").append(versionTxnType).append("; ");
+
         buffer.append("storageDataSize: ").append(storageDataSize()).append("; ");
         buffer.append("storageRowCount: ").append(storageRowCount()).append("; ");
         buffer.append("storageReplicaCount: ").append(storageReplicaCount()).append("; ");
 
         return buffer.toString();
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        if (dataVersion == 0) {
+            dataVersion = visibleVersion;
+        }
+        if (nextDataVersion == 0) {
+            nextDataVersion = nextVersion;
+        }
+        if (versionEpoch == 0) {
+            versionEpoch = nextVersionEpoch();
+        }
+        if (versionTxnType == null) {
+            versionTxnType = TransactionType.TXN_NORMAL;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -55,6 +55,9 @@ public class PartitionsMetaSystemTable {
                         .column("P50_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("MAX_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("DATA_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("VERSION_EPOCH", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("VERSION_TXN_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -37,6 +37,9 @@ public class PartitionsMetaSystemTable {
                         .column("VISIBLE_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("VISIBLE_VERSION_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("NEXT_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("DATA_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("VERSION_EPOCH", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("VERSION_TXN_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("PARTITION_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
                         // corresponding to `Range` or `List` in `SHOW PARTITIONS FROM XXX`
                         .column("PARTITION_VALUE", ScalarType.createVarchar(NAME_CHAR_LEN))
@@ -55,9 +58,6 @@ public class PartitionsMetaSystemTable {
                         .column("P50_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("MAX_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DATA_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VERSION_EPOCH", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VERSION_TXN_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -122,7 +122,10 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("AsyncWrite")
                     .add("AvgCS") // Average compaction score
                     .add("P50CS") // 50th percentile compaction score
-                    .add("MaxCS"); // Maximum compaction score
+                    .add("MaxCS") // Maximum compaction score
+                    .add("DataVersion")
+                    .add("VersionEpoch")
+                    .add("VersionTxnType");
             this.titleNames = builder.build();
         } else {
             ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
@@ -142,7 +145,10 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("LastConsistencyCheckTime")
                     .add("DataSize")
                     .add("IsInMemory")
-                    .add("RowCount");
+                    .add("RowCount")
+                    .add("DataVersion")
+                    .add("VersionEpoch")
+                    .add("VersionTxnType");
             this.titleNames = builder.build();
         }
     }
@@ -360,6 +366,10 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(tblPartitionInfo.getIsInMemory(partition.getId()));
         partitionInfo.add(physicalPartition.storageRowCount());
 
+        partitionInfo.add(physicalPartition.getDataVersion()); // DataVersion
+        partitionInfo.add(physicalPartition.getVersionEpoch()); // VersionEpoch
+        partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
+
         return partitionInfo;
     }
 
@@ -389,6 +399,11 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(String.format("%.2f", compactionScore != null ? compactionScore.getAvg() : 0.0)); // AvgCS
         partitionInfo.add(String.format("%.2f", compactionScore != null ? compactionScore.getP50() : 0.0)); // P50CS
         partitionInfo.add(String.format("%.2f", compactionScore != null ? compactionScore.getMax() : 0.0)); // MaxCS
+
+        partitionInfo.add(physicalPartition.getDataVersion()); // DataVersion
+        partitionInfo.add(physicalPartition.getVersionEpoch()); // VersionEpoch
+        partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
+
         return partitionInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
@@ -24,7 +24,7 @@ public class TxnInfoHelper {
         infoPB.txnId = state.getTransactionId();
         infoPB.combinedTxnLog = state.isUseCombinedTxnLog();
         infoPB.commitTime = state.getCommitTime() / 1000; // milliseconds to seconds
-        infoPB.txnType = state.getTxnTypePB();
+        infoPB.txnType = state.getTransactionType().toProto();
         // check whether needs to force publish
         if (state.getSourceType() == TransactionState.LoadJobSourceType.LAKE_COMPACTION &&
                 state.getTxnCommitAttachment() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -121,9 +121,9 @@ import com.starrocks.thrift.TTablet;
 import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTaskType;
-import com.starrocks.thrift.TTxnType;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupOp;
+import com.starrocks.transaction.TransactionType;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1276,7 +1276,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                         new PublishVersionTask(backendId, txnId, gtid.orElse((long) 0), dbId, commitTime,
                                 map.get(txnId).values().stream().collect(Collectors.toList()), null, null,
                                 createPublishVersionTaskTime, null,
-                                Config.enable_sync_publish, TTxnType.TXN_NORMAL);
+                                Config.enable_sync_publish, TransactionType.TXN_NORMAL);
                 batchTask.addTask(task);
                 // add to AgentTaskQueue for handling finish report.
                 AgentTaskQueue.addTask(task);
@@ -1739,7 +1739,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         AgentBatchTask batchTask = new AgentBatchTask();
         for (Long transactionId : transactionsToClear.keySet()) {
             ClearTransactionTask clearTransactionTask = new ClearTransactionTask(backendId,
-                    transactionId, transactionsToClear.get(transactionId), TTxnType.TXN_NORMAL);
+                    transactionId, transactionsToClear.get(transactionId), TransactionType.TXN_NORMAL);
             batchTask.addTask(clearTransactionTask);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationTxnCommitAttachment.java
@@ -33,17 +33,25 @@ public class ReplicationTxnCommitAttachment extends TxnCommitAttachment {
     @SerializedName("partitionVersions")
     private Map<Long, Long> partitionVersions; // The version of partitions
 
+    @SerializedName("partitionVersionEpochs")
+    private Map<Long, Long> partitionVersionEpochs; // The version epoch of partitions
+
     public ReplicationTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.REPLICATION);
     }
 
-    public ReplicationTxnCommitAttachment(Map<Long, Long> partitionVersions) {
+    public ReplicationTxnCommitAttachment(Map<Long, Long> partitionVersions, Map<Long, Long> partitionVersionEpochs) {
         super(TransactionState.LoadJobSourceType.REPLICATION);
         this.partitionVersions = partitionVersions;
+        this.partitionVersionEpochs = partitionVersionEpochs;
     }
 
     public Map<Long, Long> getPartitionVersions() {
         return partitionVersions;
+    }
+
+    public Map<Long, Long> getPartitionVersionEpochs() {
+        return partitionVersionEpochs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -374,6 +374,10 @@ public class InformationSchemaDataSource {
             partitionMetaInfo.setStorage_path(
                     table.getPartitionFilePathInfo(physicalPartition.getId()).getFullPath());
         }
+
+        partitionMetaInfo.setData_version(physicalPartition.getDataVersion());
+        partitionMetaInfo.setVersion_epoch(physicalPartition.getVersionEpoch());
+        partitionMetaInfo.setVersion_txn_type(physicalPartition.getVersionTxnType().toThrift());
     }
 
     // tables

--- a/fe/fe-core/src/main/java/com/starrocks/task/ClearTransactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ClearTransactionTask.java
@@ -19,7 +19,7 @@ package com.starrocks.task;
 
 import com.starrocks.thrift.TClearTransactionTaskRequest;
 import com.starrocks.thrift.TTaskType;
-import com.starrocks.thrift.TTxnType;
+import com.starrocks.transaction.TransactionType;
 
 import java.util.List;
 
@@ -27,9 +27,9 @@ public class ClearTransactionTask extends AgentTask {
 
     private long transactionId;
     private List<Long> partitionIds;
-    private TTxnType txnType;
+    private TransactionType txnType;
 
-    public ClearTransactionTask(long backendId, long transactionId, List<Long> partitionIds, TTxnType txnType) {
+    public ClearTransactionTask(long backendId, long transactionId, List<Long> partitionIds, TransactionType txnType) {
         super(null, backendId, TTaskType.CLEAR_TRANSACTION_TASK, -1L, -1L, -1L, -1L, -1L, transactionId);
         this.transactionId = transactionId;
         this.partitionIds = partitionIds;
@@ -40,7 +40,7 @@ public class ClearTransactionTask extends AgentTask {
     public TClearTransactionTaskRequest toThrift() {
         TClearTransactionTaskRequest clearTransactionTaskRequest = new TClearTransactionTaskRequest(
                 transactionId, partitionIds);
-        clearTransactionTaskRequest.setTxn_type(txnType);
+        clearTransactionTaskRequest.setTxn_type(txnType.toThrift());
         return clearTransactionTaskRequest;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -46,8 +46,8 @@ import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TPublishVersionRequest;
 import com.starrocks.thrift.TTabletVersionPair;
 import com.starrocks.thrift.TTaskType;
-import com.starrocks.thrift.TTxnType;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionType;
 import io.opentelemetry.api.trace.Span;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,13 +68,13 @@ public class PublishVersionTask extends AgentTask {
     private final TransactionState txnState;
     private Span span;
     private boolean enableSyncPublish;
-    private TTxnType txnType;
+    private TransactionType txnType;
     private final long globalTransactionId;
     private boolean isVersionOverwrite = false;
 
     public PublishVersionTask(long backendId, long transactionId, long globalTransactionId, long dbId, long commitTimestamp,
                               List<TPartitionVersionInfo> partitionVersionInfos, String traceParent, Span txnSpan,
-                              long createTime, TransactionState state, boolean enableSyncPublish, TTxnType txnType) {
+                              long createTime, TransactionState state, boolean enableSyncPublish, TransactionType txnType) {
         this(backendId, transactionId, globalTransactionId, dbId, commitTimestamp, partitionVersionInfos,
                 traceParent, txnSpan, createTime, state, enableSyncPublish, txnType, false);
     }
@@ -82,7 +82,7 @@ public class PublishVersionTask extends AgentTask {
     public PublishVersionTask(long backendId, long transactionId, long globalTransactionId, long dbId, long commitTimestamp,
                               List<TPartitionVersionInfo> partitionVersionInfos, String traceParent, Span txnSpan,
                               long createTime, TransactionState state, boolean enableSyncPublish,
-                              TTxnType txnType, boolean isVersionOverwrite) {
+                              TransactionType txnType, boolean isVersionOverwrite) {
         super(null, backendId, TTaskType.PUBLISH_VERSION, dbId, -1L, -1L, -1L, -1L, transactionId, createTime, traceParent);
         this.transactionId = transactionId;
         this.globalTransactionId = globalTransactionId;
@@ -109,7 +109,7 @@ public class PublishVersionTask extends AgentTask {
         publishVersionRequest.setCommit_timestamp(commitTimestamp);
         publishVersionRequest.setTxn_trace_parent(traceParent);
         publishVersionRequest.setEnable_sync_publish(enableSyncPublish);
-        publishVersionRequest.setTxn_type(txnType);
+        publishVersionRequest.setTxn_type(txnType.toThrift());
         publishVersionRequest.setGtid(globalTransactionId);
         if (isVersionOverwrite) {
             publishVersionRequest.setIs_version_overwrite(isVersionOverwrite);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1256,12 +1256,26 @@ public class DatabaseTransactionMgr {
                     continue;
                 }
                 if (transactionState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
-                    Map<Long, Long> partitionVersions = ((ReplicationTxnCommitAttachment) transactionState
-                            .getTxnCommitAttachment()).getPartitionVersions();
-                    partitionCommitInfo.setVersion(partitionVersions.get(partitionCommitInfo.getPartitionId()));
+                    ReplicationTxnCommitAttachment replicationTxnAttachment = (ReplicationTxnCommitAttachment) transactionState
+                            .getTxnCommitAttachment();
+                    Map<Long, Long> partitionVersions = replicationTxnAttachment.getPartitionVersions();
+                    long newVersion = partitionVersions.get(partitionCommitInfo.getPartitionId());
+                    long versionDiff = newVersion - partition.getVisibleVersion();
+                    partitionCommitInfo.setVersion(newVersion);
+                    partitionCommitInfo.setDataVersion(partition.getDataVersion() + versionDiff);
+                    Map<Long, Long> partitionVersionEpochs = replicationTxnAttachment.getPartitionVersionEpochs();
+                    if (partitionVersionEpochs != null) {
+                        long newVersionEpoch = partitionVersionEpochs.get(partitionCommitInfo.getPartitionId());
+                        partitionCommitInfo.setVersionEpoch(newVersionEpoch);
+                    }
                 } else if (transactionState.isVersionOverwrite()) {
                     partitionCommitInfo.setVersion(((InsertTxnCommitAttachment) transactionState
                             .getTxnCommitAttachment()).getPartitionVersion());
+                    // reset data version to visible version
+                    partitionCommitInfo.setDataVersion(partitionCommitInfo.getVersion());
+                    if (partition.getVersionTxnType() == TransactionType.TXN_REPLICATION) {
+                        partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
+                    }
                 } else {
                     Map<Long, Long> doubleWritePartitions = table.getDoubleWritePartitions();
                     if (doubleWritePartitions != null && !doubleWritePartitions.isEmpty()) {
@@ -1277,6 +1291,12 @@ public class DatabaseTransactionMgr {
                         }
                     } else {
                         partitionCommitInfo.setVersion(partition.getNextVersion());
+                    }
+                    // update data version
+                    partitionCommitInfo.setDataVersion(partition.getNextDataVersion());
+                    if (transactionState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION &&
+                            partition.getVersionTxnType() == TransactionType.TXN_REPLICATION) { 
+                        partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
                     }
                     LOG.debug("set partition {} version to {} in transaction {}",
                             partitionId, partitionCommitInfo.getVersion(), transactionState);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -31,7 +31,6 @@ import com.starrocks.lake.TxnInfoHelper;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.proto.TxnInfoPB;
-import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
@@ -173,7 +172,6 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
         boolean isFirstPartition = true;
         for (long partitionId : dirtyPartitionSet) {
             PartitionCommitInfo partitionCommitInfo;
-            long version = -1;
             if (isFirstPartition) {
                 List<ColumnId> validDictCacheColumnNames = Lists.newArrayList();
                 List<Long> validDictCacheColumnVersions = Lists.newArrayList();
@@ -183,25 +181,15 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
                     validDictCacheColumnVersions.add(dictVersion);
                 });
 
-                partitionCommitInfo = new PartitionCommitInfo(partitionId, version, 0,
+                partitionCommitInfo = new PartitionCommitInfo(partitionId, -1, 0,
                         Lists.newArrayList(invalidDictCacheColumns),
                         validDictCacheColumnNames,
                         validDictCacheColumnVersions);
             } else {
-                partitionCommitInfo = new PartitionCommitInfo(partitionId, version, 0);
+                partitionCommitInfo = new PartitionCommitInfo(partitionId, -1, 0);
             }
             tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
             isFirstPartition = false;
-        }
-
-        // The new versions in a replication transaction depend on the versions in ReplicationTxnCommitAttachment
-        if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
-            ReplicationTxnCommitAttachment attachment = (ReplicationTxnCommitAttachment) txnState
-                    .getTxnCommitAttachment();
-            Map<Long, Long> partitionVersions = attachment.getPartitionVersions();
-            for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
-                partitionCommitInfo.setVersion(partitionVersions.get(partitionCommitInfo.getPartitionId()));
-            }
         }
 
         txnState.putIdToTableCommitInfo(table.getId(), tableCommitInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -65,17 +65,22 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             }
             // The version of a replication transaction may not continuously
             if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
+                long versionDiff = partitionCommitInfo.getVersion() - partition.getNextVersion();
                 partition.setNextVersion(partitionCommitInfo.getVersion() + 1);
+                partition.setNextDataVersion(partition.getNextDataVersion() + versionDiff + 1);
             } else if (txnState.isVersionOverwrite()) {
                 // overwrite empty partition, it's next version will less than overwrite version
                 // otherwise, it's next version will not change
                 if (partitionCommitInfo.getVersion() + 1 > partition.getNextVersion()) {
                     partition.setNextVersion(partitionCommitInfo.getVersion() + 1);
+                    partition.setNextDataVersion(partition.getNextVersion());
                 }
             } else if (partitionCommitInfo.isDoubleWrite()) {
                 partition.setNextVersion(partitionCommitInfo.getVersion() + 1);
+                partition.setNextDataVersion(partition.getNextVersion());
             } else {
                 partition.setNextVersion(partition.getNextVersion() + 1);
+                partition.setNextDataVersion(partition.getNextDataVersion() + 1);
             }
             LOG.debug("partition[{}] next version[{}]", partitionId, partition.getNextVersion());
         }
@@ -166,14 +171,26 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                     }
                 } // end for tablets
             } // end for indices
+
             long versionTime = partitionCommitInfo.getVersionTime();
             if (txnState.isVersionOverwrite()) {
                 if (partition.getVisibleVersion() < version) {
                     partition.updateVisibleVersion(version, versionTime, txnState.getTransactionId());
+                    partition.setDataVersion(partitionCommitInfo.getDataVersion());
+                    if (partitionCommitInfo.getVersionEpoch() > 0) {
+                        partition.setVersionEpoch(partitionCommitInfo.getVersionEpoch());
+                    }
+                    partition.setVersionTxnType(txnState.getTransactionType());
                 }
             } else {
                 partition.updateVisibleVersion(version, versionTime, txnState.getTransactionId());
+                partition.setDataVersion(partitionCommitInfo.getDataVersion());
+                if (partitionCommitInfo.getVersionEpoch() > 0) {
+                    partition.setVersionEpoch(partitionCommitInfo.getVersionEpoch());
+                }
+                partition.setVersionTxnType(txnState.getTransactionType());
             }
+
             if (!partitionCommitInfo.getInvalidDictCacheColumns().isEmpty()) {
                 for (ColumnId column : partitionCommitInfo.getInvalidDictCacheColumns()) {
                     IDictManager.getInstance().removeGlobalDict(tableId, column);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -29,7 +29,6 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.task.AgentBatchTask;
@@ -256,7 +255,6 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         txnState.getErrorReplicas().addAll(errorReplicaIds);
         for (long partitionId : dirtyPartitionSet) {
             PartitionCommitInfo partitionCommitInfo;
-            long version = -1;
             if (isFirstPartition) {
 
                 List<ColumnId> validDictCacheColumnNames = Lists.newArrayList();
@@ -267,32 +265,18 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                     validDictCacheColumnVersions.add(dictVersion);
                 });
                 partitionCommitInfo = new PartitionCommitInfo(partitionId,
-                        version,
+                        -1,
                         System.currentTimeMillis(),
                         Lists.newArrayList(invalidDictCacheColumns),
                         validDictCacheColumnNames,
                         validDictCacheColumnVersions);
             } else {
                 partitionCommitInfo = new PartitionCommitInfo(partitionId,
-                        version,
+                        -1,
                         System.currentTimeMillis() /* use as partition visible time */);
             }
             tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
             isFirstPartition = false;
-        }
-
-        if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
-            ReplicationTxnCommitAttachment attachment = (ReplicationTxnCommitAttachment) txnState
-                    .getTxnCommitAttachment();
-            Map<Long, Long> partitionVersions = attachment.getPartitionVersions();
-            for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
-                partitionCommitInfo.setVersion(partitionVersions.get(partitionCommitInfo.getPartitionId()));
-            }
-        } else if (txnState.isVersionOverwrite()) {
-            for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
-                partitionCommitInfo.setVersion(((InsertTxnCommitAttachment) txnState
-                        .getTxnCommitAttachment()).getPartitionVersion());
-            }
         }
 
         txnState.putIdToTableCommitInfo(table.getId(), tableCommitInfo);
@@ -349,7 +333,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         synchronized (CLEAR_TRANSACTION_TASKS) {
             for (Long beId : allBeIds) {
                 ClearTransactionTask task = new ClearTransactionTask(beId, txnState.getTransactionId(),
-                        Lists.newArrayList(), txnState.getTxnType());
+                        Lists.newArrayList(), txnState.getTransactionType());
                 CLEAR_TRANSACTION_TASKS.add(task);
             }
             // try to group send tasks, not sending every time a txn is aborted. to avoid too many task rpc.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -64,6 +64,12 @@ public class PartitionCommitInfo implements Writable {
     @SerializedName(value = "versionTime")
     private long versionTime;
 
+    @SerializedName(value = "dataVersion")
+    private long dataVersion;
+
+    @SerializedName(value = "versionEpoch")
+    private long versionEpoch;
+
     // For low cardinality string column with global dict
     // TODO(KKS): move invalidDictCacheColumns and validDictCacheColumns to TableCommitInfo
     // Currently, for support FE rollback, we persist the invalidDictCacheColumns in PartitionCommitInfo by json,
@@ -135,6 +141,22 @@ public class PartitionCommitInfo implements Writable {
 
     public long getVersionTime() {
         return versionTime;
+    }
+
+    public long getDataVersion() {
+        return dataVersion;
+    }
+
+    public void setDataVersion(long dataVersion) {
+        this.dataVersion = dataVersion;
+    }
+
+    public long getVersionEpoch() {
+        return versionEpoch;
+    }
+
+    public void setVersionEpoch(long versionEpoch) {
+        this.versionEpoch = versionEpoch;
     }
 
     public void setIsDoubleWrite(boolean isDoubleWrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -50,7 +50,6 @@ import com.starrocks.common.TraceManager;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.proto.TxnTypePB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
@@ -59,7 +58,6 @@ import com.starrocks.task.PublishVersionTask;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TTabletLocation;
-import com.starrocks.thrift.TTxnType;
 import com.starrocks.thrift.TUniqueId;
 import io.opentelemetry.api.trace.Span;
 import org.apache.commons.lang3.StringUtils;
@@ -811,12 +809,9 @@ public class TransactionState implements Writable {
         return sourceType;
     }
 
-    public TTxnType getTxnType() {
-        return sourceType == LoadJobSourceType.REPLICATION ? TTxnType.TXN_REPLICATION : TTxnType.TXN_NORMAL;
-    }
-
-    public TxnTypePB getTxnTypePB() {
-        return sourceType == LoadJobSourceType.REPLICATION ? TxnTypePB.TXN_REPLICATION : TxnTypePB.TXN_NORMAL;
+    public TransactionType getTransactionType() {
+        return sourceType == LoadJobSourceType.REPLICATION ? TransactionType.TXN_REPLICATION
+                : TransactionType.TXN_NORMAL;
     }
 
     public Map<Long, PublishVersionTask> getPublishVersionTasks() {
@@ -897,7 +892,7 @@ public class TransactionState implements Writable {
                     createTime,
                     this,
                     Config.enable_sync_publish,
-                    this.getTxnType(),
+                    this.getTransactionType(),
                     isVersionOverwrite());
             this.addPublishVersionTask(backendId, task);
             tasks.add(task);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionType.java
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.transaction;
+
+import com.starrocks.proto.TxnTypePB;
+import com.starrocks.thrift.TTxnType;
+
+public enum TransactionType {
+    TXN_NORMAL(0),
+    TXN_REPLICATION(1);
+
+    private final int value;
+
+    TransactionType(int value) {
+        this.value = value;
+    }
+
+    public int value() {
+        return value;
+    }
+
+    public TTxnType toThrift() {
+        switch (value) {
+            case 0:
+                return TTxnType.TXN_NORMAL;
+
+            case 1:
+                return TTxnType.TXN_REPLICATION;
+
+            default:
+                throw new RuntimeException("Unknown transaction type value: " + value);
+        }
+    }
+
+    public TxnTypePB toProto() {
+        switch (value) {
+            case 0:
+                return TxnTypePB.TXN_NORMAL;
+
+            case 1:
+                return TxnTypePB.TXN_REPLICATION;
+
+            default:
+                throw new RuntimeException("Unknown transaction type value: " + value);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -42,6 +42,7 @@ import com.starrocks.persist.CreateTableInfo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
+import com.starrocks.transaction.GtidGenerator;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
@@ -95,6 +96,10 @@ public class DatabaseTest {
                 globalStateMgr.getNextId();
                 minTimes = 0;
                 result = 1L;
+
+                globalStateMgr.getGtidGenerator();
+                minTimes = 0;
+                result = new GtidGenerator();
             }
         };
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.TransactionType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,6 +68,13 @@ public class PhysicalPartitionImplTest {
         p.setNextVersion(6);
         Assert.assertEquals(6, p.getNextVersion());
         Assert.assertEquals(5, p.getCommittedVersion());
+
+        p.setDataVersion(5);
+        Assert.assertEquals(5, p.getDataVersion());
+
+        p.setNextDataVersion(6);
+        Assert.assertEquals(6, p.getNextDataVersion());
+        Assert.assertEquals(5, p.getCommittedDataVersion());
 
         p.createRollupIndex(new MaterializedIndex(1));
         p.createRollupIndex(new MaterializedIndex(2, IndexState.SHADOW));
@@ -122,6 +130,16 @@ public class PhysicalPartitionImplTest {
         Assert.assertEquals(1, p.getMinRetainVersion());
         p.setLastVacuumTime(1);
         Assert.assertEquals(1, p.getLastVacuumTime());
+
+        p.setDataVersion(0);
+        p.setNextDataVersion(0);
+        p.setVersionEpoch(0);
+        p.setVersionTxnType(null);
+        p.gsonPostProcess();
+        Assert.assertEquals(p.getDataVersion(), p.getVisibleVersion());
+        Assert.assertEquals(p.getNextDataVersion(), p.getNextVersion());
+        Assert.assertTrue(p.getVersionEpoch() > 0);
+        Assert.assertEquals(p.getVersionTxnType(), TransactionType.TXN_NORMAL);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -52,6 +52,7 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
+import com.starrocks.transaction.GtidGenerator;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.commons.lang3.tuple.Triple;
@@ -125,6 +126,10 @@ public class TabletSchedulerTest {
                 globalStateMgr.getLockManager();
                 minTimes = 0;
                 result = lockManager;
+
+                globalStateMgr.getGtidGenerator();
+                minTimes = 0;
+                result = new GtidGenerator();
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -52,6 +52,7 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.transaction.GtidGenerator;
 import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.Warehouse;
 import mockit.Expectations;
@@ -137,6 +138,10 @@ public class StarMgrMetaSyncerTest {
                 globalStateMgr.getLockManager();
                 minTimes = 0;
                 result = new LockManager();
+
+                globalStateMgr.getGtidGenerator();
+                minTimes = 0;
+                result = new GtidGenerator();
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -99,6 +99,10 @@ public class ReplicationJobTest {
     public void setUp() throws Exception {
         partition.updateVersionForRestore(10);
         srcPartition.updateVersionForRestore(100);
+        partition.setDataVersion(8);
+        partition.setNextDataVersion(9);
+        srcPartition.setDataVersion(98);
+        srcPartition.setNextDataVersion(99);
 
         job = new ReplicationJob(null, "test_token", db.getId(), table, srcTable,
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
@@ -159,6 +163,7 @@ public class ReplicationJobTest {
         Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
 
         Assert.assertEquals(partition.getCommittedVersion(), srcPartition.getVisibleVersion());
+        Assert.assertEquals(partition.getCommittedDataVersion(), srcPartition.getDataVersion());
     }
 
     @Test
@@ -316,6 +321,7 @@ public class ReplicationJobTest {
         Partition srcPartition = srcTable.getPartitions().iterator().next();
         partitionInfo.partition_id = partition.getId();
         partitionInfo.src_version = srcPartition.getVisibleVersion();
+        partitionInfo.src_version_epoch = srcPartition.getVersionEpoch();
         request.partition_replication_infos.put(partitionInfo.partition_id, partitionInfo);
 
         partitionInfo.index_replication_infos = new HashMap<Long, TIndexReplicationInfo>();

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -101,6 +101,10 @@ public class ReplicationMgrTest {
     public void setUp() throws Exception {
         partition.updateVersionForRestore(10);
         srcPartition.updateVersionForRestore(100);
+        partition.setDataVersion(8);
+        partition.setNextDataVersion(9);
+        srcPartition.setDataVersion(98);
+        srcPartition.setNextDataVersion(99);
 
         job = new ReplicationJob(null, "test_token", db.getId(), table, srcTable,
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
@@ -157,6 +161,7 @@ public class ReplicationMgrTest {
         Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
 
         Assert.assertEquals(partition.getCommittedVersion(), srcPartition.getVisibleVersion());
+        Assert.assertEquals(partition.getCommittedDataVersion(), srcPartition.getDataVersion());
 
         replicationMgr.replayReplicationJob(job);
     }
@@ -322,6 +327,7 @@ public class ReplicationMgrTest {
         Partition srcPartition = srcTable.getPartitions().iterator().next();
         partitionInfo.partition_id = partition.getId();
         partitionInfo.src_version = srcPartition.getVisibleVersion();
+        partitionInfo.src_version_epoch = srcPartition.getVersionEpoch();
         request.partition_replication_infos.put(partitionInfo.partition_id, partitionInfo);
 
         partitionInfo.index_replication_infos = new HashMap<Long, TIndexReplicationInfo>();

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionTypeTest.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.starrocks.proto.TxnTypePB;
+import com.starrocks.thrift.TTxnType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TransactionTypeTest {
+    @Test
+    public void testTransactionType() {
+        Assert.assertEquals(0, TransactionType.TXN_NORMAL.value());
+        Assert.assertEquals(1, TransactionType.TXN_REPLICATION.value());
+
+        Assert.assertEquals(TTxnType.TXN_NORMAL, TransactionType.TXN_NORMAL.toThrift());
+        Assert.assertEquals(TTxnType.TXN_REPLICATION, TransactionType.TXN_REPLICATION.toThrift());
+
+        Assert.assertEquals(TxnTypePB.TXN_NORMAL, TransactionType.TXN_NORMAL.toProto());
+        Assert.assertEquals(TxnTypePB.TXN_REPLICATION, TransactionType.TXN_REPLICATION.toProto());
+    }
+}

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -72,11 +72,6 @@ enum TTabletType {
     TABLET_TYPE_LAKE = 2
 }
 
-enum TTxnType {
-    TXN_NORMAL = 0,
-    TXN_REPLICATION = 1
-}
-
 struct TBinlogConfig {
     // Version of the configuration, and FE should deliver it to
     // the BE when executing 'ALTER TABLE'. The configuration with
@@ -352,7 +347,7 @@ struct TPublishVersionRequest {
     4: optional i64 commit_timestamp
     5: optional string txn_trace_parent
     6: optional bool enable_sync_publish = false
-    7: optional TTxnType txn_type = TTxnType.TXN_NORMAL
+    7: optional Types.TTxnType txn_type = Types.TTxnType.TXN_NORMAL
     8: optional i64 gtid
     9: optional bool is_version_overwrite = false
 }
@@ -365,7 +360,7 @@ struct TClearAlterTaskRequest {
 struct TClearTransactionTaskRequest {
     1: required Types.TTransactionId transaction_id
     2: required list<Types.TPartitionId> partition_id
-    3: optional TTxnType txn_type = TTxnType.TXN_NORMAL
+    3: optional Types.TTxnType txn_type = Types.TTxnType.TXN_NORMAL
 }
 
 struct TRecoverTabletReq {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1449,6 +1449,9 @@ struct TPartitionMetaInfo {
     23: optional double p50_cs
     24: optional double max_cs
     25: optional string storage_path
+    26: optional i64 data_version
+    27: optional i64 version_epoch
+    28: optional Types.TTxnType version_txn_type = Types.TTxnType.TXN_NORMAL
 }
 
 struct TGetTablesInfoRequest {
@@ -1741,6 +1744,7 @@ struct TPartitionReplicationInfo {
     1: optional i64 partition_id
     2: optional i64 src_version
     3: optional map<i64, TIndexReplicationInfo> index_replication_infos
+    4: optional i64 src_version_epoch
 }
 
 struct TTableReplicationRequest {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -581,3 +581,8 @@ struct TSnapshotInfo {
     2: optional string snapshot_path
     3: optional bool incremental_snapshot
 }
+
+enum TTxnType {
+    TXN_NORMAL = 0,
+    TXN_REPLICATION = 1
+}

--- a/test/sql/test_information_schema/R/test_partitions_meta
+++ b/test/sql/test_information_schema/R/test_partitions_meta
@@ -14,9 +14,9 @@ PROPERTIES (
 );
 -- result:
 -- !result
-select TABLE_NAME, PARTITION_NAME from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by partition_name;
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by partition_name;
 -- result:
-partitions_meta_test	p1
-partitions_meta_test	p2
-partitions_meta_test	p3
+partitions_meta_test	p1	1	TXN_NORMAL
+partitions_meta_test	p2	1	TXN_NORMAL
+partitions_meta_test	p3	1	TXN_NORMAL
 -- !result

--- a/test/sql/test_information_schema/T/test_partitions_meta
+++ b/test/sql/test_information_schema/T/test_partitions_meta
@@ -12,4 +12,4 @@ DISTRIBUTED BY HASH(`k`) BUCKETS 2
 PROPERTIES (
 "replication_num" = "1"
 );
-select TABLE_NAME, PARTITION_NAME from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by partition_name;
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by partition_name;


### PR DESCRIPTION
## Why I'm doing:
1. Help cross-cluster replication achieve eventual consistency in failover.
2. Help cross-cluster replication support do not disable compaction when replicating to a shared-data cluster.

## What I'm doing:
Introduce dataVersion, versionSeq and versionTxnType to partition:
* **dataVersion**: dataVersion equals visibleVersion in shared-nothing mode currently, in shared-data mode, compaction and schema change increase visibleVersion but not dataVersion.
* **versionEpoch**: versionEpoch  uses to check consistency of partitions in source and target cluster. 
* **versionTxnType**: the type of the transaction to generate the version

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
