### PR TITLE
[Enhancement] Support mv refresh in descending order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1188,6 +1188,12 @@ public class Config extends ConfigBase {
     public static boolean enable_materialized_view = true;
 
     /**
+     * control materialized view refresh order
+     */
+    @ConfField(mutable = true)
+    public static boolean materialized_view_refresh_ascending = true;
+
+    /**
      * Control whether to enable spill for all materialized views in the refresh mv.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -529,7 +529,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         LinkedList<String> sortedPartition = mappedPartitionsToRefresh.entrySet().stream()
                 .sorted(Map.Entry.comparingByValue(RangeUtils.RANGE_COMPARATOR))
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toCollection (LinkedList::new));
+                .collect(Collectors.toCollection(LinkedList::new));
 
         Iterator<String> partitionNameIter = Config.materialized_view_refresh_ascending
                 ? sortedPartition.iterator() : sortedPartition.descendingIterator();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -117,7 +117,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -527,13 +526,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         for (String partitionName : partitionsToRefresh) {
             mappedPartitionsToRefresh.put(partitionName, rangePartitionMap.get(partitionName));
         }
-        LinkedHashMap<String, Range<PartitionKey>> sortedPartition = mappedPartitionsToRefresh.entrySet().stream()
+        LinkedList<String> sortedPartition = mappedPartitionsToRefresh.entrySet().stream()
                 .sorted(Map.Entry.comparingByValue(RangeUtils.RANGE_COMPARATOR))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
-        LinkedList<String> partitionNames = new LinkedList<>(sortedPartition.keySet());
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toCollection (LinkedList::new));
 
         Iterator<String> partitionNameIter = Config.materialized_view_refresh_ascending
-                ? partitionNames.iterator() : partitionNames.descendingIterator();
+                ? sortedPartition.iterator() : sortedPartition.descendingIterator();
         String mvRefreshPartition = "";
         for (int i = 0; i < partitionRefreshNumber; i++) {
             if (partitionNameIter.hasNext()) {
@@ -565,7 +564,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             }
         }
         if (!Config.materialized_view_refresh_ascending) {
-            partitionNameIter = partitionNames.iterator();
+            partitionNameIter = sortedPartition.iterator();
         }
         setNextPartitionStartAndEnd(partitionsToRefresh, mappedPartitionsToRefresh, partitionNameIter);
     }


### PR DESCRIPTION
## Why I'm doing:
Currently, a partitioned mv is filled from oldest partition to newest partition.
Usually, user cares latest partitions most like last 7 days.
When lots of old data is filled into mv's base table, eg: last 1 year, the mv is filled from oldest partition which is 1 year ago. If today's partition is added to mv's base table, then the corresponding mv partition will be filled after other old partitions.
So it's better to fill the latest partition ASAP before old partitions.
## What I'm doing:
Add Config.materialized_view_refresh_ascending(default true) to control mv refresh order.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
