### PR TITLE
[Enhancement] Support table level cache for delta lake

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/DatabaseTableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/DatabaseTableName.java
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 
-package com.starrocks.connector.hive;
+package com.starrocks.connector;
 
 import java.util.Objects;
 
-public class HiveTableName {
+public class DatabaseTableName {
     private final String databaseName;
     private final String tableName;
 
-    public HiveTableName(String databaseName, String tableName) {
+    public DatabaseTableName(String databaseName, String tableName) {
         this.databaseName = databaseName;
         this.tableName = tableName;
     }
 
-    public static HiveTableName of(String databaseName, String tableName) {
-        return new HiveTableName(databaseName, tableName);
+    public static DatabaseTableName of(String databaseName, String tableName) {
+        return new DatabaseTableName(databaseName, tableName);
     }
 
     public String getDatabaseName() {
@@ -52,7 +52,7 @@ public class HiveTableName {
             return false;
         }
 
-        HiveTableName other = (HiveTableName) o;
+        DatabaseTableName other = (DatabaseTableName) o;
         return Objects.equals(databaseName.toLowerCase(), other.databaseName.toLowerCase()) &&
                 Objects.equals(tableName.toLowerCase(), other.tableName.toLowerCase());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/CachingDeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/CachingDeltaLakeMetastore.java
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.DatabaseTableName;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.metastore.CachingMetastore;
+import com.starrocks.connector.metastore.IMetastore;
+import com.starrocks.connector.metastore.MetastoreTable;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+
+public class CachingDeltaLakeMetastore extends CachingMetastore implements IMetastore {
+    public final IMetastore delegate;
+
+    public CachingDeltaLakeMetastore(IMetastore metastore, Executor executor, long expireAfterWriteSec,
+                                     long refreshIntervalSec, long maxSize) {
+        super(executor, expireAfterWriteSec, refreshIntervalSec, maxSize);
+        this.delegate = metastore;
+    }
+
+    public static CachingDeltaLakeMetastore createQueryLevelInstance(IMetastore metastore, long perQueryCacheMaxSize) {
+        return new CachingDeltaLakeMetastore(
+                metastore,
+                newDirectExecutorService(),
+                NEVER_EVICT,
+                NEVER_REFRESH,
+                perQueryCacheMaxSize);
+    }
+
+    public static CachingDeltaLakeMetastore createCatalogLevelInstance(IMetastore metastore, Executor executor,
+                                                                  long expireAfterWrite, long refreshInterval,
+                                                                  long maxSize) {
+        return new CachingDeltaLakeMetastore(metastore, executor, expireAfterWrite, refreshInterval, maxSize);
+    }
+
+    @Override
+    public List<String> getAllDatabaseNames() {
+        return get(databaseNamesCache, "");
+    }
+
+    @Override
+    public List<String> loadAllDatabaseNames() {
+        return delegate.getAllDatabaseNames();
+    }
+
+    @Override
+    public List<String> getAllTableNames(String dbName) {
+        return get(tableNamesCache, dbName);
+    }
+
+    @Override
+    public List<String> loadAllTableNames(String dbName) {
+        return delegate.getAllTableNames(dbName);
+    }
+
+    @Override
+    public Database getDb(String dbName) {
+        return get(databaseCache, dbName);
+    }
+
+    @Override
+    public Database loadDb(String dbName) {
+        return delegate.getDb(dbName);
+    }
+
+    @Override
+    public Table loadTable(DatabaseTableName databaseTableName) {
+        return delegate.getTable(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
+    }
+
+    @Override
+    public MetastoreTable getMetastoreTable(String dbName, String tableName) {
+        return get(metastoreTableCache, DatabaseTableName.of(dbName, tableName));
+    }
+
+    @Override
+    public MetastoreTable loadMetastoreTable(DatabaseTableName databaseTableNam) {
+        return delegate.getMetastoreTable(databaseTableNam.getDatabaseName(), databaseTableNam.getTableName());
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        return get(tableCache, DatabaseTableName.of(dbName, tableName));
+    }
+
+    @Override
+    public List<String> getPartitionKeys(String dbName, String tableName) {
+        // todo(Youngwb): cache partition keys
+        return delegate.getPartitionKeys(dbName, tableName);
+    }
+
+    @Override
+    public boolean tableExists(String dbName, String tableName) {
+        return delegate.tableExists(dbName, tableName);
+    }
+
+    public void refreshTable(String dbName, String tblName, boolean onlyCachedPartitions) {
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tblName);
+        tableNameLockMap.putIfAbsent(databaseTableName, dbName + "_" + tblName + "_lock");
+        synchronized (tableNameLockMap.get(databaseTableName)) {
+            MetastoreTable newMetastoreTable;
+            Table newDeltaLakeTable;
+            try {
+                newMetastoreTable = loadMetastoreTable(databaseTableName);
+                newDeltaLakeTable = loadTable(databaseTableName);
+            } catch (StarRocksConnectorException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof InvocationTargetException &&
+                        ((InvocationTargetException) cause).getTargetException() instanceof NoSuchObjectException) {
+                    invalidateTable(dbName, tblName);
+                    throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.");
+                } else {
+                    throw e;
+                }
+            }
+
+            metastoreTableCache.put(databaseTableName, newMetastoreTable);
+            tableCache.put(databaseTableName, newDeltaLakeTable);
+        }
+    }
+
+    public synchronized void invalidateTable(String dbName, String tableName) {
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
+        metastoreTableCache.invalidate(databaseTableName);
+        tableCache.invalidate(databaseTableName);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessor.java
@@ -13,16 +13,19 @@
 // limitations under the License.
 
 
-package com.starrocks.connector.odps;
+package com.starrocks.connector.delta;
 
-import com.starrocks.connector.DatabaseTableName;
+import com.starrocks.catalog.Table;
 
-public class OdpsTableName extends DatabaseTableName {
-    public OdpsTableName(String databaseName, String tableName) {
-        super(databaseName, tableName);
+public class DeltaLakeCacheUpdateProcessor {
+    private final String catalogName;
+    private final CachingDeltaLakeMetastore cachingMetastore;
+    public DeltaLakeCacheUpdateProcessor(String catalogName, CachingDeltaLakeMetastore cachingMetastore) {
+        this.catalogName = catalogName;
+        this.cachingMetastore = cachingMetastore;
     }
 
-    public static OdpsTableName of(String databaseName, String tableName) {
-        return new OdpsTableName(databaseName, tableName);
+    public void refreshTable(String dbName, Table table, boolean onlyCachedPartitions) {
+        cachingMetastore.refreshTable(dbName, table.getName(), onlyCachedPartitions);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
@@ -16,9 +16,11 @@ package com.starrocks.connector.delta;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.common.util.Util;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.ReentrantExecutor;
 import com.starrocks.connector.hive.CachingHiveMetastoreConf;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
@@ -28,7 +30,9 @@ import com.starrocks.sql.analyzer.SemanticException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
@@ -72,10 +76,22 @@ public class DeltaLakeInternalMgr {
     }
 
     public IMetastore createHMSBackedDeltaLakeMetastore() {
-        // TODO(stephen): Abstract the creator class to construct hive meta client
         HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment, properties);
         IHiveMetastore hiveMetastore = new HiveMetastore(metaClient, catalogName, metastoreType);
-        return new HMSBackedDeltaMetastore(catalogName, hiveMetastore, hdfsEnvironment.getConfiguration());
+        HMSBackedDeltaMetastore hmsBackedDeltaMetastore = new HMSBackedDeltaMetastore(catalogName, hiveMetastore,
+                hdfsEnvironment.getConfiguration());
+        IMetastore deltaLakeMetastore;
+        if (!enableMetastoreCache) {
+            deltaLakeMetastore = hmsBackedDeltaMetastore;
+        } else {
+            refreshHiveMetastoreExecutor = Executors.newCachedThreadPool(
+                    new ThreadFactoryBuilder().setNameFormat("deltalake-metastore-refresh-%d").build());
+            Executor executor = new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum());
+            deltaLakeMetastore = CachingDeltaLakeMetastore.createCatalogLevelInstance(hmsBackedDeltaMetastore, executor,
+                    hmsConf.getCacheTtlSec(), hmsConf.getCacheRefreshIntervalSec(), hmsConf.getCacheMaxNum());
+        }
+
+        return deltaLakeMetastore;
     }
 
     public void shutdown() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -17,14 +17,14 @@ package com.starrocks.connector.delta;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.hive.CachingHiveMetastoreConf;
-import com.starrocks.connector.hive.IHiveMetastore;
 import com.starrocks.connector.metastore.IMetastore;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 
 import java.util.Map;
+import java.util.Optional;
 
+import static com.starrocks.connector.delta.CachingDeltaLakeMetastore.createQueryLevelInstance;
 import static com.starrocks.connector.delta.DeltaLakeConnector.HIVE_METASTORE_URIS;
-import static com.starrocks.connector.hive.CachingHiveMetastore.createQueryLevelInstance;
 
 public class DeltaLakeMetadataFactory {
     private final String catalogName;
@@ -47,16 +47,28 @@ public class DeltaLakeMetadataFactory {
         this.metastoreType = metastoreType;
     }
 
-    protected IMetastore createQueryLevelCacheMetastore() {
-        return createQueryLevelInstance((IHiveMetastore) metastore, perQueryMetastoreMaxNum);
+    protected CachingDeltaLakeMetastore createQueryLevelCacheMetastore() {
+        return createQueryLevelInstance(metastore, perQueryMetastoreMaxNum);
     }
 
     public DeltaLakeMetadata create() {
-        // todo(ywb） support query level cache later
-        IMetastore queryLevelCacheMetastore = metastore;
+        CachingDeltaLakeMetastore queryLevelCacheMetastore = createQueryLevelCacheMetastore();
         DeltaMetastoreOperations metastoreOperations = new DeltaMetastoreOperations(queryLevelCacheMetastore,
-                false, metastoreType);
+                metastore instanceof CachingDeltaLakeMetastore, metastoreType);
 
-        return new DeltaLakeMetadata(hdfsEnvironment, catalogName, metastoreOperations);
+        Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
+        return new DeltaLakeMetadata(hdfsEnvironment, catalogName, metastoreOperations, cacheUpdateProcessor);
+    }
+
+    public synchronized Optional<DeltaLakeCacheUpdateProcessor> getCacheUpdateProcessor() {
+        Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor;
+        if (metastore instanceof CachingDeltaLakeMetastore) {
+            cacheUpdateProcessor = Optional.of(new DeltaLakeCacheUpdateProcessor(catalogName,
+                    (CachingDeltaLakeMetastore) metastore));
+        } else {
+            cacheUpdateProcessor = Optional.empty();
+        }
+
+        return cacheUpdateProcessor;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaMetastoreOperations.java
@@ -17,16 +17,16 @@ package com.starrocks.connector.delta;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.MetastoreType;
-import com.starrocks.connector.metastore.IMetastore;
 
 import java.util.List;
 
 public class DeltaMetastoreOperations {
-    private final IMetastore metastore;
+    private final CachingDeltaLakeMetastore metastore;
     private final boolean enableCatalogLevelCache;
     private final MetastoreType metastoreType;
 
-    public DeltaMetastoreOperations(IMetastore metastore, boolean enableCatalogLevelCache, MetastoreType metastoreType) {
+    public DeltaMetastoreOperations(CachingDeltaLakeMetastore metastore, boolean enableCatalogLevelCache,
+                                    MetastoreType metastoreType) {
         this.metastore = metastore;
         this.enableCatalogLevelCache = enableCatalogLevelCache;
         this.metastoreType = metastoreType;
@@ -58,5 +58,9 @@ public class DeltaMetastoreOperations {
 
     public MetastoreType getMetastoreType() {
         return metastoreType;
+    }
+
+    public void invalidateAll() {
+        this.metastore.invalidateAll();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.HiveView;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -134,7 +135,7 @@ public class CacheUpdateProcessor {
         }
     }
 
-    public Set<HiveTableName> getCachedTableNames() {
+    public Set<DatabaseTableName> getCachedTableNames() {
         if (metastore instanceof CachingHiveMetastore) {
             return ((CachingHiveMetastore) metastore).getCachedTableNames();
         } else {
@@ -302,7 +303,7 @@ public class CacheUpdateProcessor {
         }
     }
 
-    public boolean isTablePresent(HiveTableName tableName) {
+    public boolean isTablePresent(DatabaseTableName tableName) {
         return ((CachingHiveMetastore) metastore).isTablePresent(tableName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -15,7 +15,6 @@
 package com.starrocks.connector.hive;
 
 import com.google.common.base.Preconditions;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
@@ -29,9 +28,11 @@ import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
+import com.starrocks.connector.metastore.CachingMetastore;
 import com.starrocks.connector.metastore.MetastoreTable;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
@@ -58,34 +59,21 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.cache.CacheLoader.asyncReloading;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class CachingHiveMetastore implements IHiveMetastore {
+public class CachingHiveMetastore extends CachingMetastore implements IHiveMetastore {
     private static final Logger LOG = LogManager.getLogger(CachingHiveMetastore.class);
-
-    public static final long NEVER_CACHE = 0;
-    public static final long NEVER_EVICT = -1;
-    public static final long NEVER_REFRESH = -1;
 
     private final boolean enableListNameCache;
     protected final IHiveMetastore metastore;
 
-    private final Map<HiveTableName, Long> lastAccessTimeMap;
-    // Used to synchronize the refreshTable process
-    protected final Map<HiveTableName, String> tableNameLockMap;
-
-    protected LoadingCache<String, List<String>> databaseNamesCache;
-    protected LoadingCache<String, List<String>> tableNamesCache;
+    private final Map<DatabaseTableName, Long> lastAccessTimeMap;
 
     // eg: HivePartitionValue -> List("year=2022/month=10", "year=2022/month=11")
     protected LoadingCache<HivePartitionValue, List<String>> partitionKeysCache;
 
-    protected LoadingCache<String, Database> databaseCache;
-    protected LoadingCache<HiveTableName, Table> tableCache;
-
     // eg: "year=2022/month=10" -> Partition
     protected LoadingCache<HivePartitionName, Partition> partitionCache;
-    protected LoadingCache<HiveTableName, HivePartitionStats> tableStatsCache;
+    protected LoadingCache<DatabaseTableName, HivePartitionStats> tableStatsCache;
     protected LoadingCache<HivePartitionName, HivePartitionStats> partitionStatsCache;
 
     public static CachingHiveMetastore createQueryLevelInstance(IHiveMetastore metastore, long perQueryCacheMaxSize) {
@@ -106,10 +94,10 @@ public class CachingHiveMetastore implements IHiveMetastore {
 
     protected CachingHiveMetastore(IHiveMetastore metastore, Executor executor, long expireAfterWriteSec,
                                    long refreshIntervalSec, long maxSize, boolean enableListNamesCache) {
+        super(executor, expireAfterWriteSec, refreshIntervalSec, maxSize);
         this.metastore = metastore;
         this.enableListNameCache = enableListNamesCache;
         this.lastAccessTimeMap = Maps.newConcurrentMap();
-        this.tableNameLockMap = Maps.newConcurrentMap();
 
         databaseNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
                 .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
@@ -163,25 +151,11 @@ public class CachingHiveMetastore implements IHiveMetastore {
                 }, executor));
     }
 
-    private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {
-        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
-        if (expiresAfterWriteSec >= 0) {
-            cacheBuilder.expireAfterWrite(expiresAfterWriteSec, SECONDS);
-        }
-
-        if (refreshSec > 0 && expiresAfterWriteSec > refreshSec) {
-            cacheBuilder.refreshAfterWrite(refreshSec, SECONDS);
-        }
-
-        cacheBuilder.maximumSize(maximumSize);
-        return cacheBuilder;
-    }
-
     public List<String> getAllDatabaseNames() {
         return get(databaseNamesCache, "");
     }
 
-    private List<String> loadAllDatabaseNames() {
+    public List<String> loadAllDatabaseNames() {
         return metastore.getAllDatabaseNames();
     }
 
@@ -207,11 +181,11 @@ public class CachingHiveMetastore implements IHiveMetastore {
         return get(tableNamesCache, dbName);
     }
 
-    public Set<HiveTableName> getCachedTableNames() {
+    public Set<DatabaseTableName> getCachedTableNames() {
         // use partition cache to get all cached table names because partition cache is more accurate,
         // table cache will be cached when user use `use catalog.db` command.
         return partitionCache.asMap().keySet().stream().map(hivePartitionName ->
-                HiveTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName())).collect(
+                DatabaseTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName())).collect(
                 Collectors.toSet());
     }
 
@@ -242,14 +216,14 @@ public class CachingHiveMetastore implements IHiveMetastore {
         return Maps.newHashMap(partitionCache.asMap());
     }
 
-    private List<String> loadAllTableNames(String dbName) {
+    public List<String> loadAllTableNames(String dbName) {
         return metastore.getAllTableNames(dbName);
     }
 
     @Override
     public List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues) {
-        HiveTableName hiveTableName = HiveTableName.of(dbName, tableName);
-        HivePartitionValue hivePartitionValue = HivePartitionValue.of(hiveTableName, partitionValues);
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
+        HivePartitionValue hivePartitionValue = HivePartitionValue.of(databaseTableName, partitionValues);
         if (metastore instanceof CachingHiveMetastore) {
             Table table = getTable(dbName, tableName);
             if (table.isHiveTable() && !((HiveTable) table).isUseMetadataCache()) {
@@ -257,9 +231,9 @@ public class CachingHiveMetastore implements IHiveMetastore {
             }
         }
         // update last access time
-        lastAccessTimeMap.put(hiveTableName, System.currentTimeMillis());
+        lastAccessTimeMap.put(databaseTableName, System.currentTimeMillis());
         // first check if the all partition keys are cached
-        HivePartitionValue allPartitionValue = HivePartitionValue.of(hiveTableName, HivePartitionValue.ALL_PARTITION_VALUES);
+        HivePartitionValue allPartitionValue = HivePartitionValue.of(databaseTableName, HivePartitionValue.ALL_PARTITION_VALUES);
         if (partitionKeysCache.asMap().containsKey(allPartitionValue)) {
             List<String> allPartitionNames = get(partitionKeysCache, allPartitionValue);
             if (partitionValues.stream().noneMatch(Optional::isPresent)) {
@@ -285,25 +259,30 @@ public class CachingHiveMetastore implements IHiveMetastore {
         return get(databaseCache, dbName);
     }
 
-    @Override
-    public MetastoreTable getMetastoreTable(String dbName, String tableName) {
-        return metastore.getMetastoreTable(dbName, tableName);
-    }
-
-    private Database loadDb(String dbName) {
+    public Database loadDb(String dbName) {
         return metastore.getDb(dbName);
     }
 
+    @Override
+    public MetastoreTable getMetastoreTable(String dbName, String tableName) {
+        return get(metastoreTableCache, DatabaseTableName.of(dbName, tableName));
+    }
+
+    @Override
+    public MetastoreTable loadMetastoreTable(DatabaseTableName databaseTableNam) {
+        return metastore.getMetastoreTable(databaseTableNam.getDatabaseName(), databaseTableNam.getTableName());
+    }
+
     public Table getTable(String dbName, String tableName) {
-        return get(tableCache, HiveTableName.of(dbName, tableName));
+        return get(tableCache, DatabaseTableName.of(dbName, tableName));
     }
 
     public boolean tableExists(String dbName, String tableName) {
         return metastore.tableExists(dbName, tableName);
     }
 
-    private Table loadTable(HiveTableName hiveTableName) {
-        return metastore.getTable(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
+    public Table loadTable(DatabaseTableName databaseTableName) {
+        return metastore.getTable(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
     }
 
     public Partition getPartition(String dbName, String tblName, List<String> partitionValues) {
@@ -377,11 +356,11 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public HivePartitionStats getTableStatistics(String dbName, String tblName) {
-        return get(tableStatsCache, HiveTableName.of(dbName, tblName));
+        return get(tableStatsCache, DatabaseTableName.of(dbName, tblName));
     }
 
-    private HivePartitionStats loadTableStatistics(HiveTableName hiveTableName) {
-        return metastore.getTableStatistics(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
+    private HivePartitionStats loadTableStatistics(DatabaseTableName databaseTableName) {
+        return metastore.getTableStatistics(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
     }
 
     public void updateTableStatistics(String dbName, String tableName, Function<HivePartitionStats, HivePartitionStats> update) {
@@ -459,22 +438,22 @@ public class CachingHiveMetastore implements IHiveMetastore {
     @Override
     public List<HivePartitionName> refreshTable(String hiveDbName, String hiveTblName,
                                                 boolean onlyCachedPartitions) {
-        HiveTableName hiveTableName = HiveTableName.of(hiveDbName, hiveTblName);
-        tableNameLockMap.putIfAbsent(hiveTableName, hiveDbName + "_" + hiveTblName + "_lock");
-        String lockStr = tableNameLockMap.get(hiveTableName);
+        DatabaseTableName databaseTableName = DatabaseTableName.of(hiveDbName, hiveTblName);
+        tableNameLockMap.putIfAbsent(databaseTableName, hiveDbName + "_" + hiveTblName + "_lock");
+        String lockStr = tableNameLockMap.get(databaseTableName);
         synchronized (lockStr) {
-            return refreshTableWithoutSync(hiveDbName, hiveTblName, hiveTableName, onlyCachedPartitions);
+            return refreshTableWithoutSync(hiveDbName, hiveTblName, databaseTableName, onlyCachedPartitions);
         }
     }
 
     public boolean refreshView(String hiveDbName, String hiveViewName) {
-        HiveTableName hiveTableName = HiveTableName.of(hiveDbName, hiveViewName);
-        tableNameLockMap.putIfAbsent(hiveTableName, hiveDbName + "_" + hiveViewName + "_lock");
-        String lockStr = tableNameLockMap.get(hiveTableName);
+        DatabaseTableName databaseTableName = DatabaseTableName.of(hiveDbName, hiveViewName);
+        tableNameLockMap.putIfAbsent(databaseTableName, hiveDbName + "_" + hiveViewName + "_lock");
+        String lockStr = tableNameLockMap.get(databaseTableName);
         synchronized (lockStr) {
             Table updatedTable;
             try {
-                updatedTable = loadTable(hiveTableName);
+                updatedTable = loadTable(databaseTableName);
             } catch (StarRocksConnectorException e) {
                 Throwable cause = e.getCause();
                 if (cause instanceof InvocationTargetException &&
@@ -486,17 +465,17 @@ public class CachingHiveMetastore implements IHiveMetastore {
                 }
             }
 
-            tableCache.put(hiveTableName, updatedTable);
+            tableCache.put(databaseTableName, updatedTable);
         }
         return true;
     }
 
     public List<HivePartitionName> refreshTableWithoutSync(String hiveDbName, String hiveTblName,
-                                                           HiveTableName hiveTableName,
+                                                           DatabaseTableName databaseTableName,
                                                            boolean onlyCachedPartitions) {
         Table updatedTable;
         try {
-            updatedTable = loadTable(hiveTableName);
+            updatedTable = loadTable(databaseTableName);
         } catch (StarRocksConnectorException e) {
             Throwable cause = e.getCause();
             if (cause instanceof InvocationTargetException &&
@@ -508,10 +487,10 @@ public class CachingHiveMetastore implements IHiveMetastore {
             }
         }
 
-        tableCache.put(hiveTableName, updatedTable);
+        tableCache.put(databaseTableName, updatedTable);
 
         // refresh table need to refresh partitionKeysCache with all partition values
-        HivePartitionValue hivePartitionValue = HivePartitionValue.of(hiveTableName, HivePartitionValue.ALL_PARTITION_VALUES);
+        HivePartitionValue hivePartitionValue = HivePartitionValue.of(databaseTableName, HivePartitionValue.ALL_PARTITION_VALUES);
         List<String> updatedPartitionKeys = loadPartitionKeys(hivePartitionValue);
         if (enableListNameCache) {
             partitionKeysCache.put(hivePartitionValue, updatedPartitionKeys);
@@ -523,7 +502,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
             HivePartitionName hivePartitionName = HivePartitionName.of(hiveDbName, hiveTblName, Lists.newArrayList());
             Partition updatedPartition = loadPartition(hivePartitionName);
             partitionCache.put(hivePartitionName, updatedPartition);
-            tableStatsCache.put(hiveTableName, loadTableStatistics(hiveTableName));
+            tableStatsCache.put(databaseTableName, loadTableStatistics(databaseTableName));
         } else {
             List<HivePartitionName> allPartitionsInHms = updatedPartitionKeys.stream()
                     .map(key -> HivePartitionName.of(hiveDbName, hiveTblName, key))
@@ -558,15 +537,15 @@ public class CachingHiveMetastore implements IHiveMetastore {
 
     @Override
     public List<HivePartitionName> refreshTableBackground(String hiveDbName, String hiveTblName, boolean onlyCachedPartitions) {
-        HiveTableName hiveTableName = HiveTableName.of(hiveDbName, hiveTblName);
-        if (lastAccessTimeMap.containsKey(hiveTableName)) {
-            long lastAccessTime = lastAccessTimeMap.get(hiveTableName);
+        DatabaseTableName databaseTableName = DatabaseTableName.of(hiveDbName, hiveTblName);
+        if (lastAccessTimeMap.containsKey(databaseTableName)) {
+            long lastAccessTime = lastAccessTimeMap.get(databaseTableName);
             long intervalSec = (System.currentTimeMillis() - lastAccessTime) / 1000;
             long refreshIntervalSinceLastAccess = Config.background_refresh_metadata_time_secs_since_last_access_secs;
             if (refreshIntervalSinceLastAccess >= 0 && intervalSec > refreshIntervalSinceLastAccess) {
                 // invalidate table cache
                 invalidateTable(hiveDbName, hiveTblName);
-                lastAccessTimeMap.remove(hiveTableName);
+                lastAccessTimeMap.remove(databaseTableName);
                 LOG.info("{}.{} skip refresh because of the last access time is {}", hiveDbName, hiveTblName,
                         LocalDateTime.ofInstant(Instant.ofEpochMilli(lastAccessTime), ZoneId.systemDefault()));
                 return null;
@@ -574,7 +553,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
         }
 
         List<HivePartitionName> refreshPartitionNames = refreshTable(hiveDbName, hiveTblName, onlyCachedPartitions);
-        Set<HiveTableName> cachedTableNames = getCachedTableNames();
+        Set<DatabaseTableName> cachedTableNames = getCachedTableNames();
         lastAccessTimeMap.keySet().removeIf(tableName -> !(cachedTableNames.contains(tableName)));
         return refreshPartitionNames;
     }
@@ -618,22 +597,12 @@ public class CachingHiveMetastore implements IHiveMetastore {
 
             if (enableListNameCache && !partitionNames.isEmpty()) {
                 HivePartitionName firstName = partitionNames.get(0);
-                HiveTableName hiveTableName = HiveTableName.of(firstName.getDatabaseName(), firstName.getTableName());
+                DatabaseTableName databaseTableName = DatabaseTableName.of(firstName.getDatabaseName(), firstName.getTableName());
                 // refresh partitionKeysCache with all partition values
                 HivePartitionValue hivePartitionValue = HivePartitionValue.of(
-                        hiveTableName, HivePartitionValue.ALL_PARTITION_VALUES);
+                        databaseTableName, HivePartitionValue.ALL_PARTITION_VALUES);
                 partitionKeysCache.put(hivePartitionValue, loadPartitionKeys(hivePartitionValue));
             }
-        }
-    }
-
-    private static <K, V> V get(LoadingCache<K, V> cache, K key) {
-        try {
-            return cache.getUnchecked(key);
-        } catch (UncheckedExecutionException e) {
-            LOG.error("Error occurred when loading cache", e);
-            throwIfInstanceOf(e.getCause(), StarRocksConnectorException.class);
-            throw e;
         }
     }
 
@@ -672,11 +641,11 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public synchronized void invalidateTable(String dbName, String tableName) {
-        HiveTableName hiveTableName = HiveTableName.of(dbName, tableName);
-        tableCache.invalidate(hiveTableName);
-        tableStatsCache.invalidate(hiveTableName);
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
+        tableCache.invalidate(databaseTableName);
+        tableStatsCache.invalidate(databaseTableName);
         partitionKeysCache.asMap().keySet().stream().filter(hivePartitionValue -> hivePartitionValue.getHiveTableName().
-                equals(hiveTableName)).forEach(partitionKeysCache::invalidate);
+                equals(databaseTableName)).forEach(partitionKeysCache::invalidate);
         List<HivePartitionName> presentPartitions = getPresentPartitionNames(partitionCache, dbName, tableName);
         presentPartitions.forEach(p -> partitionCache.invalidate(p));
         List<HivePartitionName> presentPartitionStats = getPresentPartitionNames(partitionStatsCache, dbName, tableName);
@@ -684,9 +653,9 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public synchronized void invalidatePartition(HivePartitionName partitionName) {
-        HiveTableName hiveTableName = HiveTableName.of(partitionName.getDatabaseName(), partitionName.getTableName());
+        DatabaseTableName databaseTableName = DatabaseTableName.of(partitionName.getDatabaseName(), partitionName.getTableName());
         partitionKeysCache.asMap().keySet().stream().filter(hivePartitionValue -> hivePartitionValue.getHiveTableName().
-                equals(hiveTableName)).forEach(partitionKeysCache::invalidate);
+                equals(databaseTableName)).forEach(partitionKeysCache::invalidate);
         partitionCache.invalidate(partitionName);
         partitionStatsCache.invalidate(partitionName);
     }
@@ -700,7 +669,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
         }
     }
 
-    public boolean isTablePresent(HiveTableName tableName) {
+    public boolean isTablePresent(DatabaseTableName tableName) {
         return tableCache.getIfPresent(tableName) != null;
     }
 
@@ -711,16 +680,16 @@ public class CachingHiveMetastore implements IHiveMetastore {
     public synchronized void refreshTableByEvent(HiveTable updatedHiveTable, HiveCommonStats commonStats, Partition partition) {
         String dbName = updatedHiveTable.getDbName();
         String tableName = updatedHiveTable.getTableName();
-        HiveTableName hiveTableName = HiveTableName.of(dbName, tableName);
-        tableCache.put(hiveTableName, updatedHiveTable);
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
+        tableCache.put(databaseTableName, updatedHiveTable);
         if (updatedHiveTable.isUnPartitioned()) {
-            Map<String, HiveColumnStats> columnStats = get(tableStatsCache, hiveTableName).getColumnStats();
+            Map<String, HiveColumnStats> columnStats = get(tableStatsCache, databaseTableName).getColumnStats();
             HivePartitionStats updatedPartitionStats = createPartitionStats(commonStats, columnStats);
-            tableStatsCache.put(hiveTableName, updatedPartitionStats);
+            tableStatsCache.put(databaseTableName, updatedPartitionStats);
             partitionCache.put(HivePartitionName.of(dbName, tableName, Lists.newArrayList()), partition);
         } else {
             partitionKeysCache.asMap().keySet().stream().filter(hivePartitionValue -> hivePartitionValue.getHiveTableName().
-                    equals(hiveTableName)).forEach(partitionKeysCache::invalidate);
+                    equals(databaseTableName)).forEach(partitionKeysCache::invalidate);
             List<HivePartitionName> presentPartitions = getPresentPartitionNames(partitionCache, dbName, tableName);
             presentPartitions.forEach(p -> partitionCache.invalidate(p));
             List<HivePartitionName> presentPartitionStats = getPresentPartitionNames(partitionStatsCache, dbName, tableName);
@@ -733,9 +702,10 @@ public class CachingHiveMetastore implements IHiveMetastore {
                                                      Partition partition) {
         Map<String, HiveColumnStats> columnStats = get(partitionStatsCache, hivePartitionName).getColumnStats();
         HivePartitionStats updatedPartitionStats = createPartitionStats(commonStats, columnStats);
-        HiveTableName hiveTableName = HiveTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
+        DatabaseTableName
+                databaseTableName = DatabaseTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
         partitionKeysCache.asMap().keySet().stream().filter(hivePartitionValue -> hivePartitionValue.getHiveTableName().
-                equals(hiveTableName)).forEach(partitionKeysCache::invalidate);
+                equals(databaseTableName)).forEach(partitionKeysCache::invalidate);
         partitionCache.put(hivePartitionName, partition);
         partitionStatsCache.put(hivePartitionName, updatedPartitionStats);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.server.GlobalStateMgr;
@@ -105,7 +106,7 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
                 continue;
             }
 
-            for (HiveTableName cachedTableName : updateProcessor.getCachedTableNames()) {
+            for (DatabaseTableName cachedTableName : updateProcessor.getCachedTableNames()) {
                 String dbName = cachedTableName.getDatabaseName();
                 String tableName = cachedTableName.getTableName();
                 Table table;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionValue.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.hive;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
+import com.starrocks.connector.DatabaseTableName;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,20 +25,20 @@ public class HivePartitionValue {
     // use empty list to represent all partition values when get partition names from partitionKeysCache
     public static final List<Optional<String>> ALL_PARTITION_VALUES = ImmutableList.of();
 
-    private final HiveTableName tableName;
+    private final DatabaseTableName tableName;
 
     private final List<Optional<String>> partitionValues;
 
-    public HivePartitionValue(HiveTableName tableName, List<Optional<String>> partitionValues) {
+    public HivePartitionValue(DatabaseTableName tableName, List<Optional<String>> partitionValues) {
         this.tableName = tableName;
         this.partitionValues = partitionValues;
     }
 
-    public static HivePartitionValue of(HiveTableName tableName, List<Optional<String>> partitionValues) {
+    public static HivePartitionValue of(DatabaseTableName tableName, List<Optional<String>> partitionValues) {
         return new HivePartitionValue(tableName, partitionValues);
     }
 
-    public HiveTableName getHiveTableName() {
+    public DatabaseTableName getHiveTableName() {
         return tableName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/AlterTableEvent.java
@@ -18,10 +18,10 @@ package com.starrocks.connector.hive.events;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.hive.CacheUpdateProcessor;
 import com.starrocks.connector.hive.HiveCommonStats;
 import com.starrocks.connector.hive.HiveMetastoreApiConverter;
-import com.starrocks.connector.hive.HiveTableName;
 import com.starrocks.connector.hive.Partition;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
@@ -112,7 +112,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
         if (isResourceMappingCatalog(catalogName)) {
             return true;
         } else {
-            return cache.isTablePresent(HiveTableName.of(dbName, tblName));
+            return cache.isTablePresent(DatabaseTableName.of(dbName, tblName));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/DropTableEvent.java
@@ -17,8 +17,8 @@ package com.starrocks.connector.hive.events;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.hive.CacheUpdateProcessor;
-import com.starrocks.connector.hive.HiveTableName;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.messaging.json.JSONDropTableMessage;
 import org.apache.logging.log4j.LogManager;
@@ -62,7 +62,7 @@ public class DropTableEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean existInCache() {
-        return cache.isTablePresent(HiveTableName.of(dbName, tableName));
+        return cache.isTablePresent(DatabaseTableName.of(dbName, tableName));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/InsertEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/InsertEvent.java
@@ -18,11 +18,11 @@ package com.starrocks.connector.hive.events;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.hive.CacheUpdateProcessor;
 import com.starrocks.connector.hive.HiveCommonStats;
 import com.starrocks.connector.hive.HiveMetastoreApiConverter;
 import com.starrocks.connector.hive.HivePartitionName;
-import com.starrocks.connector.hive.HiveTableName;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
@@ -99,8 +99,8 @@ public class InsertEvent extends MetastoreTableEvent {
         if (isPartitionTbl()) {
             return cache.isPartitionPresent(getHivePartitionName());
         } else {
-            HiveTableName hiveTableName = HiveTableName.of(dbName, tblName);
-            return cache.isTablePresent(hiveTableName);
+            DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tblName);
+            return cache.isTablePresent(databaseTableName);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/MetastoreEventFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/MetastoreEventFactory.java
@@ -18,9 +18,9 @@ package com.starrocks.connector.hive.events;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.hive.CacheUpdateProcessor;
 import com.starrocks.connector.hive.HivePartitionName;
-import com.starrocks.connector.hive.HiveTableName;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -93,7 +93,7 @@ public class MetastoreEventFactory implements EventFactory {
                     continue;
                 }
             } else {
-                if (!cacheProcessor.isTablePresent(HiveTableName.of(dbName, tableName))) {
+                if (!cacheProcessor.isTablePresent(DatabaseTableName.of(dbName, tableName))) {
                     LOG.warn("Table is null on catalog [{}], table [{}.{}]. Skipping notification event {}",
                             catalogName, event.getDbName(), event.getTableName(), event);
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metastore/CachingMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metastore/CachingMetastore.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.metastore;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.DatabaseTableName;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.cache.CacheLoader.asyncReloading;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public abstract class CachingMetastore {
+    private static final Logger LOG = LogManager.getLogger(CachingMetastore.class);
+
+    protected static final long NEVER_CACHE = 0;
+    protected static final long NEVER_EVICT = -1;
+    protected static final long NEVER_REFRESH = -1;
+
+    // Used to synchronize the refreshTable process
+    public final Map<DatabaseTableName, String> tableNameLockMap;
+    protected LoadingCache<String, List<String>> databaseNamesCache;
+    protected LoadingCache<String, List<String>> tableNamesCache;
+    protected LoadingCache<String, Database> databaseCache;
+    protected LoadingCache<DatabaseTableName, MetastoreTable> metastoreTableCache;
+    protected LoadingCache<DatabaseTableName, Table> tableCache;
+
+    public CachingMetastore(Executor executor, long expireAfterWriteSec, long refreshIntervalSec, long maxSize) {
+        databaseNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
+        tableNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                .build(asyncReloading(CacheLoader.from(this::loadAllTableNames), executor));
+        databaseCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadDb), executor));
+        metastoreTableCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadMetastoreTable), executor));
+        tableCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadTable), executor));
+
+        this.tableNameLockMap = Maps.newConcurrentMap();
+    }
+
+    protected static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (expiresAfterWriteSec >= 0) {
+            cacheBuilder.expireAfterWrite(expiresAfterWriteSec, SECONDS);
+        }
+
+        if (refreshSec > 0 && expiresAfterWriteSec > refreshSec) {
+            cacheBuilder.refreshAfterWrite(refreshSec, SECONDS);
+        }
+
+        cacheBuilder.maximumSize(maximumSize);
+        return cacheBuilder;
+    }
+
+    protected abstract List<String> loadAllDatabaseNames();
+
+    protected abstract List<String> loadAllTableNames(String dbName);
+
+    protected abstract Database loadDb(String dbName);
+
+    protected abstract Table loadTable(DatabaseTableName databaseTableName);
+
+    protected abstract MetastoreTable loadMetastoreTable(DatabaseTableName databaseTableNam);
+
+    protected static <K, V> V get(LoadingCache<K, V> cache, K key) {
+        try {
+            return cache.getUnchecked(key);
+        } catch (UncheckedExecutionException e) {
+            LOG.error("Error occurred when loading cache", e);
+            throwIfInstanceOf(e.getCause(), StarRocksConnectorException.class);
+            throw e;
+        }
+    }
+
+    public synchronized void invalidateAll() {
+        databaseNamesCache.invalidateAll();
+        databaseCache.invalidateAll();
+        tableNamesCache.invalidateAll();
+        metastoreTableCache.invalidateAll();
+        tableCache.invalidateAll();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -62,10 +62,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.GlobalFunctionMgr;
 import com.starrocks.catalog.HiveMetaStoreTable;
-import com.starrocks.catalog.HiveView;
-import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InternalCatalog;
-import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MetaReplayState;
 import com.starrocks.catalog.MetaVersion;
@@ -2308,6 +2305,11 @@ public class GlobalStateMgr {
         return task;
     }
 
+    private boolean supportRefreshTableType(Table table) {
+        return table.isHiveTable() || table.isHudiTable() || table.isHiveView() || table.isIcebergTable()
+                || table.isJDBCTable() || table.isDeltalakeTable();
+    }
+
     public void refreshExternalTable(TableName tableName, List<String> partitions) {
         String catalogName = tableName.getCatalog();
         String dbName = tableName.getDb();
@@ -2322,10 +2324,14 @@ public class GlobalStateMgr {
         locker.lockDatabase(db, LockType.READ);
         try {
             table = metadataMgr.getTable(catalogName, dbName, tblName);
-            if (!(table instanceof HiveMetaStoreTable) && !(table instanceof HiveView)
-                    && !(table instanceof IcebergTable) && !(table instanceof JDBCTable)) {
-                throw new StarRocksConnectorException(
-                        "table : " + tableName + " not exists, or is not hive/hudi/iceberg/odps/jdbc external table/view");
+            if (table == null) {
+                throw new StarRocksConnectorException("table %s.%s.%s not exists", catalogName, dbName,
+                        tblName);
+            }
+            if (!supportRefreshTableType(table)) {
+                throw new StarRocksConnectorException("can not refresh external table %s.%s.%s, " +
+                                "do not support refresh external table which type is %s", catalogName, dbName,
+                        tblName, table.getType());
             }
         } finally {
             locker.unLockDatabase(db, LockType.READ);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.hive.HiveMetaClient;
+import com.starrocks.connector.hive.HiveMetastore;
+import com.starrocks.connector.hive.HiveMetastoreTest;
+import com.starrocks.connector.hive.IHiveMetastore;
+import mockit.Expectations;
+import mockit.MockUp;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class CachingDeltaLakeMetastoreTest {
+    private HiveMetaClient client;
+    private DeltaLakeMetastore metastore;
+    private ExecutorService executor;
+    private long expireAfterWriteSec = 30;
+    private long refreshAfterWriteSec = -1;
+
+    @Before
+    public void setUp() throws Exception {
+        client = new HiveMetastoreTest.MockedHiveMetaClient();
+        IHiveMetastore hiveMetastore = new HiveMetastore(client, "delta0", MetastoreType.HMS);
+        metastore = new HMSBackedDeltaMetastore("delta0", hiveMetastore, new Configuration());
+        executor = Executors.newFixedThreadPool(5);
+    }
+
+    @Test
+    public void testGetAllDatabaseNames() {
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        List<String> databaseNames = cachingDeltaLakeMetastore.getAllDatabaseNames();
+        Assert.assertEquals(Lists.newArrayList("db1", "db2"), databaseNames);
+        CachingDeltaLakeMetastore queryLevelCache = CachingDeltaLakeMetastore.
+                createQueryLevelInstance(cachingDeltaLakeMetastore, 100);
+        Assert.assertEquals(Lists.newArrayList("db1", "db2"), queryLevelCache.getAllDatabaseNames());
+    }
+
+    @Test
+    public void testGetAllTableNames() {
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        List<String> tableNames = cachingDeltaLakeMetastore.getAllTableNames("db1");
+        Assert.assertEquals(Lists.newArrayList("table1", "table2"), tableNames);
+        CachingDeltaLakeMetastore queryLevelCache = CachingDeltaLakeMetastore.
+                createQueryLevelInstance(cachingDeltaLakeMetastore, 100);
+        Assert.assertEquals(Lists.newArrayList("table1", "table2"), queryLevelCache.getAllTableNames("db1"));
+    }
+
+    @Test
+    public void testGetDb() {
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        Database database = cachingDeltaLakeMetastore.getDb("db1");
+        Assert.assertEquals("db1", database.getFullName());
+    }
+
+    @Test
+    public void testGetTable() {
+        new MockUp<DeltaUtils>() {
+            @mockit.Mock
+            public DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
+                                                         org.apache.hadoop.conf.Configuration configuration,
+                                                         long createTime) {
+                return new DeltaLakeTable(1, "delta0", "db1", "table1",
+                        Lists.newArrayList(), Lists.newArrayList("ts"), null,
+                        "s3://bucket/path/to/table", null, 0);
+            }
+        };
+
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        Table table = cachingDeltaLakeMetastore.getTable("db1", "table1");
+        Assert.assertTrue(table instanceof DeltaLakeTable);
+        DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
+        Assert.assertEquals("db1", deltaLakeTable.getDbName());
+        Assert.assertEquals("table1", deltaLakeTable.getTableName());
+        Assert.assertEquals("s3://bucket/path/to/table", deltaLakeTable.getTableLocation());
+    }
+
+    @Test
+    public void testTableExists() {
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        Assert.assertTrue(cachingDeltaLakeMetastore.tableExists("db1", "table1"));
+    }
+
+    @Test
+    public void testRefreshTable() {
+        new Expectations(metastore) {
+            {
+                metastore.getTable(anyString, "notExistTbl");
+                minTimes = 0;
+                Throwable targetException = new NoSuchObjectException("no such obj");
+                Throwable e = new InvocationTargetException(targetException);
+                result = new StarRocksConnectorException("table not exist", e);
+            }
+        };
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore = new CachingDeltaLakeMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000);
+        try {
+            cachingDeltaLakeMetastore.refreshTable("db1", "notExistTbl", true);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof StarRocksConnectorException);
+            Assert.assertTrue(e.getMessage().contains("invalidated cache"));
+        }
+
+        new MockUp<DeltaUtils>() {
+            @mockit.Mock
+            public DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
+                                                        org.apache.hadoop.conf.Configuration configuration,
+                                                        long createTime) {
+                return new DeltaLakeTable(1, "delta0", "db1", "tbl1",
+                        Lists.newArrayList(), Lists.newArrayList("ts"), null,
+                        "s3://bucket/path/to/table", null, 0);
+            }
+        };
+
+        try {
+            cachingDeltaLakeMetastore.refreshTable("db1", "tbl1", true);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -67,10 +67,11 @@ public class DeltaLakeMetadataTest {
 
         HMSBackedDeltaMetastore hmsBackedDeltaMetastore = new HMSBackedDeltaMetastore("delta0", hiveMetastore,
                 new Configuration());
-        DeltaMetastoreOperations deltaOps = new DeltaMetastoreOperations(hmsBackedDeltaMetastore, false,
+        DeltaMetastoreOperations deltaOps = new DeltaMetastoreOperations(
+                CachingDeltaLakeMetastore.createQueryLevelInstance(hmsBackedDeltaMetastore, 10000), false,
                 MetastoreType.HMS);
 
-        deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps);
+        deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps, Optional.empty());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -165,14 +166,14 @@ public class CachingHiveMetastoreTest {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertFalse(cachingHiveMetastore.tableNameLockMap.containsKey(
-                HiveTableName.of("db1", "tbl1")));
+                DatabaseTableName.of("db1", "tbl1")));
         try {
             cachingHiveMetastore.refreshTable("db1", "tbl1", true);
         } catch (Exception e) {
             Assert.fail();
         }
         Assert.assertTrue(cachingHiveMetastore.tableNameLockMap.containsKey(
-                HiveTableName.of("db1", "tbl1")));
+                DatabaseTableName.of("db1", "tbl1")));
 
         try {
             cachingHiveMetastore.refreshTable("db1", "tbl1", true);
@@ -188,7 +189,7 @@ public class CachingHiveMetastoreTest {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertFalse(cachingHiveMetastore.tableNameLockMap.containsKey(
-                HiveTableName.of("db1", "tbl1")));
+                DatabaseTableName.of("db1", "tbl1")));
         try {
             // mock query table tbl1
             List<String> partitionNames = cachingHiveMetastore.getPartitionKeysByValue("db1", "tbl1",
@@ -200,7 +201,7 @@ public class CachingHiveMetastoreTest {
         } catch (Exception e) {
             Assert.fail();
         }
-        Assert.assertTrue(cachingHiveMetastore.isTablePresent(HiveTableName.of("db1", "tbl1")));
+        Assert.assertTrue(cachingHiveMetastore.isTablePresent(DatabaseTableName.of("db1", "tbl1")));
 
         try {
             cachingHiveMetastore.refreshTableBackground("db1", "tbl1", true);
@@ -208,7 +209,7 @@ public class CachingHiveMetastoreTest {
             Assert.fail();
         }
         // not skip refresh table, table cache still exist
-        Assert.assertTrue(cachingHiveMetastore.isTablePresent(HiveTableName.of("db1", "tbl1")));
+        Assert.assertTrue(cachingHiveMetastore.isTablePresent(DatabaseTableName.of("db1", "tbl1")));
         // sleep 1s, background refresh table will be skipped
         Thread.sleep(1000);
         long oldValue = Config.background_refresh_metadata_time_secs_since_last_access_secs;
@@ -223,7 +224,7 @@ public class CachingHiveMetastoreTest {
             Config.background_refresh_metadata_time_secs_since_last_access_secs = oldValue;
         }
         // table cache will be removed because of skip refresh table
-        Assert.assertFalse(cachingHiveMetastore.isTablePresent(HiveTableName.of("db1", "tbl1")));
+        Assert.assertFalse(cachingHiveMetastore.isTablePresent(DatabaseTableName.of("db1", "tbl1")));
     }
 
     @Test
@@ -231,14 +232,14 @@ public class CachingHiveMetastoreTest {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertFalse(cachingHiveMetastore.tableNameLockMap.containsKey(
-                HiveTableName.of("db1", "tbl1")));
+                DatabaseTableName.of("db1", "tbl1")));
         try {
             cachingHiveMetastore.refreshView("db1", "hive_view");
         } catch (Exception e) {
             Assert.fail();
         }
         Assert.assertTrue(cachingHiveMetastore.tableNameLockMap.containsKey(
-                HiveTableName.of("db1", "hive_view")));
+                DatabaseTableName.of("db1", "hive_view")));
 
         new Expectations(metastore) {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -463,7 +464,7 @@ public class HiveMetastoreTest {
         public void addPartitions(String dbName, String tableName, List<Partition> partitions) {
         }
 
-        public Partition getPartition(HiveTableName name, List<String> partitionValues) {
+        public Partition getPartition(DatabaseTableName name, List<String> partitionValues) {
             StorageDescriptor sd = new StorageDescriptor();
             String hdfsPath = "hdfs://127.0.0.1:10000/hive";
             sd.setLocation(hdfsPath);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -291,7 +291,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
                 MOCK_TABLE_MAP = new CaseInsensitiveMap<>();
 
         public MockedDeltaLakeMetadata() {
-            super(null, null, null);
+            super(null, null, null, Optional.empty());
 
             long tableId = GlobalStateMgr.getCurrentState().getNextId();
             List<Column> columns = ImmutableList.<Column>builder()


### PR DESCRIPTION
## Why I'm doing:
Get delta snapshot would costs lots of time. we could cache delta lake table to improve performance
## What I'm doing:
Support two level delta lake table cache(Catalog/Query), Catalog level table cache is disbabled by default, you could enable this by add **"enable_metastore_cache"  =  "true"** to connector protperties. Query level cache is enabled by default

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
