### PR TITLE
[BugFix] RemoveAggregationFromAggTable should not remove aggregation for random distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
@@ -19,11 +19,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.PartitionInfo;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -76,6 +76,12 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
         if (!materializedIndexMeta.getKeysType().isAggregationFamily()) {
             return false;
         }
+        // random distribution table cannot remove aggregations
+        DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
+        if (distributionInfo == null || !(distributionInfo instanceof HashDistributionInfo)) {
+            return false;
+        }
+
         Set<String> keyColumnNames = Sets.newHashSet();
         List<Column> indexSchema = materializedIndexMeta.getSchema();
         for (Column column : indexSchema) {
@@ -85,14 +91,7 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
         }
 
         // group by keys contain partition columns and distribution columns
-        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
-        List<String> partitionColumnNames = Lists.newArrayList();
-        if (partitionInfo instanceof RangePartitionInfo) {
-            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
-            partitionColumnNames.addAll(rangePartitionInfo.getPartitionColumns().stream()
-                    .map(column -> column.getName().toLowerCase()).collect(Collectors.toList()));
-        }
-
+        List<String> partitionColumnNames = olapTable.getPartitionColumnNames();
         List<String> distributionColumnNames = olapTable.getDistributionColumnNames().stream()
                 .map(String::toLowerCase).collect(Collectors.toList());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -1673,4 +1673,64 @@ public class MVRewriteTest {
         String query = "SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_t1;";
         starRocksAssert.query(query).explainContains("case_when_mv1");
     }
+
+    @Test
+    public void testRewriteWithHashDistribution() throws Exception {
+        String createTableSQL = "create table t1 " +
+                " (`k1` date NULL,\n" +
+                "  `k2` int(11) NULL,\n" +
+                "  `k3` smallint(6) NULL,\n" +
+                "  `v1` varchar(2048) NULL) \n" +
+                "distributed by hash(k2) buckets 3 properties('replication_num' = '1');";
+        starRocksAssert.withTable(createTableSQL);
+
+        // mv contains complex expression, should use mv
+        String createMVSQL = "create materialized view test_mv1 " +
+                "as select k1, sum(k3) as sum1 from t1 group by k1";
+        starRocksAssert.withMaterializedView(createMVSQL);
+
+        String query = "select k1, sum(k3) from t1 where k1 = '2024-06-12' group by k1";
+        String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "Optimizer");
+        PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 1: k1 = '2024-06-12'\n" +
+                "     partitions=1/1\n" +
+                "     rollup: test_mv1");
+        PlanTestBase.assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  output: sum(5: mv_sum_k3)\n" +
+                "  |  group by: 1: k1");
+        starRocksAssert.dropTable("t1");
+        starRocksAssert.dropMaterializedView("test_mv1");
+    }
+
+    @Test
+    public void testRewriteWithRandomDistribution() throws Exception {
+        String createTableSQL = "create table t1 " +
+                " (`k1` date NULL,\n" +
+                "  `k2` int(11) NULL,\n" +
+                "  `k3` smallint(6) NULL,\n" +
+                "  `v1` varchar(2048) NULL) \n" +
+                "distributed by random properties('replication_num' = '1');";
+        starRocksAssert.withTable(createTableSQL);
+
+        // mv contains complex expression, should use mv
+        String createMVSQL = "create materialized view test_mv1 " +
+                "as select k1, sum(k3) as sum1 from t1 group by k1";
+        starRocksAssert.withMaterializedView(createMVSQL);
+
+        String query = "select k1, sum(k3) from t1 where k1 = '2024-06-12' group by k1";
+        String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "Optimizer");
+        System.out.println(plan);
+        PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 1: k1 = '2024-06-12'\n" +
+                "     partitions=1/1\n" +
+                "     rollup: test_mv1");
+        PlanTestBase.assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(5: mv_sum_k3)\n" +
+                "  |  group by: 1: k1");
+        starRocksAssert.dropTable("t1");
+        starRocksAssert.dropMaterializedView("test_mv1");
+    }
 }

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view3
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view3
@@ -1,0 +1,66 @@
+-- name: test_sync_materialized_view3
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+-- result:
+-- !result
+CREATE TABLE `store_sales` (
+  `ss_item_sk` int(11) NULL COMMENT "",
+  `ss_ticket_number` int(11) NULL COMMENT "",
+  `ss_sold_date_sk` int(11) NULL COMMENT "",
+  `ss_sold_time_sk` int(11) NULL COMMENT "",
+  `ss_customer_sk` int(11) NULL COMMENT "",
+  `ss_cdemo_sk` int(11) NULL COMMENT "",
+  `ss_hdemo_sk` int(11) NULL COMMENT "",
+  `ss_addr_sk` int(11) NULL COMMENT "",
+  `ss_store_sk` int(11) NULL COMMENT "",
+  `ss_promo_sk` int(11) NULL COMMENT "",
+  `ss_quantity` int(11) NULL COMMENT "",
+  `ss_wholesale_cost` decimal(7, 2) NULL COMMENT "",
+  `ss_list_price` decimal(7, 2) NULL COMMENT "",
+  `ss_sales_price` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_discount_amt` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_sales_price` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_wholesale_cost` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_list_price` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_tax` decimal(7, 2) NULL COMMENT "",
+  `ss_coupon_amt` decimal(7, 2) NULL COMMENT "",
+  `ss_net_paid` decimal(7, 2) NULL COMMENT "",
+  `ss_net_paid_inc_tax` decimal(7, 2) NULL COMMENT "",
+  `ss_net_profit` decimal(7, 2) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`ss_item_sk`, `ss_ticket_number`, `ss_sold_date_sk`)
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO `store_sales` (
+  `ss_item_sk`, `ss_ticket_number`, `ss_sold_date_sk`, `ss_sold_time_sk`, `ss_customer_sk`,
+  `ss_cdemo_sk`, `ss_hdemo_sk`, `ss_addr_sk`, `ss_store_sk`, `ss_promo_sk`, 
+  `ss_quantity`, `ss_wholesale_cost`, `ss_list_price`, `ss_sales_price`, `ss_ext_discount_amt`, 
+  `ss_ext_sales_price`, `ss_ext_wholesale_cost`, `ss_ext_list_price`, `ss_ext_tax`, 
+  `ss_coupon_amt`, `ss_net_paid`, `ss_net_paid_inc_tax`, `ss_net_profit`
+) VALUES 
+(1, 1001, 20230601, 123456, 10001, 20001, 30001, 40001, 50001, 60001, 10, 20.00, 30.00, 25.00, 5.00, 25.00, 20.00, 30.00, 2.50, 1.00, 23.50, 26.00, 3.50),
+(2, 1002, 20230602, 123457, 10002, 20002, 30002, 40002, 50002, 60002, 15, 22.00, 32.00, 27.00, 5.50, 27.00, 22.00, 32.00, 2.70, 1.20, 25.80, 28.50, 4.50),
+(3, 1003, 20230603, 123458, 10003, 20003, 30003, 40003, 50003, 60003, 12, 21.00, 31.00, 26.00, 5.20, 26.00, 21.00, 31.00, 2.60, 1.10, 24.90, 27.20, 3.90),
+(1, 1001, 20230601, 123456, 10001, 20001, 30001, 40001, 50001, 60001, 10, 20.00, 30.00, 25.00, 5.00, 25.00, 20.00, 30.00, 2.50, 1.00, 23.50, 26.00, 3.50),
+(2, 1002, 20230602, 123457, 10002, 20002, 30002, 40002, 50002, 60002, 15, 22.00, 32.00, 27.00, 5.50, 27.00, 22.00, 32.00, 2.70, 1.20, 25.80, 28.50, 4.50),
+(3, 1003, 20230603, 123458, 10003, 20003, 30003, 40003, 50003, 60003, 12, 21.00, 31.00, 26.00, 5.20, 26.00, 21.00, 31.00, 2.60, 1.10, 24.90, 27.20, 3.90);
+-- result:
+-- !result
+create materialized view test_mv1 as select  ss_store_sk,SUM(ss_ext_list_price) from store_sales GROUP BY ss_store_sk ;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select ss_store_sk,SUM(ss_ext_list_price) from store_sales where  ss_store_sk=50001 GROUP BY ss_store_sk;", "test_mv1")
+-- result:
+None
+-- !result
+select ss_store_sk, SUM(ss_ext_list_price) from store_sales where  ss_store_sk=50001 GROUP BY ss_store_sk order by 1;
+-- result:
+50001	60.00
+-- !result
+drop table store_sales;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view3
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view3
@@ -1,0 +1,53 @@
+-- name: test_sync_materialized_view3
+
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+CREATE TABLE `store_sales` (
+  `ss_item_sk` int(11) NULL COMMENT "",
+  `ss_ticket_number` int(11) NULL COMMENT "",
+  `ss_sold_date_sk` int(11) NULL COMMENT "",
+  `ss_sold_time_sk` int(11) NULL COMMENT "",
+  `ss_customer_sk` int(11) NULL COMMENT "",
+  `ss_cdemo_sk` int(11) NULL COMMENT "",
+  `ss_hdemo_sk` int(11) NULL COMMENT "",
+  `ss_addr_sk` int(11) NULL COMMENT "",
+  `ss_store_sk` int(11) NULL COMMENT "",
+  `ss_promo_sk` int(11) NULL COMMENT "",
+  `ss_quantity` int(11) NULL COMMENT "",
+  `ss_wholesale_cost` decimal(7, 2) NULL COMMENT "",
+  `ss_list_price` decimal(7, 2) NULL COMMENT "",
+  `ss_sales_price` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_discount_amt` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_sales_price` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_wholesale_cost` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_list_price` decimal(7, 2) NULL COMMENT "",
+  `ss_ext_tax` decimal(7, 2) NULL COMMENT "",
+  `ss_coupon_amt` decimal(7, 2) NULL COMMENT "",
+  `ss_net_paid` decimal(7, 2) NULL COMMENT "",
+  `ss_net_paid_inc_tax` decimal(7, 2) NULL COMMENT "",
+  `ss_net_profit` decimal(7, 2) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`ss_item_sk`, `ss_ticket_number`, `ss_sold_date_sk`)
+DISTRIBUTED BY RANDOM;
+
+
+INSERT INTO `store_sales` (
+  `ss_item_sk`, `ss_ticket_number`, `ss_sold_date_sk`, `ss_sold_time_sk`, `ss_customer_sk`,
+  `ss_cdemo_sk`, `ss_hdemo_sk`, `ss_addr_sk`, `ss_store_sk`, `ss_promo_sk`, 
+  `ss_quantity`, `ss_wholesale_cost`, `ss_list_price`, `ss_sales_price`, `ss_ext_discount_amt`, 
+  `ss_ext_sales_price`, `ss_ext_wholesale_cost`, `ss_ext_list_price`, `ss_ext_tax`, 
+  `ss_coupon_amt`, `ss_net_paid`, `ss_net_paid_inc_tax`, `ss_net_profit`
+) VALUES 
+(1, 1001, 20230601, 123456, 10001, 20001, 30001, 40001, 50001, 60001, 10, 20.00, 30.00, 25.00, 5.00, 25.00, 20.00, 30.00, 2.50, 1.00, 23.50, 26.00, 3.50),
+(2, 1002, 20230602, 123457, 10002, 20002, 30002, 40002, 50002, 60002, 15, 22.00, 32.00, 27.00, 5.50, 27.00, 22.00, 32.00, 2.70, 1.20, 25.80, 28.50, 4.50),
+(3, 1003, 20230603, 123458, 10003, 20003, 30003, 40003, 50003, 60003, 12, 21.00, 31.00, 26.00, 5.20, 26.00, 21.00, 31.00, 2.60, 1.10, 24.90, 27.20, 3.90),
+(1, 1001, 20230601, 123456, 10001, 20001, 30001, 40001, 50001, 60001, 10, 20.00, 30.00, 25.00, 5.00, 25.00, 20.00, 30.00, 2.50, 1.00, 23.50, 26.00, 3.50),
+(2, 1002, 20230602, 123457, 10002, 20002, 30002, 40002, 50002, 60002, 15, 22.00, 32.00, 27.00, 5.50, 27.00, 22.00, 32.00, 2.70, 1.20, 25.80, 28.50, 4.50),
+(3, 1003, 20230603, 123458, 10003, 20003, 30003, 40003, 50003, 60003, 12, 21.00, 31.00, 26.00, 5.20, 26.00, 21.00, 31.00, 2.60, 1.10, 24.90, 27.20, 3.90);
+
+create materialized view test_mv1 as select  ss_store_sk,SUM(ss_ext_list_price) from store_sales GROUP BY ss_store_sk ;
+function: wait_materialized_view_finish()
+
+function: check_hit_materialized_view("select ss_store_sk,SUM(ss_ext_list_price) from store_sales where  ss_store_sk=50001 GROUP BY ss_store_sk;", "test_mv1")
+select ss_store_sk, SUM(ss_ext_list_price) from store_sales where  ss_store_sk=50001 GROUP BY ss_store_sk order by 1;
+
+drop table store_sales;


### PR DESCRIPTION

## Why I'm doing:

If  base table is random distribution and it has a synchronized mv, it may generate a wrong plan (without aggregation)!
```
PLAN FRAGMENT 0(F01)
  Output Exprs:9: ss_store_sk | 25: sum
  Input Partition: UNPARTITIONED
  RESULT SINK

  2:EXCHANGE
     cardinality: 539311

PLAN FRAGMENT 1(F00)

  Input Partition: RANDOM
  OutPut Partition: UNPARTITIONED
  OutPut Exchange Id: 02

  1:Project
  |  output columns:
  |  9 <-> [9: ss_store_sk, INT, true]
  |  25 <-> [24: mv_sum_ss_ext_list_price, DECIMAL64(7,2), true]
  |  cardinality: 539311
  |  column statistics: 
  |  * ss_store_sk-->[1.0, 1.0, 0.0, 4.0, 51.0] ESTIMATE
  |  * sum-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
  |  
  0:OlapScanNode
     table: store_sales, rollup: store_sales_price_sum
     preAggregation: off. Reason: None aggregate function
     Predicates: [9: ss_store_sk, INT, true] = 1
     partitionsRatio=1/1, tabletsRatio=2/2
     tabletList=10111,10113
     actualRows=104, avgRowSize=6.0
     cardinality: 539311
     column statistics: 
     * ss_store_sk-->[1.0, 1.0, 0.0, 4.0, 51.0] ESTIMATE
     * mv_sum_ss_ext_list_price-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
     * sum-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
```
## What I'm doing:
- RemoveAggregationFromAggTable should not remove aggregation for random distribution
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
