### PR TITLE
[Enhancement] Optimize the procedure to update datacache quota and turn on the datacache switch by default.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -70,6 +70,7 @@ Status BlockCache::init(const CacheOptions& options) {
         return Status::NotSupported("unsupported block cache engine");
     }
     RETURN_IF_ERROR(_kv_cache->init(cache_options));
+    _refresh_quota();
     _initialized.store(true, std::memory_order_relaxed);
     if (_disk_space_monitor) {
         _disk_space_monitor->start();
@@ -152,12 +153,16 @@ Status BlockCache::remove(const CacheKey& cache_key, off_t offset, size_t size) 
     return _kv_cache->remove(block_key);
 }
 
-Status BlockCache::update_mem_quota(size_t quota_bytes) {
-    return _kv_cache->update_mem_quota(quota_bytes);
+Status BlockCache::update_mem_quota(size_t quota_bytes, bool flush_to_disk) {
+    Status st = _kv_cache->update_mem_quota(quota_bytes, flush_to_disk);
+    _refresh_quota();
+    return st;
 }
 
 Status BlockCache::update_disk_spaces(const std::vector<DirSpace>& spaces) {
-    return _kv_cache->update_disk_spaces(spaces);
+    Status st = _kv_cache->update_disk_spaces(spaces);
+    _refresh_quota();
+    return st;
 }
 
 Status BlockCache::adjust_disk_spaces(const std::vector<DirSpace>& spaces) {
@@ -195,6 +200,12 @@ Status BlockCache::shutdown() {
 
 DataCacheEngineType BlockCache::engine_type() {
     return _kv_cache->engine_type();
+}
+
+void BlockCache::_refresh_quota() {
+    auto metrics = _kv_cache->cache_metrics(0);
+    _mem_quota.store(metrics.mem_quota_bytes, std::memory_order_relaxed);
+    _disk_quota.store(metrics.disk_quota_bytes, std::memory_order_relaxed);
 }
 
 } // namespace starrocks

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -110,7 +110,7 @@ Status CacheLibWrapper::read_object(const std::string& key, DataCacheHandle* han
     return Status::NotSupported("not supported read object in cachelib");
 }
 
-Status CacheLibWrapper::update_mem_quota(size_t quota_bytes) {
+Status CacheLibWrapper::update_mem_quota(size_t quota_bytes, bool flush_to_disk) {
     return Status::NotSupported("not support updating memory cache quota for cachelib");
 }
 

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -56,7 +56,7 @@ public:
 
     Status remove(const std::string& key) override;
 
-    Status update_mem_quota(size_t quota_bytes) override;
+    Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) override;
 
     Status update_disk_spaces(const std::vector<DirSpace>& spaces) override;
 

--- a/be/src/block_cache/disk_space_monitor.h
+++ b/be/src/block_cache/disk_space_monitor.h
@@ -41,7 +41,7 @@ public:
     public:
         virtual StatusOr<SpaceInfo> space(const std::string& path) { return FileSystem::Default()->space(path); }
 
-        virtual StatusOr<size_t> directory_capacity(const std::string& dir);
+        virtual StatusOr<size_t> directory_size(const std::string& dir);
 
         virtual int disk_id(const std::string& path) { return DiskInfo::disk_id(path.c_str()); }
 

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -67,7 +67,7 @@ public:
     virtual Status remove(const std::string& key) = 0;
 
     // Update the datacache memory quota.
-    virtual Status update_mem_quota(size_t quota_bytes) = 0;
+    virtual Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) = 0;
 
     // Update the datacache disk space infomation, such as disk quota or disk path.
     virtual Status update_disk_spaces(const std::vector<DirSpace>& spaces) = 0;

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -127,8 +127,8 @@ Status StarCacheWrapper::remove(const std::string& key) {
     return Status::OK();
 }
 
-Status StarCacheWrapper::update_mem_quota(size_t quota_bytes) {
-    return to_status(_cache->update_mem_quota(quota_bytes, false));
+Status StarCacheWrapper::update_mem_quota(size_t quota_bytes, bool flush_to_disk) {
+    return to_status(_cache->update_mem_quota(quota_bytes, flush_to_disk));
 }
 
 Status StarCacheWrapper::update_disk_spaces(const std::vector<DirSpace>& spaces) {

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -40,7 +40,7 @@ public:
 
     Status remove(const std::string& key) override;
 
-    Status update_mem_quota(size_t quota_bytes) override;
+    Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) override;
 
     Status update_disk_spaces(const std::vector<DirSpace>& spaces) override;
 
@@ -78,6 +78,8 @@ inline Status to_status(const butil::Status& st) {
         return Status::IOError(st.error_str());
     case ENOMEM:
         return Status::MemoryLimitExceeded(st.error_str());
+    case ENOSPC:
+        return Status::CapacityLimitExceed(st.error_str());
     case EBUSY:
         return Status::ResourceBusy(st.error_str());
     default:

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1056,7 +1056,7 @@ CONF_mInt64(max_length_for_to_base64, "200000");
 CONF_mInt64(max_length_for_bitmap_function, "1000000");
 
 // Configuration items for datacache
-CONF_Bool(datacache_enable, "false");
+CONF_Bool(datacache_enable, "true");
 CONF_mString(datacache_mem_size, "0");
 CONF_mString(datacache_disk_size, "0");
 CONF_mString(datacache_disk_path, "");
@@ -1096,19 +1096,21 @@ CONF_mInt32(report_datacache_metrics_interval_ms, "60000");
 // Whether enable automatically adjust cache space quota.
 // If true, the cache will choose an appropriate quota based on the current remaining space as the quota.
 // and the quota also will be changed dynamiclly.
-// Once the disk space usage reach the urgent level, the quota will be decreased to keep the disk usage
+// Once the disk space usage reach the high level, the quota will be decreased to keep the disk usage
 // around the disk safe level.
-// On the other hand, if the cache is full and the disk usage falls below the disk safe level for a long time,
-// which is configured by `datacache_disk_idle_period_for_expansion`, the cache quota will be increased to keep the
+// On the other hand, if the cache is full and the disk usage falls below the disk low level for a long time,
+// which is configured by `datacache_disk_idle_seconds_for_expansion`, the cache quota will be increased to keep the
 // disk usage around the disk safe level.
 CONF_mBool(datacache_auto_adjust_enable, "false");
-// The disk usage threshold, which trigger the cache eviction and quota decreased.
-CONF_mInt64(datacache_disk_urgent_level, "80");
-// The disk usage threshold, the cache quota will be decreased to this level once it reach the urgent level.
+// The high disk usage level, which trigger the cache eviction and quota decreased.
+CONF_mInt64(datacache_disk_high_level, "80");
+// The safe disk usage level, the cache quota will be decreased to this level once it reach the high level.
 CONF_mInt64(datacache_disk_safe_level, "70");
+// The low disk usage level, which trigger the cache expansion and quota increased.
+CONF_mInt64(datacache_disk_low_level, "60");
 // The interval seconds to check the disk usage and trigger adjustment.
 CONF_mInt64(datacache_disk_adjust_interval_seconds, "10");
-// The silent period, only when the disk usage falls bellow the safe level for a time longer than this period,
+// The silent period, only when the disk usage falls bellow the low level for a time longer than this period,
 // the disk expansion can be triggered
 CONF_mInt64(datacache_disk_idle_seconds_for_expansion, "7200");
 // The minimum total disk quota bytes to adjust, once the quota to adjust is less than this value,

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -157,6 +157,8 @@ public:
 
     bool is_mem_limit_exceeded() const { return code() == TStatusCode::MEM_LIMIT_EXCEEDED; }
 
+    bool is_capacity_limit_exceeded() const { return code() == TStatusCode::CAPACITY_LIMIT_EXCEED; }
+
     bool is_thrift_rpc_error() const { return code() == TStatusCode::THRIFT_RPC_ERROR; }
 
     bool is_end_of_file() const { return code() == TStatusCode::END_OF_FILE; }

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -95,7 +95,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     }
     RETURN_IF_ERROR(_check_all_slots_nullable());
 
-    _use_datacache = config::datacache_enable;
+    _use_datacache = config::datacache_enable && BlockCache::instance()->available();
     if (state->query_options().__isset.enable_scan_datacache) {
         _use_datacache &= state->query_options().enable_scan_datacache;
     }
@@ -116,8 +116,9 @@ Status HiveDataSource::open(RuntimeState* state) {
         _scan_range.datacache_options.priority == -1) {
         _use_datacache = false;
     }
+    _use_file_metacache = config::datacache_enable && BlockCache::instance()->has_mem_cache();
     if (state->query_options().__isset.enable_file_metacache) {
-        _use_file_metacache = state->query_options().enable_file_metacache;
+        _use_file_metacache &= state->query_options().enable_file_metacache;
     }
     if (state->query_options().__isset.enable_connector_split_io_tasks) {
         _enable_split_tasks = state->query_options().enable_connector_split_io_tasks;

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -104,7 +104,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 mem_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
             }
             size_t mem_size = parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit);
-            (void)BlockCache::instance()->update_mem_quota(mem_size);
+            (void)BlockCache::instance()->update_mem_quota(mem_size, true);
         });
         _config_callback.emplace("datacache_disk_size", [&]() {
             std::vector<DirSpace> spaces;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -85,7 +85,8 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
         }
         cache_options.mem_space_size = parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit);
         if (config::datacache_disk_path.value().empty()) {
-            // If the disk cache does not be configured for datacache, set default path according storage path.
+            // If the disk cache does not be configured for datacache, set default path according storage path,
+            // and turn on the automatic adjust switch.
             std::vector<std::string> datacache_paths;
             std::for_each(storage_paths.begin(), storage_paths.end(), [&](const StorePath& root_path) {
                 std::filesystem::path sp(root_path.path);
@@ -93,6 +94,7 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
                 datacache_paths.push_back(dp.string());
             });
             config::datacache_disk_path = JoinStrings(datacache_paths, ";");
+            config::datacache_auto_adjust_enable = true;
         }
         RETURN_IF_ERROR(parse_conf_datacache_disk_spaces(config::datacache_disk_path, config::datacache_disk_size,
                                                          config::ignore_broken_disk, &cache_options.disk_spaces));

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -310,6 +310,51 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     fs::remove_all(cache_dir).ok();
 }
 
+TEST_F(BlockCacheTest, update_cache_quota) {
+    const std::string cache_dir = "./block_disk_cache5";
+    ASSERT_TRUE(fs::create_directories(cache_dir).ok());
+
+    std::unique_ptr<BlockCache> cache(new BlockCache);
+    const size_t block_size = 256 * 1024;
+
+    CacheOptions options;
+    options.mem_space_size = 1 * 1024 * 1024;
+    size_t quota = 50 * 1024 * 1024;
+    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
+    options.block_size = block_size;
+    options.max_concurrent_inserts = 100000;
+    options.max_flying_memory_mb = 100;
+    options.enable_direct_io = false;
+    options.engine = "starcache";
+    Status status = cache->init(options);
+    ASSERT_TRUE(status.ok());
+
+    {
+        auto metrics = cache->cache_metrics();
+        ASSERT_EQ(metrics.mem_quota_bytes, options.mem_space_size);
+        ASSERT_EQ(metrics.disk_quota_bytes, quota);
+    }
+
+    {
+        size_t new_mem_quota = 2 * 1024 * 1024;
+        ASSERT_TRUE(cache->update_mem_quota(new_mem_quota, false).ok());
+        auto metrics = cache->cache_metrics();
+        ASSERT_EQ(metrics.mem_quota_bytes, new_mem_quota);
+    }
+
+    {
+        size_t new_disk_quota = 100 * 1024 * 1024;
+        std::vector<DirSpace> dir_spaces;
+        dir_spaces.push_back({.path = cache_dir, .size = new_disk_quota});
+        ASSERT_TRUE(cache->update_disk_spaces(dir_spaces).ok());
+        auto metrics = cache->cache_metrics();
+        ASSERT_EQ(metrics.disk_quota_bytes, new_disk_quota);
+    }
+
+    cache->shutdown();
+    fs::remove_all(cache_dir).ok();
+}
+
 #endif
 
 #ifdef WITH_CACHELIB

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1580,7 +1580,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     @VariableMgr.VarAttr(name = ENABLE_SCAN_DATACACHE, alias = ENABLE_SCAN_BLOCK_CACHE)
-    private boolean enableScanDataCache = false;
+    private boolean enableScanDataCache = true;
 
     @VariableMgr.VarAttr(name = ENABLE_POPULATE_DATACACHE, alias = ENABLE_POPULATE_BLOCK_CACHE)
     private boolean enablePopulateDataCache = true;
@@ -1597,10 +1597,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     @VariableMgr.VarAttr(name = ENABLE_DATACACHE_ASYNC_POPULATE_MODE)
-    private boolean enableDataCacheAsyncPopulateMode = false;
+    private boolean enableDataCacheAsyncPopulateMode = true;
 
     @VariableMgr.VarAttr(name = ENABLE_DATACACHE_IO_ADAPTOR)
-    private boolean enableDataCacheIOAdaptor = false;
+    private boolean enableDataCacheIOAdaptor = true;
 
     @VariableMgr.VarAttr(name = ENABLE_DYNAMIC_PRUNE_SCAN_RANGE)
     private boolean enableDynamicPruneScanRange = true;


### PR DESCRIPTION
## Why I'm doing:
Now the datacache switch is not enabled by default, which unable to provide users with the best performance experience in out of the box versions.

## What I'm doing:
* Turn on the datacache switch and related configurations by default.
* Support updating datacache memory quota without flushing data to disk.
* Skip checking file metacache if the datacache instance has no memory layer to reduce some overhead.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
