### PR TITLE
[Feature] lake pk table support column mode partial update (part-2)

### DIFF
--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -60,6 +60,419 @@ Status LakeDeltaColumnGroupLoader::load(int64_t tablet_id, RowsetId rowsetid, ui
     return Status::NotSupported("LakeDeltaColumnGroupLoader::load not supported");
 }
 
+ColumnModePartialUpdateHandler::ColumnModePartialUpdateHandler(int64_t base_version, int64_t txn_id,
+                                                               MemTracker* tracker)
+        : _base_version(base_version), _txn_id(txn_id), _tracker(tracker) {}
+
+void ColumnModePartialUpdateHandler::_release_upserts(uint32_t start_idx, uint32_t end_idx) {
+    for (uint32_t idx = start_idx; idx < _upserts.size() && idx < end_idx; idx++) {
+        if (_upserts[idx] != nullptr) {
+            if (_upserts[idx]->is_last(idx)) {
+                _tracker->release(_upserts[idx]->upserts->memory_usage());
+            }
+            _upserts[idx].reset();
+        }
+    }
+}
+
+Status ColumnModePartialUpdateHandler::_load_upserts(const RowsetUpdateStateParams& params, const Schema& pkey_schema,
+                                                     const std::vector<ChunkIteratorPtr>& segment_iters,
+                                                     uint32_t start_idx, uint32_t* end_idx) {
+    if (_upserts.size() == 0) {
+        _upserts.resize(_rowset_ptr->num_segments());
+    } else {
+        // update files should be immutable
+        DCHECK(_upserts.size() == _rowset_ptr->num_segments());
+    }
+    if (_upserts.size() == 0) {
+        return Status::OK();
+    }
+    if (_upserts[start_idx] != nullptr) {
+        *end_idx = _upserts[start_idx]->end_idx;
+        return Status::OK();
+    }
+
+    // 2. build schema.
+    std::unique_ptr<Column> pk_column;
+    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+        std::string err_msg =
+                fmt::format("create column for primary key encoder failed, tablet_id: {}", params.tablet->id());
+        DCHECK(false) << err_msg;
+        return Status::InternalError(err_msg);
+    }
+
+    std::shared_ptr<Chunk> chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, DEFAULT_CHUNK_SIZE);
+
+    // alloc first BatchPKsPtr
+    auto header_ptr = std::make_shared<BatchPKs>();
+    header_ptr->upserts = pk_column->clone();
+    header_ptr->start_idx = start_idx;
+    for (uint32_t idx = start_idx; idx < _rowset_ptr->num_segments(); idx++) {
+        header_ptr->offsets.push_back(header_ptr->upserts->size());
+        auto chunk = chunk_shared_ptr.get();
+        auto col = pk_column->clone();
+        DeferOp iter_defer([&]() {
+            if (segment_iters[idx] != nullptr) {
+                segment_iters[idx]->close();
+            }
+        });
+        if (segment_iters[idx] != nullptr) {
+            col->reserve(DEFAULT_CHUNK_SIZE);
+            while (true) {
+                chunk->reset();
+                auto st = segment_iters[idx]->get_next(chunk);
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (!st.ok()) {
+                    return st;
+                } else {
+                    PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+                }
+            }
+        }
+        // merge pk column into BatchPKs
+        header_ptr->upserts->append(*col);
+        // This is a little bit trick. If pk column is a binary column, we will call function `raw_data()` in the following
+        // And the function `raw_data()` will build slice of pk column which will increase the memory usage of pk column
+        // So we try build slice in advance in here to make sure the correctness of memory statistics
+        header_ptr->upserts->raw_data();
+        // all idx share same ptr with start idx
+        _upserts[idx] = header_ptr;
+        *end_idx = idx + 1;
+        // quit merge PK into BatchPKs when hiting memory limit
+        if (header_ptr->upserts->memory_usage() > config::primary_key_batch_get_index_memory_limit ||
+            _tracker->any_limit_exceeded()) {
+            break;
+        }
+    }
+    // push end offset
+    header_ptr->offsets.push_back(header_ptr->upserts->size());
+    header_ptr->end_idx = *end_idx;
+    DCHECK(header_ptr->offsets.size() == header_ptr->end_idx - header_ptr->start_idx + 1);
+    _tracker->consume(header_ptr->upserts->memory_usage());
+
+    return Status::OK();
+}
+
+Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStateParams& params) {
+    if (_rowset_ptr == nullptr) {
+        _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
+        _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
+                                               -1 /*unused*/, params.tablet_schema);
+    }
+    vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
+        pk_columns.push_back((uint32_t)i);
+    }
+    Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
+    OlapReaderStatistics stats;
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, true, &stats));
+    RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset_ptr->num_segments());
+    for (uint32_t i = 0; i < _rowset_ptr->num_segments();) {
+        TRACE_COUNTER_INCREMENT("pcu_load_update_state_cnt", 1);
+        uint32_t end_idx = 0;
+        {
+            TRACE_COUNTER_SCOPE_LATENCY_US("pcu_load_upsets_us");
+            RETURN_IF_ERROR(_load_upserts(params, pkey_schema, segment_iters, i, &end_idx));
+        }
+        DCHECK(end_idx > i);
+        {
+            TRACE_COUNTER_SCOPE_LATENCY_US("pcu_prepare_partial_update_states_us");
+            RETURN_IF_ERROR(_prepare_partial_update_states(params, i, end_idx, false));
+        }
+        _release_upserts(i, end_idx);
+        i = end_idx;
+    }
+
+    return Status::OK();
+}
+
+Status ColumnModePartialUpdateHandler::_prepare_partial_update_states(const RowsetUpdateStateParams& params,
+                                                                      uint32_t start_idx, uint32_t end_idx,
+                                                                      bool need_lock) {
+    if (_partial_update_states.size() == 0) {
+        _partial_update_states.resize(_rowset_ptr->num_segments());
+    } else {
+        // update files should be immutable
+        DCHECK(_partial_update_states.size() == _rowset_ptr->num_segments());
+    }
+
+    if (_partial_update_states[start_idx].inited) {
+        // assume that states between [start_idx, end_idx) should be inited
+        RETURN_ERROR_IF_FALSE(_partial_update_states[end_idx - 1].inited);
+        return Status::OK();
+    }
+
+    EditVersion read_version;
+    _upserts[start_idx]->src_rss_rowids.resize(_upserts[start_idx]->upserts_size());
+    RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
+            params.tablet->id(), _base_version, _upserts[start_idx]->upserts, &_upserts[start_idx]->src_rss_rowids,
+            need_lock));
+
+    for (uint32_t idx = start_idx; idx < end_idx; idx++) {
+        _upserts[idx]->split_src_rss_rowids(idx, _partial_update_states[idx].src_rss_rowids);
+        // build `rss_rowid_to_update_rowid`
+        _partial_update_states[idx].read_version = read_version;
+        _partial_update_states[idx].build_rss_rowid_to_update_rowid();
+        _partial_update_states[idx].inited = true;
+    }
+    return Status::OK();
+}
+
+// this function build delta writer for delta column group's file.(end with `.col`)
+StatusOr<std::unique_ptr<SegmentWriter>> ColumnModePartialUpdateHandler::_prepare_delta_column_group_writer(
+        const RowsetUpdateStateParams& params, const std::shared_ptr<TabletSchema>& tschema) {
+    const std::string path = params.tablet->segment_location(gen_cols_filename(_txn_id));
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(auto wfile, fs::new_writable_file(opts, path));
+    SegmentWriterOptions writer_options;
+    auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), 0, tschema, writer_options);
+    RETURN_IF_ERROR(segment_writer->init(false));
+    return std::move(segment_writer);
+}
+
+StatusOr<ChunkPtr> ColumnModePartialUpdateHandler::_read_from_source_segment(const RowsetUpdateStateParams& params,
+                                                                             const Schema& schema, uint32_t rssid) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("pcu_read_from_source_us");
+    OlapReaderStatistics stats;
+    size_t footer_size_hint = 16 * 1024;
+    LakeIOOptions lake_io_opts{.fill_data_cache = true};
+    if (params.container.rssid_to_file().count(rssid) == 0) {
+        // Should not happen
+        return Status::InternalError(fmt::format("ColumnModePartialUpdateHandler read tablet {} segment {} not found",
+                                                 params.tablet->id(), rssid));
+    }
+    // 1. get relative file path by rowset segment id.
+    auto& relative_file_info = params.container.rssid_to_file().at(rssid);
+    FileInfo fileinfo{.path = params.tablet->segment_location(relative_file_info.path)};
+    if (relative_file_info.size.has_value()) {
+        fileinfo.size = relative_file_info.size;
+    }
+    uint32_t rowset_id = params.container.rssid_to_rowid().at(rssid);
+    // 2. load segment meta.
+    ASSIGN_OR_RETURN(auto segment, params.tablet->tablet_mgr()->load_segment(fileinfo, 0, &footer_size_hint,
+                                                                             lake_io_opts, true, params.tablet_schema));
+    SegmentReadOptions seg_options;
+    ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(fileinfo.path));
+    seg_options.stats = &stats;
+    seg_options.is_primary_keys = true;
+    seg_options.tablet_id = params.tablet->id();
+    seg_options.rowset_id = rowset_id;
+    seg_options.version = _base_version;
+    seg_options.tablet_schema = params.tablet_schema;
+    // not use delvec loader
+    seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(params.metadata);
+    ASSIGN_OR_RETURN(auto seg_iter, segment->new_iterator(schema, seg_options));
+    auto source_chunk_ptr = ChunkHelper::new_chunk(schema, segment->num_rows());
+    auto tmp_chunk_ptr = ChunkHelper::new_chunk(schema, 1024);
+    while (true) {
+        tmp_chunk_ptr->reset();
+        auto st = seg_iter->get_next(tmp_chunk_ptr.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (!st.ok()) {
+            return st;
+        } else {
+            source_chunk_ptr->append(*tmp_chunk_ptr);
+        }
+    }
+    return source_chunk_ptr;
+}
+
+// cut rowid pairs by source rowid's order. E.g.
+// rowid_pairs -> <101, 2>, <202, 3>, <303, 4>, <102, 5>, <203, 6>
+// After cut, it will be:
+//  inorder_source_rowids -> <101, 202, 303>, <102, 203>
+//  inorder_upt_rowids -> <2, 3, 4>, <5, 6>
+static void cut_rowids_in_order(const std::vector<RowidPairs>& rowid_pairs,
+                                std::vector<std::vector<uint32_t>>* inorder_source_rowids,
+                                std::vector<std::vector<uint32_t>>* inorder_upt_rowids) {
+    uint32_t last_source_rowid = 0;
+    std::vector<uint32_t> current_source_rowids;
+    std::vector<uint32_t> current_upt_rowids;
+    auto cut_rowids_fn = [&]() {
+        inorder_source_rowids->push_back({});
+        inorder_upt_rowids->push_back({});
+        inorder_source_rowids->back().swap(current_source_rowids);
+        inorder_upt_rowids->back().swap(current_upt_rowids);
+    };
+    for (const auto& each : rowid_pairs) {
+        if (each.first < last_source_rowid) {
+            // cut
+            cut_rowids_fn();
+        }
+        current_source_rowids.push_back(each.first);
+        current_upt_rowids.push_back(each.second);
+        last_source_rowid = each.first;
+    }
+    if (!current_source_rowids.empty()) {
+        cut_rowids_fn();
+    }
+}
+
+static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const ChunkUniquePtr& result_chunk) {
+    auto chunk = result_chunk->clone_empty(1024);
+    while (true) {
+        chunk->reset();
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (!st.ok()) {
+            return st;
+        } else {
+            result_chunk->append(*chunk);
+        }
+    }
+    return Status::OK();
+}
+
+// read from upt files and update rows in source chunk.
+Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs,
+                                                                   const Schema& partial_schema,
+                                                                   ChunkPtr* source_chunk) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("pcu_update_source_by_upt_us");
+    // build iterators
+    OlapReaderStatistics stats;
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(partial_schema, true, &stats));
+    RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset_ptr->num_segments());
+    // handle upt files one by one
+    for (const auto& each : upt_id_to_rowid_pairs) {
+        const uint32_t upt_id = each.first;
+        // 1. get chunk from upt file
+        ChunkUniquePtr upt_chunk = ChunkHelper::new_chunk(partial_schema, DEFAULT_CHUNK_SIZE);
+        DeferOp iter_defer([&]() {
+            if (segment_iters[upt_id] != nullptr) {
+                segment_iters[upt_id]->close();
+            }
+        });
+        RETURN_IF_ERROR(read_chunk_from_update_file(segment_iters[upt_id], upt_chunk));
+        const size_t upt_chunk_size = upt_chunk->memory_usage();
+        _tracker->consume(upt_chunk_size);
+        DeferOp tracker_defer([&]() { _tracker->release(upt_chunk_size); });
+        // 2. update source chunk
+        std::vector<std::vector<uint32_t>> inorder_source_rowids;
+        std::vector<std::vector<uint32_t>> inorder_upt_rowids;
+        cut_rowids_in_order(each.second, &inorder_source_rowids, &inorder_upt_rowids);
+        DCHECK(inorder_source_rowids.size() == inorder_upt_rowids.size());
+        for (int i = 0; i < inorder_source_rowids.size(); i++) {
+            auto tmp_chunk = ChunkHelper::new_chunk(partial_schema, inorder_upt_rowids[i].size());
+            tmp_chunk->append_selective(*upt_chunk, inorder_upt_rowids[i].data(), 0, inorder_upt_rowids[i].size());
+            RETURN_IF_EXCEPTION((*source_chunk)->update_rows(*tmp_chunk, inorder_source_rowids[i].data()));
+        }
+    }
+    return Status::OK();
+}
+
+template <typename T>
+static std::vector<T> append_fixed_batch(const std::vector<T>& base_array, size_t offset, size_t batch_size) {
+    std::vector<T> new_array;
+    for (int i = offset; i < offset + batch_size && i < base_array.size(); i++) {
+        new_array.push_back(base_array[i]);
+    }
+    return new_array;
+}
+
+static void padding_char_columns(const Schema& schema, const TabletSchemaCSPtr& tschema, Chunk* chunk) {
+    auto char_field_indexes = ChunkHelper::get_char_field_indexes(schema);
+    ChunkHelper::padding_char_columns(char_field_indexes, schema, tschema, chunk);
+}
+
+Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& params, MetaFileBuilder* builder) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("pcu_execute_us");
+    // 1. load update state first
+    RETURN_IF_ERROR(_load_update_state(params));
+
+    const auto& txn_meta = params.op_write.txn_meta();
+
+    std::vector<ColumnId> update_column_ids;
+    std::vector<ColumnUID> unique_update_column_ids;
+    for (ColumnId cid : txn_meta.partial_update_column_ids()) {
+        if (cid >= params.tablet_schema->num_key_columns()) {
+            update_column_ids.push_back(cid);
+        }
+    }
+    for (uint32_t uid : txn_meta.partial_update_column_unique_ids()) {
+        auto cid = params.tablet_schema->field_index(uid);
+        if (cid == -1) {
+            std::string msg = strings::Substitute("column with unique id:$0 does not exist. tablet:$1", uid,
+                                                  params.tablet->tablet_id());
+            LOG(ERROR) << msg;
+            return Status::InternalError(msg);
+        }
+        if (!params.tablet_schema->column(cid).is_key()) {
+            unique_update_column_ids.push_back(uid);
+        }
+    }
+
+    DCHECK(update_column_ids.size() == unique_update_column_ids.size());
+    const size_t BATCH_HANDLE_COLUMN_CNT = config::vertical_compaction_max_columns_per_group;
+
+    // 2. getter all rss_rowid_to_update_rowid, and prepare .col writer by the way
+    // rss_id -> update file id -> <rowid, update rowid>
+    std::map<uint32_t, UptidToRowidPairs> rss_upt_id_to_rowid_pairs;
+    for (int upt_id = 0; upt_id < _partial_update_states.size(); upt_id++) {
+        for (const auto& each : _partial_update_states[upt_id].rss_rowid_to_update_rowid) {
+            auto rssid = (uint32_t)(each.first >> 32);
+            auto rowid = (uint32_t)(each.first & ROWID_MASK);
+            rss_upt_id_to_rowid_pairs[rssid][upt_id].emplace_back(rowid, each.second);
+        }
+        TRACE_COUNTER_INCREMENT("pcu_insert_rows", _partial_update_states[upt_id].insert_rowids.size());
+        TRACE_COUNTER_INCREMENT("pcu_update_cnt", _partial_update_states[upt_id].rss_rowid_to_update_rowid.size());
+    }
+    // must record unique column id in delta column group
+    // dcg_column_ids and dcg_column_files are mapped one to the other. E.g.
+    // {{1,2}, {3,4}} -> {"aaa.cols", "bbb.cols"}
+    // It means column_1 and column_2 are stored in aaa.cols, and column_3 and column_4 are stored in bbb.cols
+    std::map<uint32_t, std::vector<std::vector<ColumnUID>>> dcg_column_ids;
+    std::map<uint32_t, std::vector<std::string>> dcg_column_files;
+    // 3. read from raw segment file and update file, and generate `.col` files one by one
+    for (uint32_t col_index = 0; col_index < update_column_ids.size(); col_index += BATCH_HANDLE_COLUMN_CNT) {
+        for (const auto& each : rss_upt_id_to_rowid_pairs) {
+            // 3.1 build column id range
+            std::vector<ColumnId> selective_update_column_ids =
+                    append_fixed_batch(update_column_ids, col_index, BATCH_HANDLE_COLUMN_CNT);
+            std::vector<ColumnUID> selective_unique_update_column_ids =
+                    append_fixed_batch(unique_update_column_ids, col_index, BATCH_HANDLE_COLUMN_CNT);
+            // 3.2 build partial schema and iterators
+            auto partial_tschema =
+                    TabletSchema::create_with_uid(params.tablet_schema, selective_unique_update_column_ids);
+            Schema partial_schema = ChunkHelper::convert_schema(params.tablet_schema, selective_update_column_ids);
+            // 3.3 read from source segment
+            ASSIGN_OR_RETURN(auto source_chunk_ptr, _read_from_source_segment(params, partial_schema, each.first));
+            const size_t source_chunk_size = source_chunk_ptr->memory_usage();
+            _tracker->consume(source_chunk_size);
+            DeferOp tracker_defer([&]() { _tracker->release(source_chunk_size); });
+            // 3.2 read from update segment
+            RETURN_IF_ERROR(_update_source_chunk_by_upt(each.second, partial_schema, &source_chunk_ptr));
+            uint64_t segment_file_size = 0;
+            uint64_t index_size = 0;
+            uint64_t footer_position = 0;
+            padding_char_columns(partial_schema, partial_tschema, source_chunk_ptr.get());
+            ASSIGN_OR_RETURN(auto delta_column_group_writer,
+                             _prepare_delta_column_group_writer(params, partial_tschema));
+            {
+                TRACE_COUNTER_SCOPE_LATENCY_US("pcu_finalize_dcg_us");
+                RETURN_IF_ERROR(delta_column_group_writer->append_chunk(*source_chunk_ptr));
+                RETURN_IF_ERROR(delta_column_group_writer->finalize(&segment_file_size, &index_size, &footer_position));
+            }
+            // 3.6 prepare column id list and dcg file list
+            dcg_column_ids[each.first].push_back(selective_unique_update_column_ids);
+            dcg_column_files[each.first].push_back(file_name(delta_column_group_writer->segment_path()));
+            TRACE_COUNTER_INCREMENT("pcu_handle_cnt", 1);
+        }
+    }
+    // 4 generate delta columngroup
+    for (const auto& each : rss_upt_id_to_rowid_pairs) {
+        builder->append_dcg(each.first, dcg_column_files[each.first], dcg_column_ids[each.first]);
+    }
+    builder->apply_column_mode_partial_update(params.op_write);
+
+    TRACE_COUNTER_INCREMENT("pcu_rss_cnt", rss_upt_id_to_rowid_pairs.size());
+    TRACE_COUNTER_INCREMENT("pcu_upt_cnt", _partial_update_states.size());
+    TRACE_COUNTER_INCREMENT("pcu_column_cnt", update_column_ids.size());
+    return Status::OK();
+}
+
 bool CompactionUpdateConflictChecker::conflict_check(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,
                                                      const TabletMetadata& metadata, MetaFileBuilder* builder) {
     if (metadata.dcg_meta().dcgs().empty()) {

--- a/be/src/storage/lake/column_mode_partial_update_handler.h
+++ b/be/src/storage/lake/column_mode_partial_update_handler.h
@@ -31,6 +31,44 @@ private:
     TabletMetadataPtr _tablet_metadata;
 };
 
+// Used in column mode partial update
+class ColumnModePartialUpdateHandler {
+public:
+    ColumnModePartialUpdateHandler(int64_t base_version, int64_t txn_id, MemTracker* tracker);
+    ~ColumnModePartialUpdateHandler() {}
+
+    Status execute(const RowsetUpdateStateParams& params, MetaFileBuilder* builder);
+
+private:
+    Status _load_update_state(const RowsetUpdateStateParams& params);
+    void _release_upserts(uint32_t start_idx, uint32_t end_idx);
+    Status _load_upserts(const RowsetUpdateStateParams& params, const Schema& pkey_schema,
+                         const std::vector<ChunkIteratorPtr>& segment_iters, uint32_t start_idx, uint32_t* end_idx);
+    Status _prepare_partial_update_states(const RowsetUpdateStateParams& params, uint32_t start_idx, uint32_t end_idx,
+                                          bool need_lock);
+    StatusOr<std::unique_ptr<SegmentWriter>> _prepare_delta_column_group_writer(
+            const RowsetUpdateStateParams& params, const std::shared_ptr<TabletSchema>& tschema);
+    Status _update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs, const Schema& partial_schema,
+                                       ChunkPtr* source_chunk);
+    StatusOr<ChunkPtr> _read_from_source_segment(const RowsetUpdateStateParams& params, const Schema& schema,
+                                                 uint32_t rssid);
+
+private:
+    // params
+    int64_t _base_version = 0;
+    int64_t _txn_id = 0;
+    MemTracker* _tracker = nullptr;
+
+    std::vector<BatchPKsPtr> _upserts;
+
+    // maintain the reference from rowids in segment files been updated to rowids in update files.
+    std::vector<ColumnPartialUpdateState> _partial_update_states;
+
+    // `_rowset_meta_ptr` contains full life cycle rowset meta in `_rowset_ptr`.
+    RowsetMetadataUniquePtr _rowset_meta_ptr;
+    std::unique_ptr<Rowset> _rowset_ptr;
+};
+
 class CompactionUpdateConflictChecker {
 public:
     static bool conflict_check(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -102,6 +102,10 @@ public:
                                       const TabletMetadataPtr& metadata, Tablet* tablet, IndexEntry* index_entry,
                                       MetaFileBuilder* builder, int64_t base_version);
 
+    Status publish_column_mode_partial_update(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
+                                              const TabletMetadataPtr& metadata, Tablet* tablet,
+                                              MetaFileBuilder* builder, int64_t base_version);
+
     // get rowids from primary index by each upserts
     Status get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
                                    std::vector<std::vector<uint64_t>*>* rss_rowids, bool need_lock);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -239,21 +239,39 @@ TEST_P(LakePartialUpdateTest, test_write) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish_with_txnlog());
         delta_writer->close();
-        EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() > 0);
+        if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
+        } else {
+            EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() > 0);
+        }
         // Publish version
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            if (i == 0) {
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+            } else {
+                // move old .cols files into orphan files.
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+            }
+        } else {
+            EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        }
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    }
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
@@ -307,6 +325,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -317,14 +336,27 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+        if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            if (i == 0) {
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+            } else {
+                // move old .cols into orphan files.
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 3);
+            }
+        } else {
+            EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+        }
     }
     config::write_buffer_size = old_size;
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    // check segment size in last metadata
-    EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+        // check segment size in last metadata
+        EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    }
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
@@ -378,6 +410,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -388,14 +421,27 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+        if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            if (i == 0) {
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+            } else {
+                // move old .cols into orphan files.
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 3);
+            }
+        } else {
+            EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+        }
     }
     config::write_buffer_size = old_size;
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 6 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    // check segment size in last metadata
-    EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+        // check segment size in last metadata
+        EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    }
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -447,6 +493,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -459,11 +506,15 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        if (GetParam().partial_update_mode != PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        }
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    if (GetParam().partial_update_mode != PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    }
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -518,6 +569,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -534,9 +586,13 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
     config::write_buffer_size = old_size;
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 6 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    // check segment size in last metadata
-    EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+        // check segment size in last metadata
+        EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    }
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -596,6 +652,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict2) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -605,11 +662,24 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict2) {
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            if (i == 0) {
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+            } else {
+                // move old .cols into orphan files.
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+            }
+        } else {
+            EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        }
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
+    }
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -662,6 +732,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -671,11 +742,24 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            if (i == 0) {
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+            } else {
+                // move old .cols into orphan files.
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+            }
+        } else {
+            EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+        }
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    }
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -733,6 +817,7 @@ TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -793,6 +878,7 @@ TEST_P(LakePartialUpdateTest, test_concurrent_write_publish) {
                                                        .set_mem_tracker(_mem_tracker.get())
                                                        .set_schema_id(_tablet_schema->id())
                                                        .set_slot_descriptors(&_slot_pointers)
+                                                       .set_partial_update_mode(GetParam().partial_update_mode)
                                                        .build());
             ASSERT_OK(delta_writer->open());
             ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -819,6 +905,7 @@ TEST_P(LakePartialUpdateTest, test_concurrent_write_publish) {
                                                        .set_mem_tracker(_mem_tracker.get())
                                                        .set_schema_id(_tablet_schema->id())
                                                        .set_slot_descriptors(&_slot_pointers)
+                                                       .set_partial_update_mode(GetParam().partial_update_mode)
                                                        .build());
             ASSERT_OK(delta_writer->open());
             ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -877,6 +964,7 @@ TEST_P(LakePartialUpdateTest, test_batch_publish) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -888,8 +976,14 @@ TEST_P(LakePartialUpdateTest, test_batch_publish) {
     ASSERT_OK(batch_publish(tablet_id, base_version, new_version, txn_ids).status());
 
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, new_version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
-    EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 3);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+        // 3 .dat + 2 .cols
+        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 5);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
+        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 3);
+    }
     _tablet_mgr->prune_metacache();
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     _update_mgr->try_remove_primary_index_cache(tablet_id);
@@ -898,13 +992,27 @@ TEST_P(LakePartialUpdateTest, test_batch_publish) {
     ASSERT_OK(batch_publish(tablet_id, base_version, new_version, txn_ids).status());
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, new_version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
-    EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 3);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
+    }
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        // 3 .dat + 2 .cols
+        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 5);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 3);
+    }
 }
 
-INSTANTIATE_TEST_SUITE_P(LakePartialUpdateTest, LakePartialUpdateTest,
-                         ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
-                                           PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE}));
+INSTANTIATE_TEST_SUITE_P(
+        LakePartialUpdateTest, LakePartialUpdateTest,
+        ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
+                          PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE},
+                          PrimaryKeyParam{.enable_persistent_index = true,
+                                          .partial_update_mode = PartialUpdateMode::COLUMN_UPDATE_MODE},
+                          PrimaryKeyParam{.enable_persistent_index = false,
+                                          .partial_update_mode = PartialUpdateMode::COLUMN_UPDATE_MODE}));
 
 class LakeIncompleteSortKeyPartialUpdateTest : public TestBase {
 public:
@@ -1039,6 +1147,7 @@ TEST_F(LakeIncompleteSortKeyPartialUpdateTest, test_incomplete_sort_key) {
 
 TEST_P(LakePartialUpdateTest, test_partial_update_retry_rewrite_check) {
     if (GetParam().enable_persistent_index) return;
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) return;
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);
     auto chunk1 = generate_data(kChunkSize, 0, true, 5);
     auto indexes = std::vector<uint32_t>(kChunkSize);
@@ -1168,6 +1277,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {
                                                    .set_mem_tracker(_mem_tracker.get())
                                                    .set_schema_id(_tablet_schema->id())
                                                    .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
                                                    .build());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -1178,15 +1288,27 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-        EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+        if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+            if (i == 0) {
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+            } else {
+                EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 3);
+            }
+        } else {
+            EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 2);
+        }
     }
     config::write_buffer_size = old_size;
     _update_mgr->update_state_mem_tracker()->set_limit(old_limit);
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 6 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    // check segment size in last metadata
-    EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    } else {
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+        // check segment size in last metadata
+        EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    }
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -1194,6 +1316,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {
 
 TEST_P(LakePartialUpdateTest, test_partial_update_retry_check_file_exist) {
     if (GetParam().enable_persistent_index) return;
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) return;
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);
     auto chunk1 = generate_data(kChunkSize, 0, true, 5);
     auto indexes = std::vector<uint32_t>(kChunkSize);

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -111,6 +111,7 @@ protected:
 struct PrimaryKeyParam {
     bool enable_persistent_index = false;
     PersistentIndexTypePB persistent_index_type = PersistentIndexTypePB::LOCAL;
+    PartialUpdateMode partial_update_mode = PartialUpdateMode::ROW_MODE;
 };
 
 inline StatusOr<TabletMetadataPtr> TEST_publish_single_version(TabletManager* tablet_mgr, int64_t tablet_id,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -82,7 +82,7 @@ public class UpdateAnalyzer {
             }
         }
 
-        if (table.isOlapTable()) {
+        if (table.isOlapTable() || table.isCloudNativeTable()) {
             if (session.getSessionVariable().getPartialUpdateMode().equals("column")) {
                 // use partial update by column
                 updateStmt.setUsePartialUpdate();


### PR DESCRIPTION
## Why I'm doing:

To support column mode partial update in lake PK table. More detail about column mode partial update: #20436

I break PR into 2 parts. And this one is second PR, it contains:
1. Modification when publish version, generate `.cols` files.
2. Update planner support column mode partial update on shared-data mode.

Fixes #46516

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
