### PR TITLE
[BugFix] Fix text reader crashed in compressed file

### DIFF
--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -464,6 +464,11 @@ Status HdfsTextScanner::_build_hive_column_name_2_index() {
 int64_t HdfsTextScanner::estimated_mem_usage() const {
     int64_t value = HdfsScanner::estimated_mem_usage();
     if (value != 0) return value;
+    // for compressed text file, if _no_data=true, means _reader is nullptr
+    if (_no_data) {
+        return 0;
+    }
+    DCHECK(_reader != nullptr);
     return _reader->buff_capacity() * 3 / 2;
 }
 

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1735,6 +1735,21 @@ TEST_F(HdfsScannerTest, TestCSVCompressed) {
         scanner->close();
     }
     {
+        auto* range = _create_scan_range(compressed_file, 1, 0);
+        auto* tuple_desc = _create_tuple_desc(csv_descs);
+        auto* param = _create_param(compressed_file, range, tuple_desc);
+        build_hive_column_names(param, tuple_desc);
+        auto scanner = std::make_shared<HdfsTextScanner>();
+
+        status = scanner->init(_runtime_state, *param);
+        ASSERT_TRUE(status.ok()) << status.message();
+
+        status = scanner->open(_runtime_state);
+        ASSERT_TRUE(status.ok()) << status.message();
+        ASSERT_EQ(0, scanner->estimated_mem_usage());
+        scanner->close();
+    }
+    {
         auto* range = _create_scan_range(compressed_file, 0, 0);
         // Forcr to parse csv as uncompressed data.
         range->text_file_desc.__set_compression_type(TCompressionType::NO_COMPRESSION);


### PR DESCRIPTION
## Why I'm doing:
fix crash:
```bash
query_id:b90a7bf5-266c-11ef-89b9-566ae86892d8, fragment_instance:b90a7bf5-266c-11ef-89b9-566ae86892d9
Hive file path: 000001_0.gz, partition id: 0, length: 69115558, offset: 201326592
tracker:process consumption: 0
tracker:query_pool consumption: 0
tracker:query_pool/connector_scan consumption: 855736320
tracker:load consumption: 0
tracker:metadata consumption: 95814
tracker:tablet_metadata consumption: 88324
tracker:rowset_metadata consumption: 7490
tracker:segment_metadata consumption: 0
tracker:column_metadata consumption: 0
tracker:tablet_schema consumption: 6196
tracker:segment_zonemap consumption: 0
tracker:short_key_index consumption: 0
tracker:column_zonemap_index consumption: 0
tracker:ordinal_index consumption: 0
tracker:bitmap_index consumption: 0
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 0
tracker:jit_cache consumption: 0
tracker:update consumption: 0
tracker:chunk_allocator consumption: 0
tracker:clone consumption: 0
tracker:consistency consumption: 0
tracker:datacache consumption: 0
tracker:replication consumption: 0
*** Aborted at 1717943414 (unix time) try "date -d @1717943414" if you are using GNU date ***
PC: @          0xfe7e965 starrocks::CSVBuffer::capacity()
*** SIGSEGV (@0x98) received by PID 419640 (TID 0x7f3235969640) from PID 152; stack trace: ***
    @         0x1c44906a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f353d0a5520 (unknown)
    @          0xfe7e965 starrocks::CSVBuffer::capacity()
    @         0x152689bc starrocks::CSVReader::buff_capacity()
    @         0x189a3e77 starrocks::HdfsTextScanner::estimated_mem_usage()
    @         0x187c8257 starrocks::connector::HiveDataSource::estimated_mem_usage()
    @          0xef15165 starrocks::pipeline::ConnectorChunkSource::close()
    @          0xee9ec67 starrocks::pipeline::ScanOperator::_close_chunk_source_unlocked()
    @          0xee9f2c3 starrocks::pipeline::ScanOperator::_finish_chunk_source_task()
    @          0xeea06ea _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlRT_E_clINS_9workgroup12YieldContextEEEDaS5_
    @          0xeea6eed _ZSt13__invoke_implIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlRT_E_JRNS0_9workgroup12YieldContextEEES5_St14__invoke_otherOT0_DpOT1_
    @          0xeea6d72 _ZSt10__invoke_rIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlRT_E_JRNS0_9workgroup12YieldContextEEENSt9enable_ifIX16is_invocable_r_vIS5_T0_DpT1_EES5_E4typeEOSD_DpOSE_
    @          0xeea68a1 _ZNSt17_Function_handlerIFvRN9starrocks9workgroup12YieldContextEEZNS0_8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlRT_E_E9_M_invokeERKSt9_Any_dataS3_
    @          0xf444363 std::function<>::operator()()
    @          0xf442fc7 starrocks::workgroup::ScanTask::run()
    @          0xf5416d6 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0xf540d2a _ZZN9starrocks9workgroup12ScanExecutor10initializeEiENKUlvE_clEv
    @          0xf54338c _ZSt13__invoke_implIvRZN9starrocks9workgroup12ScanExecutor10initializeEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @          0xf542f93 _ZSt10__invoke_rIvRZN9starrocks9workgroup12ScanExecutor10initializeEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @          0xf5428dd _ZNSt17_Function_handlerIFvvEZN9starrocks9workgroup12ScanExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0xbaafd3e std::function<>::operator()()
    @          0xc757d6a starrocks::FunctionRunnable::run()
    @          0xc753d3c starrocks::ThreadPool::dispatch_thread()
    @          0xc77399e std::__invoke_impl<>()
    @          0xc77342d std::__invoke<>()
    @          0xc7722ea _ZNSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @          0xc771027 std::_Bind<>::operator()<>()
    @          0xc76e7a6 std::__invoke_impl<>()
    @          0xc76a882 _ZSt10__invoke_rIvRSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @          0xc76668f std::_Function_handler<>::_M_invoke()
    @          0xbaafd3e std::function<>::operator()()
    @          0xc739048 starrocks::Thread::supervise_thread()
```

## What I'm doing:
When compressed text file > `max_split_size`, a single compressed text file will be separated into multiple scan ranges.
But in `BE`, when scan range's offset > 0, `TextScannerReader` will treat this scan range as a `no_data` scan range, then CSVReader will not be set, and will always be a null pointer.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
