### PR TITLE
[BugFix] Fix error when refreshing Paimon MV with null partition keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonPartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonPartitionKey.java
@@ -25,6 +25,6 @@ public class PaimonPartitionKey extends PartitionKey implements NullablePartitio
 
     @Override
     public List<String> nullPartitionValueList() {
-        return ImmutableList.of("__DEFAULT_PARTITION__");
+        return ImmutableList.of("__DEFAULT_PARTITION__", "null");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonPartitionKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonPartitionKeyTest.java
@@ -23,6 +23,6 @@ public class PaimonPartitionKeyTest {
     @Test
     public void testInit() {
         PaimonPartitionKey paimonPartitionKey = new PaimonPartitionKey();
-        assertEquals(paimonPartitionKey.nullPartitionValueList(), ImmutableList.of("__DEFAULT_PARTITION__"));
+        assertEquals(paimonPartitionKey.nullPartitionValueList(), ImmutableList.of("__DEFAULT_PARTITION__", "null"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Create a Paimon table using Spark:
```sql
CREATE TABLE p (
  user_id BIGINT,
  dt BIGINT)
USING paimon
PARTITIONED BY (dt);
```

Create MV
```sql
CREATE MATERIALIZED VIEW `pp` (`user_id`, `dt`)
PARTITION BY (`dt`)
DISTRIBUTED BY RANDOM
REFRESH MANUAL
PROPERTIES (
"replicated_storage" = "true",
"replication_num" = "1",
"storage_medium" = "HDD"
)
AS SELECT `p`.`user_id`, `p`.`dt`
FROM `paimon_fs`.`paimon_db`.`p`;
```

When refreshing this MV, there will be errors like `Invalid number format: null` .

It usually occurs when partition key type is `int` or so.

This PR fixs the problem above.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
