### PR TITLE
[BugFix] Fix mv partition intersected bug when base tables' partitions are discrete

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -560,14 +560,6 @@ public class PartitionUtil {
         return mvPartitionRangeMap;
     }
 
-    private static void putRangeToMvPartitionRangeMap(Map<String, Range<PartitionKey>> mvPartitionRangeMap,
-                                                      String lastPartitionName,
-                                                      PartitionKey lastPartitionKey,
-                                                      PartitionKey upperBound) {
-        Preconditions.checkState(!mvPartitionRangeMap.containsKey(lastPartitionName));
-        mvPartitionRangeMap.put(lastPartitionName, Range.closedOpen(lastPartitionKey, upperBound));
-    }
-
     private static void putRangeToMvPartitionRangeMapForJDBCTable(Map<String, Range<PartitionKey>> mvPartitionRangeMap,
                                                                   String partitionName,
                                                                   PartitionKey lastPartitionKey,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1136,7 +1136,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Pair<String, String> partitionRange = Pair.create(
                 context == null ? null : context.getProperties().get(TaskRun.PARTITION_START),
                 context == null ? null : context.getProperties().get(TaskRun.PARTITION_END));
-        MvPartitionDiffResult result = PartitionDiffer.computePartitionRangeDiff(materializedView, partitionRange);
+        MvPartitionDiffResult result = PartitionDiffer.computePartitionRangeDiff(db, materializedView, partitionRange);
         if (result == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -263,10 +263,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 LOG.info("no partitions to refresh for materialized view {}", materializedView.getName());
                 return mvToRefreshedPartitions;
             }
+
             // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
             filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, materializedView);
-
-            // do check again after filter
             int partitionRefreshNumber = materializedView.getTableProperty().getPartitionRefreshNumber();
             LOG.info("Filter partitions to refresh for materialized view {}, partitionRefreshNumber={}, " +
                             "partitionsToRefresh:{}, mvPotentialPartitionNames:{}, next start:{}, next end:{}",

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1130,7 +1130,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Pair<String, String> partitionRange = Pair.create(
                 context == null ? null : context.getProperties().get(TaskRun.PARTITION_START),
                 context == null ? null : context.getProperties().get(TaskRun.PARTITION_END));
-        MvPartitionDiffResult result = PartitionDiffer.computePartitionRangeDiff(db, materializedView, partitionRange);
+        MvPartitionDiffResult result = PartitionDiffer.computePartitionRangeDiff(materializedView, partitionRange);
         if (result == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -241,7 +241,6 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.common.MetaUtils;
-import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -3412,8 +3411,6 @@ public class LocalMetastore implements ConnectorMetadata {
                     partitionExprMaps.put(partitionExpr, MaterializedView.getMvPartitionSlotRef(partitionExpr));
                 }
                 materializedView.setPartitionExprMaps(partitionExprMaps);
-                // check partition schema from children
-                PartitionDiffer.computePartitionRangeDiff(db, materializedView, Pair.create(null, null));
             }
 
             MaterializedViewMgr.getInstance().prepareMaintenanceWork(stmt, materializedView);
@@ -3577,16 +3574,10 @@ public class LocalMetastore implements ConnectorMetadata {
         if (db == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
+        final Table table = db.getTable(mvName);
         MaterializedView materializedView = null;
-        Locker locker = new Locker();
-        locker.lockDatabase(db, LockType.READ);
-        try {
-            final Table table = db.getTable(mvName);
-            if (table instanceof MaterializedView) {
-                materializedView = (MaterializedView) table;
-            }
-        } finally {
-            locker.unLockDatabase(db, LockType.READ);
+        if (table instanceof MaterializedView) {
+            materializedView = (MaterializedView) table;
         }
         if (materializedView == null) {
             throw new MetaNotFoundException(mvName + " is not a materialized view");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -16,16 +16,15 @@ package com.starrocks.sql.common;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
-import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
@@ -33,11 +32,8 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.RangeUtils;
-import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.sql.analyzer.SemanticException;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.threeten.extra.PeriodDuration;
@@ -48,7 +44,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -63,6 +58,7 @@ import java.util.stream.Collectors;
 public class PartitionDiffer {
 
     private static final Logger LOG = LogManager.getLogger(PartitionDiffer.class);
+    private static final String INTERSECTED_PARTITION_PREFIX = "_intersected_";
 
     private Range<PartitionKey> rangeToInclude;
     private int partitionTTLNumber;
@@ -210,20 +206,6 @@ public class PartitionDiffer {
         return result;
     }
 
-    public static Map<String, Range<PartitionKey>> diffRange(List<PartitionRange> srcRanges,
-                                                             List<PartitionRange> dstRanges) {
-        if (!srcRanges.isEmpty() && !dstRanges.isEmpty()) {
-            List<PrimitiveType> srcTypes = srcRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
-            List<PrimitiveType> dstTypes = dstRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
-            Preconditions.checkArgument(Objects.equals(srcTypes, dstTypes), "types must be identical");
-        }
-        List<PartitionRange> diffs = ListUtils.subtract(srcRanges, dstRanges);
-        return diffs.stream()
-                .collect(Collectors.toMap(PartitionRange::getPartitionName,
-                        diff -> SyncPartitionUtils.convertToDatePartitionRange(diff).getPartitionKeyRange()
-                ));
-    }
-
     /**
      * Check whether `range` is included in `rangeToInclude`. Here we only want to
      * create partitions which is between `start` and `end` when executing
@@ -241,63 +223,118 @@ public class PartitionDiffer {
     }
 
     /**
-     * Compute the partition difference between materialized view and all ref base tables.
-     * @param db: the database of materialized view
-     * @param materializedView: the materialized view to check
-     * @param partitionRange: <partition start, partition end> pair
-     * @return MvPartitionDiffResult: the result of partition difference
+     * Collect the ref base table's partition range map.
+     * @param mv the materialized view to compute diff
+     * @param extBTMVPartitionNameMap the external base table's partition name map which to be updated
+     * @return the ref base table's partition range map: <ref base table, <partition name, partition range>>
      */
-    public static MvPartitionDiffResult computePartitionRangeDiff(Database db,
-                                                                  MaterializedView materializedView,
-                                                                  Pair<String, String> partitionRange) {
-        Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
-        Map<Table, Column> partitionTableAndColumn = materializedView.getRelatedPartitionTableAndColumn();
-        Preconditions.checkArgument(!partitionTableAndColumn.isEmpty());
+    private static Map<Table, Map<String, Range<PartitionKey>>> collectRBTPartitionKeyMap(
+            MaterializedView mv,
+            Expr mvPartitionExpr,
+            Map<Table, Map<String, Set<String>>> extBTMVPartitionNameMap) {
+        Map<Table, Column> partitionTableAndColumn = mv.getRelatedPartitionTableAndColumn();
+        if (partitionTableAndColumn.isEmpty()) {
+            return Maps.newHashMap();
+        }
 
-        Locker locker = new Locker();
-        locker.lockDatabase(db, LockType.READ);
-        Map<String, Range<PartitionKey>> mvRangePartitionMap = materializedView.getRangePartitionMap();
         Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
-        Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap = Maps.newHashMap();
-
-        Map<String, Range<PartitionKey>> allRefTablePartitionKeyMap = Maps.newHashMap();
         try {
             for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
-                Table refBaseTable = entry.getKey();
-                Column refBaseTablePartitionColumn = entry.getValue();
+                Table refBT = entry.getKey();
+                Column refBTPartitionColumn = entry.getValue();
                 // Collect the ref base table's partition range map.
                 Map<String, Range<PartitionKey>> refTablePartitionKeyMap =
-                        PartitionUtil.getPartitionKeyRange(refBaseTable, refBaseTablePartitionColumn, partitionExpr);
-                refBaseTablePartitionMap.put(refBaseTable, refTablePartitionKeyMap);
+                        PartitionUtil.getPartitionKeyRange(refBT, refBTPartitionColumn,
+                                mvPartitionExpr);
+                refBaseTablePartitionMap.put(refBT, refTablePartitionKeyMap);
 
                 // To solve multi partition columns' problem of external table, record the mv partition name to all the same
                 // partition names map here.
-                if (!refBaseTable.isNativeTableOrMaterializedView()) {
-                    refBaseTableMVPartitionMap.put(refBaseTable,
-                            PartitionUtil.getMVPartitionNameMapOfExternalTable(refBaseTable,
-                                    refBaseTablePartitionColumn, PartitionUtil.getPartitionNames(refBaseTable)));
+                if (!refBT.isNativeTableOrMaterializedView()) {
+                    extBTMVPartitionNameMap.put(refBT,
+                            PartitionUtil.getMVPartitionNameMapOfExternalTable(refBT,
+                                    refBTPartitionColumn, PartitionUtil.getPartitionNames(refBT)));
                 }
-                allRefTablePartitionKeyMap.putAll(refTablePartitionKeyMap);
             }
         } catch (UserException | SemanticException e) {
             LOG.warn("Partition differ collects ref base table partition failed.", e);
             return null;
-        } finally {
-            locker.unLockDatabase(db, LockType.READ);
+        }
+        return refBaseTablePartitionMap;
+    }
+
+    /**
+     * Merge all ref base tables' partition range map to avoid intersected partitions.
+     * @param basePartitionMap all ref base tables' partition range map
+     * @return merged partition range map: <partition name, partition range>
+     */
+    private static Map<String, Range<PartitionKey>> mergeRBTPartitionKeyMap(
+            Expr mvPartitionExpr,
+            Map<Table, Map<String, Range<PartitionKey>>> basePartitionMap) {
+
+        if (basePartitionMap.size() == 1) {
+            return basePartitionMap.values().iterator().next();
+        }
+        RangeMap<PartitionKey, String> addRanges = TreeRangeMap.create();
+        for (Map<String, Range<PartitionKey>> tRangMap : basePartitionMap.values()) {
+            for (Map.Entry<String, Range<PartitionKey>> add : tRangMap.entrySet()) {
+                // TODO: we may implement a new `merge` method in `TreeRangeMap` to merge intersected partitions later.
+                Map<Range<PartitionKey>, String> intersectedRange =
+                        addRanges.subRangeMap(add.getValue()).asMapOfRanges();
+                if (intersectedRange.isEmpty()) {
+                    addRanges.put(add.getValue(), add.getKey());
+                } else {
+                    // To be compatible old version, skip to rename partition name if the intersected partition is the same.
+                    if (intersectedRange.size() == 1) {
+                        Range<PartitionKey> existingRange = intersectedRange.keySet().iterator().next();
+                        if (existingRange.equals(add.getValue())) {
+                            continue;
+                        }
+                    }
+                    addRanges.merge(add.getValue(), add.getKey(), (o, n) -> {
+                        return String.format("%s_%s_%s", INTERSECTED_PARTITION_PREFIX, o, n);
+                    });
+                }
+            }
+        }
+        Map<String, Range<PartitionKey>> result = Maps.newHashMap();
+        for (Map.Entry<Range<PartitionKey>, String> entry : addRanges.asMapOfRanges().entrySet()) {
+            if (entry.getValue().startsWith(INTERSECTED_PARTITION_PREFIX)) {
+                String mvPartitionName = SyncPartitionUtils.getMVPartitionName(mvPartitionExpr, entry.getKey());
+                result.put(mvPartitionName, entry.getKey());
+            } else {
+                result.put(entry.getValue(), entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Compute the partition difference between materialized view and all ref base tables.
+     * @param mv: the materialized view to check
+     * @param partitionRange: <partition start, partition end> pair
+     * @return MvPartitionDiffResult: the result of partition difference
+     */
+    public static MvPartitionDiffResult computePartitionRangeDiff(MaterializedView mv,
+                                                                  Pair<String, String> partitionRange) {
+        Expr mvPartitionExpr = mv.getFirstPartitionRefTableExpr();
+        Map<Table, Column> refBaseTableAndColumns = mv.getRelatedPartitionTableAndColumn();
+        Preconditions.checkArgument(!refBaseTableAndColumns.isEmpty());
+
+        // get the materialized view's partition range map
+        Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
+        // collect all ref base table's partition range map
+        Map<Table, Map<String, Set<String>>> extRBTMVPartitionNameMap = Maps.newHashMap();
+        Map<Table, Map<String, Range<PartitionKey>>> rBTPartitionMap = collectRBTPartitionKeyMap(mv, mvPartitionExpr,
+                extRBTMVPartitionNameMap);
+        // merge all ref base tables' partition range map to avoid intersected partitions
+        Map<String, Range<PartitionKey>> mergedRBTPartitionKeyMap = mergeRBTPartitionKeyMap(mvPartitionExpr, rBTPartitionMap);
+        if (mergedRBTPartitionKeyMap == null) {
+            LOG.warn("Merge materialized view {} with base tables failed.", mv.getName());
+            return null;
         }
 
         try {
-            // Check unaligned partitions, unaligned partitions may cause uncorrected result which is not supported for now.
-            List<RangePartitionDiff> rangePartitionDiffList = Lists.newArrayList();
-            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
-                Table refBaseTable = entry.getKey();
-                PartitionDiffer differ = PartitionDiffer.build(materializedView, partitionRange);
-                rangePartitionDiffList.add(PartitionUtil.getPartitionDiff(partitionExpr,
-                        refBaseTablePartitionMap.get(refBaseTable), mvRangePartitionMap, differ));
-            }
-            // UnionALL MV may generate multiple PartitionDiff, needs to be merged into one PartitionDiff
-            RangePartitionDiff.checkRangePartitionAligned(rangePartitionDiffList);
-
             // NOTE: Use all refBaseTables' partition range to compute the partition difference between MV and refBaseTables.
             // Merge all deletes of each refBaseTab's diff may cause dropping needed partitions, the deletes should use
             // `bigcap` rather than `bigcup`.
@@ -306,14 +343,14 @@ public class PartitionDiffer {
             //
             // Diff_{deletes} = P_{MV} \setminus P_{\bigcup_{baseTables}^{}} \\
             //                = \bigcap_{baseTables} P_{MV}\setminus P_{baseTable}
-            PartitionDiffer differ = PartitionDiffer.build(materializedView, partitionRange);
-            RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, allRefTablePartitionKeyMap,
+            PartitionDiffer differ = PartitionDiffer.build(mv, partitionRange);
+            RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(mvPartitionExpr, mergedRBTPartitionKeyMap,
                     mvRangePartitionMap, differ);
             if (rangePartitionDiff == null) {
                 LOG.warn("Materialized view compute partition difference with base table failed: rangePartitionDiff is null.");
                 return null;
             }
-            return new MvPartitionDiffResult(mvRangePartitionMap, refBaseTablePartitionMap, refBaseTableMVPartitionMap,
+            return new MvPartitionDiffResult(mvRangePartitionMap, rBTPartitionMap, extRBTMVPartitionNameMap,
                     rangePartitionDiff);
         } catch (AnalysisException e) {
             LOG.warn("Materialized view compute partition difference with base table failed.", e);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -239,6 +239,7 @@ public class PartitionDiffer {
             return Maps.newHashMap();
         }
 
+        // TODO: lock base tables or use snapshot tables to avoid the partition change during the process.
         Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
         try {
             for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionMapping.java
@@ -15,9 +15,12 @@
 
 package com.starrocks.sql.common;
 
-import java.time.LocalDateTime;
+import org.jetbrains.annotations.NotNull;
 
-public class PartitionMapping {
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class PartitionMapping implements Comparable<PartitionMapping> {
 
     // the lowerDateTime is closed
     private final LocalDateTime lowerDateTime;
@@ -37,5 +40,43 @@ public class PartitionMapping {
 
     public LocalDateTime getUpperDateTime() {
         return upperDateTime;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lowerDateTime, upperDateTime);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PartitionMapping that = (PartitionMapping) o;
+        return Objects.equals(lowerDateTime, that.lowerDateTime) && Objects.equals(upperDateTime, that.upperDateTime);
+    }
+
+    @Override
+    public int compareTo(@NotNull PartitionMapping o) {
+        if (lowerDateTime == null || upperDateTime == null) {
+            return 0;
+        }
+        int ans = lowerDateTime.compareTo(o.lowerDateTime);
+        if (ans != 0) {
+            return ans;
+        }
+        return upperDateTime.compareTo(o.upperDateTime);
+    }
+
+    @Override
+    public String toString() {
+        return "PartitionMapping{" +
+                "lowerDateTime=" + lowerDateTime +
+                ", upperDateTime=" + upperDateTime +
+                '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
@@ -92,4 +92,12 @@ public class RangePartitionDiff {
             diff.getAdds().forEach((key, value) -> addRanges.put(value, key));
         }
     }
+
+    @Override
+    public String toString() {
+        return "RangePartitionDiff{" +
+                "adds=" + adds +
+                ", deletes=" + deletes +
+                '}';
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
@@ -95,9 +95,11 @@ public class RangePartitionDiff {
 
     @Override
     public String toString() {
-        return "RangePartitionDiff{" +
-                "adds=" + adds +
-                ", deletes=" + deletes +
-                '}';
+        StringBuilder sb = new StringBuilder();
+        sb.append("RangePartitionDiff{");
+        sb.append("adds=").append(adds);
+        sb.append(", deletes=").append(deletes);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVEagerRangePartitionMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVEagerRangePartitionMapper.java
@@ -1,0 +1,144 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common.mv;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.MaxLiteral;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.PartitionMapping;
+import com.starrocks.sql.common.SyncPartitionUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.starrocks.sql.common.SyncPartitionUtils.convertToDatePartitionRange;
+import static com.starrocks.sql.common.SyncPartitionUtils.getLowerDateTime;
+import static com.starrocks.sql.common.SyncPartitionUtils.getMVPartitionName;
+import static com.starrocks.sql.common.SyncPartitionUtils.toPartitionKey;
+
+/**
+ * {@link MVEagerRangePartitionMapper} will map/unroll the base table partition range by the granularity of mv partition expr.
+ * eg:
+ *  base table partition range  : [2021-01-01, 2021-01-03),
+ *  mv partition expr           : date_trunc('day', dt)
+ *
+ *  mv's partition map result   :
+ *                           p0 : [2021-01-01, 2021-01-02),
+ *                           p1 : [2021-01-02, 2021-01-03),
+ * Eager mode will generate more partitions than lazy mode, but it's more accurate and it will not generate intersected
+ * partition ranges.
+ */
+public class MVEagerRangePartitionMapper extends MVRangePartitionMapper {
+    public static final MVEagerRangePartitionMapper INSTANCE = new MVEagerRangePartitionMapper();
+
+    @Override
+    public Map<String, Range<PartitionKey>> toMappingRanges(Map<String, Range<PartitionKey>> baseRangeMap,
+                                                            String granularity, PrimitiveType partitionType) {
+
+        Map<String, Range<PartitionKey>> result = Maps.newTreeMap();
+        Set<PartitionMapping> mappings = Sets.newHashSet();
+        for (Map.Entry<String, Range<PartitionKey>> rangeEntry : baseRangeMap.entrySet()) {
+            List<PartitionMapping> rangeMappings = toMappingRanges(rangeEntry.getValue(), granularity);
+            mappings.addAll(rangeMappings);
+        }
+        try {
+            for (PartitionMapping mappedRange : mappings) {
+                LocalDateTime lowerDateTime = mappedRange.getLowerDateTime();
+                LocalDateTime upperDateTime = mappedRange.getUpperDateTime();
+
+                // mv partition name
+                String mvPartitionName = getMVPartitionName(lowerDateTime, upperDateTime, granularity);
+                // mv partition key
+                PartitionKey lowerPartitionKey = toPartitionKey(lowerDateTime, partitionType);
+                PartitionKey upperPartitionKey = toPartitionKey(upperDateTime, partitionType);
+                Range<PartitionKey> range = Range.closedOpen(lowerPartitionKey, upperPartitionKey);
+                result.put(mvPartitionName, range);
+            }
+        } catch (AnalysisException e) {
+            throw new SemanticException("Convert to PartitionMapping failed:", e);
+        }
+        return result;
+    }
+
+    private static LocalDateTime toLocalDateTime(LiteralExpr literal) {
+        DateLiteral dateLiteral;
+        if (literal instanceof MaxLiteral) {
+            dateLiteral = new DateLiteral(Type.DATE, true);
+            return dateLiteral.toLocalDateTime();
+        } else {
+            dateLiteral = (DateLiteral) literal;
+            return dateLiteral.toLocalDateTime();
+        }
+    }
+
+    /**
+     * Get the mv partition mapping by the base partition range and mv partition granularity.
+     * @param baseRange base table partition range which should be date/datetime type
+     * @param granularity mv partition granularity
+     * @return mv partition mapping with the base partition range's lower bound and upper bound in granularity
+     * @throws AnalysisException
+     */
+    public List<PartitionMapping> toMappingRanges(Range<PartitionKey> baseRange,
+                                                  String granularity) {
+        // assume expr partition must be DateLiteral and only one partition
+        baseRange = convertToDatePartitionRange(baseRange);
+        LiteralExpr lowerExpr = baseRange.lowerEndpoint().getKeys().get(0);
+        LiteralExpr upperExpr = baseRange.upperEndpoint().getKeys().get(0);
+        Preconditions.checkArgument(lowerExpr instanceof DateLiteral);
+        LocalDateTime lowerDateTime = toLocalDateTime(lowerExpr);
+        LocalDateTime upperDateTime = toLocalDateTime(upperExpr);
+
+        // if the lower bound is min, return directly
+        boolean isLowerMin = lowerExpr.isMinValue();
+        if (isLowerMin) {
+            PartitionMapping nextMapping = new PartitionMapping(lowerDateTime, upperDateTime);
+            return Lists.newArrayList(nextMapping);
+        }
+        // if the upper bound is max, return directly
+        LocalDateTime curLowerDateTime = getLowerDateTime(lowerDateTime, granularity);
+        boolean isUpperMax = upperExpr instanceof MaxLiteral;
+        if (isUpperMax) {
+            PartitionMapping nextMapping = new PartitionMapping(curLowerDateTime, upperDateTime);
+            return Lists.newArrayList(nextMapping);
+        }
+
+        // if the upper bound has covered original upper bound, return directly
+        List<PartitionMapping> result = Lists.newArrayList();
+        // iterate the current upper bound to be greater than input upper time.
+        LocalDateTime curUpperDateTime = curLowerDateTime;
+        while (upperDateTime.isAfter(curUpperDateTime)) {
+            // compute the next upper bound by current upper bound
+            LocalDateTime nextUpperDateTime = SyncPartitionUtils.nextUpperDateTime(curUpperDateTime, granularity);
+            PartitionMapping nextMapping = new PartitionMapping(curUpperDateTime, nextUpperDateTime);
+
+            // update curLowerDateTime
+            curUpperDateTime = nextUpperDateTime;
+            result.add(nextMapping);
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVLazyRangePartitionMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVLazyRangePartitionMapper.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common.mv;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.MaxLiteral;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.PartitionMapping;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.starrocks.sql.common.SyncPartitionUtils.convertToDatePartitionRange;
+import static com.starrocks.sql.common.SyncPartitionUtils.getLowerDateTime;
+import static com.starrocks.sql.common.SyncPartitionUtils.getMVPartitionName;
+import static com.starrocks.sql.common.SyncPartitionUtils.getUpperDateTime;
+import static com.starrocks.sql.common.SyncPartitionUtils.toPartitionKey;
+
+/**
+ * {@link MVLazyRangePartitionMapper} will map/unroll the base table partition range by the granularity of mv partition expr.
+ * eg:
+ *  base table partition range  : [2021-01-01, 2021-01-03),
+ *  mv partition expr           : date_trunc('day', dt)
+ *
+ *  mv's partition map result   :
+ *                           p0 : [2021-01-01, 2021-01-03),
+ *
+ * Lazy mode will generate less partition ranges, but it may generate intersected partition ranges which we will handle it in
+ * {@link com.starrocks.sql.common.PartitionDiffer#computePartitionRangeDiff}.
+ */
+public class MVLazyRangePartitionMapper extends MVRangePartitionMapper {
+    public static final MVLazyRangePartitionMapper INSTANCE = new MVLazyRangePartitionMapper();
+
+    @Override
+    public Map<String, Range<PartitionKey>> toMappingRanges(Map<String, Range<PartitionKey>> baseRangeMap,
+                                                            String granularity,
+                                                            PrimitiveType partitionType) {
+        Set<LocalDateTime> timePointSet = Sets.newTreeSet();
+        for (Map.Entry<String, Range<PartitionKey>> rangeEntry : baseRangeMap.entrySet()) {
+            PartitionMapping mappedRange = toMappingRanges(rangeEntry.getValue(), granularity);
+            // this mappedRange may exist range overlap
+            timePointSet.add(mappedRange.getLowerDateTime());
+            timePointSet.add(mappedRange.getUpperDateTime());
+        }
+        List<LocalDateTime> timePointList = Lists.newArrayList(timePointSet);
+        // deal overlap
+        Map<String, Range<PartitionKey>> result = Maps.newHashMap();
+        if (timePointList.size() < 2) {
+            return result;
+        }
+        for (int i = 1; i < timePointList.size(); i++) {
+            try {
+                LocalDateTime lowerDateTime = timePointList.get(i - 1);
+                LocalDateTime upperDateTime = timePointList.get(i);
+                PartitionKey lowerPartitionKey = toPartitionKey(lowerDateTime, partitionType);
+                PartitionKey upperPartitionKey = toPartitionKey(upperDateTime, partitionType);
+                String mvPartitionName = getMVPartitionName(lowerDateTime, upperDateTime, granularity);
+                result.put(mvPartitionName, Range.closedOpen(lowerPartitionKey, upperPartitionKey));
+            } catch (AnalysisException ex) {
+                throw new SemanticException("Convert to DateLiteral failed:", ex);
+            }
+        }
+        return result;
+    }
+
+    public PartitionMapping toMappingRanges(Range<PartitionKey> baseRange,
+                                            String granularity) {
+        // assume expr partition must be DateLiteral and only one partition
+        baseRange = convertToDatePartitionRange(baseRange);
+        LiteralExpr lowerExpr = baseRange.lowerEndpoint().getKeys().get(0);
+        LiteralExpr upperExpr = baseRange.upperEndpoint().getKeys().get(0);
+        Preconditions.checkArgument(lowerExpr instanceof DateLiteral);
+        DateLiteral lowerDate = (DateLiteral) lowerExpr;
+        LocalDateTime lowerDateTime = lowerDate.toLocalDateTime();
+        LocalDateTime truncLowerDateTime = getLowerDateTime(lowerDateTime, granularity);
+
+        DateLiteral upperDate;
+        LocalDateTime truncUpperDateTime;
+        if (upperExpr instanceof MaxLiteral) {
+            upperDate = new DateLiteral(Type.DATE, true);
+            truncUpperDateTime = upperDate.toLocalDateTime();
+        } else {
+            upperDate = (DateLiteral) upperExpr;
+            truncUpperDateTime = getUpperDateTime(upperDate.toLocalDateTime(), granularity);
+        }
+        return new PartitionMapping(truncLowerDateTime, truncUpperDateTime);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVLazyRangePartitionMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVLazyRangePartitionMapper.java
@@ -41,14 +41,19 @@ import static com.starrocks.sql.common.SyncPartitionUtils.getUpperDateTime;
 import static com.starrocks.sql.common.SyncPartitionUtils.toPartitionKey;
 
 /**
- * {@link MVLazyRangePartitionMapper} will map/unroll the base table partition range by the granularity of mv partition expr.
+ * {@link MVLazyRangePartitionMapper} will create mv partition ranges by the granularity of mv partition expr lazily, it first
+ * deduces partitions by the partition ranges of the base table, then maps/unrolls the base table partition range by the
+ * granularity of mv.
+ *
  * eg:
  *  base table partition range  : [2021-01-01, 2021-01-03),
  *  mv partition expr           : date_trunc('day', dt)
  *
  *  mv's partition map result   :
  *                           p0 : [2021-01-01, 2021-01-03),
- *
+ * rather than:
+ *                           p0 : [2021-01-01, 2021-01-02),
+ *                           p1 : [2021-01-02, 2021-01-03),
  * Lazy mode will generate less partition ranges, but it may generate intersected partition ranges which we will handle it in
  * {@link com.starrocks.sql.common.PartitionDiffer#computePartitionRangeDiff}.
  */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVRangePartitionMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVRangePartitionMapper.java
@@ -27,11 +27,11 @@ import static com.starrocks.sql.common.TimeUnitUtils.TIME_MAP;
 /**
  * {@link MVRangePartitionMapper} is used to map the partition range of the base table to the partition range of mv,
  * It's for the mv with partition expr(e.g. {@code date_trunc(granularity, dt)}).
- *
+ * </p>
  * Why are there two different implementations of {@link MVRangePartitionMapper}?
- * - Eager mode, which will map/unroll the base table partition range by the granularity of mv partition expr.
- * - Lazy mode, which will use the base table partition range directly and make the mv's range mapping continuous.
- *
+ * * Eager mode, which will map/unroll the base table partition range by the granularity of mv partition expr.
+ * * Lazy mode, which will use the base table partition range directly and make the mv's range mapping continuous.
+ * </p>
  * But eager mode may generate too many partitions when the granularity is {@code minute or hour}, so distinguish them
  * by granularity.
  */
@@ -50,7 +50,7 @@ public abstract class MVRangePartitionMapper {
     /**
      * Get the mv range partition mapper instance.
      * @param granularity mv partition expr's granularity
-     * @return mv range partition mapper instance according by the granularity
+     * @return mv range partition mapper instance according to the granularity
      */
     public static MVRangePartitionMapper getInstance(String granularity) {
         if (granularity != null && TIME_MAP.containsKey(granularity) && TIME_MAP.get(granularity) < TIME_MAP.get(DAY)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVRangePartitionMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/mv/MVRangePartitionMapper.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.common.mv;
+
+import com.google.common.collect.Range;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
+
+import java.util.Map;
+
+import static com.starrocks.sql.common.TimeUnitUtils.DAY;
+import static com.starrocks.sql.common.TimeUnitUtils.TIME_MAP;
+
+/**
+ * {@link MVRangePartitionMapper} is used to map the partition range of the base table to the partition range of mv,
+ * It's for the mv with partition expr(e.g. {@code date_trunc(granularity, dt)}).
+ *
+ * Why are there two different implementations of {@link MVRangePartitionMapper}?
+ * - Eager mode, which will map/unroll the base table partition range by the granularity of mv partition expr.
+ * - Lazy mode, which will use the base table partition range directly and make the mv's range mapping continuous.
+ *
+ * But eager mode may generate too many partitions when the granularity is {@code minute or hour}, so distinguish them
+ * by granularity.
+ */
+public abstract class MVRangePartitionMapper {
+    /**
+     * Generate the mapping ranges of mv partition by the base table partition range.
+     * @param baseRangeMap base ref table's partition range map
+     * @param granularity mv partition expr's granularity
+     * @param partitionType mv partition expr's type
+     * @return mv partition range map
+     */
+    public abstract Map<String, Range<PartitionKey>> toMappingRanges(Map<String, Range<PartitionKey>> baseRangeMap,
+                                                                     String granularity,
+                                                                     PrimitiveType partitionType);
+
+    /**
+     * Get the mv range partition mapper instance.
+     * @param granularity mv partition expr's granularity
+     * @return mv range partition mapper instance according by the granularity
+     */
+    public static MVRangePartitionMapper getInstance(String granularity) {
+        if (granularity != null && TIME_MAP.containsKey(granularity) && TIME_MAP.get(granularity) < TIME_MAP.get(DAY)) {
+            return MVLazyRangePartitionMapper.INSTANCE;
+        } else {
+            return MVEagerRangePartitionMapper.INSTANCE;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -33,7 +33,6 @@ import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
-import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;
@@ -799,7 +798,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
      * Intersected UNION partition must be same, otherwise will report error
      */
     @Test
-    public void testMvOnUnion_IntersectedPartition() throws Exception {
+    public void testMvOnUnion_IntersectedPartition1() throws Exception {
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS mv_union_t1 (\n" +
                 "    leg_id VARCHAR(100) NOT NULL,\n" +
                 "    cabin_class VARCHAR(1) NOT NULL,\n" +
@@ -842,29 +841,25 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
                 ") ");
 
         {
-            Exception e = Assert.assertThrows(IllegalArgumentException.class, () ->
-                    starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1 \n" +
-                            "PARTITION BY date_trunc('day', observation_date)\n" +
-                            "DISTRIBUTED BY HASH(leg_id)\n" +
-                            "REFRESH ASYNC\n" +
-                            "AS \n" +
-                            "SELECT * FROM mv_union_t1 t1\n" +
-                            "UNION ALL\n" +
-                            "SELECT * FROM mv_union_t2 t2\n"));
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains("partitions are intersected"));
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1 \n" +
+                    "PARTITION BY date_trunc('day', observation_date)\n" +
+                    "DISTRIBUTED BY HASH(leg_id)\n" +
+                    "REFRESH ASYNC\n" +
+                    "AS \n" +
+                    "SELECT * FROM mv_union_t1 t1\n" +
+                    "UNION ALL\n" +
+                    "SELECT * FROM mv_union_t2 t2\n", () -> {});
         }
 
         {
-            Exception e = Assert.assertThrows(IllegalArgumentException.class, () ->
-                    starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv2 \n" +
-                            "PARTITION BY date_trunc('day', observation_date)\n" +
-                            "DISTRIBUTED BY HASH(leg_id)\n" +
-                            "REFRESH ASYNC\n" +
-                            "AS \n" +
-                            "SELECT * FROM mv_union_t1 t1\n" +
-                            "UNION ALL\n" +
-                            "SELECT * FROM mv_union_t3 t2\n"));
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains("partitions are intersected"));
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv2 \n" +
+                    "PARTITION BY date_trunc('day', observation_date)\n" +
+                    "DISTRIBUTED BY HASH(leg_id)\n" +
+                    "REFRESH ASYNC\n" +
+                    "AS \n" +
+                    "SELECT * FROM mv_union_t1 t1\n" +
+                    "UNION ALL\n" +
+                    "SELECT * FROM mv_union_t3 t2\n", () -> {});
         }
 
         {
@@ -875,14 +870,10 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
                     "AS \n" +
                     "SELECT * FROM mv_union_t1 t1\n" +
                     "UNION ALL\n" +
-                    "SELECT * FROM mv_union_t4 t2\n");
+                    "SELECT * FROM mv_union_t4 t2\n", () -> {});
             // add partition to child table
             starRocksAssert.ddl("alter table mv_union_t4 add partition p20240325 values less than ('2024-03-25')");
             starRocksAssert.ddl("alter table mv_union_t1 add partition p20240326 values less than ('2024-03-26')");
-
-            Exception e = Assert.assertThrows(DmlException.class, () ->
-                    starRocksAssert.refreshMvPartition("refresh materialized view mv2"));
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains("partitions are intersected"));
         }
 
         // cleanup
@@ -891,4 +882,93 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
         starRocksAssert.dropMaterializedView("mv1");
     }
 
+    @Test
+    public void testMvOnUnion_IntersectedPartition2() throws Exception {
+        starRocksAssert
+                .withTable("CREATE TABLE t1 \n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-02')),\n" +
+                        "    PARTITION p2 values [('2022-02-02'),('2022-02-03')),\n" +
+                        "    PARTITION p3 values [('2022-02-03'),('2022-02-04')),\n" +
+                        "    PARTITION p4 values [('2022-02-04'),('2022-02-05'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE t2 \n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p2 values [('2022-02-02'),('2022-02-03')),\n" +
+                        "    PARTITION p4 values [('2022-03-02'),('2022-03-04'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1 \n" +
+                "PARTITION BY date_trunc('day', k1)\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "REFRESH ASYNC\n" +
+                "AS \n" +
+                "SELECT * FROM t1\n" +
+                "UNION ALL\n" +
+                "SELECT * FROM t2\n");
+        starRocksAssert.dropTable("t1");
+        starRocksAssert.dropTable("t2");
+        starRocksAssert.dropMaterializedView("mv1");
+    }
+
+    @Test
+    public void testMvOnUnion_IntersectedPartition3() throws Exception {
+        starRocksAssert
+                .withTable("CREATE TABLE t1 \n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int\n" +
+                        ")\n" +
+                        "PARTITION BY date_trunc('day', k1)\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE t2 \n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int\n" +
+                        ")\n" +
+                        "PARTITION BY date_trunc('day', k1)\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
+        // auto create partitions for t1/t2
+        {
+            String sql1 = "INSERT INTO t1 VALUES ('2022-02-01', 1, 1), ('2022-02-02', 2, 2), " +
+                    "('2022-02-03', 3, 3), ('2022-02-04', 4, 4)";
+            executeInsertSql(connectContext, sql1);
+
+            String sql2 = "INSERT INTO t2 values ('2022-02-02', 2, 2), ('2022-03-02', 5, 5)";
+            executeInsertSql(connectContext, sql2);
+        }
+
+        {
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1 \n" +
+                    "PARTITION BY date_trunc('day', k1)\n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "REFRESH ASYNC\n" +
+                    "AS \n" +
+                    "SELECT * FROM t1\n" +
+                    "UNION ALL\n" +
+                    "SELECT * FROM t2\n", () -> {});
+        }
+        starRocksAssert.dropTable("t1");
+        starRocksAssert.dropTable("t2");
+        starRocksAssert.dropMaterializedView("mv1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -1627,8 +1627,9 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
         executeInsertSql(connectContext, "insert into tbl2 partition(p1) values('2022-01-02', 3, 10);");
         taskRun.executeTaskRun();
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
-        Assert.assertEquals(Sets.newHashSet("p20220101_20220201"),
-                processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Set<String> mvPartitionsToRefresh = processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh();
+        System.out.println(mvPartitionsToRefresh);
+        Assert.assertTrue(mvPartitionsToRefresh.contains("p20220101_20220102"));
         Map<String, Set<String>> refBasePartitionsToRefreshMap =
                 processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();
         Map<String, String> expect = ImmutableMap.of(
@@ -2322,12 +2323,10 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
 
                                     MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
                                     System.out.println(processor.getMVTaskRunExtraMessage());
-                                    Assert.assertEquals(Sets.newHashSet("p20210701_20210801"),
-                                            extraMessage.getMvPartitionsToRefresh());
+                                    Assert.assertTrue(extraMessage.getMvPartitionsToRefresh().contains("p20210723_20210724"));
                                     Assert.assertEquals(Sets.newHashSet("p0"),
                                             extraMessage.getBasePartitionsToRefreshMap().get("mock_tbl"));
                                     Assert.assertTrue(processor.getNextTaskRun() == null);
-
                                 }
 
                                 {
@@ -2346,31 +2345,15 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
                                     TableSnapshotInfo tableSnapshotInfo =
                                             snapshotInfoMap.get(testDb.getTable("mock_tbl").getId());
                                     System.out.println(processor.getMVTaskRunExtraMessage());
-                                    Assert.assertEquals(Sets.newHashSet("p1"),
+                                    Assert.assertEquals(Sets.newHashSet("p1", "p2"),
                                             tableSnapshotInfo.getRefreshedPartitionInfos().keySet());
 
                                     MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
                                     System.out.println(processor.getMVTaskRunExtraMessage());
-                                    Assert.assertEquals(Sets.newHashSet("p20210801_20210901"),
-                                            extraMessage.getMvPartitionsToRefresh());
-                                    Assert.assertEquals(Sets.newHashSet("p1"),
+                                    Assert.assertTrue(extraMessage.getMvPartitionsToRefresh().contains("p20210811_20210812"));
+                                    Assert.assertEquals(Sets.newHashSet("p1", "p2"),
                                             extraMessage.getBasePartitionsToRefreshMap().get("mock_tbl"));
-                                    Assert.assertTrue(processor.getNextTaskRun() != null);
-
-                                    {
-                                        taskRun = processor.getNextTaskRun();
-                                        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-                                        taskRun.executeTaskRun();
-                                        processor =
-                                                (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
-                                        extraMessage = processor.getMVTaskRunExtraMessage();
-                                        System.out.println(processor.getMVTaskRunExtraMessage());
-                                        Assert.assertEquals(Sets.newHashSet("p20210901_20211001"),
-                                                extraMessage.getMvPartitionsToRefresh());
-                                        Assert.assertEquals(Sets.newHashSet("p2"),
-                                                extraMessage.getBasePartitionsToRefreshMap().get("mock_tbl"));
-                                        Assert.assertTrue(processor.getNextTaskRun() == null);
-                                    }
+                                    Assert.assertTrue(processor.getNextTaskRun() == null);
                                 }
                             });
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -33,6 +35,8 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.sql.common.mv.MVEagerRangePartitionMapper;
+import com.starrocks.sql.common.mv.MVLazyRangePartitionMapper;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -94,6 +98,11 @@ public class SyncPartitionUtilsTest {
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("date_trunc", children);
         functionCallExpr.setType(Type.fromPrimitiveType(type));
         return functionCallExpr;
+    }
+
+    private static RangePartitionDiff getRangePartitionDiffOfSlotRef(Map<String, Range<PartitionKey>> baseRangeMap,
+                                                                     Map<String, Range<PartitionKey>> mvRangeMap) {
+        return SyncPartitionUtils.getRangePartitionDiffOfSlotRef(baseRangeMap, mvRangeMap, null);
     }
 
     @Test
@@ -262,7 +271,7 @@ public class SyncPartitionUtilsTest {
         Map<String, Range<PartitionKey>> mvRange = Maps.newHashMap();
         mvRange.put("p202001", createRange("2020-01-01", "2020-02-01"));
 
-        RangePartitionDiff diff = SyncPartitionUtils.getRangePartitionDiffOfSlotRef(baseRange, mvRange);
+        RangePartitionDiff diff = getRangePartitionDiffOfSlotRef(baseRange, mvRange);
 
         Map<String, Range<PartitionKey>> adds = diff.getAdds();
         Assert.assertEquals(3, adds.size());
@@ -297,7 +306,7 @@ public class SyncPartitionUtilsTest {
         mvRange.put("p20200102", createRange("2020-01-02", "2020-01-03"));
         mvRange.put("p20200103", createRange("2020-01-03", "2020-01-04"));
 
-        diff = SyncPartitionUtils.getRangePartitionDiffOfSlotRef(baseRange, mvRange);
+        diff = getRangePartitionDiffOfSlotRef(baseRange, mvRange);
 
         adds = diff.getAdds();
         deletes = diff.getDeletes();
@@ -315,11 +324,36 @@ public class SyncPartitionUtilsTest {
                 deletes.get("p20200101").upperEndpoint().getKeys().get(0).getStringValue());
     }
 
+    private static PartitionMapping toLazyMappingRange(Range<PartitionKey> baseRange,
+                                                       String granularity) {
+        return MVLazyRangePartitionMapper.INSTANCE.toMappingRanges(baseRange, granularity);
+    }
+
+    private static List<PartitionMapping> toEagerMappingRanges(Range<PartitionKey> baseRange,
+                                                               String granularity) {
+        return MVEagerRangePartitionMapper.INSTANCE.toMappingRanges(baseRange, granularity);
+    }
+
+    public static Map<String, Range<PartitionKey>> toEagerMappingRanges(Map<String, Range<PartitionKey>> baseRangeMap,
+                                                                        String granularity, PrimitiveType partitionType) {
+        return MVEagerRangePartitionMapper.INSTANCE.toMappingRanges(baseRangeMap, granularity, partitionType);
+    }
+
+    private static List<PartitionMapping> toPartitionMappings(Range<PartitionKey> baseRange, String granularity) {
+        return toEagerMappingRanges(baseRange, granularity);
+    }
+
+    private static PartitionMapping toPartitionMapping(Range<PartitionKey> baseRange, String granularity) {
+        List<PartitionMapping> partitionMappings = toEagerMappingRanges(baseRange, granularity);
+        Preconditions.checkState(partitionMappings.size() == 1);
+        return partitionMappings.get(0);
+    }
+
     @Test
     public void testMappingRangeRollup() throws AnalysisException {
         // minute
         Range<PartitionKey> baseRange = createRange("2020-05-03 12:34:56", "2020-06-04 12:34:56");
-        PartitionMapping mappedRange = SyncPartitionUtils.mappingRange(baseRange, "minute");
+        PartitionMapping mappedRange = toLazyMappingRange(baseRange, "minute");
 
         Assert.assertEquals("2020-05-03T12:34:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -328,7 +362,7 @@ public class SyncPartitionUtilsTest {
 
         // hour
         baseRange = createRange("2020-05-03 12:34:56", "2020-06-04 12:34:56");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "hour");
+        mappedRange = toLazyMappingRange(baseRange, "hour");
 
         Assert.assertEquals("2020-05-03T12:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -337,7 +371,7 @@ public class SyncPartitionUtilsTest {
 
         // day
         baseRange = createRange("2020-05-03 12:34:56", "2020-06-04 12:34:56");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "day");
+        mappedRange = toLazyMappingRange(baseRange, "day");
 
         Assert.assertEquals("2020-05-03T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -346,7 +380,7 @@ public class SyncPartitionUtilsTest {
 
         // month
         baseRange = createRange("2020-05-03", "2020-06-04");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "month");
+        mappedRange = toLazyMappingRange(baseRange, "month");
 
         Assert.assertEquals("2020-05-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -355,7 +389,7 @@ public class SyncPartitionUtilsTest {
 
         // quarter
         baseRange = createRange("2020-05-03", "2020-06-04");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "quarter");
+        mappedRange = toLazyMappingRange(baseRange, "quarter");
 
         Assert.assertEquals("2020-04-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -364,7 +398,7 @@ public class SyncPartitionUtilsTest {
 
         // year
         baseRange = createRange("2020-05-03", "2020-06-04");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "year");
+        mappedRange = toLazyMappingRange(baseRange, "year");
 
         Assert.assertEquals("2020-01-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -378,7 +412,7 @@ public class SyncPartitionUtilsTest {
                 new DateLiteral(Type.DATE, true).toLocalDateTime().format(DateTimeFormatter.ISO_DATE_TIME);
         // minute
         Range<PartitionKey> baseRange = createMaxValueRange("2020-05-03 12:34:56");
-        PartitionMapping mappedRange = SyncPartitionUtils.mappingRange(baseRange, "minute");
+        PartitionMapping mappedRange = toPartitionMapping(baseRange, "minute");
 
         Assert.assertEquals("2020-05-03T12:34:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -386,7 +420,7 @@ public class SyncPartitionUtilsTest {
 
         // hour
         baseRange = createMaxValueRange("2020-05-03 12:34:56");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "hour");
+        mappedRange = toPartitionMapping(baseRange, "hour");
 
         Assert.assertEquals("2020-05-03T12:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -394,7 +428,7 @@ public class SyncPartitionUtilsTest {
 
         // day
         baseRange = createMaxValueRange("2020-05-03 12:34:56");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "day");
+        mappedRange = toPartitionMapping(baseRange, "day");
 
         Assert.assertEquals("2020-05-03T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -402,7 +436,7 @@ public class SyncPartitionUtilsTest {
 
         // month
         baseRange = createMaxValueRange("2020-05-03");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "month");
+        mappedRange = toPartitionMapping(baseRange, "month");
 
         Assert.assertEquals("2020-05-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -410,7 +444,7 @@ public class SyncPartitionUtilsTest {
 
         // quarter
         baseRange = createMaxValueRange("2020-05-03");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "quarter");
+        mappedRange = toPartitionMapping(baseRange, "quarter");
 
         Assert.assertEquals("2020-04-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -418,7 +452,7 @@ public class SyncPartitionUtilsTest {
 
         // year
         baseRange = createMaxValueRange("2020-05-03");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "year");
+        mappedRange = toPartitionMapping(baseRange, "year");
 
         Assert.assertEquals("2020-01-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -434,7 +468,7 @@ public class SyncPartitionUtilsTest {
         baseRangeMap.put("p202003", createRange("2020-03-01", "2020-04-01"));
         baseRangeMap.put("p202004", createMaxValueRange("2020-04-01"));
 
-        result = SyncPartitionUtils.mappingRangeList(baseRangeMap, "month", PrimitiveType.DATE);
+        result = toEagerMappingRanges(baseRangeMap, "month", PrimitiveType.DATE);
 
         Assert.assertTrue(result.containsKey("p202004_999912"));
         Assert.assertEquals(1, result.get("p202004_999912").upperEndpoint().getKeys().size());
@@ -446,19 +480,15 @@ public class SyncPartitionUtilsTest {
         baseRangeMap.put("p202002", createRange("2020-02-01 20:01:59", "2020-03-01 02:50:49"));
         baseRangeMap.put("p202003", createRange("2020-03-01 02:50:49", "2020-04-01 01:05:06"));
         baseRangeMap.put("p202004", createMaxValueRange("2020-04-01 01:05:06"));
-        result = SyncPartitionUtils.mappingRangeList(baseRangeMap, "hour", PrimitiveType.DATETIME);
-        Assert.assertTrue(result.containsKey("p2020040102_9999123100"));
-        Assert.assertEquals(1, result.get("p2020040102_9999123100").upperEndpoint().getKeys().size());
-        Assert.assertEquals("9999-12-31 00:00:00", result.get("p2020040102_9999123100").upperEndpoint().getKeys().get(0).
-                getStringValue());
+        result = toEagerMappingRanges(baseRangeMap, "hour", PrimitiveType.DATETIME);
+        Assert.assertTrue(result.size() == 2175);
     }
 
     @Test
-    public void testMappingRange() throws AnalysisException {
-
+    public void testMappingRangeWithOldVersion() throws AnalysisException {
         // less than
         Range<PartitionKey> baseRange = createLessThanRange("2020-05-03");
-        PartitionMapping mappedRange = SyncPartitionUtils.mappingRange(baseRange, "day");
+        PartitionMapping mappedRange = toPartitionMapping(baseRange, "day");
 
         Assert.assertEquals("0000-01-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -467,12 +497,38 @@ public class SyncPartitionUtilsTest {
 
         // big partition
         baseRange = createRange("2020-01-01", "2020-02-01");
-        mappedRange = SyncPartitionUtils.mappingRange(baseRange, "day");
-
+        mappedRange = toLazyMappingRange(baseRange, "day");
         Assert.assertEquals("2020-01-01T00:00:00",
                 mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
         Assert.assertEquals("2020-02-01T00:00:00",
                 mappedRange.getUpperDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
+    }
+
+    @Test
+    public void testMappingRange() throws AnalysisException {
+        // less than
+        Range<PartitionKey> baseRange = createLessThanRange("2020-05-03");
+        PartitionMapping mappedRange = toPartitionMapping(baseRange, "day");
+
+        Assert.assertEquals("0000-01-01T00:00:00",
+                mappedRange.getLowerDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
+        Assert.assertEquals("2020-05-03T00:00:00",
+                mappedRange.getUpperDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
+
+        // big partition
+        baseRange = createRange("2020-01-01", "2020-02-01");
+        {
+            List<PartitionMapping> mappedRanges = toPartitionMappings(baseRange, "day");
+            Assert.assertTrue(mappedRanges.size() == 31);
+        }
+        {
+            List<PartitionMapping> mappedRanges = toPartitionMappings(baseRange, "month");
+            Assert.assertTrue(mappedRanges.size() == 1);
+        }
+        {
+            List<PartitionMapping> mappedRanges = toPartitionMappings(baseRange, "year");
+            Assert.assertTrue(mappedRanges.size() == 1);
+        }
     }
 
     @Test
@@ -487,23 +543,23 @@ public class SyncPartitionUtilsTest {
         Map<String, Range<PartitionKey>> mvRange = Maps.newHashMap();
         RangePartitionDiff diff = SyncPartitionUtils.getRangePartitionDiffOfExpr(baseRange, mvRange,
                 createFuncExpr("month", PrimitiveType.DATETIME), null);
+        System.out.println(diff);
+
         Map<String, Range<PartitionKey>> adds = diff.getAdds();
         Map<String, Range<PartitionKey>> deletes = diff.getDeletes();
-
-        Assert.assertEquals(3, adds.size());
-        Assert.assertEquals("0000-01-01 00:00:00",
-                adds.get("p000101_202005").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-05-01 00:00:00",
-                adds.get("p000101_202005").upperEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-06-01 00:00:00",
-                adds.get("p202006_202012").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-12-01 00:00:00",
-                adds.get("p202006_202012").upperEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-05-01 00:00:00",
-                adds.get("p202005_202006").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-06-01 00:00:00",
-                adds.get("p202005_202006").upperEndpoint().getKeys().get(0).getStringValue());
+        Assert.assertEquals(8, adds.size());
         Assert.assertEquals(0, deletes.size());
+        Set<String> expectPartNames = ImmutableSet.of(
+                "p000101_202005",
+                "p202005_202006",
+                "p202006_202007",
+                "p202007_202008",
+                "p202008_202009",
+                "p202009_202010",
+                "p202010_202011",
+                "p202011_202012"
+        );
+        Assert.assertTrue(expectPartNames.containsAll(adds.keySet()));
 
         // big partition
         baseRange = Maps.newHashMap();
@@ -521,16 +577,66 @@ public class SyncPartitionUtilsTest {
 
     }
 
+    static class EPartitionMapping {
+        private final String name;
+        private final String lowerEndpoint;
+        private final String upperEndpoint;
+
+        public EPartitionMapping(String name, String lowerEndpoint, String upperEndpoint) {
+            this.name = name;
+            this.lowerEndpoint = lowerEndpoint;
+            this.upperEndpoint = upperEndpoint;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public String getLowerEndpoint() {
+            return lowerEndpoint;
+        }
+
+        public String getUpperEndpoint() {
+            return upperEndpoint;
+        }
+    }
+
+    private static boolean checkPartitionMapping(Map<String, Range<PartitionKey>> actuals,
+                                                 EPartitionMapping expect) {
+        return checkPartitionMapping(actuals, ImmutableList.of(expect));
+    }
+
+    private static boolean checkPartitionMapping(Map<String, Range<PartitionKey>> actuals,
+                                                 List<EPartitionMapping> expects) {
+        if (actuals.size() != expects.size()) {
+            return false;
+        }
+        for (EPartitionMapping expect : expects) {
+            Range<PartitionKey> actual = actuals.get(expect.getName());
+            if (actual == null) {
+                return false;
+            }
+            if (!expect.getLowerEndpoint().equals(actual.lowerEndpoint().getKeys().get(0).getStringValue())) {
+                return false;
+            }
+            if (!expect.getUpperEndpoint().equals(actual.upperEndpoint().getKeys().get(0).getStringValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Test
     public void testCalcSyncRollupPartition() throws AnalysisException {
         // overlap scenario
         String granularity = "month";
 
         Map<String, Range<PartitionKey>> baseRange = Maps.newHashMap();
+        Map<String, Range<PartitionKey>> mvRange = Maps.newHashMap();
+
         baseRange.put("p1", createRange("2020-09-12", "2020-10-12"));
         baseRange.put("p2", createRange("2020-10-12", "2020-11-12"));
 
-        Map<String, Range<PartitionKey>> mvRange = Maps.newHashMap();
         RangePartitionDiff diff = SyncPartitionUtils.getRangePartitionDiffOfExpr(baseRange, mvRange,
                 createFuncExpr(granularity, PrimitiveType.DATETIME), null);
 
@@ -538,19 +644,13 @@ public class SyncPartitionUtilsTest {
         Map<String, Range<PartitionKey>> deletes = diff.getDeletes();
 
         Assert.assertEquals(3, adds.size());
-        Assert.assertEquals("2020-09-01 00:00:00",
-                adds.get("p202009_202010").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-10-01 00:00:00",
-                adds.get("p202009_202010").upperEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-10-01 00:00:00",
-                adds.get("p202010_202011").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-11-01 00:00:00",
-                adds.get("p202010_202011").upperEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-11-01 00:00:00",
-                adds.get("p202011_202012").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-12-01 00:00:00",
-                adds.get("p202011_202012").upperEndpoint().getKeys().get(0).getStringValue());
         Assert.assertEquals(0, deletes.size());
+        List<EPartitionMapping> expects = ImmutableList.of(
+                new EPartitionMapping("p202009_202010", "2020-09-01 00:00:00", "2020-10-01 00:00:00"),
+                new EPartitionMapping("p202010_202011", "2020-10-01 00:00:00", "2020-11-01 00:00:00"),
+                new EPartitionMapping("p202011_202012", "2020-11-01 00:00:00", "2020-12-01 00:00:00")
+        );
+        Assert.assertTrue(checkPartitionMapping(adds, expects));
 
         // bigger than granularity scenario
         baseRange = Maps.newHashMap();
@@ -562,17 +662,8 @@ public class SyncPartitionUtilsTest {
                 createFuncExpr(granularity, PrimitiveType.DATETIME), null);
         adds = diff.getAdds();
         deletes = diff.getDeletes();
-        Assert.assertEquals(1, adds.size());
-        Assert.assertEquals("2020-01-01 00:00:00",
-                adds.get("p202001_202101").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2021-01-01 00:00:00",
-                adds.get("p202001_202101").upperEndpoint().getKeys().get(0).getStringValue());
-
-        Assert.assertEquals(1, deletes.size());
-        Assert.assertEquals("2020-01-01 00:00:00",
-                deletes.get("p202001_202002").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-02-01 00:00:00",
-                deletes.get("p202001_202002").upperEndpoint().getKeys().get(0).getStringValue());
+        Assert.assertEquals(11, adds.size());
+        Assert.assertEquals(0, deletes.size());
 
         baseRange = Maps.newHashMap();
         baseRange.put("p20200503", createRange("2020-05-03", "2020-06-05"));
@@ -583,15 +674,11 @@ public class SyncPartitionUtilsTest {
         adds = diff.getAdds();
         deletes = diff.getDeletes();
         Assert.assertEquals(1, adds.size());
-        Assert.assertEquals("2020-05-01 00:00:00",
-                adds.get("p202005_202007").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-07-01 00:00:00",
-                adds.get("p202005_202007").upperEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals(1, deletes.size());
-        Assert.assertEquals("2020-05-01 00:00:00",
-                deletes.get("p202005_202006").lowerEndpoint().getKeys().get(0).getStringValue());
-        Assert.assertEquals("2020-06-01 00:00:00",
-                deletes.get("p202005_202006").upperEndpoint().getKeys().get(0).getStringValue());
+        Assert.assertEquals(0, deletes.size());
+        expects = ImmutableList.of(
+                new EPartitionMapping("p202006_202007", "2020-06-01 00:00:00", "2020-07-01 00:00:00")
+        );
+        Assert.assertTrue(checkPartitionMapping(adds, expects));
 
         baseRange = Maps.newHashMap();
         baseRange.put("p20200403", createRange("2020-04-03", "2020-05-02"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -965,9 +965,9 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
             PlanTestBase.assertContains(plan, "test_mv1");
             // partition p2 has already been updated, so the mv should not be used anymore
             PlanTestBase.assertContains(plan, "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 8: ds >= '2020-02-11 00:00:00', 8: ds <= '2020-03-01 00:00:00'\n" +
-                    "     partitions=0/3");
+                            "     PREAGGREGATION: ON\n" +
+                            "     PREDICATES: 8: ds >= '2020-02-11 00:00:00', 8: ds <= '2020-03-01 00:00:00'\n" +
+                            "     partitions=0/61");
             PlanTestBase.assertContains(plan, "     TABLE: base_tbl1\n" +
                     "     PREAGGREGATION: ON\n" +
                     "     PREDICATES: time_slice(10: k1, 1, 'hour', 'floor') >= '2020-02-11 00:00:00', " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -884,14 +884,6 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
     }
 
     @Test
-    public void testViewDeltaRewriter() throws Exception {
-        Pair<QueryDumpInfo, String> replayPair =
-                getPlanFragment(getDumpInfoFromFile("query_dump/view_delta"),
-                        connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("mv_yyf_trade_water3"));
-    }
-
-    @Test
     public void testNoCTEOperatorPropertyDerived() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/no_cte_operator_test"),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -20,12 +20,14 @@ import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -232,5 +234,16 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         //        "nmock_032, nmock_033, nmock_034, nmock_035, nmock_036, nmock_037, nmock_038, nmock_039, " +
         //        "nmock_040, nmock_041 from tbl_mock_001 order by nmock_002;";
         assertNotContains(replayPair.second, "mv_tbl_mock_001");
+    }
+
+    @Test
+    public void testViewDeltaRewriter() throws Exception {
+        QueryDebugOptions debugOptions = new QueryDebugOptions();
+        debugOptions.setEnableQueryTraceLog(true);
+        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
+        Pair<QueryDumpInfo, String> replayPair =
+                getPlanFragment(getDumpInfoFromFile("query_dump/view_delta"),
+                        connectContext.getSessionVariable(), TExplainLevel.NORMAL);
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("mv_yyf_trade_water3"));
     }
 }

--- a/test/sql/test_materialized_view/R/test_materialized_view_union
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union
@@ -1,4 +1,140 @@
-
+-- name: test_materialized_view_union
+CREATE TABLE `t1` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`)
+(
+PARTITION p2 VALUES [("202301"), ("202302")),
+PARTITION p3 VALUES [("202302"), ("202303")),
+PARTITION p4 VALUES [("202303"), ("202304")),
+PARTITION p5 VALUES [("202304"), ("202305")),
+PARTITION p6 VALUES [("202305"), ("202306")))
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`)
+(
+PARTITION p2 VALUES [("202301"), ("202302")),
+PARTITION p3 VALUES [("202302"), ("202303")),
+PARTITION p4 VALUES [("202303"), ("202304")),
+PARTITION p5 VALUES [("202304"), ("202305")),
+PARTITION p6 VALUES [("202305"), ("202306")))
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `test_union_mv1_${uuid0}`
+PARTITION BY (`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+REFRESH DEFERRED ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS select k1, v1, v2 from t1
+union all
+select k1, v1, v2 from t2;
+-- result:
+-- !result
+insert into t1 values ("202301",1,1),("202305",1,2);
+-- result:
+-- !result
+refresh materialized view test_union_mv1_${uuid0} with sync mode;
+select * from test_union_mv1_${uuid0} order by k1, v1;
+-- result:
+202301	1	1
+202305	1	2
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result
+drop materialized view test_union_mv1_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`)
+(
+PARTITION p2 VALUES [("202301"), ("202302")),
+PARTITION p3 VALUES [("202302"), ("202303")),
+PARTITION p4 VALUES [("202303"), ("202304")),
+PARTITION p5 VALUES [("202304"), ("202305")),
+PARTITION p6 VALUES [("202305"), ("202306")))
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 values (202301,1,1),(202305,1,2);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `test_union_mv2_${uuid0}`
+PARTITION BY (`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+REFRESH DEFERRED ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD",
+"auto_refresh_partitions_limit" = "1"
+)
+AS select k1, v1, v2 from t1
+union
+select k1, v1, v2 from t2;
+-- result:
+-- !result
+refresh materialized view test_union_mv2_${uuid0} with sync mode;
+select * from test_union_mv2_${uuid0} order by k1, v1;
+-- result:
+202301	1	1
+202305	1	2
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result
+drop materialized view test_union_mv2_${uuid0};
+-- result:
+-- !result
 -- name: test_materialized_view_union_all_unaligned
 CREATE TABLE IF NOT EXISTS t1 (
     leg_id VARCHAR(100) NOT NULL,
@@ -74,7 +210,7 @@ SELECT * FROM t2;
 	
 REFRESH MATERIALIZED VIEW v1 WITH SYNC MODE;
 -- result:
-4c6f86f1-2d22-11ef-9d69-e67f2420b196
+031065ac-2d7e-11ef-b31f-e67f2420b196
 -- !result
 select count(*) from v1;
 -- result:

--- a/test/sql/test_materialized_view/R/test_materialized_view_union
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union
@@ -1,140 +1,4 @@
--- name: test_materialized_view_union
-CREATE TABLE `t1` (
-  `k1` int(11) NULL COMMENT "",
-  `v1` int(11) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT ""
-) ENGINE=OLAP
-DUPLICATE KEY(`k1`)
-COMMENT "OLAP"
-PARTITION BY RANGE(`k1`)
-(
-PARTITION p2 VALUES [("202301"), ("202302")),
-PARTITION p3 VALUES [("202302"), ("202303")),
-PARTITION p4 VALUES [("202303"), ("202304")),
-PARTITION p5 VALUES [("202304"), ("202305")),
-PARTITION p6 VALUES [("202305"), ("202306")))
-DISTRIBUTED BY HASH(`k1`) BUCKETS 2
-PROPERTIES (
-"replication_num" = "1"
-);
--- result:
--- !result
-CREATE TABLE `t2` (
-  `k1` int(11) NULL COMMENT "",
-  `v1` int(11) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT ""
-) ENGINE=OLAP
-DUPLICATE KEY(`k1`)
-COMMENT "OLAP"
-PARTITION BY RANGE(`k1`)
-(
-PARTITION p2 VALUES [("202301"), ("202302")),
-PARTITION p3 VALUES [("202302"), ("202303")),
-PARTITION p4 VALUES [("202303"), ("202304")),
-PARTITION p5 VALUES [("202304"), ("202305")),
-PARTITION p6 VALUES [("202305"), ("202306")))
-DISTRIBUTED BY HASH(`k1`) BUCKETS 2
-PROPERTIES (
-"replication_num" = "1"
-);
--- result:
--- !result
-CREATE MATERIALIZED VIEW `test_union_mv1_${uuid0}`
-PARTITION BY (`k1`)
-DISTRIBUTED BY HASH(`k1`) BUCKETS 2
-REFRESH DEFERRED ASYNC
-PROPERTIES (
-"replication_num" = "1",
-"storage_medium" = "HDD"
-)
-AS select k1, v1, v2 from t1
-union all
-select k1, v1, v2 from t2;
--- result:
--- !result
-insert into t1 values ("202301",1,1),("202305",1,2);
--- result:
--- !result
-refresh materialized view test_union_mv1_${uuid0} with sync mode;
-select * from test_union_mv1_${uuid0} order by k1, v1;
--- result:
-202301	1	1
-202305	1	2
--- !result
-drop table t1;
--- result:
--- !result
-drop table t2;
--- result:
--- !result
-drop materialized view test_union_mv1_${uuid0};
--- result:
--- !result
-CREATE TABLE `t1` (
-  `k1` int(11) NULL COMMENT "",
-  `v1` int(11) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT ""
-) ENGINE=OLAP
-DUPLICATE KEY(`k1`)
-COMMENT "OLAP"
-PARTITION BY RANGE(`k1`)
-(
-PARTITION p2 VALUES [("202301"), ("202302")),
-PARTITION p3 VALUES [("202302"), ("202303")),
-PARTITION p4 VALUES [("202303"), ("202304")),
-PARTITION p5 VALUES [("202304"), ("202305")),
-PARTITION p6 VALUES [("202305"), ("202306")))
-DISTRIBUTED BY HASH(`k1`) BUCKETS 2
-PROPERTIES (
-"replication_num" = "1"
-);
--- result:
--- !result
-CREATE TABLE `t2` (
-  `k1` int(11) NULL COMMENT "",
-  `v1` int(11) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT ""
-) ENGINE=OLAP
-DUPLICATE KEY(`k1`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 2
-PROPERTIES (
-"replication_num" = "1"
-);
--- result:
--- !result
-insert into t1 values (202301,1,1),(202305,1,2);
--- result:
--- !result
-CREATE MATERIALIZED VIEW `test_union_mv2_${uuid0}`
-PARTITION BY (`k1`)
-DISTRIBUTED BY HASH(`k1`) BUCKETS 2
-REFRESH DEFERRED ASYNC
-PROPERTIES (
-"replication_num" = "1",
-"storage_medium" = "HDD",
-"auto_refresh_partitions_limit" = "1"
-)
-AS select k1, v1, v2 from t1
-union
-select k1, v1, v2 from t2;
--- result:
--- !result
-refresh materialized view test_union_mv2_${uuid0} with sync mode;
-select * from test_union_mv2_${uuid0} order by k1, v1;
--- result:
-202301	1	1
-202305	1	2
--- !result
-drop table t1;
--- result:
--- !result
-drop table t2;
--- result:
--- !result
-drop materialized view test_union_mv2_${uuid0};
--- result:
--- !result
+
 -- name: test_materialized_view_union_all_unaligned
 CREATE TABLE IF NOT EXISTS t1 (
     leg_id VARCHAR(100) NOT NULL,
@@ -210,7 +74,7 @@ SELECT * FROM t2;
 	
 REFRESH MATERIALIZED VIEW v1 WITH SYNC MODE;
 -- result:
-6932ab39-ed87-11ee-87f3-865ace43c879
+4c6f86f1-2d22-11ef-9d69-e67f2420b196
 -- !result
 select count(*) from v1;
 -- result:
@@ -225,7 +89,6 @@ SELECT * FROM t1
 UNION ALL
 SELECT * FROM t3;
 -- result:
-[REGEX]E: \(1064, 'Unexpected exception: partitions are intersected.*
 -- !result
 CREATE MATERIALIZED VIEW v3
 PARTITION BY date_trunc('day', observation_date)
@@ -236,5 +99,4 @@ SELECT * FROM t1
 UNION ALL
 SELECT * FROM t4;
 -- result:
-[REGEX]E: \(1064, 'Unexpected exception: partitions are intersected.*
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union1
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union1
@@ -1,0 +1,453 @@
+-- name: test_mv_refresh_with_multi_union1
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+-- result:
+-- !result
+	 
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u3
+    union all
+    select dt from u4;
+-- result:
+-- !result
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+     select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv7`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv8`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt
+from (
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+) t
+group by dt;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("test_mv1")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv2")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv3")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv4")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv5")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv6")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv7")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv8")
+-- result:
+None
+-- !result
+select count(1) from test_mv1;
+-- result:
+17
+-- !result
+select count(1) from test_mv2;
+-- result:
+13
+-- !result
+select count(1) from test_mv3;
+-- result:
+36
+-- !result
+select count(1) from test_mv4;
+-- result:
+10
+-- !result
+select count(1) from test_mv5;
+-- result:
+10
+-- !result
+select count(1) from test_mv6;
+-- result:
+84
+-- !result
+select count(1) from test_mv7;
+-- result:
+85
+-- !result
+select count(1) from test_mv8;
+-- result:
+10
+-- !result
+select dt from test_mv1 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv2 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv3 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv4 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv5 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv6 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv7 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv8 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv3;
+-- result:
+-- !result
+drop materialized view test_mv4;
+-- result:
+-- !result
+drop materialized view test_mv5;
+-- result:
+-- !result
+drop materialized view test_mv6;
+-- result:
+-- !result
+drop materialized view test_mv7;
+-- result:
+-- !result
+drop materialized view test_mv8;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union1
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union1
@@ -259,38 +259,14 @@ from (
 group by dt;
 -- result:
 -- !result
-function: wait_async_materialized_view_finish("test_mv1")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv2")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv3")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv4")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv5")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv6")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv7")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv8")
--- result:
-None
--- !result
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+refresh materialized view test_mv7 with sync mode;
+refresh materialized view test_mv8 with sync mode;
 select count(1) from test_mv1;
 -- result:
 17
@@ -313,11 +289,11 @@ select count(1) from test_mv5;
 -- !result
 select count(1) from test_mv6;
 -- result:
-84
+86
 -- !result
 select count(1) from test_mv7;
 -- result:
-85
+86
 -- !result
 select count(1) from test_mv8;
 -- result:

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
@@ -1,0 +1,439 @@
+-- name: test_mv_refresh_with_multi_union2
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-01"), ("2024-04-02")),
+  PARTITION p7 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2023-01-01"), ("2024-01-01")),
+  PARTITION p2 VALUES [("2024-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p2 VALUES [("2024-04-01"), ("2024-05-01")),
+  PARTITION p3 VALUES [("2024-05-01"), ("2024-06-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-01-01"), ("2024-02-01")),
+  PARTITION p2 VALUES [("2024-02-01"), ("2024-03-01")),
+  PARTITION p3 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p4 VALUES [("2024-04-01"), ("2024-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE (dt) (
+  START ("2024-01-01") END ("2024-05-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14');
+-- result:
+-- !result
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13');
+-- result:
+-- !result
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+-- result:
+-- !result
+	 
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u3
+    union all
+    select dt from u4;
+-- result:
+-- !result
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+     select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv7`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv8`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt
+from (
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+) t
+group by dt;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("test_mv1")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv2")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv3")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv4")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv5")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv6")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv7")
+-- result:
+None
+-- !result
+function: wait_async_materialized_view_finish("test_mv8")
+-- result:
+None
+-- !result
+select count(1) from test_mv1;
+-- result:
+10
+-- !result
+select count(1) from test_mv2;
+-- result:
+12
+-- !result
+select count(1) from test_mv3;
+-- result:
+29
+-- !result
+select count(1) from test_mv4;
+-- result:
+6
+-- !result
+select count(1) from test_mv5;
+-- result:
+6
+-- !result
+select count(1) from test_mv6;
+-- result:
+63
+-- !result
+select count(1) from test_mv7;
+-- result:
+63
+-- !result
+select count(1) from test_mv8;
+-- result:
+6
+-- !result
+select dt from test_mv1 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-04-10
+-- !result
+select dt from test_mv2 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+-- !result
+select dt from test_mv3 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv4 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-04-10
+-- !result
+select dt from test_mv5 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-04-10
+-- !result
+select dt from test_mv6 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv7 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-03-15
+2024-03-16
+2024-03-17
+2024-03-18
+2024-04-10
+-- !result
+select dt from test_mv8 group by dt order by 1;
+-- result:
+2024-03-10
+2024-03-11
+2024-03-12
+2024-03-13
+2024-03-14
+2024-04-10
+-- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
@@ -300,7 +300,7 @@ select count(1) from test_mv1;
 -- !result
 select count(1) from test_mv2;
 -- result:
-12
+13
 -- !result
 select count(1) from test_mv3;
 -- result:
@@ -316,11 +316,11 @@ select count(1) from test_mv5;
 -- !result
 select count(1) from test_mv6;
 -- result:
-63
+64
 -- !result
 select count(1) from test_mv7;
 -- result:
-63
+64
 -- !result
 select count(1) from test_mv8;
 -- result:
@@ -346,6 +346,7 @@ select dt from test_mv2 group by dt order by 1;
 2024-03-16
 2024-03-17
 2024-03-18
+2024-04-10
 -- !result
 select dt from test_mv3 group by dt order by 1;
 -- result:

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
@@ -286,38 +286,14 @@ from (
 group by dt;
 -- result:
 -- !result
-function: wait_async_materialized_view_finish("test_mv1")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv2")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv3")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv4")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv5")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv6")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv7")
--- result:
-None
--- !result
-function: wait_async_materialized_view_finish("test_mv8")
--- result:
-None
--- !result
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+refresh materialized view test_mv7 with sync mode;
+refresh materialized view test_mv8 with sync mode;
 select count(1) from test_mv1;
 -- result:
 10
@@ -436,4 +412,28 @@ select dt from test_mv8 group by dt order by 1;
 2024-03-13
 2024-03-14
 2024-04-10
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv3;
+-- result:
+-- !result
+drop materialized view test_mv4;
+-- result:
+-- !result
+drop materialized view test_mv5;
+-- result:
+-- !result
+drop materialized view test_mv6;
+-- result:
+-- !result
+drop materialized view test_mv7;
+-- result:
+-- !result
+drop materialized view test_mv8;
+-- result:
 -- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union1
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union1
@@ -234,14 +234,14 @@ from (
 ) t
 group by dt;
 
-function: wait_async_materialized_view_finish("test_mv1")
-function: wait_async_materialized_view_finish("test_mv2")
-function: wait_async_materialized_view_finish("test_mv3")
-function: wait_async_materialized_view_finish("test_mv4")
-function: wait_async_materialized_view_finish("test_mv5")
-function: wait_async_materialized_view_finish("test_mv6")
-function: wait_async_materialized_view_finish("test_mv7")
-function: wait_async_materialized_view_finish("test_mv8")
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+refresh materialized view test_mv7 with sync mode;
+refresh materialized view test_mv8 with sync mode;
 
 select count(1) from test_mv1;
 select count(1) from test_mv2;
@@ -251,6 +251,7 @@ select count(1) from test_mv5;
 select count(1) from test_mv6;
 select count(1) from test_mv7;
 select count(1) from test_mv8;
+
 select dt from test_mv1 group by dt order by 1;
 select dt from test_mv2 group by dt order by 1;
 select dt from test_mv3 group by dt order by 1;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union1
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union1
@@ -1,0 +1,270 @@
+-- name: test_mv_refresh_with_multi_union1
+
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+	 
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u3
+    union all
+    select dt from u4;
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+     select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv7`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv8`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt
+from (
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+) t
+group by dt;
+
+function: wait_async_materialized_view_finish("test_mv1")
+function: wait_async_materialized_view_finish("test_mv2")
+function: wait_async_materialized_view_finish("test_mv3")
+function: wait_async_materialized_view_finish("test_mv4")
+function: wait_async_materialized_view_finish("test_mv5")
+function: wait_async_materialized_view_finish("test_mv6")
+function: wait_async_materialized_view_finish("test_mv7")
+function: wait_async_materialized_view_finish("test_mv8")
+
+select count(1) from test_mv1;
+select count(1) from test_mv2;
+select count(1) from test_mv3;
+select count(1) from test_mv4;
+select count(1) from test_mv5;
+select count(1) from test_mv6;
+select count(1) from test_mv7;
+select count(1) from test_mv8;
+select dt from test_mv1 group by dt order by 1;
+select dt from test_mv2 group by dt order by 1;
+select dt from test_mv3 group by dt order by 1;
+select dt from test_mv4 group by dt order by 1;
+select dt from test_mv5 group by dt order by 1;
+select dt from test_mv6 group by dt order by 1;
+select dt from test_mv7 group by dt order by 1;
+select dt from test_mv8 group by dt order by 1;
+
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop materialized view test_mv3;
+drop materialized view test_mv4;
+drop materialized view test_mv5;
+drop materialized view test_mv6;
+drop materialized view test_mv7;
+drop materialized view test_mv8;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union2
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union2
@@ -1,0 +1,295 @@
+-- name: test_mv_refresh_with_multi_union2
+
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-01"), ("2024-04-02")),
+  PARTITION p7 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2023-01-01"), ("2024-01-01")),
+  PARTITION p2 VALUES [("2024-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p2 VALUES [("2024-04-01"), ("2024-05-01")),
+  PARTITION p3 VALUES [("2024-05-01"), ("2024-06-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-01-01"), ("2024-02-01")),
+  PARTITION p2 VALUES [("2024-02-01"), ("2024-03-01")),
+  PARTITION p3 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p4 VALUES [("2024-04-01"), ("2024-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE (dt) (
+  START ("2024-01-01") END ("2024-05-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14');
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13');
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+	 
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u3
+    union all
+    select dt from u4;
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+     select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt 
+from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt;
+
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('day', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv7`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv8`
+PARTITION BY date_trunc('month', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH ASYNC 
+AS 
+select dt
+from (
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+) t
+group by dt;
+
+function: wait_async_materialized_view_finish("test_mv1")
+function: wait_async_materialized_view_finish("test_mv2")
+function: wait_async_materialized_view_finish("test_mv3")
+function: wait_async_materialized_view_finish("test_mv4")
+function: wait_async_materialized_view_finish("test_mv5")
+function: wait_async_materialized_view_finish("test_mv6")
+function: wait_async_materialized_view_finish("test_mv7")
+function: wait_async_materialized_view_finish("test_mv8")
+
+select count(1) from test_mv1;
+select count(1) from test_mv2;
+select count(1) from test_mv3;
+select count(1) from test_mv4;
+select count(1) from test_mv5;
+select count(1) from test_mv6;
+select count(1) from test_mv7;
+select count(1) from test_mv8;
+select dt from test_mv1 group by dt order by 1;
+select dt from test_mv2 group by dt order by 1;
+select dt from test_mv3 group by dt order by 1;
+select dt from test_mv4 group by dt order by 1;
+select dt from test_mv5 group by dt order by 1;
+select dt from test_mv6 group by dt order by 1;
+select dt from test_mv7 group by dt order by 1;
+select dt from test_mv8 group by dt order by 1;
+
+-- drop materialized view test_mv1;
+-- drop materialized view test_mv2;
+-- drop materialized view test_mv3;
+-- drop materialized view test_mv4;
+-- drop materialized view test_mv5;
+-- drop materialized view test_mv6;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union2
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union2
@@ -261,14 +261,14 @@ from (
 ) t
 group by dt;
 
-function: wait_async_materialized_view_finish("test_mv1")
-function: wait_async_materialized_view_finish("test_mv2")
-function: wait_async_materialized_view_finish("test_mv3")
-function: wait_async_materialized_view_finish("test_mv4")
-function: wait_async_materialized_view_finish("test_mv5")
-function: wait_async_materialized_view_finish("test_mv6")
-function: wait_async_materialized_view_finish("test_mv7")
-function: wait_async_materialized_view_finish("test_mv8")
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+refresh materialized view test_mv7 with sync mode;
+refresh materialized view test_mv8 with sync mode;
 
 select count(1) from test_mv1;
 select count(1) from test_mv2;
@@ -278,6 +278,7 @@ select count(1) from test_mv5;
 select count(1) from test_mv6;
 select count(1) from test_mv7;
 select count(1) from test_mv8;
+
 select dt from test_mv1 group by dt order by 1;
 select dt from test_mv2 group by dt order by 1;
 select dt from test_mv3 group by dt order by 1;
@@ -287,9 +288,11 @@ select dt from test_mv6 group by dt order by 1;
 select dt from test_mv7 group by dt order by 1;
 select dt from test_mv8 group by dt order by 1;
 
--- drop materialized view test_mv1;
--- drop materialized view test_mv2;
--- drop materialized view test_mv3;
--- drop materialized view test_mv4;
--- drop materialized view test_mv5;
--- drop materialized view test_mv6;
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop materialized view test_mv3;
+drop materialized view test_mv4;
+drop materialized view test_mv5;
+drop materialized view test_mv6;
+drop materialized view test_mv7;
+drop materialized view test_mv8;


### PR DESCRIPTION
## Why I'm doing:

SR v3.3 has supported multi ref base tables for the mv, but it will throw `partitions are intersected` if the base table's partitions are not aliagned.
```
CREATE TABLE t1 
(
    k1 date,
    k2 int,
    v1 int
)
PARTITION BY RANGE(k1)
(
    PARTITION p1 values [('2022-02-01'),('2022-02-02')),
    PARTITION p2 values [('2022-02-02'),('2022-02-03')),
    PARTITION p3 values [('2022-02-03'),('2022-02-04')),
    PARTITION p4 values [('2022-02-04'),('2022-02-05'))
)
DISTRIBUTED BY HASH(k2) BUCKETS 3
PROPERTIES('replication_num' = '1');

CREATE TABLE t2 
(
    k1 date,
    k2 int,
    v1 int
)
PARTITION BY RANGE(k1)
(
    PARTITION p2 values [('2022-02-02'),('2022-02-03')),
    PARTITION p4 values [('2022-03-02'),('2022-03-04'))
)
DISTRIBUTED BY HASH(k2) BUCKETS 3
PROPERTIES('replication_num' = '1');

-- partitions are intersected
CREATE MATERIALIZED VIEW mv1 
PARTITION BY date_trunc('day', k1)
DISTRIBUTED BY RANDOM
REFRESH ASYNC
AS 
SELECT * FROM t1
UNION ALL
SELECT * FROM t2;

-- partitions are intersected
CREATE MATERIALIZED VIEW mv1 
PARTITION BY k1
DISTRIBUTED BY RANDOM
REFRESH ASYNC
AS 
SELECT * FROM t1
UNION ALL
SELECT * FROM t2

```
## What I'm doing:
Add `mergeRBTPartitionKeyMap` method to split the intersected partitions:

![image](https://github.com/StarRocks/starrocks/assets/5104975/9f4d8fe0-991f-4648-8f0b-ad1efc82ed56)

codes:
```
    /**
     * Merge all ref base tables' partition range map to avoid intersected partitions.
     * @param basePartitionMap all ref base tables' partition range map
     * @return merged partition range map: <partition name, partition range>
     */
    private static Map<String, Range<PartitionKey>> mergeRBTPartitionKeyMap(
            Expr mvPartitionExpr,
            Map<Table, Map<String, Range<PartitionKey>>> basePartitionMap) {

        if (basePartitionMap.size() == 1) {
            return basePartitionMap.values().iterator().next();
        }
        RangeMap<PartitionKey, String> addRanges = TreeRangeMap.create();
        for (Map<String, Range<PartitionKey>> tRangMap : basePartitionMap.values()) {
            for (Map.Entry<String, Range<PartitionKey>> add : tRangMap.entrySet()) {
                // TODO: we may implement a new `merge` method in `TreeRangeMap` to merge intersected partitions later.
                Map<Range<PartitionKey>, String> intersectedRange =
                        addRanges.subRangeMap(add.getValue()).asMapOfRanges();
                if (intersectedRange.isEmpty()) {
                    addRanges.put(add.getValue(), add.getKey());
                } else {
                    // To be compatible old version, skip to rename partition name if the intersected partition is the same.
                    if (intersectedRange.size() == 1) {
                        Range<PartitionKey> existingRange = intersectedRange.keySet().iterator().next();
                        if (existingRange.equals(add.getValue())) {
                            continue;
                        }
                    }
                    addRanges.merge(add.getValue(), add.getKey(), (o, n) -> {
                        return String.format("%s_%s_%s", INTERSECTED_PARTITION_PREFIX, o, n);
                    });
                }
            }
        }
        Map<String, Range<PartitionKey>> result = Maps.newHashMap();
        for (Map.Entry<Range<PartitionKey>, String> entry : addRanges.asMapOfRanges().entrySet()) {
            if (entry.getValue().startsWith(INTERSECTED_PARTITION_PREFIX)) {
                String mvPartitionName = SyncPartitionUtils.getMVPartitionName(mvPartitionExpr, entry.getKey());
                result.put(mvPartitionName, entry.getKey());
            } else {
                result.put(entry.getValue(), entry.getKey());
            }
        }
        return result;
    }
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
