### PR TITLE
[UT] fix be crash when iceberg v2 read empty chuck after probe

### DIFF
--- a/be/src/connector/binlog_connector.cpp
+++ b/be/src/connector/binlog_connector.cpp
@@ -104,7 +104,7 @@ Status BinlogDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
         _need_seek_binlog.store(false);
     }
 
-    _init_chunk(chunk, state->chunk_size());
+    RETURN_IF_ERROR(_init_chunk_if_needed(chunk, state->chunk_size()));
     status = _binlog_reader->get_next(chunk, _max_version_exclusive);
     VLOG_IF(3, !status.ok()) << "Fail to read binlog, tablet: " << _tablet->full_name()
                              << ", binlog reader id: " << _binlog_reader->reader_id()

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -101,7 +101,11 @@ protected:
     TupleDescriptor* _tuple_desc = nullptr;
     pipeline::ScanSplitContext* _split_context = nullptr;
 
-    virtual void _init_chunk(ChunkPtr* chunk, size_t n) { *chunk = ChunkHelper::new_chunk(*_tuple_desc, n); }
+    virtual Status _init_chunk_if_needed(ChunkPtr* chunk, size_t n) {
+        *chunk = ChunkHelper::new_chunk(*_tuple_desc, n);
+        return Status::OK();
+    }
+
     pipeline::ScanMorsel* _morsel = nullptr;
 };
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -661,8 +661,9 @@ Status HiveDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
     if (_no_data) {
         return Status::EndOfFile("no data");
     }
-    _init_chunk(chunk, _runtime_state->chunk_size());
+
     do {
+        RETURN_IF_ERROR(_init_chunk_if_needed(chunk, _runtime_state->chunk_size()));
         RETURN_IF_ERROR(_scanner->get_next(state, chunk));
     } while ((*chunk)->num_rows() == 0);
 
@@ -674,7 +675,11 @@ Status HiveDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
     return Status::OK();
 }
 
-void HiveDataSource::_init_chunk(ChunkPtr* chunk, size_t n) {
+Status HiveDataSource::_init_chunk_if_needed(ChunkPtr* chunk, size_t n) {
+    if ((*chunk) != nullptr && (*chunk)->num_columns() != 0) {
+        return Status::OK();
+    }
+
     *chunk = ChunkHelper::new_chunk(*_tuple_desc, n);
 
     if (!_equality_delete_slots.empty()) {
@@ -690,6 +695,7 @@ void HiveDataSource::_init_chunk(ChunkPtr* chunk, size_t n) {
             }
         }
     }
+    return Status::OK();
 }
 
 const std::string HiveDataSource::get_custom_coredump_msg() const {

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -81,7 +81,7 @@ public:
     bool can_estimate_mem_usage() const override { return true; }
 
     void get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) override;
-    void _init_chunk(ChunkPtr* chunk, size_t n) override;
+    Status _init_chunk_if_needed(ChunkPtr* chunk, size_t n) override;
 
 private:
     const HiveDataSourceProvider* _provider;

--- a/be/src/connector/jdbc_connector.cpp
+++ b/be/src/connector/jdbc_connector.cpp
@@ -96,7 +96,7 @@ void JDBCDataSource::close(RuntimeState* state) {
 
 Status JDBCDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
     bool eos = false;
-    _init_chunk(chunk, 0);
+    RETURN_IF_ERROR(_init_chunk_if_needed(chunk, 0));
     do {
         RETURN_IF_ERROR(_scanner->get_next(state, chunk, &eos));
     } while (!eos && (*chunk)->num_rows() == 0);

--- a/be/src/connector/mysql_connector.cpp
+++ b/be/src/connector/mysql_connector.cpp
@@ -227,7 +227,7 @@ Status MySQLDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
         return Status::EndOfFile("finished!");
     }
 
-    _init_chunk(chunk, 0);
+    RETURN_IF_ERROR(_init_chunk_if_needed(chunk, 0));
     // indicates whether there are more rows to process. Set in _hbase_scanner.next().
     bool mysql_eos = false;
     int row_num = 0;

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -73,8 +73,10 @@ Status IcebergMORProcessor::get_next(RuntimeState* state, ChunkPtr* chunk) {
         _prepared_probe.store(true);
     }
 
-    RETURN_IF_ERROR(_hash_joiner->push_chunk(state, std::move(*chunk)));
-    *chunk = std::move(_hash_joiner->pull_chunk(state)).value();
+    ChunkPtr tmp = *chunk;
+    RETURN_IF_ERROR(_hash_joiner->push_chunk(state, std::move(tmp)));
+    ASSIGN_OR_RETURN(*chunk, _hash_joiner->pull_chunk(state));
+
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -375,7 +375,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return delegate.getTableScan(table, scanContext);
     }
 
-
     private CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long maximumSize) {
         CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
         if (expiresAfterWriteSec >= 0) {

--- a/test/sql/test_iceberg/R/test_iceberg_v2_filter_all_rows
+++ b/test/sql/test_iceberg/R/test_iceberg_v2_filter_all_rows
@@ -1,0 +1,11 @@
+-- name: test_iceberg_v2_filter_all_rows
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_eq_all_row_filter order by k1 limit 1;
+-- result:
+1	6
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_v2_filter_all_rows
+++ b/test/sql/test_iceberg/T/test_iceberg_v2_filter_all_rows
@@ -1,0 +1,7 @@
+-- name: test_iceberg_v2_filter_all_rows
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_eq_all_row_filter order by k1 limit 1;
+
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
If the result row num is 0 in the `get_next` of hive_connector,  it will reuse the chunk to execute next `get_next`.  But the  `get_next` of mor_processor will return a chunk without column info when probe phase filters all rows.  If we use the chunk from parquet/orc file to fill the chunk without column info, this will cause a be crash. 

## What I'm doing:
we should check if chunk is empty after `get_next`. if yes, we shoud init_check again to fill column info.

Fixes #issue

```
tracker:replication consumption: 0
*** Aborted at 1718109279 (unix time) try "date -d @1718109279" if you are using GNU date ***
PC: @          0x6d29ccb starrocks::parquet::ScalarColumnReader::fill_dst_column()
*** SIGSEGV (@0x0) received by PID 548886 (TID 0x7fede17fe640) from PID 0; stack trace: ***
    @          0x9c8aa1a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fefe8d8825a os::Linux::chained_handler()
    @     0x7fefe8d8d6f2 JVM_handle_linux_signal
    @     0x7fefe8d81748 signalHandler()
    @     0x7fefe7d06520 (unknown)
    @          0x6d29ccb starrocks::parquet::ScalarColumnReader::fill_dst_column()
    @          0x6d2297a starrocks::parquet::GroupReader::_fill_dst_chunk()
    @          0x6d23114 starrocks::parquet::GroupReader::get_next()
    @          0x6cf4830 starrocks::parquet::FileReader::get_next()
    @          0x6b30c0f starrocks::HdfsParquetScanner::do_get_next()
    @          0x6b2086b starrocks::HdfsScanner::get_next()
    @          0x6aadb56 starrocks::connector::HiveDataSource::get_next()
    @          0x3f351ff starrocks::pipeline::ConnectorChunkSource::_read_chunk()
    @          0x4286d86 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x3f25588 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlRT_E_clINS_9workgroup12YieldContextEEEDaS5_.constprop.0
    @          0x4047c7b starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x34f960c starrocks::ThreadPool::dispatch_thread()
    @          0x34f37ea starrocks::Thread::supervise_thread()
    @     0x7fefe7d58ac3 (unknown)
    @     0x7fefe7dea850 (unknown)
    @                0x0 (unknown)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
