### PR TITLE
[BugFix] complex type no need to initial default value when set not null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -913,7 +913,7 @@ public abstract class Type implements Cloneable {
     }
 
     public boolean isComplexType() {
-        return isStructType() || isCollectionType();
+        return isStructType() || isCollectionType() || isJsonType();
     }
 
     public boolean isCollectionType() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -575,7 +575,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             }
         }
 
-        if (!columnDef.isAllowNull() && columnDef.defaultValueIsNull()) {
+        if (!columnDef.isAllowNull() && columnDef.defaultValueIsNull() && !columnDef.getType().isComplexType()) {
             throw new SemanticException(PARSER_ERROR_MSG.withOutDefaultVal(columnDef.getName()), columnDef.getPos());
         }
 
@@ -608,7 +608,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             } catch (AnalysisException e) {
                 throw new SemanticException(PARSER_ERROR_MSG.invalidColumnDef(e.getMessage()), colDef.getPos());
             }
-            if (!colDef.isAllowNull() && colDef.defaultValueIsNull()) {
+            if (!colDef.isAllowNull() && colDef.defaultValueIsNull() && !colDef.getType().isComplexType()) {
                 throw new SemanticException(PARSER_ERROR_MSG.withOutDefaultVal(colDef.getName()), colDef.getPos());
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -250,7 +250,7 @@ public class AlterTest {
     @AfterClass
     public static void tearDown() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
-        String dropSQL = "drop table test_partition_exception";
+        String dropSQL = "drop table if exists test_partition_exception";
         try {
             DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
             GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
@@ -2588,5 +2588,17 @@ public class AlterTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testCatalogAddComplexColumns() throws Exception {
+        String stmt = "alter table test.tbl1 add column ("
+                + "`col1` array<string> not null,"
+                + "`col2` json not null" +
+                ");";
+        AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt,
+                starRocksAssert.getCtx());
+        AddColumnsClause clause = (AddColumnsClause) alterTableStmt.getOps().get(0);
+        Assert.assertEquals(null, clause.getRollupName());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
+ 1. add complex type column without default value when set not null
```
mysql> alter table table_sr add column _arr array<string> not null ;
ERROR 1064 (HY000): Field '_arr' is not null but doesn't have a default value
```

+ 2. add complex type column with default value when set not null
```
mysql> alter table table_sr add column _arr array<string> not null default '[]';
ERROR 1064 (HY000): Analyze columnDef error: Invalid default value for '_arr': Default value for complex type 'ARRAY<VARCHAR(65533)>' not supported
```
## What I'm doing:
> Fix this contradictory verification method
```
alter table table_sr add column _arr array<string> not null ;
```


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5