### PR TITLE
[BugFix] Abort transaction when plan insert failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -74,12 +74,16 @@ import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.RemoteTransactionMgr;
 import com.starrocks.transaction.RunningTxnExceedException;
 import com.starrocks.transaction.TransactionState;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class StatementPlanner {
+    private static final Logger LOG = LogManager.getLogger(StatementPlanner.class);
 
     public static ExecPlan plan(StatementBase stmt, ConnectContext session) {
         if (session instanceof HttpConnectContext) {
@@ -137,6 +141,11 @@ public class StatementPlanner {
             } else if (stmt instanceof DeleteStmt) {
                 return new DeletePlanner().plan((DeleteStmt) stmt, session);
             }
+        } catch (Throwable e) {
+            if (stmt instanceof DmlStmt) {
+                abortTransaction((DmlStmt) stmt, session, e.getMessage());
+            }
+            throw e;
         } finally {
             if (needWholePhaseLock) {
                 unLock(plannerMetaLocker);
@@ -473,5 +482,37 @@ public class StatementPlanner {
         }
 
         stmt.setTxnId(txnId);
+    }
+
+    private static void abortTransaction(DmlStmt stmt, ConnectContext session, String errMsg) {
+        long txnId = stmt.getTxnId();
+        if (txnId == 0) {
+            return;
+        }
+
+        MetaUtils.normalizationTableName(session, stmt.getTableName());
+        String catalogName = stmt.getTableName().getCatalog();
+        String dbName = stmt.getTableName().getDb();
+        Database db = MetaUtils.getDatabase(catalogName, dbName);
+        Table targetTable = MetaUtils.getSessionAwareTable(session, db, stmt.getTableName());
+        try {
+            if (targetTable instanceof ExternalOlapTable) {
+                ExternalOlapTable tbl = (ExternalOlapTable) targetTable;
+                RemoteTransactionMgr.abortRemoteTransaction(tbl.getSourceTableDbId(), txnId, tbl.getSourceTableHost(),
+                        tbl.getSourceTablePort(), errMsg, Collections.emptyList(), Collections.emptyList());
+            } else if (targetTable instanceof OlapTable) {
+                GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+                transactionMgr.abortTransaction(
+                        db.getId(),
+                        txnId,
+                        errMsg,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        null);
+            }
+        } catch (Throwable e) {
+            // Just print a log if abort txn failed, this failure do not need to pass to user.
+            LOG.warn("errors when abort txn", e);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -434,7 +434,7 @@ public class StatementPlanner {
 
         GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
-        long txnId = -1L;
+        long txnId = DmlStmt.INVALID_TXN_ID;
         if (targetTable instanceof ExternalOlapTable) {
             if (!(stmt instanceof InsertStmt)) {
                 throw UnsupportedException.unsupportedException("External OLAP table only supports insert statement");
@@ -486,7 +486,7 @@ public class StatementPlanner {
 
     private static void abortTransaction(DmlStmt stmt, ConnectContext session, String errMsg) {
         long txnId = stmt.getTxnId();
-        if (txnId == 0) {
+        if (txnId == DmlStmt.INVALID_TXN_ID) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
@@ -19,7 +19,10 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.sql.parser.NodePosition;
 
 public abstract class DmlStmt extends StatementBase {
-    private long txnId = 0L;
+    public static final long INVALID_TXN_ID = -1L;
+
+    private long txnId = INVALID_TXN_ID;
+
     protected DmlStmt(NodePosition pos) {
         super(pos);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
@@ -19,7 +19,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.sql.parser.NodePosition;
 
 public abstract class DmlStmt extends StatementBase {
-    private long txnId;
+    private long txnId = 0L;
     protected DmlStmt(NodePosition pos) {
         super(pos);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -24,21 +24,29 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.List;
+
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getConnectContext;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getStarRocksAssert;
 
 public class AnalyzeInsertTest {
@@ -376,5 +384,34 @@ public class AnalyzeInsertTest {
                 "\t\"format\"=\"parquet\", \n" +
                 "\t\"compression\" = \"uncompressed\" ) \n" +
                 "select 1 as a, 2 as a", "expect column names to be distinct, but got duplicate(s): [a]");
+    }
+
+    @Test
+    public void testInsertFailAbortTransaction() throws Exception {
+        StarRocksAssert starRocksAssert = getStarRocksAssert();
+        ConnectContext connectContext = getConnectContext();
+        starRocksAssert.withDatabase("insert_fail").withTable("create table insert_fail.t1 (k1 int, k2 int) " +
+                "distributed by hash(k1) buckets 1 properties ('replication_num' = '1')");
+
+        String insertSql = "insert into insert_fail.t1 values (1)";
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        StatementBase statement = SqlParser.parseSingleStatement(insertSql, connectContext.getSessionVariable().getSqlMode());
+        try {
+            new StmtExecutor(connectContext, statement).execute();
+        } catch (Exception e) {
+            Assert.assertTrue(
+                    e.getMessage().contains("Inserted target column count: 2 doesn't match select/value column count: 1"));
+        }
+
+        List<List<String>> results = starRocksAssert.show("show proc '/transactions/insert_fail'");
+        Assert.assertEquals(2, results.size());
+        for (List<String> row : results) {
+            Assert.assertEquals(2, row.size());
+            if (row.get(0).equals("running")) {
+                Assert.assertEquals("0", row.get(1));
+            } else if (row.get(0).equals("finished")) {
+                Assert.assertEquals("1", row.get(1));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
miss abort transaction when plan dml statement failed.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/7725

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
