### PR TITLE
[BugFix] no incremental data for hudi mor table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -116,7 +116,8 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
 
     public HudiTable(long id, String name, String catalogName, String hiveDbName, String hiveTableName,
                      String resourceName, String comment, List<Column> schema, List<String> dataColumnNames,
-                     List<String> partColumnNames, long createTime, Map<String, String> properties) {
+                     List<String> partColumnNames, long createTime, Map<String, String> properties,
+                     HudiTableType type) {
         super(id, name, TableType.HUDI, schema);
         this.catalogName = catalogName;
         this.hiveDbName = hiveDbName;
@@ -127,6 +128,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         this.createTime = createTime;
         this.hudiProperties = properties;
         this.comment = comment;
+        this.tableType = type;
     }
 
     public String getDbName() {
@@ -526,7 +528,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
 
         public HudiTable build() {
             return new HudiTable(id, tableName, catalogName, hiveDbName, hiveTableName, resourceName, comment,
-                    fullSchema, dataColNames, partitionColNames, createTime, hudiProperties);
+                    fullSchema, dataColNames, partitionColNames, createTime, hudiProperties, tableType);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

No incremental data got for Hudi MOR table with log files.

![image](https://github.com/StarRocks/starrocks/assets/130516674/eac93ecd-cb33-4dbb-9061-450b3440b154)

I think this is involed by #44032 

## What I'm doing:

The hudi table type doesn't pass to HudiTable.

![image](https://github.com/StarRocks/starrocks/assets/130516674/6d21c170-dbe6-4347-8cb0-fa44b8d377b4)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
