### PR TITLE
[BugFix] fix concurrency issue between pk tablet migrate and pk index major compaction

### DIFF
--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -3020,6 +3020,7 @@ TEST_P(PersistentIndexTest, pindex_compaction_disk_limit) {
 }
 
 TEST_P(PersistentIndexTest, pindex_compaction_schedule) {
+    config::pindex_major_compaction_schedule_interval_seconds = 0;
     TabletSharedPtr tablet = create_tablet(rand(), rand());
     ASSERT_OK(tablet->init());
     TabletSharedPtr tablet2 = create_tablet(rand(), rand());
@@ -3038,6 +3039,7 @@ TEST_P(PersistentIndexTest, pindex_compaction_schedule) {
 }
 
 TEST_P(PersistentIndexTest, pindex_compaction_schedule_with_migration) {
+    config::pindex_major_compaction_schedule_interval_seconds = 0;
     TabletSharedPtr tablet = create_tablet(rand(), rand());
     ASSERT_OK(tablet->init());
     tablet->set_is_migrating(true);
@@ -3048,6 +3050,8 @@ TEST_P(PersistentIndexTest, pindex_compaction_schedule_with_migration) {
         ret.emplace_back(tablet->tablet_id(), 1.0);
         return ret;
     });
+    sleep(2);
+    ASSERT_FALSE(mgr.is_running(tablet->tablet_id()));
 }
 
 TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_update) {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -3037,6 +3037,19 @@ TEST_P(PersistentIndexTest, pindex_compaction_schedule) {
     });
 }
 
+TEST_P(PersistentIndexTest, pindex_compaction_schedule_with_migration) {
+    TabletSharedPtr tablet = create_tablet(rand(), rand());
+    ASSERT_OK(tablet->init());
+    tablet->set_is_migrating(true);
+    PersistentIndexCompactionManager mgr;
+    ASSERT_OK(mgr.init());
+    mgr.schedule([&]() {
+        std::vector<TabletAndScore> ret;
+        ret.emplace_back(tablet->tablet_id(), 1.0);
+        return ret;
+    });
+}
+
 TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_update) {
     int64_t old_config = config::max_allow_pindex_l2_num;
     config::max_allow_pindex_l2_num = 100;


### PR DESCRIPTION
## Why I'm doing:
There are two issues here:
1. Concurrency issue between tablet migrate and pk index major compaction. BE will crash:
```
PC: @          0x540c550 starrocks::ShardByLengthMutableIndex::~ShardByLengthMutableIndex()
*** SIGSEGV (@0x0) received by PID 160027 (TID 0x2c6508e61700) from PID 0; stack trace: ***
    @          0x67c3642 google::(anonymous namespace)::FailureSignalHandler()
    @     0x2b0a3c181acf os::Linux::chained_handler()
    @     0x2b0a3c187938 JVM_handle_linux_signal
    @     0x2b0a3c179338 signalHandler()
    @     0x2b0a3cae7630 (unknown)
    @          0x540c550 starrocks::ShardByLengthMutableIndex::~ShardByLengthMutableIndex()
    @          0x53a13f3 starrocks::PersistentIndex::_reload()
    @          0x53a7acb starrocks::PersistentIndex::major_compaction()
    @          0x500424b starrocks::PrimaryIndex::major_compaction()
    @          0x511683d starrocks::TabletUpdates::pk_index_major_compaction()
    @          0x5352272 starrocks::PkIndexMajorCompactionTask::run()
    @          0x2e7aadd starrocks::ThreadPool::dispatch_thread()
    @          0x2e744fa starrocks::Thread::supervise_thread()
    @     0x2b0a3cadfea5 start_thread
    @     0x2b0a3d71a96d __clone
    @                0x0 (unknown)
```
2. Missing call `unmark_running` when `pk_index_major_compaction()` fail.

## What I'm doing:
Fix these issues.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
