### PR TITLE
[BugFix] add an id argument to mark  non-deterministic functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -71,7 +71,8 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
                 .put(ArraySliceOperator.class, (op, childOps) -> new ArraySliceOperator(op.getType(), childOps))
                 .put(CallOperator.class, (op, childOps) -> {
                     CallOperator call = (CallOperator) op;
-                    return new CallOperator(call.getFnName(), call.getType(), childOps, call.getFunction(), call.isDistinct()); })
+                    return new CallOperator(call.getFnName(), call.getType(), childOps, call.getFunction(), call.isDistinct(),
+                            call.isRemovedDistinct()); })
                 .put(PredicateOperator.class, (op, childOps) -> op)
                 .put(BetweenPredicateOperator.class, (op, childOps) -> {
                     BetweenPredicateOperator between = (BetweenPredicateOperator) op;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -163,11 +163,11 @@ public class ScalarOperatorsReuse {
 
         @Override
         public ScalarOperator visitCall(CallOperator call, Void context) {
-            ScalarOperator operator = new CallOperator(call.getFnName(),
+            CallOperator operator = new CallOperator(call.getFnName(),
                     call.getType(),
                     call.getChildren().stream().map(argument -> argument.accept(this, null)).collect(toImmutableList()),
                     call.getFunction(),
-                    call.isDistinct());
+                    call.isDistinct(), call.isRemovedDistinct());
             return tryRewrite(operator);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -50,8 +50,8 @@ import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollect
  * 3. Generate new dictionary column:
  *  a. Generate corresponding dictionary ref based on the string ref
  *  b. Generate the define expression of global dictionary column
- *  b. Rewrite string expressions
- *  c. Rewrite string aggregate expressions
+ *  c. Rewrite string expressions
+ *  d. Rewrite string aggregate expressions
  *  e. Generate the global dictionary expression
  */
 class DecodeContext {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -680,6 +680,12 @@ public final class SqlToScalarOperatorTranslator {
                     .map(child -> visit(child, context.clone(node)))
                     .collect(Collectors.toList());
 
+            // for nonDeterministicFunctions, we need add an argument as its unique id to distinguish
+            // the reusing behavior in common exprs
+            if (FunctionSet.nonDeterministicFunctions.contains(node.getFnName().getFunction())) {
+                arguments.add(ConstantOperator.createInt(columnRefFactory.getNextUniqueId()));
+            }
+
             CallOperator callOperator = new CallOperator(
                     node.getFnName().getFunction(),
                     node.getType(),
@@ -687,9 +693,6 @@ public final class SqlToScalarOperatorTranslator {
                     node.getFn(),
                     node.getParams().isDistinct());
             callOperator.setHints(node.getHints());
-            if (FunctionSet.nonDeterministicFunctions.contains(node.getFnName().getFunction())) {
-                callOperator.setId(columnRefFactory.getNextUniqueId());
-            }
             return callOperator;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -479,6 +479,7 @@ public class ScalarOperatorToExpr {
                 case "user":
                 case "current_user":
                 case "current_role":
+                case "session_id":
                     callExpr = new InformationFunction(fnName,
                             ((ConstantOperator) call.getChild(0)).getVarchar(),
                             0);
@@ -488,9 +489,20 @@ public class ScalarOperatorToExpr {
                             "",
                             ((ConstantOperator) call.getChild(0)).getBigint());
                     break;
-                case "session_id":
-                    callExpr = new InformationFunction(fnName,
-                            ((ConstantOperator) call.getChild(0)).getVarchar(), 0);
+                case "rand":
+                case "random":
+                case "uuid":
+                    callExpr = new FunctionCallExpr(call.getFnName(), new FunctionParams(false, List.of()));
+                    Preconditions.checkNotNull(call.getFunction());
+                    callExpr.setFn(call.getFunction());
+                    callExpr.setIgnoreNulls(call.getIgnoreNulls());
+                    break;
+                case "sleep":
+                    Expr child =  buildExpr.build(call.getChild(0), context);
+                    callExpr = new FunctionCallExpr(call.getFnName(), new FunctionParams(false, List.of(child)));
+                    Preconditions.checkNotNull(call.getFunction());
+                    callExpr.setFn(call.getFunction());
+                    callExpr.setIgnoreNulls(call.getIgnoreNulls());
                     break;
                 default:
                     List<Expr> arg = call.getChildren().stream()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
@@ -58,6 +58,20 @@ public class ScalarOperatorsReuseRuleTest extends PlanTestBase {
                     "  |  <slot 2> : random()\n" +
                     "  |  <slot 3> : random()");
         }
+
+        {
+            String query = "select a, b, a + b from (select random() * 1000 a, random() * 1000 b from t0) t";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 4> : 9: multiply\n" +
+                    "  |  <slot 5> : 10: multiply\n" +
+                    "  |  <slot 6> : 9: multiply + 10: multiply\n" +
+                    "  |  common expressions:\n" +
+                    "  |  <slot 7> : random()\n" +
+                    "  |  <slot 8> : random()\n" +
+                    "  |  <slot 9> : 7: random * 1000.0\n" +
+                    "  |  <slot 10> : 8: random * 1000.0");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
The old id field in callOperator may be erased in rewriting process.

## What I'm doing:
Add an id parameters to mark non-deterministic functions. Ensure that no uniqueness markers are lost during any copy operations.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [x] 2.5
