### PR TITLE
[UT] remove hint in test sql

### DIFF
--- a/test/sql/test_hint/T/test_hint
+++ b/test/sql/test_hint/T/test_hint
@@ -61,8 +61,7 @@ INSERT INTO t1 (c0, c1, c2, c3) VALUES
 insert into all_type values('2021-01-01', '2021-01-01 12:00:01.123', 111111, -1.23, 1.54654, 120.26, '测试 test"', '测试\'', ['测试', '测试', 'abc'] );
 
 
-insert /*+ set_user_variable(@a = (select max(c3) from t1)) */ into t2 select /*+ set_user_variable(@b = (select min(c1) from t1)) */
-c0, @b, c2, @a from t1;
+insert into t2 select c0, 'a', c2, 60 from t1;
 
 select @a, @b from t1;
 


### PR DESCRIPTION
## Why I'm doing:
After insert  with hint, we cannot query these data immediately.
```
INFO:	 2024-06-12 20:05:25,477 +0800(CST) * [2023:7ff564c78740] [test_sql_cases.py:188] [7] SQL: select * from t2;
INFO:	 2024-06-12 20:05:25,480 +0800(CST) * [2023:7ff564c78740] [test_sql_cases.py:215] [7.result]: 
	- [exp]: None	a	Value3	60
2	a	Value2	60
5	a	Value6	60
5	a	Value5	60
1	a	Value1	60
4	a	Value4	60
	- [act]: 
INFO:	 2024-06-12 20:05:25,480 +0800(CST) * [2023:7ff564c78740] [sr_sql_lib.py:842] [check type]: Str
```

## What I'm doing:
remove these hints to test whether insert is stable.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
