### PR TITLE
[BugFix] remove the setUseComputeNodes(0) limit when olapTableSink

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
@@ -261,8 +261,6 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
         if (CollectionUtils.isNotEmpty(plan.getFragments()) &&
                 plan.getTopFragment().getSink() instanceof OlapTableSink) {
             ConnectContext context = queryCoordinator.getConnectContext();
-            context.getSessionVariable().setPreferComputeNode(false);
-            context.getSessionVariable().setUseComputeNodes(0);
             OlapTableSink dataSink = getMVOlapTableSink();
             // NOTE use a fake transaction id, the real one would be generated when epoch started
             long fakeTransactionId = 1;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -112,9 +112,6 @@ public class DeletePlanner {
                     session.getCurrentWarehouseId());
             execPlan.getFragments().get(0).setSink(dataSink);
 
-            // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
-            session.getSessionVariable().setPreferComputeNode(false);
-            session.getSessionVariable().setUseComputeNodes(0);
             OlapTableSink olapTableSink = (OlapTableSink) dataSink;
             TableName catalogDbTable = deleteStatement.getTableName();
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogDbTable.getCatalog(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -383,9 +383,6 @@ public class InsertPlanner {
                     ((OlapTableSink) dataSink).setAutomaticBucketSize(olapTable.getAutomaticBucketSize());
                 }
 
-                // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
-                session.getSessionVariable().setPreferComputeNode(false);
-                session.getSessionVariable().setUseComputeNodes(0);
                 OlapTableSink olapTableSink = (OlapTableSink) dataSink;
                 TableName catalogDbTable = insertStmt.getTableName();
                 Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogDbTable.getCatalog(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -466,9 +466,6 @@ public class LoadPlanner {
                 ((OlapTableSink) dataSink).setPartialUpdateMode(partialUpdateMode);
                 ((OlapTableSink) dataSink).complete(mergeConditionStr);
             }
-            // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
-            context.getSessionVariable().setPreferComputeNode(false);
-            context.getSessionVariable().setUseComputeNodes(0);
         } else {
             throw new SemanticException("Unknown table type " + destTable.getType());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -147,9 +147,6 @@ public class UpdatePlanner {
                 execPlan.getFragments().get(0).setSink(dataSink);
                 execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
 
-                // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
-                session.getSessionVariable().setPreferComputeNode(false);
-                session.getSessionVariable().setUseComputeNodes(0);
                 OlapTableSink olapTableSink = (OlapTableSink) dataSink;
                 TableName catalogDbTable = updateStmt.getTableName();
                 Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogDbTable.getCatalog(),


### PR DESCRIPTION
## Why I'm doing:
it can not insert by cn now

## What I'm doing:
remove the limit of UseComputeNodes 0 when olapTableSink

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5