### PR TITLE
[Enhancement] Parquet writer support writing datetime with timezone and microseconds precision

### DIFF
--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -257,8 +257,7 @@ arrow::Result<::parquet::schema::NodePtr> ParquetBuildHelper::_make_schema_node(
     }
     case TYPE_DATETIME: {
         return ::parquet::schema::PrimitiveNode::Make(
-                name, rep_type,
-                ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
+                name, rep_type, ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
                 ::parquet::Type::INT64, -1, file_column_id.field_id);
     }
     case TYPE_DECIMAL32: {

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -256,10 +256,9 @@ arrow::Result<::parquet::schema::NodePtr> ParquetBuildHelper::_make_schema_node(
                                                       ::parquet::Type::INT32, -1, file_column_id.field_id);
     }
     case TYPE_DATETIME: {
-        // TODO(letian-jiang): set isAdjustedToUTC to true, and normalize datetime values
         return ::parquet::schema::PrimitiveNode::Make(
                 name, rep_type,
-                ::parquet::LogicalType::Timestamp(false, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
+                ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
                 ::parquet::Type::INT64, -1, file_column_id.field_id);
     }
     case TYPE_DECIMAL32: {

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -257,7 +257,7 @@ arrow::Result<::parquet::schema::NodePtr> ParquetBuildHelper::_make_schema_node(
     }
     case TYPE_DATETIME: {
         return ::parquet::schema::PrimitiveNode::Make(
-                name, rep_type, ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
+                name, rep_type, ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MICROS),
                 ::parquet::Type::INT64, -1, file_column_id.field_id);
     }
     case TYPE_DECIMAL32: {

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -368,9 +368,9 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
             *nanosecond = timestamp::to_time(timestamp) * 1000;
         } else {
             int64_t value = timestamp::to_julian(timestamp);
-            value *= SECS_PER_DAY * 1000;
-            value += timestamp::to_time(timestamp) / 1000;
-            value -= timestamp::UNIX_EPOCH_SECONDS * 1000;
+            value *= USECS_PER_DAY;
+            value += timestamp::to_time(timestamp);
+            value -= timestamp::UNIX_EPOCH_SECONDS * USECS_PER_SEC;
             values[i] = value;
         }
     }

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -359,15 +359,19 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
     DeferOp defer([&] { delete[] values; });
 
     for (size_t i = 0; i < col->size(); i++) {
+        // normalize to utc
+        auto timestamp = timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, _offset);
         if constexpr (use_int96_timestamp_encoding) {
-            // normalize to utc
-            auto timestamp = timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, _offset);
             auto date = reinterpret_cast<int32_t*>(values[i].value + 2);
             auto nanosecond = reinterpret_cast<int64_t*>(values[i].value);
             *date = timestamp::to_julian(timestamp);
             *nanosecond = timestamp::to_time(timestamp) * 1000;
         } else {
-            values[i] = data_col[i].to_unix_second() * 1000;
+            int64_t value = timestamp::to_julian(timestamp);
+            value *= SECS_PER_DAY * 1000;
+            value += timestamp::to_time(timestamp) / 1000;
+            value -= timestamp::UNIX_EPOCH_SECONDS * 1000;
+            values[i] = value;
         }
     }
 

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -393,7 +393,6 @@ arrow::Result<::parquet::schema::NodePtr> ParquetFileWriter::_make_schema_node(c
                                                       ::parquet::Type::INT32, -1, file_column_id.field_id);
     }
     case TYPE_DATETIME: {
-        // TODO(letian-jiang): set isAdjustedToUTC to true, and normalize datetime value
         // Apache Hive version 3 or lower does not support reading timestamps encoded as INT64
         if (_writer_options->use_int96_timestamp_encoding) {
             return ::parquet::schema::PrimitiveNode::Make(name, rep_type, ::parquet::Type::INT96,
@@ -401,7 +400,7 @@ arrow::Result<::parquet::schema::NodePtr> ParquetFileWriter::_make_schema_node(c
         } else {
             return ::parquet::schema::PrimitiveNode::Make(
                     name, rep_type,
-                    ::parquet::LogicalType::Timestamp(false, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
+                    ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
                     ::parquet::Type::INT64, -1, file_column_id.field_id);
         }
     }

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -400,7 +400,7 @@ arrow::Result<::parquet::schema::NodePtr> ParquetFileWriter::_make_schema_node(c
         } else {
             return ::parquet::schema::PrimitiveNode::Make(
                     name, rep_type,
-                    ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MILLIS),
+                    ::parquet::LogicalType::Timestamp(true, ::parquet::LogicalType::TimeUnit::unit::MICROS),
                     ::parquet::Type::INT64, -1, file_column_id.field_id);
         }
     }

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -153,8 +153,8 @@ public:
     static TimestampValue MIN_TIMESTAMP_VALUE;
 
     /**
-     * Milliseconds since January 1, 2000, 00:00:00. A negative number indicates the number of
-     * milliseconds before January 1, 2000, 00:00:00.
+     * Microseconds since January 1, 2000, 00:00:00. A negative number indicates the number of
+     * microseconds before January 1, 2000, 00:00:00.
      */
     Timestamp _timestamp;
 };

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -359,17 +359,18 @@ TEST_F(FileWriterTest, TestWriteDatetime) {
         auto data_column = TimestampColumn::create();
         {
             Datum datum;
-            datum.set_timestamp(TimestampValue::create(1999, 9, 9, 0, 0, 0));
+            datum.set_timestamp(TimestampValue::create(2023, 9, 9, 23, 59, 59));
             data_column->append_datum(datum);
             datum.set_timestamp(TimestampValue::create(1999, 9, 10, 1, 1, 1));
             data_column->append_datum(datum);
-            datum.set_timestamp(TimestampValue::create(1999, 9, 11, 2, 2, 2));
+            datum.set_timestamp(TimestampValue::create(1970, 1, 1, 0, 0, 0));
             data_column->append_datum(datum);
-            data_column->append_default();
+            datum.set_timestamp(TimestampValue::create(1970, 1, 1, 1, 1, 1));
+            data_column->append_datum(datum);
         }
 
         auto null_column = UInt8Column::create();
-        std::vector<uint8_t> nulls = {1, 0, 1, 0};
+        std::vector<uint8_t> nulls = {0, 0, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
         auto nullable_column = NullableColumn::create(data_column, null_column);
         chunk->append_column(nullable_column, chunk->num_columns());

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -506,17 +506,17 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetime) {
         auto data_column = TimestampColumn::create();
         {
             Datum datum;
-            datum.set_timestamp(TimestampValue::create(1999, 9, 9, 0, 0, 0));
+            datum.set_timestamp(TimestampValue::create(2023, 9, 9, 23, 59, 59));
             data_column->append_datum(datum);
             datum.set_timestamp(TimestampValue::create(1999, 9, 10, 1, 1, 1));
             data_column->append_datum(datum);
-            datum.set_timestamp(TimestampValue::create(1999, 9, 11, 2, 2, 2));
+            datum.set_timestamp(TimestampValue::create(1970, 1, 1, 0, 0, 0));
             data_column->append_datum(datum);
-            data_column->append_default();
+            datum.set_timestamp(TimestampValue::create(1970, 1, 1, 1, 1, 1));
         }
 
         auto null_column = UInt8Column::create();
-        std::vector<uint8_t> nulls = {1, 0, 1, 0};
+        std::vector<uint8_t> nulls = {0, 0, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
         auto nullable_column = NullableColumn::create(data_column, null_column);
         chunk->append_column(nullable_column, chunk->num_columns());

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -513,6 +513,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetime) {
             datum.set_timestamp(TimestampValue::create(1970, 1, 1, 0, 0, 0));
             data_column->append_datum(datum);
             datum.set_timestamp(TimestampValue::create(1970, 1, 1, 1, 1, 1));
+            data_column->append_datum(datum);
         }
 
         auto null_column = UInt8Column::create();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/49127

1. normalize datetime using timezone in runtime state
2. retain precision of microseconds

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
