### PR TITLE
[UT] fix UT compile failure because of code merge conflict

### DIFF
--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -977,7 +977,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_with_clear_txnlog) {
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
-        auto txn_log_st = delta_writer->finish();
+        auto txn_log_st = delta_writer->finish_with_txnlog();
         ASSERT_OK(txn_log_st);
         _tablet_mgr->prune_metacache();
         std::const_pointer_cast<TxnLogPB>(txn_log_st.value())->Clear();


### PR DESCRIPTION
## Why I'm doing:
Fix UT compile failure:
```
[ 84%] Building CXX object test/CMakeFiles/starrocks_test_objs.dir/storage/rowset/column_reader_writer_test.cpp.o
  /root/starrocks/be/test/storage/lake/primary_key_publish_test.cpp: In member function 'virtual void starrocks::lake::LakePrimaryKeyPublishTest_test_write_with_clear_txnlog_Test::TestBody()':
  /root/starrocks/be/test/storage/lake/primary_key_publish_test.cpp:983:54: error: 'class starrocks::Status' has no member named 'value'
    983 |         std::const_pointer_cast<TxnLogPB>(txn_log_st.value())->Clear();
        |                                                      ^~~~~
  make[2]: *** [test/CMakeFiles/starrocks_test_objs.dir/storage/lake/primary_key_publish_test.cpp.o] Error 1
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
