### PR TITLE
[Enhancement] add support for mysql tools, such as mysqldump

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -16,7 +16,7 @@ grammar StarRocks;
 import StarRocksLex;
 
 sqlStatements
-    : singleStatement+ EOF
+    : singleStatement* EOF
     ;
 
 singleStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -38,6 +38,8 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.ast.EmptyStmt;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.ExecPlan;
@@ -684,5 +686,12 @@ public class SelectStmtTest {
                 "         NULL\n" +
                 "     limit: 1\n" +
                 "     cardinality: 1\n"));
+    }
+
+    @Test
+    void testCommentLines() throws Exception {
+        String sql = "/*!50503 SET NAMES utf8mb4 */;";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        Assertions.assertTrue(stmt instanceof EmptyStmt);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -589,6 +589,4 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         Assert.assertFalse(Strings.isNullOrEmpty(QueryDetailQueue.getQueryDetailsAfterTime(0).get(0).getSql()));
     }
-
-
 }

--- a/test/sql/test_agg/R/test_distinct_agg
+++ b/test/sql/test_agg/R/test_distinct_agg
@@ -217,10 +217,8 @@ select count(distinct t1.c1, if(t2.c3 is null, 1, 0)), sum(t1.c2 + if(t2.c3 is n
 -- result:
 1	5000
 -- !result
-# streaming_preaggregation_mode = 'auto' new_planner_agg_stage = '0'
 set streaming_preaggregation_mode = 'auto';
 -- result:
-E: (1064, "Getting syntax error at line 1, column 2. Detail message: Unexpected input 'streaming_preaggregation_mode', the most similar input is {'ADMIN', 'GRANT', 'STOP', 'TRUNCATE', 'INSERT', '(', ';'}.")
 -- !result
 set new_planner_agg_stage = '0';
 -- result:
@@ -489,10 +487,8 @@ select array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group b
 [3]	1	5000
 [3]	1	5000
 -- !result
-# streaming_preaggregation_mode = 'force_streaming' new_planner_agg_stage = '2'
 set streaming_preaggregation_mode = 'force_streaming';
 -- result:
-E: (1064, "Getting syntax error at line 1, column 2. Detail message: Unexpected input 'streaming_preaggregation_mode', the most similar input is {'ADMIN', 'GRANT', 'STOP', 'TRUNCATE', 'INSERT', '(', ';'}.")
 -- !result
 set new_planner_agg_stage = '0';
 -- result:
@@ -737,10 +733,8 @@ select array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group b
 [3]	1	5000
 [3]	1	5000
 -- !result
-# streaming_preaggregation_mode = 'force_preaggregation' new_planner_agg_stage = '2'
 set streaming_preaggregation_mode = 'force_preaggregation';
 -- result:
-E: (1064, "Getting syntax error at line 1, column 2. Detail message: Unexpected input 'streaming_preaggregation_mode', the most similar input is {'ADMIN', 'GRANT', 'STOP', 'TRUNCATE', 'INSERT', '(', ';'}.")
 -- !result
 set new_planner_agg_stage = '0';
 -- result:

--- a/test/sql/test_agg/T/test_distinct_agg
+++ b/test/sql/test_agg/T/test_distinct_agg
@@ -90,7 +90,7 @@ select count(distinct c1, c2), count(distinct c2, c3), sum(c2) from skew_agg lim
 select count(distinct c1, c2, c3), count(distinct c2, c3), sum(c2) from skew_agg group by c4 limit 500;
 select count(distinct t1.c1, if(t2.c3 is null, 1, 0)), sum(t1.c2 + if(t2.c3 is null, 1, 0)) from skew_agg t1 left join skew_agg t2 on t1.c4 > t2.c4 group by t1.c4 limit 500;
 
-# streaming_preaggregation_mode = 'auto' new_planner_agg_stage = '0'
+-- streaming_preaggregation_mode = 'auto' new_planner_agg_stage = '0'
 set streaming_preaggregation_mode = 'auto';
 set new_planner_agg_stage = '0';
 select group_concat(distinct c2, upper(c4) order by abs(c2 + c3)), array_agg(c3 order by 1, c4),  ceil(sum(c5)) from (select * from skew_agg order by 1,2,3,4,5,6 limit 10) t;
@@ -171,7 +171,7 @@ select group_concat(distinct c2), array_agg(distinct c2), count(distinct c2), su
 select array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group by rollup(c1, c2);
 
 
-# streaming_preaggregation_mode = 'force_streaming' new_planner_agg_stage = '2'
+-- streaming_preaggregation_mode = 'force_streaming' new_planner_agg_stage = '2'
 set streaming_preaggregation_mode = 'force_streaming';
 set new_planner_agg_stage = '0';
 select group_concat(distinct c2, upper(c4) order by abs(c2 + c3)), array_agg(c3 order by 1, c4),  ceil(sum(c5)) from (select * from skew_agg order by 1,2,3,4,5,6 limit 10) t;
@@ -247,7 +247,7 @@ select group_concat(distinct c2), array_agg(distinct c2), count(distinct c2), su
 select array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group by rollup(c1, c2);
 
 
-# streaming_preaggregation_mode = 'force_preaggregation' new_planner_agg_stage = '2'
+-- streaming_preaggregation_mode = 'force_preaggregation' new_planner_agg_stage = '2'
 set streaming_preaggregation_mode = 'force_preaggregation';
 set new_planner_agg_stage = '0';
 select group_concat(distinct c2, upper(c4) order by abs(c2 + c3)), array_agg(c3 order by 1, c4),  ceil(sum(c5)) from (select * from skew_agg order by 1,2,3,4,5,6 limit 10) t;


### PR DESCRIPTION
## Why I'm doing:

For some mysql tools, such as mysqldump, some comments will added for compatibility, such as.

```
/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
/*!50503 SET NAMES utf8mb4 */;
/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
/*!40103 SET TIME_ZONE='+00:00' */;
/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
```
which is supported by mysql only, and got errors under starrocks, you could also refer #32076 

![image](https://github.com/StarRocks/starrocks/assets/130516674/1b03fd6b-86e1-4bd8-bf5c-78a113b596f5)

## What I'm doing:

Just ignore this kind of comments.

So we could backup and restore some table with the following commands.

```
mysqldump -h 127.0.0.1 -P9030 -u root --no-tablespaces --column-statistics=0 tpch1g nation > /tmp/nation.sql
mysql -h 127.0.0.1 -P9030 -u root test < /tmp/nation.sql
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5