### PR TITLE
[BugFix] Fix case when rewrite bug for synchronized materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -52,6 +53,15 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
         return optExpression.getOp().accept(this, optExpression, context);
     }
 
+    public static boolean isCaseWhenScalarOperator(ScalarOperator operator) {
+        if (operator instanceof CaseWhenOperator) {
+            return true;
+        }
+
+        return operator instanceof CallOperator &&
+                FunctionSet.IF.equalsIgnoreCase(((CallOperator) operator).getFnName());
+    }
+
     @Override
     public OptExpression visit(OptExpression optExpression, MaterializedViewRule.RewriteContext context) {
         for (int childIdx = 0; childIdx < optExpression.arity(); ++childIdx) {
@@ -71,18 +81,24 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
 
         Map<ColumnRefOperator, ScalarOperator> newProjectMap = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : projectOperator.getColumnRefMap().entrySet()) {
-            if (kv.getValue().getUsedColumns().contains(context.queryColumnRef)) {
-                if (kv.getValue() instanceof ColumnRefOperator) {
+            ColumnRefOperator queryColRef = kv.getKey();
+            ScalarOperator queryScalarOperator = kv.getValue();
+            if (queryScalarOperator.getUsedColumns().contains(context.queryColumnRef)) {
+                if (queryScalarOperator instanceof ColumnRefOperator) {
                     newProjectMap.put(context.mvColumnRef, context.mvColumnRef);
-                } else {
-                    // rewrite query column ref into mv agg column ref
+                } else if (isCaseWhenScalarOperator(queryScalarOperator)) {
+                    // rewrite query column ref into mv agg column ref,
+                    // eg: sum(case when a > 1 then b else 0 end), rewrite to sum(case when mv_column > 1 then b else 0 end)
                     Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
                     replaceMap.put(context.queryColumnRef, context.mvColumnRef);
                     ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
-                    newProjectMap.put(kv.getKey(), replaceColumnRefRewriter.rewrite(kv.getValue()));
+                    newProjectMap.put(queryColRef, replaceColumnRefRewriter.rewrite(kv.getValue()));
+                } else {
+                    // eg: bitmap_union(to_bitmap(a)), still rewrite to bitmap_union(to_bitmap(a))
+                    newProjectMap.put(queryColRef, context.mvColumnRef);
                 }
             } else {
-                newProjectMap.put(kv.getKey(), kv.getValue());
+                newProjectMap.put(queryColRef, queryScalarOperator);
             }
         }
         return OptExpression.create(new LogicalProjectOperator(newProjectMap), optExpression.getInputs());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -75,7 +75,11 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                 if (kv.getValue() instanceof ColumnRefOperator) {
                     newProjectMap.put(context.mvColumnRef, context.mvColumnRef);
                 } else {
-                    newProjectMap.put(kv.getKey(), context.mvColumnRef);
+                    // rewrite query column ref into mv agg column ref
+                    Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
+                    replaceMap.put(context.queryColumnRef, context.mvColumnRef);
+                    ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
+                    newProjectMap.put(kv.getKey(), replaceColumnRefRewriter.rewrite(kv.getValue()));
                 }
             } else {
                 newProjectMap.put(kv.getKey(), kv.getValue());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -45,7 +45,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -59,6 +58,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.rule.mv.MaterializedViewRewriter.isCaseWhenScalarOperator;
 
 /**
  * Select best materialized view for olap scan node
@@ -851,7 +852,7 @@ public class MaterializedViewRule extends Rule {
 
         if (!queryFnChild0.isColumnRef()) {
             IsNoCallChildrenValidator validator = new IsNoCallChildrenValidator(keyColumns, aggregateColumns);
-            if (!(isSupportScalarOperator(queryFnChild0) && queryFnChild0.accept(validator, null))) {
+            if (!(isCaseWhenScalarOperator(queryFnChild0) && queryFnChild0.accept(validator, null))) {
                 ColumnRefOperator mvColumnRef = factory.getColumnRef(mvColumnFnChild0.getUsedColumns().getFirstId());
                 Column mvColumn = factory.getColumn(mvColumnRef);
                 if (mvColumn.getDefineExpr() != null && mvColumn.getDefineExpr() instanceof FunctionCallExpr &&
@@ -873,7 +874,7 @@ public class MaterializedViewRule extends Rule {
             return true;
         }
 
-        if (isSupportScalarOperator(queryFnChild0)) {
+        if (isCaseWhenScalarOperator(queryFnChild0)) {
             int[] queryColumnIds = queryFnChild0.getUsedColumns().getColumnIds();
             Set<Integer> mvColumnIdSet = usedBaseColumnIds.stream()
                     .collect(Collectors.toSet());
@@ -922,14 +923,5 @@ public class MaterializedViewRule extends Rule {
             this.mvColumnRef = mvColumnRef;
             this.mvColumn = mvColumn;
         }
-    }
-
-    private boolean isSupportScalarOperator(ScalarOperator operator) {
-        if (operator instanceof CaseWhenOperator) {
-            return true;
-        }
-
-        return operator instanceof CallOperator &&
-                FunctionSet.IF.equalsIgnoreCase(((CallOperator) operator).getFnName());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -725,13 +725,19 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             Preconditions.checkState(targetColumn instanceof CallOperator);
             return (CallOperator) targetColumn;
         } else {
+            if (targetColumn instanceof CallOperator) {
+                // if it's aggregate function, it should be rewritten by group by keys, return it directly.
+                CallOperator targetCall = (CallOperator) targetColumn;
+                if (targetCall.isAggregate()) {
+                    return targetCall;
+                }
+            }
             if (!targetColumn.isColumnRef()) {
                 OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext.getMVName(),
                         "Rewrite aggregate rollup {} failed: only column-ref is supported after rewrite",
                         aggCall.toString());
                 return null;
             }
-            // Aggregate must be CallOperator
             CallOperator newAggregate = getRollupAggregateFunc(aggCall, (ColumnRefOperator) targetColumn, false);
             if (newAggregate == null) {
                 OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext.getMVName(),

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -351,15 +351,10 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
         starRocksAssert.withMaterializedView("create materialized view mv0" +
                 " distributed by random" +
                 " as select t1a, t1b, sum(t1f) as total from test.test_all_type group by t1a, t1b;", () -> {
-            setTracLogModule("MV");
             {
                 String query = "select t1a, sum(if(t1b=0, t1f, 0)) as total from test.test_all_type group by t1a;";
-                sql(query)
-                        .contains("mv0")
-                        .contains("  1:AGGREGATE (update serialize)\n" +
-                                "  |  STREAMING\n" +
-                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
-                                "  |  group by: 13: t1a");
+                // TODO: fix this later.
+                sql(query).notContain("mv0");
             }
             {
                 String query = "select t1a, sum(if(t1b=0, t1b, 0)) as total from test.test_all_type group by t1a;";

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -345,4 +345,88 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
             starRocksAssert.dropMaterializedView("mv0");
         }
     }
+
+    @Test
+    public void testRewriteWithCaseWhen() {
+        starRocksAssert.withMaterializedView("create materialized view mv0" +
+                " distributed by random" +
+                " as select t1a, t1b, sum(t1f) as total from test.test_all_type group by t1a, t1b;", () -> {
+            setTracLogModule("MV");
+            {
+                String query = "select t1a, sum(if(t1b=0, t1f, 0)) as total from test.test_all_type group by t1a;";
+                sql(query)
+                        .contains("mv0")
+                        .contains("  1:AGGREGATE (update serialize)\n" +
+                                "  |  STREAMING\n" +
+                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
+                                "  |  group by: 13: t1a");
+            }
+            {
+                String query = "select t1a, sum(if(t1b=0, t1b, 0)) as total from test.test_all_type group by t1a;";
+                sql(query)
+                        .contains("mv0")
+                        .contains("  1:AGGREGATE (update serialize)\n" +
+                                "  |  STREAMING\n" +
+                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
+                                "  |  group by: 13: t1a");
+            }
+            {
+                String query = "select t1a, sum(if(murmur_hash3_32(t1b %3) = 0, t1b, 0)) as total from test.test_all_type group" +
+                        " by t1a;";
+                sql(query)
+                        .contains("mv0")
+                        .contains("  1:AGGREGATE (update serialize)\n" +
+                                "  |  STREAMING\n" +
+                                "  |  output: sum(if(murmur_hash3_32(CAST(14: t1b % 3 AS VARCHAR)) = 0, 14: t1b, 0))\n" +
+                                "  |  group by: 13: t1a");
+            }
+            {
+                String query = "select t1a, sum(case when(t1b=0) then t1b else 0 end) as total from test.test_all_type " +
+                        "group by t1a;";
+                sql(query)
+                        .contains("mv0")
+                        .contains("  1:AGGREGATE (update serialize)\n" +
+                                "  |  STREAMING\n" +
+                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
+                                "  |  group by: 13: t1a");
+            }
+            {
+                String query = "select t1a, sum(case when(t1b=0) then t1b else 0 end) as total from test.test_all_type " +
+                        "group by t1a;";
+                sql(query)
+                        .contains("mv0")
+                        .contains("  1:AGGREGATE (update serialize)\n" +
+                                "  |  STREAMING\n" +
+                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
+                                "  |  group by: 13: t1a");
+            }
+        });
+    }
+
+    @Test
+    public void testRewriteWithOnlyGroupByKeys() {
+        starRocksAssert.withMaterializedView("create materialized view mv0" +
+                " distributed by random" +
+                " as select sum(t1f) as total, t1a, t1b from test.test_all_type group by t1a, t1b;", () -> {
+            {
+                String query = "select t1a, sum(t1b) as total from test.test_all_type group by t1a;";
+                sql(query)
+                        .contains("mv0")
+                        .contains("  1:AGGREGATE (update serialize)\n" +
+                                "  |  STREAMING\n" +
+                                "  |  output: sum(14: t1b)\n" +
+                                "  |  group by: 12: t1a\n" +
+                                "  |  ");
+            }
+            {
+                String query = "select t1a, sum(t1b + 1) as total from test.test_all_type group by t1a;";
+                sql(query)
+                        .contains("mv0")
+                        .contains("  1:AGGREGATE (update serialize)\n" +
+                                "  |  STREAMING\n" +
+                                "  |  output: sum(CAST(15: t1b AS INT) + 1)\n" +
+                                "  |  group by: 13: t1a");
+            }
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -755,9 +755,13 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteFail(mv, "select empid, deptno,\n" +
                 " sum(salary) as total, count(1)  as cnt\n" +
                 " from emps group by empid, deptno");
-        testRewriteFail(mv, "select empid,\n" +
+        testRewriteOK(mv, "select empid,\n" +
                 " sum(salary) as total, count(1)  as cnt\n" +
-                " from emps group by empid");
+                " from emps group by empid")
+                .contains("  1:AGGREGATE (update serialize)\n" +
+                        "  |  STREAMING\n" +
+                        "  |  output: sum(11: total), count(1)\n" +
+                        "  |  group by: 9: empid");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -524,7 +524,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                     "GROUP BY `test_base_part`.`c3`, `test_base_part`.`c1`;");
 
             String query = "select c1, c3, sum(c4) from test_base_part where c3 < 2000 group by c1, c3;";
-            String plan = getFragmentPlan(query, "MV");
+            String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "partial_mv_11", "TABLE: test_base_part\n" +
                     "     PREAGGREGATION: ON\n" +
                     "     partitions=1/5");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -486,7 +486,7 @@ public class MVRewriteTest {
         query = "select deptno, sum(if(empid=0,0,1)) from " + EMPS_TABLE_NAME + " group by deptno";
         starRocksAssert.query(query).explainWithout(EMPS_MV_NAME);
     }
-    
+
     @Test
     public void testAggregateMVCalcGroupByQuery1() throws Exception {
         String createEmpsMVSQL = "create materialized view " + EMPS_MV_NAME + " as select deptno, empid, sum(salary) "
@@ -1191,14 +1191,14 @@ public class MVRewriteTest {
                     "FROM kkk AS T1\n" +
                     "GROUP BY T1.dt";
             String plan  = starRocksAssert.query(query).explainQuery();
-        PlanTestBase.assertContains(plan, "  1:Project\n" +
-                "  |  <slot 3> : 3: dt\n" +
-                "  |  <slot 5> : 5: mv_bitmap_union_user_id_td\n" +
-                "  |  <slot 6> : if(1: is_finish = '1', 5: mv_bitmap_union_user_id_td, NULL)");
-        PlanTestBase.assertContains(plan, "     TABLE: kkk\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=1/1\n" +
-                "     rollup: kkk_mv");
+            PlanTestBase.assertContains(plan, "  1:Project\n" +
+                    "  |  <slot 3> : 3: dt\n" +
+                    "  |  <slot 5> : 5: mv_bitmap_union_user_id_td\n" +
+                    "  |  <slot 6> : if(1: is_finish = '1', 5: mv_bitmap_union_user_id_td, NULL)");
+            PlanTestBase.assertContains(plan, "     TABLE: kkk\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: kkk_mv");
         }
 
         starRocksAssert.dropTable("kkk");
@@ -1443,7 +1443,7 @@ public class MVRewriteTest {
                 + "from " + EMPS_TABLE_NAME + " group by empid, deptno;";
         String query = "select * from ods_order where bank_transaction_id " +
                 "not in (select sum(cast(salary as smallint)) as ssalary from " +
-                        EMPS_TABLE_NAME + " group by deptno)";
+                EMPS_TABLE_NAME + " group by deptno)";
         starRocksAssert.withMaterializedView(createEmpsMVSQL).query(query).explainContains(QUERY_USE_EMPS);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -1089,7 +1089,6 @@ public class MVRewriteTest {
                 + " " + EMPS_TABLE_NAME + " where deptno < 200 group by empid) a group by a.empid";
         String plan = starRocksAssert.withMaterializedView(createMVSQL).query(union).explainQuery();
         // NOTE: Since `deptno` is key column of the new mv, so use `PREAGGREGATION` instead.
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("1:OlapScanNode\n" +
                 "     TABLE: emps\n" +
                 "     PREAGGREGATION: ON\n" +
@@ -1221,7 +1220,6 @@ public class MVRewriteTest {
 
         String query = "select k1, sum(case when(k2=0) then k3 else 0 end) from t1 group by k1";
         String plan = starRocksAssert.query(query).explainQuery();
-        System.out.println(plan);
         PlanTestBase.assertContains(plan, "  1:Project\n" +
                 "  |  <slot 1> : 1: k1\n" +
                 "  |  <slot 6> : if(2: k2 = 0, 3: k3, 0)\n");
@@ -1249,7 +1247,6 @@ public class MVRewriteTest {
         // query contains sum1 and sum2, should use mv
         String query = "select k1, sum(k3) as sum1, sum(case when(k2=0) then k3 else 0 end) as sum2 from t1 group by k1";
         String plan = starRocksAssert.query(query).explainQuery();
-        System.out.println(plan);
         PlanTestBase.assertContains(plan, "  1:Project\n" +
                 "  |  <slot 1> : 1: k1\n" +
                 "  |  <slot 5> : 5: mv_sum_k3\n" +
@@ -1278,13 +1275,8 @@ public class MVRewriteTest {
 
         String query = "select k1, sum(case when(k2=0) then k3 else 0 end) from t1 group by k1";
         String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "MV");
-        System.out.println(plan);
-        PlanTestBase.assertContains(plan, "  1:Project\n" +
-                "  |  <slot 1> : 1: k1\n" +
-                "  |  <slot 6> : if(2: k2 = 0, 3: k3, 0)\n");
-        PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                "     PREAGGREGATION: OFF. Reason: The result of ELSE isn't value column\n" +
-                "     partitions=1/1");
+        // TODO: support this for amv
+        PlanTestBase.assertNotContains(plan, "test_mv1)\n");
         starRocksAssert.dropTable("t1");
         starRocksAssert.dropMaterializedView("test_mv1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -1290,9 +1290,8 @@ public class MVRewriteTest {
         String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "MV");
         System.out.println(plan);
         PlanTestBase.assertContains(plan, USER_TAG_MV_NAME);
-        PlanTestBase.assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
-                "  |  output: bitmap_agg(2: user_id)\n" +
-                "  |  group by: ");
+        PlanTestBase.assertContains(plan, "  |  <slot 2> : 2: user_id\n" +
+                "  |  <slot 6> : 5: mv_bitmap_union_tag_id");
         starRocksAssert.dropMaterializedView(USER_TAG_MV_NAME);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -168,7 +168,19 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
 
         String query9 = "select sum(c3) from test_base_part";
         String plan9 = getFragmentPlan(query9);
-        PlanTestBase.assertNotContains(plan9, "partial_mv_5");
+        PlanTestBase.assertContains(plan9, "UNION");
+        PlanTestBase.assertContains(plan9, "  1:OlapScanNode\n" +
+                "     TABLE: partial_mv_5\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=5/5");
+        PlanTestBase.assertContains(plan9, "  4:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(13: c2)\n" +
+                "  |  group by: 12: c1, 14: c3\n" +
+                "  |  \n" +
+                "  3:OlapScanNode\n" +
+                "     TABLE: test_base_part\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/6");
         dropMv("test", "partial_mv_5");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -522,6 +522,22 @@ public class UtFrameUtils {
         }
     }
 
+    public static String getFragmentPlan(ConnectContext connectContext, String sql, String traceModule) {
+        try {
+            Pair<String, Pair<ExecPlan, String>> result =
+                    UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);
+            Pair<ExecPlan, String> execPlanWithQuery = result.second;
+            String traceLog = execPlanWithQuery.second;
+            if (!Strings.isNullOrEmpty(traceLog)) {
+                System.out.println(traceLog);
+            }
+            return execPlanWithQuery.first.getExplainString(TExplainLevel.NORMAL);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+            return null;
+        }
+    }
+
     public static Pair<String, Pair<ExecPlan, String>> getFragmentPlanWithTrace(
             ConnectContext connectContext, String sql, String module) throws Exception {
         if (Strings.isNullOrEmpty(module)) {

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite_with_case_when
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite_with_case_when
@@ -1,0 +1,233 @@
+-- name: test_sync_materialized_view_rewrite_with_case_when
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k1` date NULL COMMENT "",   
+    `k2` datetime NULL COMMENT "",   
+    `k3` char(20) NULL COMMENT "",   
+    `k4` varchar(20) NULL COMMENT "",   
+    `k5` boolean NULL COMMENT "",   
+    `k6` tinyint(4) NULL COMMENT "",   
+    `k7` smallint(6) NULL COMMENT "",   
+    `k8` int(11) NULL COMMENT "",   
+    `k9` bigint(20) NULL COMMENT "",   
+    `k10` largeint(40) NULL COMMENT "",   
+    `k11` float NULL COMMENT "",   
+    `k12` double NULL COMMENT "",   
+    `k13` decimal128(27, 9) NULL COMMENT "",   
+    INDEX idx1 (`k6`) USING BITMAP 
+) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+-- result:
+-- !result
+insert into t1 values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  2, 2, 2, 2, 2, 2.0, 2.0, 1.0),
+    ('2023-06-16', '2023-06-16 00:00:00', 'c', 'a', false, 3, 1, 3, 3, 3, 3.0, 3.0, 1.0),
+    ('2023-06-17', '2023-06-17 00:00:00', 'd', 'a', true,  4, 1, 4, 4, 4, 4.0, 4.0, 1.0)
+;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+AS SELECT k1, k6, SUM(k7) as sum1, SUM(k9) as sum2, SUM(k8) as sum3 FROM t1 GROUP BY k1, k6;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	3
+2023-06-17	4
+-- !result
+SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	3
+2023-06-16	4
+2023-06-17	5
+-- !result
+SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	1
+2023-06-16	0
+2023-06-17	0
+-- !result
+SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	0
+2023-06-17	0
+-- !result
+SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;
+-- result:
+2023-06-15	3	0	1	2
+2023-06-16	3	0	0	0
+2023-06-17	4	0	0	0
+-- !result
+SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	3
+2023-06-17	4
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+AS SELECT k1, k6, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) as sum2 FROM t1 GROUP BY k1, k6;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	3
+2023-06-17	4
+-- !result
+SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	3
+2023-06-16	4
+2023-06-17	5
+-- !result
+SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	1
+2023-06-16	0
+2023-06-17	0
+-- !result
+SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	0
+2023-06-17	0
+-- !result
+SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;
+-- result:
+2023-06-15	3	0	1	2
+2023-06-16	3	0	0	0
+2023-06-17	4	0	0	0
+-- !result
+SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	3
+2023-06-17	4
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY RANDOM
+AS SELECT k1, k6, SUM(k7) as sum1, SUM(k9) as sum2, SUM(k8) as sum3 FROM t1 GROUP BY k1, k6;
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	3
+2023-06-17	4
+-- !result
+SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	3
+2023-06-16	4
+2023-06-17	5
+-- !result
+SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	1
+2023-06-16	0
+2023-06-17	0
+-- !result
+SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	0
+2023-06-17	0
+-- !result
+SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;
+-- result:
+2023-06-15	2
+2023-06-16	3
+2023-06-17	4
+-- !result
+drop table t1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite_with_case_when
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite_with_case_when
@@ -1,0 +1,89 @@
+-- name: test_sync_materialized_view_rewrite_with_case_when
+
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
+CREATE TABLE `t1` (
+    `k1` date NULL COMMENT "",   
+    `k2` datetime NULL COMMENT "",   
+    `k3` char(20) NULL COMMENT "",   
+    `k4` varchar(20) NULL COMMENT "",   
+    `k5` boolean NULL COMMENT "",   
+    `k6` tinyint(4) NULL COMMENT "",   
+    `k7` smallint(6) NULL COMMENT "",   
+    `k8` int(11) NULL COMMENT "",   
+    `k9` bigint(20) NULL COMMENT "",   
+    `k10` largeint(40) NULL COMMENT "",   
+    `k11` float NULL COMMENT "",   
+    `k12` double NULL COMMENT "",   
+    `k13` decimal128(27, 9) NULL COMMENT "",   
+    INDEX idx1 (`k6`) USING BITMAP 
+) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+
+insert into t1 values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  2, 2, 2, 2, 2, 2.0, 2.0, 1.0),
+    ('2023-06-16', '2023-06-16 00:00:00', 'c', 'a', false, 3, 1, 3, 3, 3, 3.0, 3.0, 1.0),
+    ('2023-06-17', '2023-06-17 00:00:00', 'd', 'a', true,  4, 1, 4, 4, 4, 4.0, 4.0, 1.0)
+;
+
+CREATE MATERIALIZED VIEW test_mv1
+AS SELECT k1, k6, SUM(k7) as sum1, SUM(k9) as sum2, SUM(k8) as sum3 FROM t1 GROUP BY k1, k6;
+function: wait_materialized_view_finish()
+
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+
+SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;
+SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+CREATE MATERIALIZED VIEW test_mv1
+AS SELECT k1, k6, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) as sum2 FROM t1 GROUP BY k1, k6;
+
+function: wait_materialized_view_finish()
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+
+SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;
+SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;
+DROP MATERIALIZED VIEW test_mv1;
+
+
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY RANDOM
+AS SELECT k1, k6, SUM(k7) as sum1, SUM(k9) as sum2, SUM(k8) as sum3 FROM t1 GROUP BY k1, k6;
+
+refresh materialized view test_mv1 with sync mode;
+
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+
+SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;
+SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;
+
+drop table t1;


### PR DESCRIPTION
## Why I'm doing:
```
-- mv
CREATE MATERIALIZED VIEW rdb_test_mv AS
SELECT a,
c,
SUM(cnt1) AS cnt1,
SUM(cnt2) AS cnt2,
SUM(cnt3) AS cnt3
FROM oks.rdb_test1
GROUP BY
a,c;

-- Query will get a wrong result which it will ignore the case when expr!!!
SELECT
a,
SUM(cnt1) as cnt1,
SUM(IF(c = 1, cnt1, 0)) as cnt2,
SUM(IF(c = 2, cnt1, 0)) as cnt3
from
oks.rdb_test1
group by
a;
```
## What I'm doing:
- In SMV, rewrite query column ref into mv agg column ref to keep the case when expr;
- In AMV, support rewrite only group by keys .

Further: support case when rewrite for amv: https://github.com/StarRocks/starrocks/issues/46750

Fixes #issue




## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
