### PR TITLE
[BugFix] Fix inconsistent dictionary in replace partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -98,6 +98,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -2676,6 +2677,10 @@ public class OlapTable extends Table {
                 renamePartition(tempPartitionNames.get(i), partitionNames.get(i));
             }
         }
+
+        for (Column column : getColumns()) {
+            IDictManager.getInstance().removeGlobalDict(this.getId(), column.getName());
+        }
     }
 
     // used for unpartitioned table in insert overwrite
@@ -2701,6 +2706,10 @@ public class OlapTable extends Table {
 
         // rename partition
         renamePartition(tempPartitionName, sourcePartitionName);
+
+        for (Column column : getColumns()) {
+            IDictManager.getInstance().removeGlobalDict(this.getId(), column.getName());
+        }
     }
 
     public void addTempPartition(Partition partition) {

--- a/test/sql/test_global_dict/R/temporary_partition
+++ b/test/sql/test_global_dict/R/temporary_partition
@@ -1,0 +1,64 @@
+-- name: test_temporary_partition
+CREATE TABLE `allstringx` (
+  `c0` bigint DEFAULT NULL,
+  `c1` string DEFAULT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c0`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into allstringx values (1, 'S0');
+-- result:
+-- !result
+insert into allstringx values (4096, 'S1');
+-- result:
+-- !result
+select distinct c1 from allstringx order by 1;
+-- result:
+S0
+S1
+-- !result
+function: wait_global_dict_ready('c1', 'allstringx')
+-- result:
+
+-- !result
+ALTER TABLE allstringx ADD TEMPORARY PARTITION px VALUES [("4096"), ("8192"));
+-- result:
+-- !result
+insert into allstringx TEMPORARY PARTITION(px) values (4096, 'S2');
+-- result:
+-- !result
+select distinct c1 from allstringx;
+-- result:
+S1
+S0
+-- !result
+function: wait_global_dict_ready('c1', 'allstringx')
+-- result:
+
+-- !result
+insert into allstringx values (4096, 'S1');
+-- result:
+-- !result
+ALTER TABLE allstringx REPLACE PARTITION(p5) WITH TEMPORARY PARTITION (px);
+-- result:
+-- !result
+select distinct c1 from allstringx order by 1;
+-- result:
+S0
+S2
+-- !result

--- a/test/sql/test_global_dict/T/temporary_partition
+++ b/test/sql/test_global_dict/T/temporary_partition
@@ -1,0 +1,37 @@
+-- name: test_temporary_partition
+
+CREATE TABLE `allstringx` (
+  `c0` bigint DEFAULT NULL,
+  `c1` string DEFAULT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c0`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+
+insert into allstringx values (1, 'S0');
+insert into allstringx values (4096, 'S1');
+select distinct c1 from allstringx order by 1;
+function: wait_global_dict_ready('c1', 'allstringx')
+
+ALTER TABLE allstringx ADD TEMPORARY PARTITION px VALUES [("4096"), ("8192"));
+insert into allstringx TEMPORARY PARTITION(px) values (4096, 'S2');
+select distinct c1 from allstringx;
+function: wait_global_dict_ready('c1', 'allstringx')
+insert into allstringx values (4096, 'S1');
+
+ALTER TABLE allstringx REPLACE PARTITION(p5) WITH TEMPORARY PARTITION (px);
+
+select distinct c1 from allstringx order by 1;


### PR DESCRIPTION
## Why I'm doing:
reproduce case see test_temporary_partition

```
CREATE TABLE `allstringx` (
  `c0` bigint DEFAULT NULL,
  `c1` string DEFAULT NULL
) ENGINE=OLAP 
DUPLICATE KEY(`c0`)
COMMENT "OLAP"
PARTITION BY RANGE(`c0`)
(
PARTITION p1 VALUES [("-2147483648"), ("0")),
PARTITION p2 VALUES [("0"), ("1024")),
PARTITION p3 VALUES [("1024"), ("2048")),
PARTITION p4 VALUES [("2048"), ("4096")),
PARTITION p5 VALUES [("4096"), ("8192")),
PARTITION p6 VALUES [("8192"), ("65536")),
PARTITION p7 VALUES [("65536"), ("2100000000")))
DISTRIBUTED BY HASH(`c0`) BUCKETS 4
PROPERTIES (
"replication_num" = "1",
"compression" = "LZ4"
);

insert into allstringx values (1, 'S0'); # version = 0
insert into allstringx values (4096, 'S1'); # version = 1
# make sure dictionary has been collected
select distinct c1 from allstringx order by 1; # global dicts (S1, S0), version=1

# create temp partition 
ALTER TABLE allstringx ADD TEMPORARY PARTITION px VALUES [("4096"), ("8192")); 
insert into allstringx TEMPORARY PARTITION(px) values (4096, 'S2'); # version = 2, clear dictionary
select distinct c1 from allstringx;  # global dicts (S1, S0), version = 1
insert into allstringx values (4096, 'S1');  # version =3 update global dicts to 3

# swap temp partition
ALTER TABLE allstringx REPLACE PARTITION(p5) WITH TEMPORARY PARTITION (px);

# error here
select distinct c1 from allstringx order by 1;
```

## What I'm doing:
invalid dictionary when swap partitions

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
