### PR TITLE
[BugFix] Fix auto partition fail make routine load paused

### DIFF
--- a/test/sql/test_automatic_partition/R/test_automatic_partition_fail
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_fail
@@ -1,0 +1,17 @@
+-- name: test_create_partition_fail @sequential
+CREATE TABLE ss( event_day DATE, pv BIGINT, cc int) DUPLICATE KEY(event_day) PARTITION BY date_trunc('month', event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+admin set frontend config ("max_automatic_partition_number"="0");
+-- result:
+-- !result
+insert into ss values('2002-01-01', 1, 2);
+-- result:
+E: (5025, 'The row create partition failed since Runtime error:  Automatically created partitions exceeded the maximum limit: 0. You can modify this restriction on by setting max_automatic_partition_number larger.. Row: [2002-01-01, 1, 2]')
+-- !result
+admin set frontend config ("max_automatic_partition_number"="4096");
+-- result:
+-- !result
+insert into ss values('2002-01-01', 1, 2);
+-- result:
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_fail
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_fail
@@ -1,0 +1,6 @@
+-- name: test_create_partition_fail @sequential
+CREATE TABLE ss( event_day DATE, pv BIGINT, cc int) DUPLICATE KEY(event_day) PARTITION BY date_trunc('month', event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "1");
+admin set frontend config ("max_automatic_partition_number"="0");
+insert into ss values('2002-01-01', 1, 2);
+admin set frontend config ("max_automatic_partition_number"="4096");
+insert into ss values('2002-01-01', 1, 2);


### PR DESCRIPTION
## Why I'm doing:
Failure to create a partition during ingestion will currently be classified as a data error as if the partition did not exist during ingestion. This will cause the routine load to trigger paused due to data quality issues. 
The logic behind data quality issues triggering paused is that retrying cannot solve the problem, but partition creation failure can be retried.

## What I'm doing:
make create partition failure as ingestion error, not data error.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
