### PR TITLE
[Enhancement] change cloud native pk index's major compact function to static

### DIFF
--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -35,8 +35,7 @@ Status CompactionTask::execute_index_major_compaction(TxnLogPB* txn_log) {
         auto metadata = _tablet.metadata();
         if (metadata->enable_persistent_index() &&
             metadata->persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE) {
-            return _tablet.tablet_manager()->update_mgr()->execute_index_major_compaction(_tablet.metadata()->id(),
-                                                                                          *metadata, txn_log);
+            return _tablet.tablet_manager()->update_mgr()->execute_index_major_compaction(*metadata, txn_log);
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -114,7 +114,7 @@ public:
 
     Status minor_compact();
 
-    Status major_compact(const TabletMetadata& metadata, int64_t min_retain_version, TxnLogPB* txn_log);
+    static Status major_compact(TabletManager* tablet_mgr, const TabletMetadata& metadata, TxnLogPB* txn_log);
 
     Status apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
 
@@ -151,11 +151,11 @@ private:
     static void set_difference(KeyIndexSet* key_indexes, const KeyIndexSet& found_key_indexes);
 
     // get sstable's iterator that need to compact and modify txn_log
-    Status prepare_merging_iterator(const TabletMetadata& metadata, TxnLogPB* txn_log,
-                                    std::vector<std::shared_ptr<PersistentIndexSstable>>* merging_sstables,
-                                    std::unique_ptr<sstable::Iterator>* merging_iter_ptr);
+    static Status prepare_merging_iterator(TabletManager* tablet_mgr, const TabletMetadata& metadata, TxnLogPB* txn_log,
+                                           std::vector<std::shared_ptr<PersistentIndexSstable>>* merging_sstables,
+                                           std::unique_ptr<sstable::Iterator>* merging_iter_ptr);
 
-    Status merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder);
+    static Status merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder);
 
 private:
     std::unique_ptr<PersistentIndexMemtable> _memtable;

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -237,30 +237,6 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
     return Status::OK();
 }
 
-Status LakePrimaryIndex::major_compact(const TabletMetadata& metadata, TxnLogPB* txn_log) {
-    if (!_enable_persistent_index) {
-        return Status::OK();
-    }
-
-    switch (metadata.persistent_index_type()) {
-    case PersistentIndexTypePB::LOCAL: {
-        return Status::OK();
-    }
-    case PersistentIndexTypePB::CLOUD_NATIVE: {
-        auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
-        if (lake_persistent_index != nullptr) {
-            return lake_persistent_index->major_compact(metadata, 0 /** min_retain_version **/, txn_log);
-        } else {
-            return Status::InternalError("Persistent index is not a LakePersistentIndex.");
-        }
-    }
-    default:
-        return Status::InternalError("Unsupported lake_persistent_index_type " +
-                                     PersistentIndexTypePB_Name(metadata.persistent_index_type()));
-    }
-    return Status::OK();
-}
-
 double LakePrimaryIndex::get_local_pk_index_write_amp_score() {
     if (!_enable_persistent_index) {
         return 0.0;

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -68,8 +68,6 @@ public:
 
     Status commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder);
 
-    Status major_compact(const TabletMetadata& metadata, TxnLogPB* txn_log);
-
     double get_local_pk_index_write_amp_score();
 
     void set_local_pk_index_write_amp_score(double score);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -985,17 +985,8 @@ void UpdateManager::set_enable_persistent_index(int64_t tablet_id, bool enable_p
     }
 }
 
-Status UpdateManager::execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata,
-                                                     TxnLogPB* txn_log) {
-    auto index_entry = _index_cache.get(tablet_id);
-    if (index_entry == nullptr) {
-        return Status::OK();
-    }
-    index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
-    // release index entry but keep it in cache
-    DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
-    auto& index = index_entry->value();
-    return index.major_compact(metadata, txn_log);
+Status UpdateManager::execute_index_major_compaction(const TabletMetadata& metadata, TxnLogPB* txn_log) {
+    return LakePersistentIndex::major_compact(_tablet_mgr, metadata, txn_log);
 }
 
 Status UpdateManager::pk_index_major_compaction(int64_t tablet_id, DataDir* data_dir) {

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -195,7 +195,7 @@ public:
 
     void set_enable_persistent_index(int64_t tablet_id, bool enable_persistent_index);
 
-    Status execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata, TxnLogPB* txn_log);
+    Status execute_index_major_compaction(const TabletMetadata& metadata, TxnLogPB* txn_log);
 
     PersistentIndexBlockCache* block_cache() { return _block_cache.get(); }
 

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -233,7 +233,9 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     get_values.clear();
     get_values.reserve(M * N);
     auto txn_log = std::make_shared<TxnLogPB>();
-    ASSERT_OK(index->major_compact(*_tablet_metadata, 0, txn_log.get()));
+    ASSERT_OK(LakePersistentIndex::major_compact(_tablet_mgr.get(), *_tablet_metadata, txn_log.get()));
+    ASSERT_TRUE(txn_log->op_compaction().input_sstables_size() > 0);
+    ASSERT_TRUE(txn_log->op_compaction().has_output_sstable());
     ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));
     ASSERT_OK(index->get(M * N, total_key_slices.data(), get_values.data()));
     for (int i = 0; i < M * N; i++) {

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "storage/lake/meta_file.h"
 #include "test_util.h"
 #include "testutil/assert.h"
 
@@ -224,16 +225,24 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
         index->prepare(EditVersion(i, 0), 0);
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
+        // generate sst files.
+        index->minor_compact();
     }
 
-    index->minor_compact();
+    Tablet tablet(_tablet_mgr.get(), tablet_id);
+    auto tablet_metadata_ptr = std::make_shared<TabletMetadata>();
+    tablet_metadata_ptr->CopyFrom(*_tablet_metadata);
+    MetaFileBuilder builder(tablet, tablet_metadata_ptr);
+    // commit sst files
+    ASSERT_OK(index->commit(&builder));
     vector<IndexValue> get_values(M * N);
     ASSERT_OK(index->get(M * N, total_key_slices.data(), get_values.data()));
 
     get_values.clear();
     get_values.reserve(M * N);
     auto txn_log = std::make_shared<TxnLogPB>();
-    ASSERT_OK(LakePersistentIndex::major_compact(_tablet_mgr.get(), *_tablet_metadata, txn_log.get()));
+    // try to compact sst files.
+    ASSERT_OK(LakePersistentIndex::major_compact(_tablet_mgr.get(), *tablet_metadata_ptr, txn_log.get()));
     ASSERT_TRUE(txn_log->op_compaction().input_sstables_size() > 0);
     ASSERT_TRUE(txn_log->op_compaction().has_output_sstable());
     ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));


### PR DESCRIPTION
## Why I'm doing:
In current implement, if cloud native pk index not exist in `_index_cache`, then major compaction can't be trigger even `sstable` number requirement is meet.

## What I'm doing:
Make `LakePersistentIndex::major_compact` become static function, so even index object not exist in `_index_cache`, we can still run major compaction.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
