### PR TITLE
[BugFix] Fix hudi jni can not read timestamp type when upgrade hudi to 0.14

### DIFF
--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiColumnValue.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiColumnValue.java
@@ -17,6 +17,7 @@ package com.starrocks.hudi.reader;
 import com.starrocks.jni.connector.ColumnType;
 import com.starrocks.jni.connector.ColumnValue;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -24,11 +25,15 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.io.LongWritable;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -160,9 +165,15 @@ public class HudiColumnValue implements ColumnValue {
 
     @Override
     public LocalDateTime getDateTime(ColumnType.TypeValue type) {
-        Long dateTime = ((LongWritable) fieldData).get();
-        TimeUnit timeUnit = TIMESTAMP_UNIT_MAPPING.get(type);
-        LocalDateTime localDateTime = HudiScannerUtils.getTimestamp(dateTime, timeUnit, timezone);
-        return localDateTime;
+        if (fieldData instanceof Timestamp) {
+            return ((Timestamp) fieldData).toLocalDateTime();
+        } else if (fieldData instanceof TimestampWritableV2) {
+            return LocalDateTime.ofInstant(Instant.ofEpochSecond((((TimestampObjectInspector) fieldInspector)
+                    .getPrimitiveJavaObject(fieldData)).toEpochSecond()), ZoneId.of(timezone));
+        } else {
+            Long dateTime = ((LongWritable) fieldData).get();
+            TimeUnit timeUnit = TIMESTAMP_UNIT_MAPPING.get(type);
+            return HudiScannerUtils.getTimestamp(dateTime, timeUnit, timezone);
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Fix hudi jni can not read timestamp type when upgrade hudi to 0.14
Fixes #46498 
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
