### PR TITLE
[Enhancement] Files table function support credential desensitization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -251,7 +251,7 @@ public class ConnectProcessor {
 
         ctx.getAuditEventBuilder().setFeIp(FrontendOptions.getLocalHostAddress());
 
-        if (!ctx.getState().isQuery() && (parsedStmt != null && parsedStmt.needAuditEncryption())) {
+        if (parsedStmt != null && parsedStmt.needAuditEncryption()) {
             // Some information like username, password in the stmt should not be printed.
             ctx.getAuditEventBuilder().setStmt(AstToSQLBuilder.toSQL(parsedStmt));
         } else if (parsedStmt == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2501,7 +2501,7 @@ public class StmtExecutor {
             return;
         }
         String sql;
-        if (!context.getState().isQuery() && parsedStmt.needAuditEncryption()) {
+        if (parsedStmt.needAuditEncryption()) {
             sql = AstToSQLBuilder.toSQL(parsedStmt);
         } else {
             sql = parsedStmt.getOrigStmt().originStmt;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -802,16 +802,7 @@ public class AstToStringBuilder {
             StringBuilder sb = new StringBuilder();
             sb.append(FileTableFunctionRelation.IDENTIFIER);
             sb.append("(");
-            boolean first = true;
-            for (Map.Entry<String, String> entry : node.getProperties().entrySet()) {
-                if (!first) {
-                    sb.append(",");
-                }
-                first = false;
-                sb.append("'").append(entry.getKey()).append("'");
-                sb.append("=");
-                sb.append("'").append((entry.getValue())).append("'");
-            }
+            sb.append(new PrintableMap<String, String>(node.getProperties(), "=", true, false, true));
             sb.append(")");
             return sb.toString();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/FileTableFunctionRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/FileTableFunctionRelation.java
@@ -38,4 +38,9 @@ public class FileTableFunctionRelation extends TableRelation {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitFileTableFunction(this, context);
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -322,4 +322,12 @@ public class InsertStmt extends DmlStmt {
         List<Column> columns = collectSelectedFieldsFromQueryStatement();
         return new TableFunctionTable(columns, getTableFunctionProperties(), sessionVariable);
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        if (tableFunctionAsTargetTable) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
@@ -163,4 +163,9 @@ public class QueryStatement extends StatementBase {
         }
         return null;
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return queryRelation.needAuditEncryption();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/Relation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/Relation.java
@@ -113,4 +113,8 @@ public abstract class Relation implements ParseNode {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitRelation(this, context);
     }
+
+    public boolean needAuditEncryption() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -311,4 +311,9 @@ public class SelectRelation extends QueryRelation {
     public Map<Expr, SlotRef> getGeneratedExprToColumnRef() {
         return generatedExprToColumnRef;
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return relation.needAuditEncryption();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetOperationRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetOperationRelation.java
@@ -59,4 +59,14 @@ public abstract class SetOperationRelation extends QueryRelation {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitSetOp(this, context);
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        for (QueryRelation relation : relations) {
+            if (relation.needAuditEncryption()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
@@ -65,4 +65,9 @@ public class SubqueryRelation extends QueryRelation {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitSubquery(this, context);
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return queryStatement.needAuditEncryption();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -20,8 +20,12 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.fs.HdfsUtil;
+import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TBrokerFileStatus;
@@ -231,5 +235,19 @@ public class TableFunctionTableTest {
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
                 "illegal value of csv.trim_space: FALS, only true/false allowed",
                 () -> new TableFunctionTable(properties));
+    }
+
+    @Test
+    public void testFilesCredentialDesensitization() {
+        String sql = "insert into files('path' = 's3://xxx/yyy', 'format' = 'parquet', 'aws.s3.access_key' = 'abc', " +
+                "'aws.s3.secret_key' = 'def', 'aws.s3.region' = 'us-west-2') " +
+                "select * from files('path' = 's3://xxx/zzz', 'format' = 'parquet', 'aws.s3.access_key' = 'ghi', " +
+                "'aws.s3.secret_key' = 'jkl', 'aws.s3.region' = 'us-west-1')";
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        String desensitizationSql = AstToSQLBuilder.toSQL(stmt);
+        Assert.assertEquals("INSERT INTO FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-2\", " +
+                "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/yyy\") SELECT *\n" +
+                "FROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
+                "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/zzz\")", desensitizationSql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -980,7 +980,7 @@ public class PipeManagerTest {
             piece.addFile(new PipeFileRecord(pipe.getId(), "b.parquet", "v1", 1));
             String sql = FilePipeSource.buildInsertSql(pipe, piece, "insert_label");
             Assert.assertEquals("INSERT INTO `tbl1` WITH LABEL `insert_label` SELECT *\n" +
-                    "FROM FILES('format'='parquet','path'='a.parquet,b.parquet')", sql);
+                    "FROM FILES(\"format\" = \"parquet\", \"path\" = \"a.parquet,b.parquet\")", sql);
             dropPipe(pipeName);
         }
 
@@ -994,7 +994,7 @@ public class PipeManagerTest {
             piece.addFile(new PipeFileRecord(pipe.getId(), "b.parquet", "v1", 1));
             String sql = FilePipeSource.buildInsertSql(pipe, piece, "insert_label");
             Assert.assertEquals("INSERT INTO `tbl1` WITH LABEL `insert_label` SELECT `col_int`, `col_string`\n" +
-                    "FROM FILES('format'='parquet','path'='a.parquet,b.parquet')", sql);
+                    "FROM FILES(\"format\" = \"parquet\", \"path\" = \"a.parquet,b.parquet\")", sql);
             dropPipe(pipeName);
         }
 
@@ -1010,7 +1010,7 @@ public class PipeManagerTest {
             Assert.assertEquals("INSERT INTO `tbl1` " +
                     "WITH LABEL `insert_label` " +
                     "(`col_int`) SELECT `col_int`\n" +
-                    "FROM FILES('format'='parquet','path'='a.parquet,b.parquet')", sql);
+                    "FROM FILES(\"format\" = \"parquet\", \"path\" = \"a.parquet,b.parquet\")", sql);
             SqlParser.parse(sql, new SessionVariable());
             dropPipe(pipeName);
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
insert into files("path" = "/path", "aws.s3.access_key" = "***", "aws.s3.secret_key" = "***");
select * from files("path" = "/path", "aws.s3.access_key" = "***", "aws.s3.secret_key" = "***");
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
