### PR TITLE
[Enhancement] improve cloud native pk index rebuild strategy

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -986,7 +986,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
-CONF_mInt32(lake_pk_index_sst_max_compaction_bytes, /*1GB*/ "1073741824");
+CONF_mInt32(lake_pk_index_sst_max_compaction_bytes, /*5GB*/ "5368709120");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -44,9 +44,9 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
             nfound += old_value.get_value() != NullIndexValue;
             update_index_value(&old_index_value_vers, version, value);
         }
+        _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
     *num_found = nfound;
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 
@@ -65,8 +65,8 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
             return Status::AlreadyExist(msg);
         }
         _keys_size += key.capacity() + sizeof(std::string);
+        _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 
@@ -90,7 +90,6 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
         }
     }
     *num_found = nfound;
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 
@@ -106,8 +105,8 @@ Status PersistentIndexMemtable::replace(const Slice* keys, const IndexValue* val
         } else {
             _keys_size += key.capacity() + sizeof(std::string);
         }
+        _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -58,7 +58,7 @@ public:
 
     void clear();
 
-    const int64_t max_version() const { return _max_version; }
+    const int64_t max_rss_rowid() const { return _max_rss_rowid; }
 
 private:
     static void update_index_value(std::list<IndexValueWithVer>* index_value_info, int64_t version,
@@ -67,8 +67,8 @@ private:
 private:
     // The size can be up to 230K. The performance of std::map may be poor.
     phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>> _map;
-    int64_t _max_version{0};
     int64_t _keys_size{0};
+    uint64_t _max_rss_rowid{0};
 };
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -682,8 +682,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
         auto sstable_meta = new_tablet_metadata->sstable_meta();
         for (auto& sstable : sstable_meta.sstables()) {
-            EXPECT_GT(sstable.version(), 0);
-            EXPECT_LE(sstable.version(), version);
+            EXPECT_GT(sstable.max_rss_rowid(), 0);
         }
     }
 }

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -707,13 +707,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
-        auto sstable_meta = new_tablet_metadata->sstable_meta();
-        for (auto& sstable : sstable_meta.sstables()) {
-            EXPECT_GT(sstable.version(), 0);
-            EXPECT_LE(sstable.version(), version);
-        }
-    }
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 
@@ -989,6 +982,61 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_with_clear_txnlog) {
         version++;
     }
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_write_with_cloud_native_index_rebuild) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
+    std::vector<ChunkPtr> chunk_vec;
+    std::vector<std::vector<uint32_t>> indexes_vec;
+    auto [chunk0, indexes0] = gen_data_and_index(kChunkSize * 3, 0, true, true);
+    chunk_vec.push_back(chunk0);
+    indexes_vec.push_back(indexes0);
+    auto [chunk1, indexes1] = gen_data_and_index(kChunkSize * 3, 1, true, true);
+    chunk_vec.push_back(chunk1);
+    indexes_vec.push_back(indexes1);
+    auto [chunk2, indexes2] = gen_data_and_index(kChunkSize * 3, 2, true, true);
+    chunk_vec.push_back(chunk2);
+    indexes_vec.push_back(indexes2);
+    auto [chunk3, indexes3] = gen_data_and_index(kChunkSize * 3, 3, true, true);
+    chunk_vec.push_back(chunk3);
+    indexes_vec.push_back(indexes3);
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    auto do_load_func = [&]() {
+        for (int i = 0; i < 4; i++) {
+            int64_t txn_id = next_id();
+            ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(tablet_id)
+                                                       .set_txn_id(txn_id)
+                                                       .set_partition_id(_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_schema_id(_tablet_schema->id())
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(*chunk_vec[i], indexes_vec[i].data(), indexes_vec[i].size()));
+            auto txn_log_st = delta_writer->finish_with_txnlog();
+            ASSERT_OK(txn_log_st);
+            delta_writer->close();
+            // Publish version
+            ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+            version++;
+        }
+    };
+    // 1. first time
+    const auto old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+    do_load_func();
+    config::l0_max_mem_usage = old_val;
+    ASSERT_EQ(kChunkSize * 3 * 4, read_rows(tablet_id, version));
+    // 2. release persistent index and rebuild index
+    _update_mgr->unload_and_remove_primary_index(tablet_id);
+    // 3. second time
+    do_load_func();
+    ASSERT_EQ(kChunkSize * 3 * 4, read_rows(tablet_id, version));
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -184,9 +184,10 @@ message IndexValuesWithVerPB {
 }
 
 message PersistentIndexSstablePB {
-    optional int64 version = 1;
-    optional string filename = 2;
-    optional int64 filesize = 3;
+    optional string filename = 1;
+    optional int64 filesize = 2;
+    // used for rebuild point of persistent index
+    optional uint64 max_rss_rowid = 3;
 }
 
 message PersistentIndexSstableMetaPB {


### PR DESCRIPTION
## Why I'm doing:
Use `rss_rowid` (rowset + segment id + rowid) as rebuild point instead of version, this is because `rss_rowid` enables finer-grained index rebuild point, which reduces the time required for cloud native persistent index rebuilds.

## What I'm doing:
1. Replace `version` by `max_rss_rowid`.
2. Increase the maximum amount of data that can be merged when persistent index compact by the way.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
