### PR TITLE
[Enhancement] Reduce getAliveComputeNodes call to reduce rpc call

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -509,6 +509,13 @@ public class OlapScanNode extends ScanNode {
         selectedPartitionNames.add(partition.getName());
         selectedPartitionVersions.add(visibleVersion);
 
+        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            if (CollectionUtils.isEmpty(warehouseManager.getAliveComputeNodes(warehouseId))) {
+                Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
+                ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
+            }
+        }
         for (Tablet tablet : tablets) {
             long tabletId = tablet.getId();
             LOG.debug("{} tabletId={}", (logNum++), tabletId);
@@ -538,12 +545,6 @@ public class OlapScanNode extends ScanNode {
             List<Replica> allQueryableReplicas = Lists.newArrayList();
             List<Replica> localReplicas = Lists.newArrayList();
             if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
-                WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-                if (CollectionUtils.isEmpty(warehouseManager.getAliveComputeNodes(warehouseId))) {
-                    Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
-                    ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
-                }
-
                 tablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
                         visibleVersion, localBeId, schemaHash, warehouseId);
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -274,15 +274,13 @@ public class WarehouseManagerTest {
                 return RunMode.SHARED_DATA;
             }
         };
-        try {
-            OlapScanNode scanNode = newOlapScanNode();
-            Partition partition = new Partition(123, "aaa", null, null);
-            MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
-            scanNode.addScanRangeLocations(partition, partition, index, Collections.emptyList(), 1);
-            Assert.fail();
-        } catch (ErrorReportException e) {
-            Assert.assertEquals("No alive backend or compute node in warehouse null.", e.getMessage());   // can not be here
-        }
+
+        OlapScanNode scanNode = newOlapScanNode();
+        Partition partition = new Partition(123, "aaa", null, null);
+        MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
+        ErrorReportException ex = Assert.assertThrows(ErrorReportException.class,
+                () -> scanNode.addScanRangeLocations(partition, partition, index, Collections.emptyList(),1));
+        Assert.assertEquals("No alive backend or compute node in warehouse null.", ex.getMessage());
     }
 
     private OlapScanNode newOlapScanNode() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -15,11 +15,19 @@
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.UserException;
 import com.starrocks.lake.StarOSAgent;
+import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.PlanNodeId;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -34,6 +42,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -258,5 +267,29 @@ public class WarehouseManagerTest {
         } catch (ErrorReportException e) {
             Assert.assertEquals(1, 2);   // can not be here
         }
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+        try {
+            OlapScanNode scanNode = newOlapScanNode();
+            Partition partition = new Partition(123, "aaa", null, null);
+            MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
+            scanNode.addScanRangeLocations(partition, partition, index, Collections.emptyList(), 1);
+            Assert.fail();
+        } catch (ErrorReportException e) {
+            Assert.assertEquals("No alive backend or compute node in warehouse null.", e.getMessage());   // can not be here
+        }
+    }
+
+    private OlapScanNode newOlapScanNode() {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        OlapTable table = new OlapTable();
+        table.setDefaultDistributionInfo(new HashDistributionInfo(3, Collections.emptyList()));
+        desc.setTable(table);
+        return new OlapScanNode(new PlanNodeId(1), desc, "OlapScanNode");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -279,7 +279,7 @@ public class WarehouseManagerTest {
         Partition partition = new Partition(123, "aaa", null, null);
         MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
         ErrorReportException ex = Assert.assertThrows(ErrorReportException.class,
-                () -> scanNode.addScanRangeLocations(partition, partition, index, Collections.emptyList(),1));
+                () -> scanNode.addScanRangeLocations(partition, partition, index, Collections.emptyList(), 1));
         Assert.assertEquals("No alive backend or compute node in warehouse null.", ex.getMessage());
     }
 


### PR DESCRIPTION
## Why I'm doing:

In shared_data mode, it is very time consuming calling `warehouseManager.getAliveComputeNodes()` which issues a rpc call inside

## What I'm doing:

Reduce `warehouseManager.getAliveComputeNodes()` call in `OlapScanNode`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
