### PR TITLE
[BugFix] Fix error msg about not supported compression type

### DIFF
--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -42,7 +42,7 @@ CSVFileWriter::~CSVFileWriter() = default;
 
 Status CSVFileWriter::init() {
     if (_compression_type != TCompressionType::NO_COMPRESSION) {
-        return Status::NotSupported(fmt::format("not supported compression type {}", _compression_type));
+        return Status::NotSupported(fmt::format("not supported compression type {}", to_string(_compression_type)));
     }
 
     RETURN_IF_ERROR(ColumnEvaluator::init(_column_evaluators));

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -382,7 +382,7 @@ StatusOr<orc::CompressionKind> ORCFileWriter::_convert_compression_type(TCompres
         break;
     }
     default: {
-        return Status::NotSupported(fmt::format("not supported compression type {}", type));
+        return Status::NotSupported(fmt::format("not supported compression type {}", to_string(type)));
     }
     }
 

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -316,7 +316,7 @@ StatusOr<::parquet::Compression::type> ParquetFileWriter::_convert_compression_t
         break;
     }
     default: {
-        return Status::NotSupported(fmt::format("not supported compression type {}", type));
+        return Status::NotSupported(fmt::format("not supported compression type {}", to_string(type)));
     }
     }
 

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -492,6 +492,21 @@ TEST_F(CSVFileWriterTest, TestWriteWithExecutors) {
     ASSERT_EQ(content, expect);
 }
 
+TEST_F(CSVFileWriterTest, TestUnknownCompression) {
+    auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);
+    std::vector<TypeDescriptor> type_descs{type_bool};
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    auto writer = std::make_unique<formats::CSVFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::UNKNOWN_COMPRESSION, writer_options, []() {}, nullptr, nullptr);
+    ASSERT_ERROR(writer->init());
+}
+
 TEST_F(CSVFileWriterTest, TestFactory) {
     auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);
     std::vector<TypeDescriptor> type_descs{type_bool};

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -1000,6 +1000,21 @@ TEST_F(OrcFileWriterTest, TestWriteWithExecutors) {
     ASSERT_EQ(result.file_statistics.record_count, 8);
 }
 
+TEST_F(OrcFileWriterTest, TestUnknownCompression) {
+    auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);
+    std::vector<TypeDescriptor> type_descs{type_bool};
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs->new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<OrcOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ORCWriterOptions>();
+    auto writer = std::make_unique<formats::ORCFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::UNKNOWN_COMPRESSION, writer_options, []() {}, nullptr, nullptr);
+    ASSERT_ERROR(writer->init());
+}
+
 TEST_F(OrcFileWriterTest, TestFactory) {
     auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);
     std::vector<TypeDescriptor> type_descs{type_bool};

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -1125,6 +1125,21 @@ TEST_F(ParquetFileWriterTest, TestWriteWithFieldID) {
     ASSERT_EQ(result.file_statistics.record_count, 8);
 }
 
+TEST_F(ParquetFileWriterTest, TestUnknownCompression) {
+    auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);
+    std::vector<TypeDescriptor> type_descs{type_bool};
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<parquet::ParquetOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
+    auto writer = std::make_unique<formats::ParquetFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::UNKNOWN_COMPRESSION, writer_options, []() {}, nullptr, nullptr);
+    ASSERT_ERROR(writer->init());
+}
+
 TEST_F(ParquetFileWriterTest, TestFactory) {
     auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);
     std::vector<TypeDescriptor> type_descs{type_bool};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Using `std::string to_string(const TCompressionType::type& val)` to convert thrift enum to string.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
