### PR TITLE
[BugFix] Fix aws class not found after bump hadoop to 3.4.0

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
@@ -36,7 +36,7 @@ public class AWSCloudConfigurationTest {
         Assert.assertNotNull(cloudConfiguration);
         Configuration configuration = new Configuration();
         cloudConfiguration.applyToConfiguration(configuration);
-        Assert.assertEquals("com.amazonaws.auth.DefaultAWSCredentialsProviderChain",
+        Assert.assertEquals("software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider",
                 configuration.get("fs.s3a.aws.credentials.provider"));
     }
 
@@ -50,7 +50,7 @@ public class AWSCloudConfigurationTest {
         Assert.assertNotNull(cloudConfiguration);
         Configuration configuration = new Configuration();
         cloudConfiguration.applyToConfiguration(configuration);
-        Assert.assertEquals("com.amazonaws.auth.DefaultAWSCredentialsProviderChain",
+        Assert.assertEquals("software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider",
                 configuration.get("fs.s3a.assumed.role.credentials.provider"));
         Assert.assertEquals("com.starrocks.credential.provider.AssumedRoleCredentialProvider",
                 configuration.get("fs.s3a.aws.credentials.provider"));


### PR DESCRIPTION
## Why I'm doing:
Fix
```bash
2024-06-06 00:25:54.107-07:00 ERROR (pull-hive-remote-files-6|552) [HiveRemoteFileIO.getRemoteFiles():119] Failed to get hive remote file's metadata on path: s3://starrocks-qa/system_data/glue_sqltest_data/hive_glue_s3_csv
org.apache.hadoop.fs.s3a.impl.InstantiationIOException: `s3://starrocks-qa/system_data/glue_sqltest_data/hive_glue_s3_csv': Class com.amazonaws.auth.DefaultAWSCredentialsProviderChain instantiation exception java.lang.ClassNotFoundException: com.amazonaws.auth.DefaultAWSCredentialsProviderChain (configuration key fs.s3a.assumed.role.credentials.provider): com.amazonaws.auth.DefaultAWSCredentialsProviderChain
        at org.apache.hadoop.fs.s3a.impl.InstantiationIOException.instantiationException(InstantiationIOException.java:178) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.S3AUtils.getInstanceFromReflection(S3AUtils.java:694) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSV2CredentialProvider(CredentialProviderListFactory.java:307) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.buildAWSProviderList(CredentialProviderListFactory.java:253) ~[hadoop-aws-3.4.0.jar:?]
        at com.starrocks.credential.provider.AssumedRoleCredentialProvider.<init>(AssumedRoleCredentialProvider.java:146) ~[starrocks-fe.jar:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[?:?]
        at org.apache.hadoop.fs.s3a.S3AUtils.getInstanceFromReflection(S3AUtils.java:656) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSV2CredentialProvider(CredentialProviderListFactory.java:307) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.buildAWSProviderList(CredentialProviderListFactory.java:253) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSCredentialProviderList(CredentialProviderListFactory.java:145) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.S3AFileSystem.bindAWSClient(S3AFileSystem.java:1030) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.s3a.S3AFileSystem.initialize(S3AFileSystem.java:673) ~[hadoop-aws-3.4.0.jar:?]
        at org.apache.hadoop.fs.FileSystem.createFileSystemInternal(FileSystem.java:3740) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem.lambda$createFileSystem$0(FileSystem.java:3760) ~[starrocks-hadoop-ext.jar:?]
        at com.starrocks.connector.hadoop.HadoopExtEPack.doAs(HadoopExtEPack.java:168) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3760) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem.access$300(FileSystem.java:199) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3859) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3807) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:601) ~[starrocks-hadoop-ext.jar:?]
        at com.starrocks.connector.hive.HiveRemoteFileIO.getRemoteFiles(HiveRemoteFileIO.java:77) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.hive.HiveRemoteFileIO.getRemoteFiles(HiveRemoteFileIO.java:66) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.CachingRemoteFileIO.loadRemoteFiles(CachingRemoteFileIO.java:93) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.CachingRemoteFileIO$1.load(CachingRemoteFileIO.java:54) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.CachingRemoteFileIO$1.load(CachingRemoteFileIO.java:51) ~[starrocks-fe.jar:?]
        at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2312) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache.get(LocalCache.java:4011) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010) ~[spark-dpp-1.0.0.jar:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.connector.CachingRemoteFileIO.getRemoteFiles(CachingRemoteFileIO.java:84) ~[starrocks-fe.jar:?]
```

## What I'm doing:
Fix it


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
