### PR TITLE
[Enhancement] remove partition version check in plan validation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -257,9 +257,6 @@ public class OlapTable extends Table {
 
     // Record the alter, schema change, MV update time
     public AtomicLong lastSchemaUpdateTime = new AtomicLong(-1);
-    // Record the start and end time for data load version update phase
-    public AtomicLong lastVersionUpdateStartTime = new AtomicLong(-1);
-    public AtomicLong lastVersionUpdateEndTime = new AtomicLong(0);
 
     public OlapTable() {
         this(TableType.OLAP);
@@ -366,8 +363,6 @@ public class OlapTable extends Table {
 
         // Shallow copy shared data to check whether the copied table has changed or not.
         olapTable.lastSchemaUpdateTime = this.lastSchemaUpdateTime;
-        olapTable.lastVersionUpdateStartTime = this.lastVersionUpdateStartTime;
-        olapTable.lastVersionUpdateEndTime = this.lastVersionUpdateEndTime;
         olapTable.sessionId = this.sessionId;
     }
 
@@ -1967,9 +1962,6 @@ public class OlapTable extends Table {
         }
 
         lastSchemaUpdateTime = new AtomicLong(-1);
-        // Record the start and end time for data load version update phase
-        lastVersionUpdateStartTime = new AtomicLong(-1);
-        lastVersionUpdateEndTime = new AtomicLong(0);
     }
 
     public OlapTable selectiveCopy(Collection<String> reservedPartitions, boolean resetState, IndexExtState extState) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/OptimisticVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/OptimisticVersion.java
@@ -36,10 +36,6 @@ public class OptimisticVersion {
      */
     public static boolean validateTableUpdate(OlapTable olapTable, long candidateVersion) {
         long schemaUpdate = olapTable.lastSchemaUpdateTime.get();
-        long dataUpdateStart = olapTable.lastVersionUpdateStartTime.get();
-        long dataUpdateEnd = olapTable.lastVersionUpdateEndTime.get();
-
-        return (schemaUpdate < candidateVersion) &&
-                (dataUpdateEnd >= dataUpdateStart && dataUpdateEnd < candidateVersion);
+        return schemaUpdate < candidateVersion;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -52,6 +51,7 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.UnsupportedException;
@@ -78,8 +78,6 @@ import com.starrocks.transaction.TransactionState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 
 public class StatementPlanner {
 
@@ -248,9 +246,11 @@ public class StatementPlanner {
 
         // TODO: double check relatedMvs for OlapTable
         // only collect once to save the original olapTable info
+        // the original olapTable in queryStmt had been replaced with the copied olapTable
         Set<OlapTable> olapTables = collectOriginalOlapTables(session, queryStmt);
+        long planStartTime = 0;
         for (int i = 0; i < Config.max_query_retry_time; ++i) {
-            long planStartTime = OptimisticVersion.generate();
+            planStartTime = OptimisticVersion.generate();
             if (!isSchemaValid) {
                 reAnalyzeStmt(queryStmt, session, plannerMetaLocker);
                 colNames = queryStmt.getQueryRelation().getColumnOutputNames();
@@ -287,43 +287,32 @@ public class StatementPlanner {
 
             try (Timer ignored = Tracers.watchScope("ExecPlanBuild")) {
                 // 3. Build fragment exec plan
-                /*
-                 * SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
-                 * currently only used in Spark/Flink Connector
-                 * Because the connector sends only simple queries, it only needs to remove the output fragment
-                 */
-                // For only olap table queries, we need to lock db here.
-                // Because we need to ensure multi partition visible versions are consistent.
-                long buildFragmentStartTime = OptimisticVersion.generate();
+                // SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
+                // currently only used in Spark/Flink Connector
+                // Because the connector sends only simple queries, it only needs to remove the output fragment
                 ExecPlan plan = PlanFragmentBuilder.createPhysicalPlan(
                         optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
                         resultSinkType,
                         !session.getSessionVariable().isSingleNodeExecPlan());
-                isSchemaValid = olapTables.stream().noneMatch(t -> t.lastSchemaUpdateTime.get() > planStartTime);
-
-                isSchemaValid = isSchemaValid && olapTables.stream().allMatch(t ->
-                        t.lastVersionUpdateEndTime.get() < buildFragmentStartTime &&
-                                t.lastVersionUpdateEndTime.get() >= t.lastVersionUpdateStartTime.get());
+                final long finalPlanStartTime = planStartTime;
+                isSchemaValid = olapTables.stream().noneMatch(t -> OptimisticVersion.validateTableUpdate(t,
+                        finalPlanStartTime));
                 if (isSchemaValid) {
                     plan.setLogicalPlan(logicalPlan);
                     plan.setColumnRefFactory(columnRefFactory);
                     return plan;
                 }
-
-                // if exists table is applying visible log, we wait 10 ms to retry
-                if (olapTables.stream().anyMatch(t -> t.lastVersionUpdateStartTime.get() > t.lastVersionUpdateEndTime.get())) {
-                    try (Timer timer = Tracers.watchScope("PlanRetrySleepTime")) {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        throw new StarRocksPlannerException("query had been interrupted", INTERNAL_ERROR);
-                    }
-                }
-
             }
         }
-        Preconditions.checkState(false, "The tablet write operation update metadata " +
-                "take a long time");
-        return null;
+
+        List<String> updatedTables = Lists.newArrayList();
+        for (OlapTable olapTable : olapTables) {
+            if (!OptimisticVersion.validateTableUpdate(olapTable, planStartTime)) {
+                updatedTables.add(olapTable.getName());
+            }
+        }
+        throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
+                "schema of %s had been updated frequently during the plan generation", updatedTables);
     }
 
     public static Set<OlapTable> collectOriginalOlapTables(ConnectContext session, StatementBase queryStmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -295,7 +295,7 @@ public class StatementPlanner {
                         resultSinkType,
                         !session.getSessionVariable().isSingleNodeExecPlan());
                 final long finalPlanStartTime = planStartTime;
-                isSchemaValid = olapTables.stream().noneMatch(t -> OptimisticVersion.validateTableUpdate(t,
+                isSchemaValid = olapTables.stream().allMatch(t -> OptimisticVersion.validateTableUpdate(t,
                         finalPlanStartTime));
                 if (isSchemaValid) {
                     plan.setLogicalPlan(logicalPlan);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -85,8 +85,6 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
 
         long maxPartitionVersionTime = -1;
 
-        table.lastVersionUpdateStartTime.set(System.nanoTime());
-
         for (PartitionCommitInfo partitionCommitInfo : commitInfo.getIdToPartitionCommitInfo().values()) {
             long partitionId = partitionCommitInfo.getPartitionId();
             PhysicalPartition partition = table.getPhysicalPartition(partitionId);
@@ -174,7 +172,6 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
         }
 
-        table.lastVersionUpdateEndTime.set(System.nanoTime());
         if (!GlobalStateMgr.isCheckpointThread() && dictCollectedVersions.size() == validDictCacheColumns.size()) {
             for (int i = 0; i < validDictCacheColumns.size(); i++) {
                 String columnName = validDictCacheColumns.get(i);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
@@ -148,9 +148,6 @@ public class LakeTableTest {
         }
 
         Assert.assertEquals(-1, newLakeTable.lastSchemaUpdateTime.longValue());
-        Assert.assertEquals(-1, newLakeTable.lastVersionUpdateStartTime.longValue());
-        Assert.assertEquals(0, newLakeTable.lastVersionUpdateEndTime.longValue());
-
         Assert.assertTrue(newLakeTable.delete(dbId, false));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.planner;
 
-import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
@@ -65,10 +64,6 @@ public class QueryPlanLockFreeTest {
     @Test
     public void testPlanStrategy() throws Exception {
         String sql = "select * from t0";
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getTable("default_catalog", DB_NAME, "t0");
-        table.lastVersionUpdateStartTime.set(2);
-        table.lastVersionUpdateEndTime.set(1);
         try {
             UtFrameUtils.getPlanAndFragment(connectContext, sql);
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/OptimisticVersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/OptimisticVersionTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,13 +58,6 @@ class OptimisticVersionTest extends PlanTestBase {
 
         // schema change
         table.lastSchemaUpdateTime.set(OptimisticVersion.generate());
-        assertTrue(OptimisticVersion.validateTableUpdate(table, OptimisticVersion.generate()));
-
-        // in update
-        table.lastVersionUpdateStartTime.set(OptimisticVersion.generate());
-        assertFalse(OptimisticVersion.validateTableUpdate(table, OptimisticVersion.generate()));
-
-        table.lastVersionUpdateEndTime.set(OptimisticVersion.generate());
         assertTrue(OptimisticVersion.validateTableUpdate(table, OptimisticVersion.generate()));
     }
 


### PR DESCRIPTION
## Why I'm doing:
In a large number of real-time import scenarios, if a complex query contains multiple tables, verifying the partitioned versions of multiple tables may still cause the plan to fail.
![image](https://github.com/StarRocks/starrocks/assets/110370499/12eb6762-137f-41dc-8735-895db91a10f2)


## What I'm doing:
When the partition is shallow copied, the version number is copied while holding the lock, and the historical snapshot version can be used for query. So we can remove this partition version check.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [x] 2.5
