### PR TITLE
[Enhancement] compatible with lower version kudu-client api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
@@ -38,10 +38,12 @@ public class KuduTable extends Table {
     public static final Set<String> KUDU_INPUT_FORMATS = Sets.newHashSet(
             "org.apache.hadoop.hive.kudu.KuduInputFormat", "org.apache.kudu.mapreduce.KuduTableInputFormat");
     public static final String PARTITION_NULL_VALUE = "null";
+    public static final String PARAMETER_KEY_KUDU_TABLE_NAME = "kudu.table_name";
     private String masterAddresses;
     private String catalogName;
     private String databaseName;
     private String tableName;
+    private String kuduTableName;
     private List<String> partColNames;
     private Map<String, String> properties;
 
@@ -49,20 +51,22 @@ public class KuduTable extends Table {
         super(TableType.KUDU);
     }
 
-    public KuduTable(String masterAddresses, String catalogName, String dbName, String tblName, List<Column> schema,
-                     List<String> partColNames) {
+    public KuduTable(String masterAddresses, String catalogName, String dbName, String tblName, String kuduTableName,
+                     List<Column> schema, List<String> partColNames) {
         super(CONNECTOR_ID_GENERATOR.getNextId().asInt(), tblName, TableType.KUDU, schema);
         this.masterAddresses = masterAddresses;
         this.catalogName = catalogName;
         this.databaseName = dbName;
         this.tableName = tblName;
+        this.kuduTableName = kuduTableName;
         this.partColNames = partColNames;
     }
 
     public static KuduTable fromMetastoreTable(org.apache.hadoop.hive.metastore.api.Table table, String catalogName,
                                                List<Column> fullSchema, List<String> partColNames) {
+        String kuduTableName = table.getParameters().get(PARAMETER_KEY_KUDU_TABLE_NAME);
         return new KuduTable(StringUtils.EMPTY, catalogName, table.getDbName(), table.getTableName(),
-                fullSchema, partColNames);
+                kuduTableName, fullSchema, partColNames);
     }
 
     public String getMasterAddresses() {
@@ -79,6 +83,9 @@ public class KuduTable extends Table {
 
     public String getTableName() {
         return tableName;
+    }
+    public String getKuduTableName() {
+        return kuduTableName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,7 +44,7 @@ public class KuduTable extends Table {
     private String catalogName;
     private String databaseName;
     private String tableName;
-    private String kuduTableName;
+    private Optional<String> kuduTableName;
     private List<String> partColNames;
     private Map<String, String> properties;
 
@@ -58,7 +59,7 @@ public class KuduTable extends Table {
         this.catalogName = catalogName;
         this.databaseName = dbName;
         this.tableName = tblName;
-        this.kuduTableName = kuduTableName;
+        this.kuduTableName = Optional.ofNullable(kuduTableName);
         this.partColNames = partColNames;
     }
 
@@ -84,7 +85,7 @@ public class KuduTable extends Table {
     public String getTableName() {
         return tableName;
     }
-    public String getKuduTableName() {
+    public Optional<String> getKuduTableName() {
         return kuduTableName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -250,8 +250,8 @@ public class KuduMetadata implements ConnectorMetadata {
     }
 
     private String getKuduFullTableName(KuduTable table) {
-        return table.getKuduTableName() != null ? table.getKuduTableName() :
-                getKuduFullTableName(table.getDbName(), table.getTableName());
+        return table.getKuduTableName().orElse(
+                getKuduFullTableName(table.getDbName(), table.getTableName()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -44,6 +44,7 @@ import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduPredicate;
 import org.apache.kudu.client.KuduScanToken;
+import org.apache.kudu.client.RpcRemoteException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -231,7 +232,8 @@ public class KuduMetadata implements ConnectorMetadata {
                                 partColNames.add(fieldName);
                             }
                         }
-                        return new KuduTable(masterAddresses, this.catalogName, dbName, tblName, columns, partColNames);
+                        return new KuduTable(masterAddresses, this.catalogName, dbName, tblName, fullTableName,
+                                columns, partColNames);
                     });
         } catch (KuduException e) {
             throw new StarRocksConnectorException("Failed to get table %s.", fullTableName, e);
@@ -244,8 +246,12 @@ public class KuduMetadata implements ConnectorMetadata {
     }
 
     private String getKuduFullTableName(String dbName, String tblName) {
-        return schemaEmulationEnabled ?
-                (schemaEmulationPrefix + dbName + DATABASE_TABLE_JOINER + tblName) : tblName;
+        return schemaEmulationEnabled ? (schemaEmulationPrefix + dbName + DATABASE_TABLE_JOINER + tblName) : tblName;
+    }
+
+    private String getKuduFullTableName(KuduTable table) {
+        return table.getKuduTableName() != null ? table.getKuduTableName() :
+                getKuduFullTableName(table.getDbName(), table.getTableName());
     }
 
     @Override
@@ -254,7 +260,7 @@ public class KuduMetadata implements ConnectorMetadata {
                                                    List<String> fieldNames, long limit) {
         RemoteFileInfo remoteFileInfo = new RemoteFileInfo();
         KuduTable kuduTable = (KuduTable) table;
-        String kuduTableName = getKuduFullTableName(kuduTable.getDbName(), kuduTable.getTableName());
+        String kuduTableName = getKuduFullTableName(kuduTable);
         org.apache.kudu.client.KuduTable nativeTable;
         try {
             nativeTable = kuduClient.openTable(kuduTableName);
@@ -315,13 +321,24 @@ public class KuduMetadata implements ConnectorMetadata {
 
         } else {
             try {
-                String kuduTableName = getKuduFullTableName(kuduTable.getDbName(), kuduTable.getTableName());
+                String kuduTableName = getKuduFullTableName(kuduTable);
                 rowCount = kuduClient.openTable(kuduTableName).getTableStatistics().getLiveRowCount();
+            } catch (RpcRemoteException e) {
+                if (isGetTableStatisticsUnsupported(e)) {
+                    LOG.warn("GetTableStatistics method not supported. Fallback to return default row count 1.");
+                    rowCount = 1;
+                } else {
+                    throw new RuntimeException("RPC error while getting table statistics", e);
+                }
             } catch (KuduException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeException("Error while accessing Kudu table", e);
             }
         }
         builder.setOutputRowCount(rowCount);
         return builder.build();
+    }
+
+    private static boolean isGetTableStatisticsUnsupported(RpcRemoteException e) {
+        return e.getMessage().contains("invalid method name: GetTableStatistics");
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -318,7 +318,6 @@ public class KuduMetadata implements ConnectorMetadata {
             HivePartitionStats tableStatistics =
                     metastore.get().getTableStatistics(kuduTable.getDbName(), kuduTable.getTableName());
             rowCount = tableStatistics.getCommonStats().getRowNums();
-
         } else {
             try {
                 String kuduTableName = getKuduFullTableName(kuduTable);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/KuduTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/KuduTableTest.java
@@ -49,7 +49,9 @@ public class KuduTableTest {
         String catalogName = "testCatalog";
         String dbName = "testDB";
         String tableName = "testTable";
-        KuduTable kuduTable = new KuduTable("localhost:7051", catalogName, dbName, tableName, fullSchema, partColNames);
+        String kuduTableName = "impala::testDB.testTable";
+        KuduTable kuduTable = new KuduTable("localhost:7051", catalogName, dbName, tableName,
+                kuduTableName, fullSchema, partColNames);
         List<Column> partitionColumns = kuduTable.getPartitionColumns();
         Assertions.assertThat(partitionColumns).hasSameElementsAs(partitionSchema);
     }
@@ -70,7 +72,8 @@ public class KuduTableTest {
         String catalogName = "testCatalog";
         String dbName = "testDB";
         String tableName = "testTable";
-        KuduTable kuduTable = new KuduTable("localhost:7051", catalogName, dbName, tableName, fullSchema, new ArrayList<>());
+        KuduTable kuduTable = new KuduTable("localhost:7051", catalogName, dbName, tableName,
+                null, fullSchema, new ArrayList<>());
 
         TTableDescriptor tTableDescriptor = kuduTable.toThrift(null);
         Assert.assertEquals(tTableDescriptor.getDbName(), dbName);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.kudu.Schema;
@@ -27,13 +28,18 @@ import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduScanToken;
 import org.apache.kudu.client.PartitionSchema;
+import org.apache.kudu.client.RpcRemoteException;
+import org.apache.kudu.client.Status;
+import org.apache.kudu.rpc.RpcHeader;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -142,5 +148,40 @@ public class KuduMetadataTest {
         Assert.assertEquals(1, remoteFileInfos.size());
         Assert.assertEquals(1, remoteFileInfos.get(0).getFiles().size());
         Assert.assertEquals(1, remoteFileInfos.get(0).getFiles().get(0).getKuduScanTokens().size());
+    }
+
+    @Test
+    public void testUnsupportedGetTableStatistics(@Mocked org.apache.kudu.client.KuduTable mockedTable) throws Exception {
+        KuduMetadata metadata = new KuduMetadata(KUDU_CATALOG, new HdfsEnvironment(), KUDU_MASTER, true,
+                SCHEMA_EMULATION_PREFIX, Optional.empty());
+        RpcRemoteException exception = createRpcRemoteException("server sent error Invalid argument: " +
+                "Call on service kudu.master.MasterService received at " +
+                "0.0.0.0:7051 from 0.0.0.0:43670 with an invalid method name: GetTableStatistics");
+        new Expectations() {
+            {
+                client.tableExists(anyString);
+                result = true;
+                client.openTable(anyString);
+                result = mockedTable;
+                mockedTable.getTableStatistics();
+                result = exception;
+            }
+        };
+        Table table = metadata.getTable("db1", "tbl1");
+        KuduTable kuduTable = (KuduTable) table;
+        Statistics statistics = metadata.getTableStatistics(
+                null, kuduTable, Collections.emptyMap(), Collections.emptyList(), null, -1);
+        Assert.assertEquals(1D, statistics.getOutputRowCount(), 0.01);
+    }
+
+    private RpcRemoteException createRpcRemoteException(String message) throws Exception {
+        Status status = Status.IllegalState(message);
+        RpcHeader.ErrorStatusPB errPb = RpcHeader.ErrorStatusPB.getDefaultInstance();
+
+        Constructor<RpcRemoteException>
+                constructor = RpcRemoteException.class.getDeclaredConstructor(
+                        Status.class, RpcHeader.ErrorStatusPB.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(status, errPb);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/KuduScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/KuduScanNodeTest.java
@@ -117,7 +117,7 @@ public class KuduScanNodeTest {
     }
 
     private KuduTable createTestKuduTable(List<Column> columns) {
-        return new KuduTable(KUDU_MASTER, KUDU_CATALOG, "db1", "tb1", columns, new ArrayList<>());
+        return new KuduTable(KUDU_MASTER, KUDU_CATALOG, "db1", "tb1", null, columns, new ArrayList<>());
     }
 
     private TupleDescriptor setupDescriptorTable(KuduTable kuduTable, List<Column> columns) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Ensures compatibility with older versions of the `kudu-client` API by returning a default row count if the GetTableStatistics method is unsupported.
2. Prioritizes the use of `kudu.table_name` from the metastore when `catalog.type` is configured to `hive`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5