### PR TITLE
[Enhancement] use hashset instead of list to fix the performance bottleneck

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -271,7 +271,7 @@ public class CatalogUtils {
             throws DdlException {
         try {
             ListPartitionInfo listPartitionInfo = (ListPartitionInfo) olapTable.getPartitionInfo();
-            List<Long> partitionIds = listPartitionInfo.getPartitionIds(isTemp);
+            Set<Long> partitionIds = Sets.newHashSet(listPartitionInfo.getPartitionIds(isTemp));
 
             if (partitionDesc instanceof SingleItemListPartitionDesc) {
                 listPartitionInfo.setBatchLiteralExprValues(listPartitionInfo.getIdToValues());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.optimizer.rewrite;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.LiteralExpr;
@@ -270,7 +271,7 @@ public class OptOlapPartitionPruner {
         List<Long> specifyPartitionIds = null;
         // single item list partition has only one column mapper
         Map<Long, List<LiteralExpr>> literalExprValuesMap = listPartitionInfo.getLiteralExprValues();
-        List<Long> partitionIds = Lists.newArrayList();
+        Set<Long> partitionIds = Sets.newHashSet();
         if (operator.getPartitionNames() != null) {
             for (String partName : operator.getPartitionNames().getPartitionNames()) {
                 boolean isTemp = operator.getPartitionNames().isTemp();
@@ -283,9 +284,9 @@ public class OptOlapPartitionPruner {
                 }
                 partitionIds.add(part.getId());
             }
-            specifyPartitionIds = partitionIds;
+            specifyPartitionIds = Lists.newArrayList(partitionIds);
         } else {
-            partitionIds = listPartitionInfo.getPartitionIds(false);
+            partitionIds = Sets.newHashSet(listPartitionInfo.getPartitionIds(false));
         }
 
         if (literalExprValuesMap != null && literalExprValuesMap.size() > 0) {
@@ -299,8 +300,7 @@ public class OptOlapPartitionPruner {
                 if (values == null || values.isEmpty()) {
                     continue;
                 }
-                values.forEach(value ->
-                        putValueMapItem(partitionValueToIds, partitionId, value));
+                values.forEach(value -> putValueMapItem(partitionValueToIds, partitionId, value));
             }
             // single item list partition has only one column
             Column column = listPartitionInfo.getPartitionColumns().get(0);
@@ -342,7 +342,7 @@ public class OptOlapPartitionPruner {
         try {
             List<Long> prune = partitionPruner.prune();
             if (prune == null && isTemporaryPartitionPrune) {
-                return partitionIds;
+                return Lists.newArrayList(partitionIds);
             } else {
                 return prune;
             }


### PR DESCRIPTION
## Why I'm doing:
- `com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner#listPartitionPrune` would be the performance bottleneck when using `ArrayList::contains`

<img width="1172" alt="image" src="https://github.com/StarRocks/starrocks/assets/96611012/9f536c9b-2b13-4e33-8bee-2ba1ffc9de6e">


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
