### PR TITLE
[BugFix]fix in-filter get values for string runtime filter

### DIFF
--- a/be/src/exprs/in_const_predicate.hpp
+++ b/be/src/exprs/in_const_predicate.hpp
@@ -331,8 +331,10 @@ public:
     ColumnPtr get_all_values() const {
         ColumnPtr values = ColumnHelper::create_column(TypeDescriptor{Type}, true);
         if constexpr (isSliceLT<Type>) {
-            for (auto c : _string_values) {
-                values->append_datum(c->get(0));
+            for (auto v : _hash_set) {
+                // v -> SliceWithHash
+                Slice s{v.data, v.size};
+                values->append_datum(s);
             }
         } else {
             for (auto v : _hash_set) {

--- a/test/sql/test_external_file/R/test_parquet_read_range
+++ b/test/sql/test_external_file/R/test_parquet_read_range
@@ -146,6 +146,10 @@ select * from read_range_test where c0 in (1, 4000);
 1	20000	1	[1,null,0]
 4000	16001	None	None
 -- !result
+select count(*) from read_range_test a join[broadcast] read_range_big_page_test b on a.c2 = b.c2 where b.c0 < 5;
+-- result:
+800
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_external_file/test_parquet_read_range/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_external_file/T/test_parquet_read_range
+++ b/test/sql/test_external_file/T/test_parquet_read_range
@@ -84,4 +84,7 @@ select * from repeated_value where c0 = 1;
 -- test lazy decode
 select * from read_range_test where c0 in (1, 4000);
 
+-- test runtime in filter string type
+select count(*) from read_range_test a join[broadcast] read_range_big_page_test b on a.c2 = b.c2 where b.c0 < 5;
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_external_file/test_parquet_read_range/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
for string type runtime in filter, there is no _string_values, and only values in hash set.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7792
https://github.com/StarRocks/StarRocksTest/issues/7793

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
