### PR TITLE
[BugFix] Fix write crash when automatic partition open fail

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -658,6 +658,7 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
                         return Status::EAgain("");
                     } else {
                         _automatic_partition_token->wait();
+                        RETURN_IF_ERROR(this->_automatic_partition_status);
                         // after the partition is created, go through the data again
                         RETURN_IF_ERROR(_vectorized_partition->find_tablets(chunk, &_partitions, &_tablet_indexes,
                                                                             &_validate_selection, &invalid_row_indexs,
@@ -665,6 +666,7 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
                     }
                 }
             } else {
+                RETURN_IF_ERROR(this->_automatic_partition_status);
                 RETURN_IF_ERROR(_vectorized_partition->find_tablets(chunk, &_partitions, &_tablet_indexes,
                                                                     &_validate_selection, &invalid_row_indexs, _txn_id,
                                                                     nullptr));
@@ -687,18 +689,7 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
 
             if (num_rows_after_validate - _validate_select_idx.size() > 0) {
                 std::stringstream ss;
-                // create partition failed is a recoverable error
-                // so we can't put it into error rows which will make routine load paused
-                if (_enable_automatic_partition) {
-                    ss << "The row create partition failed since " << _automatic_partition_status.to_string();
-                    if (invalid_row_indexs.size() > 0) {
-                        std::string debug_row = chunk->debug_row(invalid_row_indexs.back());
-                        ss << ". Row: " << debug_row;
-                    }
-                    return Status::InternalError(ss.str());
-                } else {
-                    ss << "The row is out of partition ranges. Please add a new partition.";
-                }
+                ss << "The row is out of partition ranges. Please add a new partition.";
                 if (!state->has_reached_max_error_msg_num() && invalid_row_indexs.size() > 0) {
                     std::string debug_row = chunk->debug_row(invalid_row_indexs.back());
                     state->append_error_msg_to_file(debug_row, ss.str());

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_fail
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_fail
@@ -1,17 +1,21 @@
 -- name: test_create_partition_fail @sequential
 CREATE TABLE ss( event_day DATE, pv BIGINT, cc int) DUPLICATE KEY(event_day) PARTITION BY date_trunc('month', event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "1");
 -- result:
+[]
 -- !result
 admin set frontend config ("max_automatic_partition_number"="0");
 -- result:
+[]
 -- !result
 insert into ss values('2002-01-01', 1, 2);
 -- result:
-E: (5025, 'The row create partition failed since Runtime error:  Automatically created partitions exceeded the maximum limit: 0. You can modify this restriction on by setting max_automatic_partition_number larger.. Row: [2002-01-01, 1, 2]')
+E: (5025, ' Automatically created partitions exceeded the maximum limit: 0. You can modify this restriction on by setting max_automatic_partition_number larger.')
 -- !result
 admin set frontend config ("max_automatic_partition_number"="4096");
 -- result:
+[]
 -- !result
 insert into ss values('2002-01-01', 1, 2);
 -- result:
+[]
 -- !result


### PR DESCRIPTION
## Why I'm doing:

When the create partition request succeeds, but the open delta writer request fails (for example, the table is deleted), the sinker does not handle it correctly since it only based on the partition information , causing the add chunk to access the null delta writer.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
