### PR TITLE
[Feature] List Partition For AMV(Part 2): Support list partition for asynchronous materialized view with non-nullable partition columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
@@ -69,6 +69,10 @@ public class MvBaseTableUpdateInfo {
         nameToPartKeys.put(partitionName, listPartitionKey);
     }
 
+    public void addListPartitionKeys(Map<String, PListCell> listPartitionKeys) {
+        nameToPartKeys.putAll(listPartitionKeys);
+    }
+
     /**
      * Get the partition name with its associated range partition key when the mv is range partitioned.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -117,10 +117,10 @@ public class MvRefreshArbiter {
      * Check whether mv needs to refresh based on the ref base table. It's a shortcut version of getMvBaseTableUpdateInfo.
      * @return Optional<Boolean> : true if needs to refresh, false if not, empty if there are some unkown results.
      */
-    public static Optional<Boolean> needsToRefreshTable(MaterializedView mv,
-                                                        Table baseTable,
-                                                        boolean withMv,
-                                                        boolean isQueryRewrite) {
+    private static Optional<Boolean> needsToRefreshTable(MaterializedView mv,
+                                                         Table baseTable,
+                                                         boolean withMv,
+                                                         boolean isQueryRewrite) {
         if (baseTable.isView()) {
             // do nothing
             return Optional.of(false);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.mv.MVTimelinessArbiter;
+import com.starrocks.catalog.mv.MVTimelinessListPartitionArbiter;
 import com.starrocks.catalog.mv.MVTimelinessNonPartitionArbiter;
 import com.starrocks.catalog.mv.MVTimelinessRangePartitionArbiter;
 import com.starrocks.common.AnalysisException;
@@ -104,6 +105,8 @@ public class MvRefreshArbiter {
             return new MVTimelinessNonPartitionArbiter(mv, isQueryRewrite);
         } else if (partitionInfo.isRangePartition()) {
             return new MVTimelinessRangePartitionArbiter(mv, isQueryRewrite);
+        } else if (partitionInfo.isListPartition()) {
+            return new MVTimelinessListPartitionArbiter(mv, isQueryRewrite);
         } else {
             throw UnsupportedException.unsupportedException("unsupported partition info type:" +
                     partitionInfo.getClass().getName());
@@ -195,9 +198,7 @@ public class MvRefreshArbiter {
                 if (mvPartitionInfo.isListPartition()) {
                     Map<String, PListCell> partitionNameWithRange = getMVPartitionNameWithList(baseTable,
                             partitionColumn, updatedPartitionNamesList);
-                    for (Map.Entry<String, PListCell> e : partitionNameWithRange.entrySet()) {
-                        baseTableUpdateInfo.addListPartitionKeys(e.getKey(), e.getValue());
-                    }
+                    baseTableUpdateInfo.addListPartitionKeys(partitionNameWithRange);
                     baseTableUpdateInfo.addToRefreshPartitionNames(partitionNameWithRange.keySet());
                 } else if (mvPartitionInfo.isRangePartition()) {
                     Expr partitionExpr = MaterializedView.getPartitionExpr(mv);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.mv;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvUpdateInfo;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.common.ListPartitionDiff;
+import com.starrocks.sql.common.ListPartitionDiffResult;
+import com.starrocks.sql.common.ListPartitionDiffer;
+import com.starrocks.sql.common.PListCell;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
+
+public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter {
+    private static final Logger LOG = LogManager.getLogger(MVTimelinessListPartitionArbiter.class);
+
+    public MVTimelinessListPartitionArbiter(MaterializedView mv, boolean isQueryRewrite) {
+        super(mv, isQueryRewrite);
+    }
+
+    @Override
+    public MvUpdateInfo getMVTimelinessUpdateInfoInChecked() throws AnalysisException {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        Preconditions.checkState(partitionInfo instanceof ListPartitionInfo);
+        Map<Table, Column> refBaseTableAndColumns = mv.getRelatedPartitionTableAndColumn();
+        if (refBaseTableAndColumns.isEmpty()) {
+            mv.setInactiveAndReason("partition configuration changed");
+            LOG.warn("mark mv:{} inactive for get partition info failed", mv.getName());
+            throw new RuntimeException(String.format("getting partition info failed for mv: %s", mv.getName()));
+        }
+
+        // if it needs to refresh based on non-ref base tables, return full refresh directly.
+        boolean isRefreshBasedOnNonRefTables = needsRefreshOnNonRefBaseTables(refBaseTableAndColumns);
+        logMVPrepare(mv, "Is refresh based on non-ref base table:{}", isRefreshBasedOnNonRefTables);
+        if (isRefreshBasedOnNonRefTables) {
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+        }
+
+        MvUpdateInfo mvTimelinessInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL);
+        ListPartitionDiffResult result = ListPartitionDiffer.computeListPartitionDiff(mv);
+        if (result == null) {
+            logMVPrepare(mv, "Partitioned mv compute list diff failed");
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+        }
+
+        final Map<Table, Map<String, PListCell>> refBaseTablePartitionMap = result.refBaseTablePartitionMap;
+        // update into mv's to refresh partitions
+        Set<String> mvToRefreshPartitionNames = mvTimelinessInfo.getMvToRefreshPartitionNames();
+        final ListPartitionDiff listPartitionDiff = result.listPartitionDiff;
+        mvToRefreshPartitionNames.addAll(listPartitionDiff.getDeletes().keySet());
+        // remove ref base table's deleted partitions from `mvPartitionMap`
+        Map<String, PListCell> mvPartitionNameToListMap = mv.getListPartitionItems();
+        listPartitionDiff.getDeletes().keySet().forEach(mvPartitionNameToListMap::remove);
+        // refresh ref base table's new added partitions
+        mvToRefreshPartitionNames.addAll(listPartitionDiff.getAdds().keySet());
+        mvPartitionNameToListMap.putAll(listPartitionDiff.getAdds());
+
+        final Map<Table, List<Integer>> refBaseTableRefIdxMap = result.refBaseTableRefIdxMap;
+        Map<Table, Map<String, Set<String>>> baseToMvNameRef = ListPartitionDiffer
+                .generateBaseRefMap(refBaseTablePartitionMap, refBaseTableRefIdxMap, mvPartitionNameToListMap);
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRef = ListPartitionDiffer
+                .generateMvRefMap(mvPartitionNameToListMap, refBaseTableRefIdxMap, refBaseTablePartitionMap);
+        mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);
+        mvTimelinessInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
+
+        // update mv's to refresh partitions based on base table's partition changes
+        Map<Table, Set<String>> baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTableAndColumns,
+                mvTimelinessInfo);
+        mvToRefreshPartitionNames.addAll(getMVToRefreshPartitionNames(baseChangedPartitionNames, baseToMvNameRef));
+
+        return mvTimelinessInfo;
+    }
+
+    @Override
+    public MvUpdateInfo getMVTimelinessUpdateInfoInLoose() {
+        MvUpdateInfo mvUpdateInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL,
+                TableProperty.QueryRewriteConsistencyMode.LOOSE);
+        ListPartitionDiff listPartitionDiff = null;
+        try {
+            ListPartitionDiffResult result = ListPartitionDiffer.computeListPartitionDiff(mv);
+            if (result == null) {
+                logMVPrepare(mv, "Partitioned mv compute list diff failed");
+                return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+            }
+            listPartitionDiff = result.listPartitionDiff;
+        } catch (Exception e) {
+            LOG.warn("Materialized view compute partition difference with base table failed.", e);
+            return null;
+        }
+        if (listPartitionDiff == null) {
+            LOG.warn("Materialized view compute partition difference with base table failed, the diff of range partition" +
+                    " is null.");
+            return null;
+        }
+        Map<String, PListCell> adds = listPartitionDiff.getAdds();
+        for (Map.Entry<String, PListCell> addEntry : adds.entrySet()) {
+            String mvPartitionName = addEntry.getKey();
+            mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName);
+        }
+        return mvUpdateInfo;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -74,7 +74,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         }
 
         // There may be a performance issue here, because it will fetch all partitions of base tables and mv partitions.
-        RangePartitionDiffResult differ = RangePartitionDiffer.computeRangePartitionDiff(mv);
+        RangePartitionDiffResult differ = RangePartitionDiffer.computeRangePartitionDiff(mv, null, true);
         if (differ == null) {
             throw new AnalysisException(String.format("Compute partition difference of mv %s with base table failed.",
                     mv.getName()));
@@ -134,7 +134,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         RangePartitionDiff rangePartitionDiff = null;
         try {
             // There may be a performance issue here, because it will fetch all partitions of base tables and mv partitions.
-            RangePartitionDiffResult differ = RangePartitionDiffer.computeRangePartitionDiff(mv);
+            RangePartitionDiffResult differ = RangePartitionDiffer.computeRangePartitionDiff(mv, null, true);
             if (differ == null) {
                 return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.UNKNOWN);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -15,14 +15,12 @@
 package com.starrocks.catalog.mv;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.MvBaseTableUpdateInfo;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
@@ -42,7 +40,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 
 /**
@@ -128,24 +125,6 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         // update mv's to refresh partitions
         mvTimelinessInfo.addMvToRefreshPartitionNames(mvToRefreshPartitionNames);
         return mvTimelinessInfo;
-    }
-
-    /**
-     * Collect ref base table's update partition infos
-     * @param refBaseTableAndColumns ref base table and columns of mv
-     * @return ref base table's changed partition names
-     */
-    private Map<Table, Set<String>> collectBaseTableUpdatePartitionNames(Map<Table, Column> refBaseTableAndColumns,
-                                                                         MvUpdateInfo mvUpdateInfo) {
-        Map<Table, Set<String>> baseChangedPartitionNames = Maps.newHashMap();
-        for (Map.Entry<Table, Column> e : refBaseTableAndColumns.entrySet()) {
-            Table baseTable = e.getKey();
-            MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, baseTable,
-                    true, true);
-            mvUpdateInfo.getBaseTableUpdateInfos().put(baseTable, mvBaseTableUpdateInfo);
-            baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPartitionNames());
-        }
-        return baseChangedPartitionNames;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -103,6 +103,36 @@ public class ExecuteOption {
         isReplay = replay;
     }
 
+    private boolean containsKey(String key) {
+        return taskRunProperties.containsKey(key) && taskRunProperties.get(key) != null;
+    }
+
+    /**
+     * If the execute option contains the properties that need to be merged into the task run, eg: it's an internal partition
+     * refresh, needs to merge it into the newer task run.
+     * task in mv refresh
+     * @return
+     */
+    public boolean containsToMergeProperties() {
+        if (taskRunProperties == null) {
+            return false;
+        }
+        if (containsKey(TaskRun.PARTITION_START) || containsKey(TaskRun.PARTITION_END)
+                || containsKey(TaskRun.START_TASK_RUN_ID)) {
+            return true;
+        }
+        return false;
+    }
+
+    public void mergeProperties(ExecuteOption option) {
+        if (option.taskRunProperties != null) {
+            if (taskRunProperties == null) {
+                taskRunProperties = Maps.newHashMap();
+            }
+            taskRunProperties.putAll(option.taskRunProperties);
+        }
+    }
+
     @Override
     public String toString() {
         return GsonUtils.GSON.toJson(this);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -69,6 +69,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.mv.MVPCTMetaRepairer;
+import com.starrocks.scheduler.mv.MVPCTRefreshListPartitioner;
 import com.starrocks.scheduler.mv.MVPCTRefreshNonPartitioner;
 import com.starrocks.scheduler.mv.MVPCTRefreshPartitioner;
 import com.starrocks.scheduler.mv.MVPCTRefreshPlanBuilder;
@@ -997,6 +998,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             return new MVPCTRefreshNonPartitioner(mvContext, context, db, mv);
         } else if (partitionInfo.isRangePartition()) {
             return new MVPCTRefreshRangePartitioner(mvContext, context, db, mv);
+        } else if (partitionInfo.isListPartition()) {
+            return new MVPCTRefreshListPartitioner(mvContext, context, db, mv);
         } else {
             throw new DmlException(String.format("materialized view:%s in database:%s refresh failed: partition info %s not " +
                     "supported", mv.getName(), context.ctx.getDatabase(), partitionInfo));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -1,0 +1,311 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.scheduler.mv;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.TableSnapshotInfo;
+import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
+import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.DistributionDesc;
+import com.starrocks.sql.ast.MultiItemListPartitionDesc;
+import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.common.ListPartitionDiff;
+import com.starrocks.sql.common.ListPartitionDiffResult;
+import com.starrocks.sql.common.ListPartitionDiffer;
+import com.starrocks.sql.common.PListCell;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
+    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshListPartitioner.class);
+
+    public MVPCTRefreshListPartitioner(MvTaskRunContext mvContext,
+                                       TaskRunContext context,
+                                       Database db,
+                                       MaterializedView mv) {
+        super(mvContext, context, db, mv);
+    }
+
+    @Override
+    public boolean syncAddOrDropPartitions() {
+        // collect mv partition items with lock
+        Locker locker = new Locker();
+        if (!locker.tryLockDatabase(db, LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
+            throw new LockTimeoutException("Failed to lock database: " + db.getFullName() + " in syncPartitionsForList");
+        }
+
+        ListPartitionDiffResult result;
+        try {
+            result = ListPartitionDiffer.computeListPartitionDiff(mv);
+            if (result == null) {
+                LOG.warn("compute list partition diff failed: mv: {}", mv.getName());
+                return false;
+            }
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
+
+        {
+            ListPartitionDiff partitionDiff = result.listPartitionDiff;
+            // We should delete the old partition first and then add the new one,
+            // because the old and new partitions may overlap
+            Map<String, PListCell> deletes = partitionDiff.getDeletes();
+            for (String mvPartitionName : deletes.keySet()) {
+                dropPartition(db, mv, mvPartitionName);
+            }
+            LOG.info("The process of synchronizing materialized view [{}] delete partitions range [{}]",
+                    mv.getName(), deletes);
+
+            // add partitions
+            Map<String, String> partitionProperties = MvUtils.getPartitionProperties(mv);
+            DistributionDesc distributionDesc = MvUtils.getDistributionDesc(mv);
+            Map<String, PListCell> adds = partitionDiff.getAdds();
+
+            // filter by partition_ttl_number
+            int ttlNumber = mv.getTableProperty().getPartitionTTLNumber();
+            filterPartitionsByNumber(adds, ttlNumber);
+            // add partitions for mv
+            addListPartitions(db, mv, adds, partitionProperties, distributionDesc);
+            LOG.info("The process of synchronizing materialized view [{}] add partitions list [{}]",
+                    mv.getName(), adds);
+
+            // add into mv context
+            result.mvListPartitionMap.putAll(adds);
+        }
+        {
+            final Map<Table, List<Integer>> refBaseTableRefIdxMap = result.refBaseTableRefIdxMap;
+            final Map<Table, Map<String, PListCell>> refBaseTablePartitionMap = result.refBaseTablePartitionMap;
+            // base table -> Map<partition name -> mv partition names>
+            Map<Table, Map<String, Set<String>>> baseToMvNameRef = ListPartitionDiffer
+                    .generateBaseRefMap(refBaseTablePartitionMap, refBaseTableRefIdxMap, result.mvListPartitionMap);
+            // mv partition name -> Map<base table -> base partition names>
+            Map<String, Map<Table, Set<String>>> mvToBaseNameRef = ListPartitionDiffer
+                    .generateMvRefMap(result.mvListPartitionMap, refBaseTableRefIdxMap, refBaseTablePartitionMap);
+            mvContext.setRefBaseTableMVIntersectedPartitions(baseToMvNameRef);
+            mvContext.setMvRefBaseTableIntersectedPartitions(mvToBaseNameRef);
+            mvContext.setRefBaseTableListPartitionMap(refBaseTablePartitionMap);
+        }
+        return true;
+    }
+
+    @Override
+    public Expr generatePartitionPredicate(Table table, Set<String> refBaseTablePartitionNames,
+                                           Expr mvPartitionSlotRef) throws AnalysisException {
+        Map<Table, Map<String, PListCell>> basePartitionMaps = mvContext.getRefBaseTableListPartitionMap();
+        if (basePartitionMaps.isEmpty()) {
+            return null;
+        }
+        Table refBaseTable = mvContext.getRefBaseTable();
+        Map<String, PListCell> baseListPartitionMap = basePartitionMaps.get(refBaseTable);
+        if (baseListPartitionMap == null || baseListPartitionMap.isEmpty()) {
+            return null;
+        }
+
+        List<LiteralExpr> sourceTablePartitionList = Lists.newArrayList();
+        List<Column> partitionCols = refBaseTable.getPartitionColumns();
+        Map<Table, Column> partitionTableAndColumn = mv.getRelatedPartitionTableAndColumn();
+        if (partitionTableAndColumn == null || !partitionTableAndColumn.containsKey(refBaseTable)) {
+            return null;
+        }
+        Column refPartitionColumn = partitionTableAndColumn.get(table);
+        int refIndex = ListPartitionDiffer.getRefBaseTableIdx(refBaseTable, refPartitionColumn);
+        Type partitionType = partitionCols.get(refIndex).getType();
+        for (String tablePartitionName : refBaseTablePartitionNames) {
+            PListCell cell = baseListPartitionMap.get(tablePartitionName);
+            for (List<String> values : cell.getPartitionItems()) {
+                if (partitionCols.size() != values.size()) {
+                    return null;
+                }
+                LiteralExpr partitionValue = new PartitionValue(values.get(refIndex)).getValue(partitionType);
+                sourceTablePartitionList.add(partitionValue);
+            }
+        }
+        List<Expr> partitionPredicates = MvUtils.convertList(mvPartitionSlotRef, sourceTablePartitionList);
+        return Expr.compoundOr(partitionPredicates);
+    }
+
+    @Override
+    public Set<String> getMVPartitionsToRefreshWithForce(int partitionTTLNumber) {
+        return mv.getValidListPartitionMap(partitionTTLNumber).keySet();
+    }
+
+    @Override
+    public Set<String> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
+                                                Map<Long, TableSnapshotInfo> snapshotBaseTables,
+                                                String start, String end, boolean force,
+                                                Set<String> mvPotentialPartitionNames) {
+        // list partitioned materialized view
+        boolean isAutoRefresh = mvContext.getTaskType().isAutoRefresh();
+        int partitionTTLNumber = mvContext.getPartitionTTLNumber();
+        Set<String> mvListPartitionNames = getMVPartitionNamesWithTTL(mv, start, end, partitionTTLNumber, isAutoRefresh);
+
+        // check non-ref base tables
+        if (needsRefreshBasedOnNonRefTables(snapshotBaseTables)) {
+            if (start == null && end == null) {
+                // if non-partition table changed, should refresh all partitions of materialized view
+                return mvListPartitionNames;
+            } else {
+                // If the user specifies the start and end ranges, and the non-partitioned table still changes,
+                // it should be refreshed according to the user-specified range, not all partitions.
+                return getMvPartitionNamesToRefresh(mvListPartitionNames, true);
+            }
+        } else {
+            // check the ref base table
+            return getMvPartitionNamesToRefresh(mvListPartitionNames, force);
+        }
+    }
+
+    @Override
+    public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
+                                                  String start, String end,
+                                                  int partitionTTLNumber,
+                                                  boolean isAutoRefresh) {
+        int autoRefreshPartitionsLimit = materializedView.getTableProperty().getAutoRefreshPartitionsLimit();
+        int lastPartitionNum;
+        if (partitionTTLNumber > 0 && isAutoRefresh && autoRefreshPartitionsLimit > 0) {
+            lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);
+        } else if (isAutoRefresh && autoRefreshPartitionsLimit > 0) {
+            lastPartitionNum = autoRefreshPartitionsLimit;
+        } else if (partitionTTLNumber > 0) {
+            lastPartitionNum = partitionTTLNumber;
+        } else {
+            lastPartitionNum = TableProperty.INVALID;
+        }
+        return materializedView.getValidListPartitionMap(lastPartitionNum).keySet();
+    }
+
+    /**
+     * Filter partitions by partition_ttl_number
+     * @param inputPartitions the partitions to refresh/add
+     * @param filterNumber the number to filter/reserve
+     * @return <startPartitionName, endPartitionName> pair after the reserved partition_ttl_number
+     */
+    private Pair<String, String> filterPartitionsByNumber(Map<String, PListCell> inputPartitions,
+                                                          int filterNumber) {
+        if (filterNumber <= 0 || filterNumber >= inputPartitions.size()) {
+            return null;
+        }
+        // TODO: Sort by List Partition's value is weird because there maybe meaningless or un-sortable,
+        // users should take care of `partition_ttl_number` for list partition.
+        LinkedHashMap<String, PListCell> sortedPartition = inputPartitions.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+        Iterator<String> iter = sortedPartition.keySet().iterator();
+        // iterate partition_ttl_number times
+        for (int i = 0; i < filterNumber; i++) {
+            if (iter.hasNext()) {
+                iter.next();
+            }
+        }
+        String start = null;
+        String end = null;
+        if (iter.hasNext()) {
+            String startPartitionName = iter.next();
+            start = startPartitionName;
+            end = startPartitionName;
+            inputPartitions.remove(end);
+        }
+        while (iter.hasNext()) {
+            end = iter.next();
+            inputPartitions.remove(end);
+        }
+        LOG.info("Filter partitions by partition_ttl_number, ttl_number:{}, start: {}, end: {}, result:{}",
+                filterNumber, start, end, inputPartitions);
+        return Pair.create(start, end);
+    }
+
+    @Override
+    public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
+                                               Set<String> mvPotentialPartitionNames) {
+        Map<String, PListCell> mappedPartitionsToRefresh = Maps.newHashMap();
+        Map<String, PListCell> listPartitionMap = mv.getListPartitionItems();
+        for (String partitionName : mvPartitionsToRefresh) {
+            PListCell listCell = listPartitionMap.get(partitionName);
+            if (listCell == null) {
+                LOG.warn("Partition {} is not found in materialized view {}", partitionName, mv.getName());
+                continue;
+            }
+            mappedPartitionsToRefresh.put(partitionName, listCell);
+        }
+        int refreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
+        Pair<String, String> result = filterPartitionsByNumber(mappedPartitionsToRefresh, refreshNumber);
+        if (result == null) {
+            return;
+        }
+        // partitionNameIter has just been traversed, and endPartitionName is not updated
+        // will cause endPartitionName == null
+        mvContext.setNextPartitionStart(result.first);
+        mvContext.setNextPartitionEnd(result.second);
+    }
+
+    private void addListPartitions(Database database, MaterializedView materializedView,
+                                   Map<String, PListCell> adds, Map<String, String> partitionProperties,
+                                   DistributionDesc distributionDesc) {
+        if (adds == null || adds.isEmpty()) {
+            return;
+        }
+
+        // TODO: support to add partitions by batch
+        for (Map.Entry<String, PListCell> addEntry : adds.entrySet()) {
+            String mvPartitionName = addEntry.getKey();
+            PListCell partitionCell = addEntry.getValue();
+            List<List<String>> partitionItems = partitionCell.getPartitionItems();
+            // the order is not guaranteed
+            MultiItemListPartitionDesc multiItemListPartitionDesc =
+                    new MultiItemListPartitionDesc(false, mvPartitionName, partitionItems, partitionProperties);
+            AddPartitionClause addPartitionClause =
+                    new AddPartitionClause(multiItemListPartitionDesc, distributionDesc, partitionProperties, false);
+            AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(materializedView);
+            analyzer.analyze(mvContext.getCtx(), addPartitionClause);
+            try {
+                GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(
+                        mvContext.getCtx(), database, materializedView.getName(), addPartitionClause);
+            } catch (Exception e) {
+                throw new DmlException("add list partition failed: %s, db: %s, table: %s", e, e.getMessage(),
+                        database.getFullName(), materializedView.getName());
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -147,8 +147,8 @@ public abstract class MVPCTRefreshPartitioner {
         Map<String, Set<String>> refBaseTableMVPartitionMap = refBaseTableMVPartitionMaps.get(refBaseTable);
         for (String basePartitionName : baseTablePartitionNames) {
             if (!refBaseTableMVPartitionMap.containsKey(basePartitionName)) {
-                LOG.warn("Cannot find need refreshed ref base table partition from synced partition info: {}",
-                        basePartitionName);
+                LOG.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
+                                "refBaseTableMVPartitionMaps: {}", basePartitionName, refBaseTableMVPartitionMaps);
                 return null;
             }
             result.addAll(refBaseTableMVPartitionMap.get(basePartitionName));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -97,7 +97,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         Preconditions.checkState(partitionColumnOpt.isPresent());
         Column partitionColumn = partitionColumnOpt.get();
         Range<PartitionKey> rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
-        RangePartitionDiffResult result = RangePartitionDiffer.computeRangePartitionDiff(mv, rangeToInclude);
+        RangePartitionDiffResult result = RangePartitionDiffer.computeRangePartitionDiff(mv, rangeToInclude, false);
         if (result == null) {
             // TODO: throw exception?
             LOG.warn("compute range partition diff failed: mv: {}", mv.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -117,10 +117,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         DistributionDesc distributionDesc = MvUtils.getDistributionDesc(mv);
         Map<String, Range<PartitionKey>> adds = result.rangePartitionDiff.getAdds();
         addRangePartitions(db, mv, adds, partitionProperties, distributionDesc);
-        for (Map.Entry<String, Range<PartitionKey>> addEntry : adds.entrySet()) {
-            String mvPartitionName = addEntry.getKey();
-            result.mvRangePartitionMap.put(mvPartitionName, addEntry.getValue());
-        }
+        adds.entrySet().stream().forEach(entry -> result.mvRangePartitionMap.put(entry.getKey(), entry.getValue()));
         LOG.info("The process of synchronizing materialized view [{}] add partitions range [{}]",
                 mv.getName(), adds);
 
@@ -189,7 +186,6 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                                                 String start, String end, boolean force,
                                                 Set<String> mvPotentialPartitionNames) throws AnalysisException {
         // range partitioned materialized views
-        Expr partitionExpr = mv.getPartitionExpr();
         boolean isAutoRefresh = mvContext.getTaskType().isAutoRefresh();
         int partitionTTLNumber = mvContext.getPartitionTTLNumber();
         Set<String> mvRangePartitionNames = getMVPartitionNamesWithTTL(mv, start, end, partitionTTLNumber, isAutoRefresh);
@@ -303,7 +299,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                                                Set<String> mvPotentialPartitionNames) {
         int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
         Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
-        if (partitionRefreshNumber >= mvRangePartitionMap.size()) {
+        if (partitionRefreshNumber <= 0 || partitionRefreshNumber >= mvRangePartitionMap.size()) {
             return;
         }
         Map<String, Range<PartitionKey>> mappedPartitionsToRefresh = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiff.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiff.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.common;
+
+import java.util.Map;
+
+/**
+ * Diff result of list partitions.
+ */
+public final class ListPartitionDiff extends PartitionDiff {
+
+    Map<String, PListCell> adds;
+
+    Map<String, PListCell> deletes;
+
+    public ListPartitionDiff(Map<String, PListCell> adds, Map<String, PListCell> deletes) {
+        this.adds = adds;
+        this.deletes = deletes;
+    }
+
+    public Map<String, PListCell> getAdds() {
+        return adds;
+    }
+
+    public void setAdds(Map<String, PListCell> adds) {
+        this.adds = adds;
+    }
+
+    public Map<String, PListCell> getDeletes() {
+        return deletes;
+    }
+
+    public void setDeletes(Map<String, PListCell> deletes) {
+        this.deletes = deletes;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffResult.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.starrocks.catalog.Table;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The result of diffing between materialized view and the base tables.
+ */
+public class ListPartitionDiffResult {
+    // The partition range of the materialized view: <mv partition name, mv partition range>
+    public final Map<String, PListCell> mvListPartitionMap;
+    // The partition range of the base tables: <base table, <base table partition name, base table partition range>>
+    public final Map<Table, Map<String, PListCell>> refBaseTablePartitionMap;
+    // The diff result of partition range between materialized view and base tables
+    public final ListPartitionDiff listPartitionDiff;
+
+    // MV partition column ref index for each base table's partition columns
+    public final Map<Table, List<Integer>> refBaseTableRefIdxMap;
+
+    public ListPartitionDiffResult(Map<String, PListCell> mvListPartitionMap,
+                                   Map<Table, Map<String, PListCell>> refBaseTablePartitionMap,
+                                   ListPartitionDiff listPartitionDiff,
+                                   Map<Table, List<Integer>> refBaseTableRefIdxMap) {
+        this.mvListPartitionMap = mvListPartitionMap;
+        this.refBaseTablePartitionMap = refBaseTablePartitionMap;
+        this.listPartitionDiff = listPartitionDiff;
+        this.refBaseTableRefIdxMap = refBaseTableRefIdxMap;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
@@ -14,11 +14,23 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.connector.PartitionUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 
 public final class ListPartitionDiffer extends PartitionDiffer {
     private static final Logger LOG = LogManager.getLogger(ListPartitionDiffer.class);
@@ -26,6 +38,22 @@ public final class ListPartitionDiffer extends PartitionDiffer {
     /**
      * Iterate srcListMap, if the partition name is not in dstListMap or the partition value is different, add into result.
      *
+     * Compare the partition of the base table and the partition of the mv.
+     * @param baseItems the partition name to its list partition cell of the base table
+     * @param mvItems the partition name to its list partition cell of the mv
+     * @return the list partition diff between the base table and the mv
+     */
+    public static ListPartitionDiff getListPartitionDiff(Map<String, PListCell> baseItems,
+                                                         Map<String, PListCell> mvItems) {
+        // This synchronization method has a one-to-one correspondence
+        // between the base table and the partition of the mv.
+        Map<String, PListCell> adds = diffList(baseItems, mvItems);
+        Map<String, PListCell> deletes = diffList(mvItems, baseItems);
+        return new ListPartitionDiff(adds, deletes);
+    }
+
+    /**
+     * Iterate srcListMap, if the partition name is not in dstListMap or the partition value is different, add into result.
      * @param srcListMap src partition list map
      * @param dstListMap dst partition list map
      * @return the different partition list map
@@ -65,7 +93,6 @@ public final class ListPartitionDiffer extends PartitionDiffer {
 
     /**
      * Check if src list map is different from dst list map.
-     *
      * @param srcListMap src partition list map
      * @param dstListMap dst partition list map
      * @return true if the partition has changed, otherwise false
@@ -80,5 +107,225 @@ public final class ListPartitionDiffer extends PartitionDiffer {
             }
         }
         return false;
+    }
+
+    private static Map<PListAtom, Set<PListCellPlus>> toAtoms(Map<String, PListCell> partitionMap,
+                                                              List<Integer> refIdxes) {
+        Map<PListAtom, Set<PListCellPlus>> result = Maps.newHashMap();
+        for (Map.Entry<String, PListCell> e : partitionMap.entrySet()) {
+            PListCellPlus plus = new PListCellPlus(e.getKey(), e.getValue());
+            plus.toAtoms(refIdxes).stream()
+                    .forEach(x -> result.computeIfAbsent(x, k -> Sets.newHashSet())
+                            .add(new PListCellPlus(e.getKey(), e.getValue())));
+        }
+        return result;
+    }
+
+    private static Map<PListAtom, Set<PListCellPlus>> toAtoms(Map<String, PListCell> partitionMap) {
+        Map<PListAtom, Set<PListCellPlus>> result = Maps.newHashMap();
+        for (Map.Entry<String, PListCell> e : partitionMap.entrySet()) {
+            PListCellPlus plus = new PListCellPlus(e.getKey(), e.getValue());
+            plus.toAtoms().stream()
+                    .forEach(x -> result.computeIfAbsent(x, k -> Sets.newHashSet())
+                            .add(new PListCellPlus(e.getKey(), e.getValue())));
+        }
+        return result;
+    }
+
+    public static Map<String, Set<String>> generateBaseRefMap(Map<PListAtom, Set<PListCellPlus>> mvPartitionMap,
+                                                              List<Integer> refIdxes,
+                                                              Map<String, PListCell> baseTablePartitionMap) {
+        if (mvPartitionMap.isEmpty()) {
+            return Maps.newHashMap();
+        }
+        // for each partition of base, find the corresponding partition of mv
+        Map<PListAtom, Set<PListCellPlus>> baseAtoms = toAtoms(baseTablePartitionMap, refIdxes);
+        Map<String, Set<String>> result = Maps.newHashMap();
+        for (Map.Entry<PListAtom, Set<PListCellPlus>> e : baseAtoms.entrySet()) {
+            // once base table's singleton is found in mv, add the partition name of mv into result
+            PListAtom baseAtom = e.getKey();
+            if (mvPartitionMap.containsKey(baseAtom)) {
+                Set<PListCellPlus> mvCellPluses = mvPartitionMap.get(baseAtom);
+                for (PListCellPlus baseCellPlus : e.getValue()) {
+                    mvCellPluses.stream().forEach(x ->
+                            result.computeIfAbsent(baseCellPlus.getPartitionName(), k -> Sets.newHashSet())
+                                    .add(x.getPartitionName())
+                    );
+                }
+            } else {
+                // add an empty set
+                Set<PListCellPlus> baseCellPluses = e.getValue();
+                baseCellPluses.stream().forEach(x -> result.computeIfAbsent(x.getPartitionName(), k -> Sets.newHashSet()));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * MV's partition column may not be the same as the base table's partition column, so we need to convert the base
+     * which contains multiple columns to the MV's partition cell which only contains one column.
+     * @param table ref base table
+     * @param inputs ref base table's partition cells
+     * @param refIdxes mv's ref indexes to the base table's partition columns
+     * @return converted base table partition cells which aligned with mv's partition column
+     */
+    private static Map<String, PListCell> alignBasePartitionCells(Table table,
+                                                                  Map<String, PListCell> inputs,
+                                                                  List<Integer> refIdxes) {
+        if (table.getPartitionColumnNames().size() == 1) {
+            return inputs;
+        }
+        // sort by partition name to ensure the result is stable
+        Map<String, PListCell> sorted = ImmutableSortedMap.copyOf(inputs);
+        Set<PListCell> cells = Sets.newHashSet();
+        Map<String, PListCell> result = Maps.newTreeMap();
+        for (Map.Entry<String, PListCell> e : sorted.entrySet()) {
+            String partName = e.getKey();
+            PListCell cell = e.getValue();
+            PListCell newCell = cell.toPListCell(refIdxes);
+            if (cells.contains(newCell)) {
+                continue;
+            }
+            cells.add(newCell);
+            result.put(partName, newCell);
+        }
+        return result;
+    }
+
+    /**
+     * Get the index of the partition column in the base table.
+     * @param refBaseTable base table
+     * @param refPartitionColumn base table's column which is referenced by the mv
+     * @return the index of the partition column in the base table, throw DmlException if not found
+     */
+    public static int getRefBaseTableIdx(Table refBaseTable,
+                                         Column refPartitionColumn) {
+        List<Column> partitionColumns = PartitionUtil.getPartitionColumns(refBaseTable);
+        int refIndex = partitionColumns.indexOf(refPartitionColumn);
+        if (refIndex == -1) {
+            throw new DmlException("Partition column not found in base table: %s", refPartitionColumn.getName());
+        }
+        return refIndex;
+    }
+
+    /**
+     * Collect base table's partition infos.
+     * @param basePartitionMaps result to collect base table's partition cells for each table
+     * @param allBasePartitionItems result to collect all base table's partition cells(merged)
+     * @param tableRefIdxes result to collect mv's ref indexes to the base table's partition columns
+     * @return true if success, otherwise false
+     */
+    private static boolean syncBaseTablePartitionInfos(MaterializedView mv,
+                                                       Map<Table, Map<String, PListCell>> basePartitionMaps,
+                                                       Map<String, PListCell> allBasePartitionItems,
+                                                       Map<Table, List<Integer>> tableRefIdxes) {
+        Map<Table, Column> partitionTableAndColumn = mv.getRelatedPartitionTableAndColumn();
+        try {
+            for (Map.Entry<Table, Column> e1 : partitionTableAndColumn.entrySet()) {
+                Table refBaseTable = e1.getKey();
+                Column refPartitionColumn = e1.getValue();
+
+                // support one column partition only, we can support multi columns later.
+                int refIndex = getRefBaseTableIdx(refBaseTable, refPartitionColumn);
+                List<Integer> refIdxes = Lists.newArrayList(refIndex);
+                tableRefIdxes.put(refBaseTable, refIdxes);
+
+                // collect base table's partition cells
+                Map<String, PListCell> basePartitionCells = PartitionUtil.getPartitionList(refBaseTable,
+                        refPartitionColumn);
+                basePartitionMaps.put(refBaseTable, basePartitionCells);
+
+                // convert to base partition cell to mv partition cell(only one column)
+                // eg: base table partition column: (dt, region), mv partition column: dt
+                Map<String, PListCell> newBasePartitionCells = alignBasePartitionCells(refBaseTable,
+                        basePartitionCells, refIdxes);
+                // merge into total map to compute the difference
+                for (Map.Entry<String, PListCell> e2 : newBasePartitionCells.entrySet()) {
+                    String partitionName = e2.getKey();
+                    PListCell partitionCell = e2.getValue();
+                    allBasePartitionItems.computeIfAbsent(partitionName, k -> new PListCell(Lists.newArrayList()))
+                            .addItems(partitionCell.getPartitionItems());
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Materialized view compute partition difference with base table failed.",
+                    DebugUtil.getStackTrace(e));
+            return false;
+        }
+        return true;
+    }
+
+    public static ListPartitionDiffResult computeListPartitionDiff(MaterializedView mv) {
+        // table -> map<partition name -> partition cell>
+        Map<Table, Map<String, PListCell>> refBaseTablePartitionMap = Maps.newHashMap();
+        // merge all base table partition cells
+        Map<String, PListCell> allBasePartitionItems = Maps.newHashMap();
+        Map<Table, List<Integer>> tableRefIdxes = Maps.newHashMap();
+        if (!syncBaseTablePartitionInfos(mv, refBaseTablePartitionMap, allBasePartitionItems, tableRefIdxes)) {
+            logMVPrepare(mv, "Partitioned mv collect base table infos failed");
+            return null;
+        }
+        // TODO: prune the partitions based on ttl
+        Map<String, PListCell> mvPartitionNameToListMap = mv.getListPartitionItems();
+        ListPartitionDiff diff = ListPartitionDiffer.getListPartitionDiff(
+                allBasePartitionItems, mvPartitionNameToListMap);
+        return new ListPartitionDiffResult(mvPartitionNameToListMap, refBaseTablePartitionMap, diff, tableRefIdxes);
+    }
+
+    /**
+     * Generate the reference map between the base table and the mv.
+     * @param basePartitionMaps src partition list map of the base table
+     * @param mvPartitionMap mv partition name to its list partition cell
+     * @return base table -> <partition name, mv partition names> mapping
+     */
+    public static Map<Table, Map<String, Set<String>>> generateBaseRefMap(Map<Table, Map<String, PListCell>> basePartitionMaps,
+                                                                          Map<Table, List<Integer>> tableRefIdxes,
+                                                                          Map<String, PListCell> mvPartitionMap) {
+        Map<PListAtom, Set<PListCellPlus>> mvAtoms = toAtoms(mvPartitionMap);
+        Map<Table, Map<String, Set<String>>> result = Maps.newHashMap();
+        for (Map.Entry<Table, Map<String, PListCell>> entry : basePartitionMaps.entrySet()) {
+            Table baseTable = entry.getKey();
+            Map<String, PListCell> baseTablePartitionMap = entry.getValue();
+            List<Integer> baseTablePartitionIdxes = tableRefIdxes.get(baseTable);
+            Map<String, Set<String>> baseTableRefMap = generateBaseRefMap(mvAtoms,
+                    baseTablePartitionIdxes, baseTablePartitionMap);
+            result.put(baseTable, baseTableRefMap);
+        }
+        return result;
+    }
+
+    /**
+     * Generate the reference map between the mv and the base table.
+     * @param mvPartitionMap mv partition name to its list partition cell
+     * @param basePartitionMaps src partition list map of the base table
+     * @return mv partition name -> <base table, base partition names> mapping
+     */
+    public static  Map<String, Map<Table, Set<String>>> generateMvRefMap(Map<String, PListCell> mvPartitionMap,
+                                                                         Map<Table, List<Integer>> tableRefIdxes,
+                                                                         Map<Table, Map<String, PListCell>> basePartitionMaps) {
+        Map<String, Map<Table, Set<String>>> result = Maps.newHashMap();
+        // for each partition of base, find the corresponding partition of mv
+        Map<PListAtom, Set<PListCellPlus>> mvAtoms = toAtoms(mvPartitionMap);
+        for (Map.Entry<Table, Map<String, PListCell>> entry : basePartitionMaps.entrySet()) {
+            Table baseTable = entry.getKey();
+            Map<String, PListCell> basePartitionMap = entry.getValue();
+            List<Integer> refIdxes = tableRefIdxes.get(baseTable);
+            Map<PListAtom, Set<PListCellPlus>> baseAtoms = toAtoms(basePartitionMap, refIdxes);
+            for (Map.Entry<PListAtom, Set<PListCellPlus>> e : baseAtoms.entrySet()) {
+                PListAtom singleton = e.getKey();
+                Set<PListCellPlus> baseCellPluses = e.getValue();
+                if (mvAtoms.containsKey(singleton)) {
+                    Set<PListCellPlus> mvCellPluses = mvAtoms.get(singleton);
+                    for (PListCellPlus mvCell : mvCellPluses) {
+                        baseCellPluses.stream().forEach(x ->
+                                result.computeIfAbsent(mvCell.getPartitionName(), k -> Maps.newHashMap())
+                                        .computeIfAbsent(baseTable, k -> Sets.newHashSet())
+                                        .add(x.getPartitionName())
+                        );
+                    }
+                }
+            }
+        }
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListAtom.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListAtom.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link PListAtom} represents a partition atom with a value which is used in the List Partition tables.
+ * eg: partition p1 values in (1, 'a') is a partition item which contains one value with multi partition columns
+ */
+public final class PListAtom {
+    // a partition key may contain multi columns
+    private final List<String> partitionItem;
+
+    public PListAtom(List<String> partitionKeys) {
+        this.partitionItem = partitionKeys;
+    }
+
+    public List<String> getPartitionItem() {
+        return partitionItem;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof PListAtom)) {
+            return false;
+        }
+        PListAtom other = (PListAtom) o;
+        List<String> otherSelectedPartitionKeys = other.getPartitionItem();
+        if (otherSelectedPartitionKeys.size() != partitionItem.size()) {
+            return false;
+        }
+        int len = partitionItem.size();
+        for (int i = 0; i < len; i++) {
+            if (!partitionItem.get(i).equals(otherSelectedPartitionKeys.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        // only consider partition key
+        return Objects.hash(partitionItem);
+    }
+
+    @Override
+    public String toString() {
+        return "PListAtom{" +
+                "partitionItems=" + partitionItem +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.common;
 
+import com.google.api.client.util.Lists;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -34,6 +36,29 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
 
     public List<List<String>> getPartitionItems() {
         return partitionItems;
+    }
+
+    /**
+     * Add a list of partition items as the partition values
+     * @param items new partition items
+     */
+    public void addItems(List<List<String>> items) {
+        partitionItems.addAll(items);
+    }
+
+    /**
+     * Construct a new partition cell by using selected idx
+     */
+    public PListCell toPListCell(List<Integer> selectColIds) {
+        List<List<String>> partitionItems = Lists.newArrayList();
+        for (List<String> partitionKey : this.partitionItems) {
+            List<String> selectedPartitionKey = Lists.newArrayList();
+            for (Integer i : selectColIds) {
+                selectedPartitionKey.add(partitionKey.get(i));
+            }
+            partitionItems.add(selectedPartitionKey);
+        }
+        return new PListCell(partitionItems);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCellPlus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCellPlus.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.api.client.util.Lists;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link PListCell} means a list partition with multiple values.
+ * eg: partition p1 values in ((1, 'a'), (2, 'b')) is a partition items which contains multi values with multi partition columns
+ *  partitionName: p1
+ *  partitionItems: ((1, 'a'), (2, 'b'))
+ */
+public final class PListCellPlus {
+    // multi values: the order is not important
+    private final PListCell cell;
+    private final String partitionName;
+
+    public PListCellPlus(String partitionName,
+                         PListCell cell) {
+        this.partitionName = partitionName;
+        this.cell = cell;
+    }
+
+    public PListCell getCell() {
+        return cell;
+    }
+
+    public String getPartitionName() {
+        return partitionName;
+    }
+
+    /**
+     * Convert a list of partition items to a map with partition name as key
+     */
+    public List<PListAtom> toAtoms() {
+        List<PListAtom> partitionValues = Lists.newArrayList();
+        for (List<String> item : cell.getPartitionItems()) {
+            partitionValues.add(new PListAtom(item));
+        }
+        return partitionValues;
+    }
+
+    public List<PListAtom> toAtoms(List<Integer> refIds) {
+        List<PListAtom> partitionValues = Lists.newArrayList();
+        for (List<String> partitionKey : cell.getPartitionItems()) {
+            List<String> selectedPartitionKey = Lists.newArrayList();
+            for (Integer i : refIds) {
+                selectedPartitionKey.add(partitionKey.get(i));
+            }
+            partitionValues.add(new PListAtom(selectedPartitionKey));
+        }
+        return partitionValues;
+    }
+
+    @Override
+    public int hashCode() {
+        // only consider partition key
+        return Objects.hash(partitionName, cell);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof PListCellPlus)) {
+            return false;
+        }
+        return partitionName.equals(((PListCellPlus) o).partitionName)
+                && cell.equals(((PListCellPlus) o).cell);
+    }
+
+    @Override
+    public String toString() {
+        return "PListCell{" +
+                "cell=" + cell +
+                ", partitionName='" + partitionName + '\'' +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -87,7 +87,6 @@ public final class RangePartitionDiffer extends PartitionDiffer {
         int partitionTTLNumber = mv.getTableProperty().getPartitionTTLNumber();
         PeriodDuration partitionTTL = mv.getTableProperty().getPartitionTTL();
         List<Column> partitionColumns = mv.getPartitionInfo().getPartitionColumns(mv.getIdToColumn());
-        Column partitionColumn = partitionColumns.get(0);
         return new RangePartitionDiffer(rangeToInclude, partitionTTLNumber, partitionTTL, partitionInfo, partitionColumns);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -304,54 +304,15 @@ public final class RangePartitionDiffer extends PartitionDiffer {
 
     /**
      * Compute the partition difference between materialized view and all ref base tables.
-     * </p>
-     * NOTE: This method is used for query rewrite, and it's different from
-     * {@link RangePartitionDiffer#computeRangePartitionDiff(MaterializedView, Range)}:
-     * 1. It ignores some extra checks to improve performance.
-     * 2. It uses simple differ rather the new differ because query rewrite cannot ignore ttl partitions.
-     * </p>
-     * @param materializedView: the materialized view to check
-     * @return MvPartitionDiffResult: the result of partition difference
-     */
-    public static RangePartitionDiffResult computeRangePartitionDiff(MaterializedView materializedView) {
-        Expr partitionExpr = materializedView.getPartitionExpr();
-        Map<Table, Column> partitionTableAndColumn = materializedView.getRelatedPartitionTableAndColumn();
-        Preconditions.checkArgument(!partitionTableAndColumn.isEmpty());
-        
-        Map<String, Range<PartitionKey>> mvRangePartitionMap = materializedView.getRangePartitionMap();
-        Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
-        Map<String, Range<PartitionKey>> allRefTablePartitionKeyMap = Maps.newHashMap();
-        try {
-            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
-                Table refBaseTable = entry.getKey();
-                Column refBaseTablePartitionColumn = entry.getValue();
-                // Collect the ref base table's partition range map.
-                Map<String, Range<PartitionKey>> refTablePartitionKeyMap =
-                        PartitionUtil.getPartitionKeyRange(refBaseTable, refBaseTablePartitionColumn, partitionExpr);
-                refBaseTablePartitionMap.put(refBaseTable, refTablePartitionKeyMap);
-                allRefTablePartitionKeyMap.putAll(refTablePartitionKeyMap);
-            }
-            RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, allRefTablePartitionKeyMap,
-                    mvRangePartitionMap, null);
-            if (rangePartitionDiff == null) {
-                LOG.warn("Materialized view compute partition difference with base table failed: rangePartitionDiff is null.");
-                return null;
-            }
-            return new RangePartitionDiffResult(mvRangePartitionMap, refBaseTablePartitionMap, null, rangePartitionDiff);
-        } catch (Exception e) {
-            LOG.warn("Materialized view compute partition difference with base table failed.", e);
-            return null;
-        }
-    }
-
-    /**
-     * Compute the partition difference between materialized view and all ref base tables.
      * @param mv: the materialized view to check
      * @param rangeToInclude: <partition start, partition end> pair
+     * @param isQueryRewrite: whether it's used for query rewrite or refresh which the difference is that query rewrite will not
+     *                      consider partition_ttl_number and mv refresh will consider it to avoid creating too much partitions
      * @return MvPartitionDiffResult: the result of partition difference
      */
     public static RangePartitionDiffResult computeRangePartitionDiff(MaterializedView mv,
-                                                                     Range<PartitionKey> rangeToInclude) {
+                                                                     Range<PartitionKey> rangeToInclude,
+                                                                     boolean isQueryRewrite) {
         Expr mvPartitionExpr = mv.getPartitionExpr();
         Map<Table, Column> refBaseTableAndColumns = mv.getRelatedPartitionTableAndColumn();
         Preconditions.checkArgument(!refBaseTableAndColumns.isEmpty());
@@ -396,7 +357,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             //
             // Diff_{deletes} = P_{MV} \setminus P_{\bigcup_{baseTables}^{}} \\
             //                = \bigcap_{baseTables} P_{MV}\setminus P_{baseTable}
-            RangePartitionDiffer differ = RangePartitionDiffer.build(mv, rangeToInclude);
+            RangePartitionDiffer differ = isQueryRewrite ? null : RangePartitionDiffer.build(mv, rangeToInclude);
             RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(mvPartitionExpr, mergedRBTPartitionKeyMap,
                     mvRangePartitionMap, differ);
             if (rangePartitionDiff == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -3676,10 +3676,8 @@ public class CreateMaterializedViewTest {
                 "as select dt, province, avg(age) from list_partition_tbl1 group by dt, province;";
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(
-                    e.getMessage().contains("Materialized view related base table partition type: LIST not supports."));
+            Assert.fail(e.getMessage());
         }
         starRocksAssert.dropTable("list_partition_tbl1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1,0 +1,892 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Partition;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.time.Instant;
+import java.util.Collection;
+
+import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
+    private static String T1;
+    private static String T2;
+    private static String T3;
+    private static String T4;
+    private static String T5;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MVRefreshTestBase.beforeClass();
+        // table whose partitions have multiple values
+        T1 = "CREATE TABLE t1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table whose partitions have only single values
+        T2 = "CREATE TABLE t2 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table whose partitions have multi columns
+        T3 = "CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province, dt) (\n" +
+                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\"))  ,\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\")), \n" +
+                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\"))  ,\n" +
+                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table with partition expression whose partitions have multiple values
+        T4 = "CREATE TABLE t4 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY (province) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table with partition expression whose partitions have multi columns
+        T5 = "CREATE TABLE t5 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY (province, dt) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        cleanupEphemeralMVs(starRocksAssert, startSuiteTime);
+    }
+
+    @Before
+    public void before() {
+        startCaseTime = Instant.now().getEpochSecond();
+    }
+
+    @After
+    public void after() throws Exception {
+        cleanupEphemeralMVs(starRocksAssert, startCaseTime);
+    }
+
+    protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+
+        for (String expected : explain) {
+            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
+                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
+        }
+    }
+
+    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+    }
+
+    private ExecPlan getExecPlan(TaskRun taskRun) {
+        try {
+            initAndExecuteTaskRun(taskRun);
+
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                    taskRun.getProcessor();
+            MvTaskRunContext mvContext = processor.getMvContext();
+            ExecPlan execPlan = mvContext.getExecPlan();
+            return execPlan;
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+            return null;
+        }
+    }
+
+    private ExecPlan getExecPlanAfterInsert(TaskRun taskRun, String insertSql) {
+        try {
+            executeInsertSql(connectContext, insertSql);
+        } catch (Exception e) {
+            Assert.fail();
+            return null;
+        }
+        ExecPlan execPlan = getExecPlan(taskRun);
+        Assert.assertTrue(execPlan != null);
+        return execPlan;
+    }
+
+    private void addListPartition(String tbl, String pName, String pVal) {
+        String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION %s VALUES IN ('%s')", tbl, pName, pVal);
+        StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
+        try {
+            new StmtExecutor(connectContext, stmt).execute();
+        } catch (Exception e) {
+            Assert.fail("add partition failed:" + e);
+        }
+    }
+
+    private void addListPartition(String tbl, String pName, String pVal1, String pVal2) {
+        String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION %s VALUES IN (('%s', '%s'))", tbl, pName, pVal1,
+                pVal2);
+        StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
+        try {
+            new StmtExecutor(connectContext, stmt).execute();
+        } catch (Exception e) {
+            Assert.fail("add partition failed:" + e);
+        }
+    }
+
+    @Test
+    public void testRefreshNonPartitionedMV() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTable(T2, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "as select dt, province, sum(age) from t2 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/2");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(1, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t2", "p3", "hangzhou");
+
+                            String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=3/3");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(1, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshSingleColumnMVWithSingleValues() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTable(T2, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as select dt, province, sum(age) from t2 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'beijing'\n" +
+                                    "     partitions=1/2");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t2", "p3", "hangzhou");
+
+                            String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'hangzhou'\n" +
+                                    "     partitions=1/3");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshSingleColumnWithMultiValues() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTable(T1, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as select dt, province, sum(age) from t1 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province IN ('beijing', 'chongqing')\n" +
+                                    "     partitions=1/2");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t1", "p3", "hangzhou");
+
+                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'hangzhou'\n" +
+                                    "     partitions=1/3");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshMultiColumnsMV1() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTable(T3, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as select dt, province, sum(age) from t3 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                                    "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'beijing'\n" +
+                                    "     partitions=2/4");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+                            insertSql = "insert into t3 partition(p3) values(1, 1, '2024-01-02', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'beijing'\n" +
+                                    "     partitions=2/4");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t3", "p5", "hangzhou", "2022-01-01");
+                            String insertSql = "INSERT INTO t3 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'hangzhou'\n" +
+                                    "     partitions=1/5");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshMultiColumnsMV2() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTable(T3, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by dt \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as select dt, province, sum(age) from t3 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t3 values (1, 1, '2024-01-01', 'beijing')," +
+                                    "(2, 20, '2024-01-01', 'guangdong'), (3, 30, '2024-01-02', 'guangdong');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 3: dt IN ('2024-01-01', '2024-01-02')\n" +
+                                    "     partitions=4/4");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+                            insertSql = "insert into t3 partition(p3) values(1, 1, '2024-01-02', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 3: dt IN ('2024-01-01', '2024-01-02')\n" +
+                                    "     partitions=4/4");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t3", "p5", "hangzhou", "2024-01-01");
+                            String insertSql = "INSERT INTO t3 partition(p5) values(1, 1, '2024-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 3: dt = '2024-01-01'\n" +
+                                    "     partitions=3/5");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshSingleColumnMVWithPartitionExpr() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTable(T4, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as select dt, province, sum(age) from t4 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            addListPartition("t4", "p1", "beijing");
+                            String insertSql = "insert into t4 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'beijing'\n" +
+                                    "     partitions=1/2");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(1, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t4", "p3", "hangzhou");
+
+                            String insertSql = "INSERT INTO t4 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'hangzhou'\n" +
+                                    "     partitions=1/3");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshMultiColumnsMVWithPartitionExpr() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTable(T5, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as select dt, province, sum(age) from t5 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t5", "p1", "beijing", "2022-01-01");
+                            String insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'beijing'\n" +
+                                    "     partitions=1/2");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(1, partitions.size());
+                            Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            String insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+                            addListPartition("t5", "p2", "beijing", "2022-01-02");
+                            insertSql = "insert into t5 partition(p2) values(1, 1, '2021-12-02', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'beijing'\n" +
+                                    "     partitions=2/3");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(1, partitions.size());
+                            Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t5", "p5", "hangzhou", "2022-01-01");
+                            String insertSql = "INSERT INTO t5 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'hangzhou'\n" +
+                                    "     partitions=1/4");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshMultiBaseTablesWithSingleColumn() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTables(ImmutableList.of(T2, T4), () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as " +
+                            "   select dt, province, sum(age) from t2 group by dt, province " +
+                            " union all " +
+                            "   select dt, province, sum(age) from t4 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // only one table has updated
+                            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "  1:OlapScanNode\n" +
+                                    "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2\n" +
+                                    "     rollup: t2");
+                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/1\n" +
+                                    "     rollup: t4");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // t2 add a new partition
+                            addListPartition("t2", "p3", "hangzhou");
+                            String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            executeInsertSql(connectContext, insertSql);
+
+                            // t4 add a new partition
+                            addListPartition("t4", "p3", "hangzhou");
+                            insertSql = "INSERT INTO t4 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            executeInsertSql(connectContext, insertSql);
+
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/3");
+                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshMultiBaseTablesWithMultiColumns() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTables(ImmutableList.of(T1, T5), () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1') \n" +
+                            "as select dt, province, sum(age) from t1 group by dt, province \n" +
+                            " union all\n" +
+                            " select dt, province, sum(age) from t5 group by dt, province",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // only t1 has updated
+                            String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2\n" +
+                                    "     rollup: t1");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t1", "p3", "hangzhou");
+
+                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/3");
+                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/1\n" +
+                                    "     rollup: t5");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+
+                        {
+                            // t1 add a new partition
+                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            executeInsertSql(connectContext, insertSql);
+                            // t5 add a new partition
+                            addListPartition("t5", "p1", "beijing", "2022-01-01");
+                            insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/3\n" +
+                                    "     rollup: t1");
+                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRefreshJoinWithMultiColumns1() {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        starRocksAssert.withTables(ImmutableList.of(T1, T5), () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1') \n" +
+                            "as select t1.dt, t5.province, sum(t5.age) from t1 join t5 on t1.province=t5.province " +
+                            "group by t1.dt, t5.province \n",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                        {
+                            // no partition has changed, no need to refresh
+                            ExecPlan execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // only t1 has updated
+                            String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2\n" +
+                                    "     rollup: t1");
+
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(2, partitions.size());
+                            // refresh again, refreshed partitions should not be refreshed again.
+                            execPlan = getExecPlan(taskRun);
+                            Assert.assertTrue(execPlan == null);
+                        }
+
+                        {
+                            // add a new partition
+                            addListPartition("t1", "p3", "hangzhou");
+
+                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/3");
+                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/1\n" +
+                                    "     rollup: t5");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+
+                        {
+                            // t1 add a new partition
+                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            executeInsertSql(connectContext, insertSql);
+                            // t5 add a new partition
+                            addListPartition("t5", "p1", "beijing", "2022-01-01");
+                            insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            executeInsertSql(connectContext, insertSql);
+
+                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 4: province = 'beijing'\n" +
+                                    "     partitions=1/3");
+                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     PREDICATES: 8: province = 'beijing'\n" +
+                                    "     partitions=1/2");
+                            Collection<Partition> partitions = materializedView.getPartitions();
+                            Assert.assertEquals(3, partitions.size());
+                        }
+                    });
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteListPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteListPartitionTest.java
@@ -1,0 +1,365 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MvRewriteListPartitionTest extends MvRewriteTestBase {
+    private static String T1;
+    private static String T2;
+    private static String T3;
+    private static String T4;
+    private static String T5;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // table whose partitions have multiple values
+        T1 = "CREATE TABLE t1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table whose partitions have only single values
+        T2 = "CREATE TABLE t2 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table whose partitions have multi columns
+        T3 = "CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province, dt) (\n" +
+                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\"))  ,\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\")), \n" +
+                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\"))  ,\n" +
+                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table with partition expression whose partitions have multiple values
+        T4 = "CREATE TABLE t4 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY (province) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table with partition expression whose partitions have multi columns
+        T5 = "CREATE TABLE t5 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY (province, dt) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        MvRewriteTestBase.beforeClass();
+    }
+
+    @Test
+    public void testRewriteWithNonPartitionedMV() {
+        starRocksAssert.withTable(T2, () -> {
+            // update base table
+            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+            executeInsertSql(connectContext, insertSql);
+            // refresh complete
+            withRefreshedMV("create materialized view mv1\n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "as select dt, province, sum(age) from t2 group by dt, province;",
+                    () -> {
+                        String query = "select dt, province, sum(age) from t2 group by dt, province;";
+                        String plan = getFragmentPlan(query);
+                        System.out.println(plan);
+                        // assert contains mv1
+                        PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv1");
+                    });
+        });
+    }
+
+    @Test
+    public void testRewriteWithSingleColumnPartitionedMV() {
+        starRocksAssert.withTable(T2, () -> {
+            // update base table
+            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+            executeInsertSql(connectContext, insertSql);
+            // refresh complete
+            withRefreshedMV("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "as select dt, province, sum(age) from t2 group by dt, province;",
+                    () -> {
+                        String query = "select dt, province, sum(age) from t2 group by dt, province;";
+                        {
+                            String plan = getFragmentPlan(query);
+                            // assert contains mv1
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/2\n" +
+                                    "     rollup: mv1");
+                        }
+                        {
+                            addListPartition("t2", "p3", "hangzhou");
+                            String sql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            executeInsertSql(connectContext, sql);
+                            String plan = getFragmentPlan(query);
+                            // assert contains union
+                            PlanTestBase.assertContains(plan, "UNION");
+                            // assert contains mv1
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/2\n" +
+                                    "     rollup: mv1");
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/3");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRewriteMultiBaseTablesWithSingleColumnPartitionedMV() {
+        starRocksAssert.withTables(ImmutableList.of(T2, T4), () -> {
+            // update base table
+            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+            executeInsertSql(connectContext, insertSql);
+            // refresh complete
+            withRefreshedMV("create materialized view mv1\n" +
+                            "distributed by random \n" +
+                            "partition by province \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "as select t2.dt, t2.province, sum(t4.age) from t2 join t4 on t2.province = t4.province\n" +
+                            "group by t2.dt, t2.province;",
+                    () -> {
+                        String query = "select t2.dt, t2.province, sum(t4.age) from t2 join t4 on t2.province = t4.province\n" +
+                                "group by t2.dt, t2.province;";
+                        {
+                            String plan = getFragmentPlan(query);
+                            // assert contains mv1
+                            PlanTestBase.assertContains(plan, "    TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/2\n" +
+                                    "     rollup: mv1");
+                        }
+                        {
+                            addListPartition("t2", "p3", "hangzhou");
+                            String sql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            executeInsertSql(connectContext, sql);
+                            String plan = getFragmentPlan(query);
+                            // assert contains union
+                            PlanTestBase.assertContains(plan, "UNION");
+                            // assert contains mv1
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/2\n" +
+                                    "     rollup: mv1");
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/3");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRewriteSingleColumnPartitionedMVUnionRewrite() {
+        starRocksAssert.withTable(T2, () -> {
+            // update base table
+            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+            executeInsertSql(connectContext, insertSql);
+            // refresh complete
+            withRefreshedMV("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "as select dt, province, sum(age) from t2 group by dt, province;",
+                    () -> {
+                        // TODO: support list partition partial refresh
+                        // refreshMaterializedViewWithPartition(DB_NAME, mvName, "beijing", "beijing");
+
+                        String query = "select dt, province, sum(age) from t2 group by dt, province;";
+                        {
+                            String plan = getFragmentPlan(query);
+                            // assert contains mv1
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/2\n" +
+                                    "     rollup: mv1");
+                        }
+                        {
+                            String sql = "insert into t2 partition(p1) values (2, 2, '2021-12-02', 'guangdong');";
+                            executeInsertSql(connectContext, sql);
+                            // mv is only partial refreshed, needs to union rewrite
+                            String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, "UNION");
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2");
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2\n" +
+                                    "     rollup: t2");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRewriteMultiColumnsPartitionedMVUnionRewrite1() {
+        starRocksAssert.withTable(T3, () -> {
+            // update base table
+            String insertSql = "insert into t3 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+            executeInsertSql(connectContext, insertSql);
+            // refresh complete
+            withRefreshedMV("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '-1')" +
+                            "as select dt, province, sum(age) from t3 group by dt, province;",
+                    () -> {
+                        // TODO: support list partition partial refresh
+                        // refreshMaterializedViewWithPartition(DB_NAME, mvName, "beijing", "beijing");
+
+                        String query = "select dt, province, sum(age) from t3 group by dt, province;";
+                        {
+                            String plan = getFragmentPlan(query);
+                            // assert contains mv1
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/2\n" +
+                                    "     rollup: mv1");
+                        }
+                        {
+                            String sql = "insert into t3 partition(p2) values(1, 1, '2021-12-02', 'beijing');";
+                            executeInsertSql(connectContext, sql);
+                            // mv is only partial refreshed, needs to union rewrite
+                            String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, "UNION");
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/2");
+                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/4");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testRewriteMultiColumnsPartitionedMVWithTTLPartitionNumber() {
+        starRocksAssert.withTable(T3, () -> {
+            // update base table
+            String insertSql = "insert into t3 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+            executeInsertSql(connectContext, insertSql);
+            // refresh complete
+            withRefreshedMV("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_ttl_number' = '1')" +
+                            "as select dt, province, sum(age) from t3 group by dt, province;",
+                    () -> {
+                        // TODO: support list partition partial refresh
+                        // refreshMaterializedViewWithPartition(DB_NAME, mvName, "beijing", "beijing");
+
+                        String query = "select dt, province, sum(age) from t3 group by dt, province;";
+                        {
+                            String plan = getFragmentPlan(query);
+                            // assert contains mv1
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/1\n" +
+                                    "     rollup: mv1");
+                        }
+                        {
+                            String sql = "insert into t3 partition(p2) values(1, 1, '2021-12-02', 'beijing');";
+                            executeInsertSql(connectContext, sql);
+                            // mv is only partially refreshed, needs it to union rewrite
+                            String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, "UNION");
+                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=1/1");
+                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                    "     PREAGGREGATION: ON\n" +
+                                    "     partitions=2/4");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testTransparentRewrite() {
+        starRocksAssert.withTable(T2, () -> {
+            // update base table
+            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+            executeInsertSql(connectContext, insertSql);
+            // refresh complete
+            withRefreshedMV("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            " PROPERTIES ('transparent_mv_rewrite_mode' = 'true') " +
+                            "as select dt, province, sum(age) from t2 group by dt, province;",
+                    () -> {
+                        // TODO: support list partition partial refresh
+                        // refreshMaterializedViewWithPartition(DB_NAME, mvName, "beijing", "beijing");
+                        String sql = "insert into t2 partition(p1) values (2, 2, '2021-12-02', 'guangdong');";
+                        executeInsertSql(connectContext, sql);
+                        // mv is only partial refreshed, needs to union rewrite
+                        String[] sqls = {
+                                "SELECT * from mv1",
+                                "SELECT * from mv1 where province = 'beijing'",
+                                "SELECT * from mv1 where province = 'guangdong'",
+                        };
+                        for (String query : sqls) {
+                            String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, "UNION", "mv1", "t2");
+                        }
+                    });
+        });
+    }
+}

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1427,8 +1427,9 @@ class StarrocksSQLApiLib(object):
         if not res["status"]:
             print(res)
         tools.assert_true(res["status"])
+        plan = str(res["result"])
         for expect in expects:
-            tools.assert_true(str(res["result"]).find(expect) > 0, "assert expect %s is not found in plan" % (expect))
+            tools.assert_true(plan.find(expect) > 0, "assert expect %s is not found in plan" % (expect))
 
     def assert_equal_result(self, *sqls):
         if len(sqls) < 2:
@@ -2021,3 +2022,8 @@ class StarrocksSQLApiLib(object):
         else:
             tools.assert_true(False, "clear stale column stats timeout. The number of stale column stats is %s" % num)
                
+    def assert_table_partitions_num(self, table_name, expect_num):
+        res = self.execute_sql("SHOW PARTITIONS FROM %s" % table_name, True)
+        tools.assert_true(res["status"], "show schema change task error")
+        ans = res["result"]
+        tools.assert_true(len(ans) == expect_num, "The number of partitions is %s" % len(ans))

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
@@ -1,0 +1,596 @@
+-- name: test_mv_refresh_list_partitions_basic
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")) 
+)
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+CREATE TABLE t4 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province) 
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t4 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+CREATE TABLE t5 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (province, dt) 
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t5 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	100
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	100
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	100
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	140
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table t3;
+-- result:
+-- !result
+drop table t4;
+-- result:
+-- !result
+drop table t5;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
@@ -516,6 +516,10 @@ function: assert_table_partitions_num("test_mv1", 1)
 -- result:
 None
 -- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 -- result:
 2024-01-01	beijing	100
@@ -560,6 +564,10 @@ select * from test_mv1 order by 1, 2;
 2024-01-01	guangdong	20
 -- !result
 function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
 None
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_rewrite
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_rewrite
@@ -1,0 +1,503 @@
+-- name: test_mv_refresh_list_partitions_rewrite
+CREATE TABLE t1 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+     PARTITION p1 VALUES IN ("beijing", "chongqing") ,
+     PARTITION p2 VALUES IN ("guangdong") 
+)
+DISTRIBUTED BY HASH(id) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+CREATE TABLE t2 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+     PARTITION p1 VALUES IN ("chongqing"),
+     PARTITION p2 VALUES IN ("guangdong"),
+     PARTITION p3 VALUES IN ("beijing")
+)
+DISTRIBUTED BY HASH(id) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t2 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")) 
+)
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province 
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t1 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t1 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+-- !result
+select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t1 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t1 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province 
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t2 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t2 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+-- !result
+select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t2 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t2 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+-- !result
+select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result
+drop table t3;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
@@ -245,7 +245,7 @@ as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 function: assert_table_partitions_num("test_mv1", 1)
--- function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
@@ -266,7 +266,7 @@ refresh materialized view  test_mv1;
 function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
 select * from test_mv1 order by 1, 2;
 function: assert_table_partitions_num("test_mv1", 1)
--- function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
@@ -1,0 +1,278 @@
+-- name: test_mv_refresh_list_partitions_basic
+
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")) 
+)
+DISTRIBUTED BY RANDOM;
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+CREATE TABLE t4 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province) 
+DISTRIBUTED BY RANDOM;
+INSERT INTO t4 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+CREATE TABLE t5 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (province, dt) 
+DISTRIBUTED BY RANDOM;
+INSERT INTO t5 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+--------- t3 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t4 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t5 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t6 ---------
+-- test sync refresh & partition_refresh_number= -1 && partition_ttl_number =1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+-- function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+-- function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+drop table t3;
+drop table t4;
+drop table t5;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_rewrite
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_rewrite
@@ -1,0 +1,187 @@
+-- name: test_mv_refresh_list_partitions_rewrite
+
+CREATE TABLE t1 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+     PARTITION p1 VALUES IN ("beijing", "chongqing") ,
+     PARTITION p2 VALUES IN ("guangdong") 
+)
+DISTRIBUTED BY HASH(id) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+CREATE TABLE t2 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+     PARTITION p1 VALUES IN ("chongqing"),
+     PARTITION p2 VALUES IN ("guangdong"),
+     PARTITION p3 VALUES IN ("beijing")
+)
+DISTRIBUTED BY HASH(id) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+INSERT INTO t2 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")) 
+)
+DISTRIBUTED BY RANDOM;
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+-- case1: partition by province and base table only contains multi values
+create materialized view test_mv1
+partition by province 
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t1 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+
+select * from test_mv1 order by 1, 2;
+
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t1 group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+
+INSERT INTO t1 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 group by dt, province order by 1, 2;", "test_mv1")
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t1 group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where province = 'beijing' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where province = 'guangdong' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where dt = '2024-01-01' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where dt = '2024-01-02' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t1 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+
+drop materialized view test_mv1;
+
+-- case2: partition by province and base table only contains single values
+create materialized view test_mv1
+partition by province 
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t2 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t2 group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+
+INSERT INTO t2 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 group by dt, province order by 1, 2;", "test_mv1")
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t2 group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where province = 'beijing' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where province = 'guangdong' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where dt = '2024-01-01' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where dt = '2024-01-02' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t2 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+
+drop materialized view test_mv1;
+
+-- case3: partition by base table which contains multi partition columns
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;", "test_mv1")
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where province = 'beijing' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where province = 'guangdong' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where province in ('beijing', 'guangdong') group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where dt = '2024-01-01' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where dt = '2024-01-02' group by dt, province order by 1, 2;
+select dt, province, sum(age) from t3 where dt >= '2024-01-02' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+drop table t1;
+drop table t2;
+drop table t3;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Support mv refresh for list partitioned amv;
- Support mv rewrite for list partitioned amv;

```
CREATE TABLE t3 (
      id BIGINT,
      province VARCHAR(64) not null,
      age SMALLINT,
      dt VARCHAR(10) not null
)
DUPLICATE KEY(id)
PARTITION BY LIST (province, dt) (
     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")) 
)
DISTRIBUTED BY RANDOM;
INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');

-- test sync refresh & partition_refresh_number= 1
create materialized view test_mv1
partition by province
REFRESH DEFERRED MANUAL
distributed by hash(dt, province) buckets 10 
PROPERTIES (
"replication_num" = "1"
) 
as select dt, province, sum(age) from t3 group by dt, province;
refresh materialized view  test_mv1 with sync mode;
select * from test_mv1 order by 1, 2;
function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
drop materialized view test_mv1;

```
Fixes [#46087](https://github.com/StarRocks/starrocks/issues/46087)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
