### PR TITLE
[BugFix] Fix wrong display for cache select in profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataCacheSelectStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataCacheSelectStatement.java
@@ -39,7 +39,7 @@ public class DataCacheSelectStatement extends DdlStmt {
         this.insertStmt = insertStmt;
         this.properties = properties;
         Preconditions.checkNotNull(properties, "properties can't be null");
-        insertStmt.setOrigStmt(new OriginStatement("CACHE SELECT " + AstToSQLBuilder.toSQL(insertStmt.getQueryStatement())));
+        insertStmt.setOrigStmt(new OriginStatement("CACHE " + AstToSQLBuilder.toSQL(insertStmt.getQueryStatement())));
     }
 
     public InsertStmt getInsertStmt() {


### PR DESCRIPTION
## Why I'm doing:
display wrong cache select sql in profile

<img width="926" alt="image" src="https://github.com/StarRocks/starrocks/assets/18729228/675f1eb8-6c1e-4e82-ae33-b077a768fa3c">


## What I'm doing:
Fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
