### PR TITLE
[BugFix] Fixed missing break statement while handling Disk migration task in TabletScheduler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -908,8 +908,10 @@ public class TabletScheduler extends FrontendDaemon {
                     break;
                 case DISK_MIGRATION:
                     handleDiskMigration(tabletCtx, batchTask);
+                    break;
                 case LOCATION_MISMATCH:
                     handleLocationMismatch(tabletCtx, batchTask);
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
## Why I'm doing:


## What I'm doing:
Fixed missing break statement while handling Disk migration task in TabletScheduler



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
