### PR TITLE
[Enhancement] support inline properties for CreateFunction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5183,6 +5183,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 properties.put(property.getKey(), property.getValue());
             }
         }
+        if (context.inlineProperties() != null) {
+            properties = new HashMap<>();
+            List<Property> propertyList = visit(context.inlineProperties().inlineProperty(), Property.class);
+            for (Property property : propertyList) {
+                properties.put(property.getKey(), property.getValue());
+            }
+        }
         String inlineContent = null;
         if (context.inlineFunction() != null) {
             String content = context.inlineFunction().ATTACHMENT().getText();
@@ -7130,6 +7137,14 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitProperty(StarRocksParser.PropertyContext context) {
         return new Property(
                 ((StringLiteral) visit(context.key)).getStringValue(),
+                ((StringLiteral) visit(context.value)).getStringValue(),
+                createPos(context));
+    }
+
+    @Override
+    public ParseNode visitInlineProperty(StarRocksParser.InlinePropertyContext context) {
+        return new Property(
+                ((Identifier) visit(context.key)).getValue(),
                 ((StringLiteral) visit(context.value)).getStringValue(),
                 createPos(context));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1253,7 +1253,7 @@ dropFunctionStatement
     ;
 
 createFunctionStatement
-    : CREATE orReplace GLOBAL? functionType=(TABLE | AGGREGATE)? FUNCTION qualifiedName '(' typeList ')' RETURNS returnType=type properties? inlineFunction?
+    : CREATE orReplace GLOBAL? functionType=(TABLE | AGGREGATE)? FUNCTION qualifiedName '(' typeList ')' RETURNS returnType=type (properties|inlineProperties)?? inlineFunction?
     ;
 inlineFunction
     : AS ATTACHMENT
@@ -2454,6 +2454,14 @@ userPropertyList
 
 property
     : key=string '=' value=string
+    ;
+
+inlineProperties
+    : inlineProperty ( inlineProperty)*
+    ;
+
+inlineProperty
+    : key=identifier '=' value=string
     ;
 
 varType

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
@@ -66,6 +66,33 @@ public class CreateFunctionStmtTest {
     }
 
     @Test
+    public void testInlinePropertiesUDF() throws Exception {
+        String createFunctionSql = "CREATE FUNCTION get_typeb(INT) RETURNS \n" +
+                "STRING\n" +
+                " type = 'Python'\n" +
+                " symbol = 'echo'\n" +
+                "AS  \n" +
+                "$$ \n" +
+                "def echo(x):\n" +
+                "    return str(type(x))  \n" +
+                "$$;";
+        CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                createFunctionSql, 32).get(0);
+        Assert.assertEquals("Python", stmt.getProperties().get("type"));
+        Assert.assertEquals("echo", stmt.getProperties().get("symbol"));
+
+        createFunctionSql = "CREATE FUNCTION get_type(INT) RETURNS\n" +
+                "STRING\n" +
+                " type = 'Python'\n" +
+                " symbol = 'echo'\n" +
+                " file = 'http://localhost:8000/echo.py.zip';";
+        stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                createFunctionSql, 32).get(0);
+        Assert.assertEquals(stmt.getProperties().get("file"), "http://localhost:8000/echo.py.zip");
+
+    }
+
+    @Test
     public void testCreateUDFWithContent() {
         String createFunctionSql = "CREATE FUNCTION echo(int) \n"
                 + "RETURNS int \n"


### PR DESCRIPTION
support such grammar for create function:

```
CREATE FUNCTION get_type(INT) RETURNS
STRING
type = 'Python'
symbol = 'echo'
AS
$$
def echo(x):
    return str(type(x))
$$
;
```

no-inline function
```
CREATE FUNCTION get_type(INT) RETURNS 
STRING
type = 'Python'
symbol = 'echo'
file = 'http://localhost:8000/echo.py'
;

```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
