### PR TITLE
[Enhancement] Support zstd level

### DIFF
--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -372,7 +372,7 @@ ScalarColumnWriter::~ScalarColumnWriter() {
 }
 
 Status ScalarColumnWriter::init() {
-    RETURN_IF_ERROR(get_block_compression_codec(_opts.meta->compression(), &_compress_codec));
+    RETURN_IF_ERROR(get_block_compression_codec(_opts.meta->compression(), &_compress_codec, _opts.meta->compression_level()));
 
     if (!_opts.need_speculate_encoding) {
         auto st = set_encoding(_opts.meta->encoding());

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -372,7 +372,8 @@ ScalarColumnWriter::~ScalarColumnWriter() {
 }
 
 Status ScalarColumnWriter::init() {
-    RETURN_IF_ERROR(get_block_compression_codec(_opts.meta->compression(), &_compress_codec, _opts.meta->compression_level()));
+    RETURN_IF_ERROR(
+            get_block_compression_codec(_opts.meta->compression(), &_compress_codec, _opts.meta->compression_level()));
 
     if (!_opts.need_speculate_encoding) {
         auto st = set_encoding(_opts.meta->encoding());

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -87,6 +87,7 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, co
     // copy the contents of the slice `nullmap` into the slice `encoded values`, but the cost of copying is still not small.
     // Here we set the compression from _tablet_schema which given from CREATE TABLE statement.
     meta->set_compression(_tablet_schema->compression_type());
+    meta->set_compression_level(_tablet_schema->compression_level());
     meta->set_is_nullable(column.is_nullable());
 
     // TODO(mofei) set the format_version from column

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -109,7 +109,7 @@ public:
                const TTabletSchema& tablet_schema, uint32_t next_unique_id, bool enable_persistent_index,
                const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id, const TabletUid& tablet_uid,
                TTabletType::type tabletType, TCompressionType::type compression_type,
-               int32_t primary_index_cache_expire_sec, TStorageType::type storage_type);
+               int32_t primary_index_cache_expire_sec, TStorageType::type storage_type, int compression_level);
 
     virtual ~TabletMeta();
 

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -450,6 +450,7 @@ void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
     _index_map_col_unique_id.clear();
     _cols.clear();
     _compression_type = schema.compression_type();
+    _compression_level = schema.compression_level();
     for (auto& column_pb : schema.column()) {
         TabletColumn column;
         column.init_from_pb(column_pb);
@@ -518,6 +519,7 @@ Status TabletSchema::_build_current_tablet_schema(int64_t schema_id, int32_t ver
     _num_short_key_columns = column_param.short_key_column_count();
     _num_rows_per_row_block = ori_tablet_schema.num_rows_per_row_block();
     _compression_type = ori_tablet_schema.compression_type();
+    _compression_level = ori_tablet_schema.compression_level();
 
     // todo(yixiu): unique_id
     _next_column_unique_id = ori_tablet_schema.next_column_unique_id();
@@ -592,6 +594,7 @@ void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_schema_pb) const {
     }
     tablet_schema_pb->set_next_column_unique_id(_next_column_unique_id);
     tablet_schema_pb->set_compression_type(_compression_type);
+    tablet_schema_pb->set_compression_level(_compression_level);
     tablet_schema_pb->mutable_sort_key_idxes()->Add(_sort_key_idxes.begin(), _sort_key_idxes.end());
     tablet_schema_pb->mutable_sort_key_unique_ids()->Add(_sort_key_uids.begin(), _sort_key_uids.end());
     tablet_schema_pb->set_schema_version(_schema_version);

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -297,6 +297,7 @@ public:
     bool has_bf_fpp() const { return _has_bf_fpp; }
     double bf_fpp() const { return _bf_fpp; }
     CompressionTypePB compression_type() const { return _compression_type; }
+    int compression_level() const { return _compression_level; }
     void append_column(TabletColumn column);
 
     int32_t schema_version() const { return _schema_version; }
@@ -376,6 +377,8 @@ private:
 
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
     CompressionTypePB _compression_type = CompressionTypePB::LZ4_FRAME;
+    // only use for zstd compression type
+    int _compression_level = -1;
 
     std::unordered_map<int32_t, int32_t> _unique_id_to_index;
 

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -727,7 +727,7 @@ public:
     }
 
     static const ZstdBlockCompression* instance(int level) {
-        if (level <= 0 || level >= 22) {
+        if (level <= 0 || level >= 23) {
             return nullptr;
         }
 

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -732,13 +732,12 @@ public:
         }
 
         static ZstdBlockCompression s_instances[22] = {
-            ZstdBlockCompression(1), ZstdBlockCompression(2), ZstdBlockCompression(3), ZstdBlockCompression(4),
-            ZstdBlockCompression(5), ZstdBlockCompression(6), ZstdBlockCompression(7), ZstdBlockCompression(8),
-            ZstdBlockCompression(9), ZstdBlockCompression(10), ZstdBlockCompression(11), ZstdBlockCompression(12),
-            ZstdBlockCompression(13), ZstdBlockCompression(14), ZstdBlockCompression(15), ZstdBlockCompression(16),
-            ZstdBlockCompression(17), ZstdBlockCompression(18), ZstdBlockCompression(19), ZstdBlockCompression(20),
-            ZstdBlockCompression(21), ZstdBlockCompression(22)
-        };
+                ZstdBlockCompression(1), ZstdBlockCompression(2), ZstdBlockCompression(3), ZstdBlockCompression(4),
+                ZstdBlockCompression(5), ZstdBlockCompression(6), ZstdBlockCompression(7), ZstdBlockCompression(8),
+                ZstdBlockCompression(9), ZstdBlockCompression(10), ZstdBlockCompression(11), ZstdBlockCompression(12),
+                ZstdBlockCompression(13), ZstdBlockCompression(14), ZstdBlockCompression(15), ZstdBlockCompression(16),
+                ZstdBlockCompression(17), ZstdBlockCompression(18), ZstdBlockCompression(19), ZstdBlockCompression(20),
+                ZstdBlockCompression(21), ZstdBlockCompression(22)};
         return &s_instances[level - 1];
     }
 

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -727,7 +727,7 @@ public:
     }
 
     static const ZstdBlockCompression* instance(int level) {
-        if (level <= 0 || level >= 23) {
+        if (level < 1 || level > 22) {
             return nullptr;
         }
 

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -732,9 +732,9 @@ public:
         }
 
         static ZstdBlockCompression s_instances[22] = {
-                ZstdBlockCompression(1), ZstdBlockCompression(2), ZstdBlockCompression(3), ZstdBlockCompression(4),
-                ZstdBlockCompression(5), ZstdBlockCompression(6), ZstdBlockCompression(7), ZstdBlockCompression(8),
-                ZstdBlockCompression(9), ZstdBlockCompression(10), ZstdBlockCompression(11), ZstdBlockCompression(12),
+                ZstdBlockCompression(1),  ZstdBlockCompression(2),  ZstdBlockCompression(3),  ZstdBlockCompression(4),
+                ZstdBlockCompression(5),  ZstdBlockCompression(6),  ZstdBlockCompression(7),  ZstdBlockCompression(8),
+                ZstdBlockCompression(9),  ZstdBlockCompression(10), ZstdBlockCompression(11), ZstdBlockCompression(12),
                 ZstdBlockCompression(13), ZstdBlockCompression(14), ZstdBlockCompression(15), ZstdBlockCompression(16),
                 ZstdBlockCompression(17), ZstdBlockCompression(18), ZstdBlockCompression(19), ZstdBlockCompression(20),
                 ZstdBlockCompression(21), ZstdBlockCompression(22)};

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -718,11 +718,28 @@ public:
 
 class ZstdBlockCompression final : public BlockCompressionCodec {
 public:
-    ZstdBlockCompression() : BlockCompressionCodec(CompressionTypePB::ZSTD) {}
+    ZstdBlockCompression() : BlockCompressionCodec(CompressionTypePB::ZSTD), _level(-1) {}
+    ZstdBlockCompression(int level) : BlockCompressionCodec(CompressionTypePB::ZSTD), _level(level) {}
 
     static const ZstdBlockCompression* instance() {
         static ZstdBlockCompression s_instance;
         return &s_instance;
+    }
+
+    static const ZstdBlockCompression* instance(int level) {
+        if (level <= 0 || level >= 22) {
+            return nullptr;
+        }
+
+        static ZstdBlockCompression s_instances[22] = {
+            ZstdBlockCompression(1), ZstdBlockCompression(2), ZstdBlockCompression(3), ZstdBlockCompression(4),
+            ZstdBlockCompression(5), ZstdBlockCompression(6), ZstdBlockCompression(7), ZstdBlockCompression(8),
+            ZstdBlockCompression(9), ZstdBlockCompression(10), ZstdBlockCompression(11), ZstdBlockCompression(12),
+            ZstdBlockCompression(13), ZstdBlockCompression(14), ZstdBlockCompression(15), ZstdBlockCompression(16),
+            ZstdBlockCompression(17), ZstdBlockCompression(18), ZstdBlockCompression(19), ZstdBlockCompression(20),
+            ZstdBlockCompression(21), ZstdBlockCompression(22)
+        };
+        return &s_instances[level - 1];
     }
 
     ~ZstdBlockCompression() override = default;
@@ -753,6 +770,23 @@ private:
         }
         compression::ZSTDCompressionContext* context = ref.value().get();
         ZSTD_CCtx* ctx = context->ctx;
+        size_t ret;
+
+        // Every zstd compression context get from pool will be inited by default
+        // with level = ZSTD_CLEVEL_DEFAULT(3). And the context will be return to the
+        // pool by reseting back to level = ZSTD_CLEVEL_DEFAULT(3).
+        // What we should do here is simply set the level as we wanted.
+        if (_level != -1) {
+            if (_level < 1 || _level > 22) {
+                return Status::InternalError(strings::Substitute("ZSTD with invalid compression level: $0", _level));
+            }
+            ret = ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionLevel, _level);
+            if (ZSTD_isError(ret)) {
+                context->compression_fail = true;
+                return Status::InternalError(
+                        strings::Substitute("ZSTD set level failed: $0", ZSTD_getErrorString(ZSTD_getErrorCode(ret))));
+            }
+        }
 
         [[maybe_unused]] faststring* compression_buffer = nullptr;
         [[maybe_unused]] size_t max_len = 0;
@@ -783,7 +817,6 @@ private:
         out_buf.size = output->size;
         out_buf.pos = 0;
 
-        size_t ret;
         for (auto& input : inputs) {
             ZSTD_inBuffer in_buf;
             in_buf.src = input.data;
@@ -846,6 +879,7 @@ private:
         }
         compression::ZSTDDecompressContext* context = ref.value().get();
         ZSTD_DCtx* ctx = context->ctx;
+        // Decompression context does not depend on level parameter
 
         if (output->data == nullptr) {
             // We may pass a NULL 0-byte output buffer but some zstd versions
@@ -865,6 +899,8 @@ private:
         output->size = ret;
         return Status::OK();
     }
+
+    int _level;
 };
 
 class GzipBlockCompression : public ZlibBlockCompression {
@@ -1075,7 +1111,7 @@ public:
     size_t max_compressed_len(size_t len) const override { return size_t(-1); }
 };
 
-Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec) {
+Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec, int compression_level) {
     switch (type) {
     case CompressionTypePB::NO_COMPRESSION:
         *codec = nullptr;
@@ -1093,7 +1129,11 @@ Status get_block_compression_codec(CompressionTypePB type, const BlockCompressio
         *codec = ZlibBlockCompression::instance();
         break;
     case CompressionTypePB::ZSTD:
-        *codec = ZstdBlockCompression::instance();
+        if (compression_level != -1) {
+            *codec = ZstdBlockCompression::instance(compression_level);
+        } else {
+            *codec = ZstdBlockCompression::instance();
+        }
         break;
     case CompressionTypePB::GZIP:
 #ifdef __x86_64__

--- a/be/src/util/compression/block_compression.h
+++ b/be/src/util/compression/block_compression.h
@@ -106,7 +106,8 @@ protected:
 // data. And client doesn't have to release the codec.
 //
 // Return not OK, if error happens.
-Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec, int compression_level = -1);
+Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec,
+                                   int compression_level = -1);
 
 bool use_compression_pool(CompressionTypePB type);
 

--- a/be/src/util/compression/block_compression.h
+++ b/be/src/util/compression/block_compression.h
@@ -106,7 +106,7 @@ protected:
 // data. And client doesn't have to release the codec.
 //
 // Return not OK, if error happens.
-Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec);
+Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec, int compression_level = -1);
 
 bool use_compression_pool(CompressionTypePB type);
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -388,6 +388,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                                 .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
                                 .setTabletType(TTabletType.TABLET_TYPE_LAKE)
                                 .setCompressionType(table.getCompressionType())
+                                .setCompressionLevel(table.getCompressionLevel())
                                 .setCreateSchemaFile(createSchemaFile)
                                 .setTabletSchema(tabletSchema)
                                 .build();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -327,6 +327,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 .setPrimaryIndexCacheExpireSec(tbl.primaryIndexCacheExpireSec())
                                 .setTabletType(tabletType)
                                 .setCompressionType(tbl.getCompressionType())
+                                .setCompressionLevel(tbl.getCompressionLevel())
                                 .setCreateSchemaFile(true)
                                 .setBaseTabletId(tabletIdMap.get(rollupTabletId))
                                 .setTabletSchema(tabletSchema)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -378,6 +378,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     .setPrimaryIndexCacheExpireSec(tbl.primaryIndexCacheExpireSec())
                                     .setTabletType(tbl.getPartitionInfo().getTabletType(partition.getParentId()))
                                     .setCompressionType(tbl.getCompressionType())
+                                    .setCompressionLevel(tbl.getCompressionLevel())
                                     .setBaseTabletId(baseTabletId)
                                     .setTabletSchema(tabletSchema)
                                     .build();

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -937,6 +937,7 @@ public class RestoreJob extends AbstractJob {
                                 .setPrimaryIndexCacheExpireSec(localTbl.primaryIndexCacheExpireSec())
                                 .setTabletType(localTbl.getPartitionInfo().getTabletType(restorePart.getId()))
                                 .setCompressionType(localTbl.getCompressionType())
+                                .setCompressionLevel(localTbl.getCompressionLevel())
                                 .setInRestoreMode(true)
                                 .setTabletSchema(tabletSchema)
                                 .build();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2612,11 +2612,22 @@ public class OlapTable extends Table {
         tableProperty.buildCompressionType();
     }
 
+    public void setCompressionLevel(int compressionLevel) {
+        tableProperty.setCompressionLevel(compressionLevel);
+    }
+
     public TCompressionType getCompressionType() {
         if (tableProperty == null) {
             return TCompressionType.LZ4_FRAME;
         }
         return tableProperty.getCompressionType();
+    }
+
+    public int getCompressionLevel() {
+        if (tableProperty == null) {
+            return -1;
+        }
+        return tableProperty.getCompressionLevel();   
     }
 
     public void setPartitionLiveNumber(int number) {
@@ -2998,7 +3009,12 @@ public class OlapTable extends Table {
         if (compressionType == TCompressionType.LZ4_FRAME) {
             compressionType = TCompressionType.LZ4;
         }
-        properties.put(PropertyAnalyzer.PROPERTIES_COMPRESSION, compressionType.name());
+        int compressionLevel = getCompressionLevel();
+        String compressionTypeName = compressionType.name();
+        if (compressionLevel != -1) {
+            compressionTypeName = compressionTypeName + "(" + String.valueOf(compressionLevel) + ")";
+        }
+        properties.put(PropertyAnalyzer.PROPERTIES_COMPRESSION, compressionTypeName);
 
         // unique properties
         properties.putAll(getUniqueProperties());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2613,6 +2613,9 @@ public class OlapTable extends Table {
     }
 
     public void setCompressionLevel(int compressionLevel) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
         tableProperty.setCompressionLevel(compressionLevel);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -244,6 +244,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // the default compression type of this table.
     private TCompressionType compressionType = TCompressionType.LZ4_FRAME;
 
+    @SerializedName(value = "compressionLevel")
     // the default compression level of this table, only used for zstd for now.
     private int compressionLevel = -1;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -244,6 +244,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // the default compression type of this table.
     private TCompressionType compressionType = TCompressionType.LZ4_FRAME;
 
+    // the default compression level of this table, only used for zstd for now.
+    private int compressionLevel = -1;
+
     // the default write quorum
     private TWriteQuorumType writeQuorum = TWriteQuorumType.MAJORITY;
 
@@ -609,6 +612,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 return this;
             }
         }
+
         compressionType = TCompressionType.LZ4_FRAME;
         return this;
     }
@@ -753,6 +757,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return replicationNum;
     }
 
+    public void setCompressionLevel(int compressionLevel) {
+        this.compressionLevel = compressionLevel;
+    }
+
     public void setPartitionTTLNumber(int partitionTTLNumber) {
         this.partitionTTLNumber = partitionTTLNumber;
     }
@@ -887,6 +895,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public TCompressionType getCompressionType() {
         return compressionType;
+    }
+
+    public int getCompressionLevel() {
+        return compressionLevel;
     }
 
     public boolean hasDelete() {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -964,6 +964,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     .setPrimaryIndexCacheExpireSec(olapTable.primaryIndexCacheExpireSec())
                     .setTabletType(olapTable.getPartitionInfo().getTabletType(partitionId))
                     .setCompressionType(olapTable.getCompressionType())
+                    .setCompressionLevel(olapTable.getCompressionLevel())
                     .setRecoverySource(RecoverySource.SCHEDULER)
                     .setTabletSchema(tabletSchema)
                     .build();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -776,15 +776,11 @@ public class PropertyAnalyzer {
         Matcher m = r.matcher(noSpacesCompression);
         if (m.matches()) {
             String levelString = m.group(1);
-            try {
-                int number = Integer.parseInt(levelString);
-                if (number >= 1 && number <= 22) {
-                    properties.remove(PROPERTIES_COMPRESSION);
-                    return new Pair<TCompressionType, Integer>(TCompressionType.ZSTD, number);
-                } else {
-                    throw new AnalysisException("Invalid level for zstd compression type");
-                }
-            } catch (NumberFormatException e) {
+            int number = Integer.parseInt(levelString);
+            if (number >= 1 && number <= 22) {
+                properties.remove(PROPERTIES_COMPRESSION);
+                return number;
+            } else {
                 throw new AnalysisException("Invalid level for zstd compression type");
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -767,21 +767,51 @@ public class PropertyAnalyzer {
         return timeout;
     }
 
+    // parse compression level if possible
+    public static int analyzeCompressionLevel(Map<String, String> properties) throws AnalysisException {
+        String compressionName = properties.get(PROPERTIES_COMPRESSION);
+        String noSpacesCompression = compressionName.replace(" ", "");
+        String pattern = "^zstd\\((\\d+)\\)$";
+        Pattern r = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+        Matcher m = r.matcher(noSpacesCompression);
+        if (m.matches()) {
+            String levelString = m.group(1);
+            try {
+                int number = Integer.parseInt(levelString);
+                if (number >= 1 && number <= 22) {
+                    properties.remove(PROPERTIES_COMPRESSION);
+                    return new Pair<TCompressionType, Integer>(TCompressionType.ZSTD, number);
+                } else {
+                    throw new AnalysisException("Invalid level for zstd compression type");
+                }
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid level for zstd compression type");
+            }
+        }
+        return -1;
+    }
+
     // analyzeCompressionType will parse the compression type from properties
-    public static TCompressionType analyzeCompressionType(Map<String, String> properties) throws AnalysisException {
+    public static Pair<TCompressionType, Integer> analyzeCompressionType(
+                                                    Map<String, String> properties) throws AnalysisException {
         TCompressionType compressionType = TCompressionType.LZ4_FRAME;
         if (ConnectContext.get() != null) {
             String defaultCompression = ConnectContext.get().getSessionVariable().getDefaultTableCompression();
             compressionType = CompressionUtils.getCompressTypeByName(defaultCompression);
         }
         if (properties == null || !properties.containsKey(PROPERTIES_COMPRESSION)) {
-            return compressionType;
+            return new Pair<TCompressionType, Integer>(compressionType, -1);
         }
+        int level = analyzeCompressionLevel(properties);
+        if (level != -1) {
+            return new Pair<TCompressionType, Integer>(TCompressionType.ZSTD, level);
+        }
+
         String compressionName = properties.get(PROPERTIES_COMPRESSION);
         properties.remove(PROPERTIES_COMPRESSION);
 
         if (CompressionUtils.getCompressTypeByName(compressionName) != null) {
-            return CompressionUtils.getCompressTypeByName(compressionName);
+            return new Pair<TCompressionType, Integer>(CompressionUtils.getCompressTypeByName(compressionName), -1);
         } else {
             throw new AnalysisException("unknown compression type: " + compressionName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -944,6 +944,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                             .setPrimaryIndexCacheExpireSec(olapTable.primaryIndexCacheExpireSec())
                                             .setTabletType(olapTable.getPartitionInfo().getTabletType(partitionId))
                                             .setCompressionType(olapTable.getCompressionType())
+                                            .setCompressionLevel(olapTable.getCompressionLevel())
                                             .setRecoverySource(RecoverySource.REPORT)
                                             .setTabletSchema(tabletSchema)
                                             .build();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1978,6 +1978,7 @@ public class LocalMetastore implements ConnectorMetadata {
                         .setBinlogConfig(table.getCurBinlogConfig())
                         .setTabletType(tabletType)
                         .setCompressionType(table.getCompressionType())
+                        .setCompressionLevel(table.getCompressionLevel())
                         .setTabletSchema(tabletSchema)
                         .setCreateSchemaFile(createSchemaFile)
                         .build();

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -593,12 +593,16 @@ public class OlapTableFactory implements AbstractTableFactory {
 
             // get compression type
             TCompressionType compressionType = TCompressionType.LZ4_FRAME;
+            Integer compressionLevel = -1;
             try {
-                compressionType = PropertyAnalyzer.analyzeCompressionType(properties);
+                Pair<TCompressionType, Integer> result = PropertyAnalyzer.analyzeCompressionType(properties);
+                compressionType = result.first;
+                compressionLevel = result.second;
             } catch (AnalysisException e) {
                 throw new DdlException(e.getMessage());
             }
             table.setCompressionType(compressionType);
+            table.setCompressionLevel(compressionLevel);
 
             // partition live number
             int partitionLiveNumber;

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -60,6 +60,7 @@ public class CreateReplicaTask extends AgentTask {
 
     private final long version;
     private final TCompressionType compressionType;
+    private final int compressionLevel;
     private final TStorageMedium storageMedium;
     private final boolean enablePersistentIndex;
     private TPersistentIndexType persistentIndexType;
@@ -94,6 +95,7 @@ public class CreateReplicaTask extends AgentTask {
         this.persistentIndexType = builder.getPersistentIndexType();
         this.tabletType = builder.getTabletType();
         this.compressionType = builder.getCompressionType();
+        this.compressionLevel = builder.getCompressionLevel();
         this.tabletSchema = builder.getTabletSchema();
         this.binlogConfig = builder.getBinlogConfig();
         this.createSchemaFile = builder.isCreateSchemaFile();
@@ -169,6 +171,7 @@ public class CreateReplicaTask extends AgentTask {
             createTabletReq.setBase_schema_hash(baseSchemaHash);
         }
         createTabletReq.setCompression_type(compressionType);
+        createTabletReq.setCompression_level(compressionLevel);
         createTabletReq.setTablet_type(tabletType);
         createTabletReq.setCreate_schema_file(createSchemaFile);
         return createTabletReq;
@@ -185,6 +188,7 @@ public class CreateReplicaTask extends AgentTask {
         private long tabletId = INVALID_ID;
         private long version = INVALID_ID;
         private TCompressionType compressionType;
+        private int compressionLevel;
         private TStorageMedium storageMedium;
         private boolean enablePersistentIndex;
         private TPersistentIndexType persistentIndexType;
@@ -272,6 +276,15 @@ public class CreateReplicaTask extends AgentTask {
             this.compressionType = compressionType;
             return this;
         }
+
+        public int getCompressionLevel() {
+            return compressionLevel;
+        }
+
+        public Builder setCompressionLevel(int compressionLevel) {
+            this.compressionLevel = compressionLevel;
+            return this;
+        }        
 
         public TStorageMedium getStorageMedium() {
             return storageMedium;

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -271,21 +271,21 @@ public class PropertyAnalyzerTest {
     @Test
     public void testDefaultTableCompression() throws AnalysisException {
         // No session
-        Assert.assertEquals(TCompressionType.LZ4_FRAME, (PropertyAnalyzer.analyzeCompressionType(ImmutableMap.of())));
+        Assert.assertEquals(TCompressionType.LZ4_FRAME, (PropertyAnalyzer.analyzeCompressionType(ImmutableMap.of()).first));
 
         // Default in the session
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         ctx.setThreadLocalInfo();
-        Assert.assertEquals(TCompressionType.LZ4_FRAME, (PropertyAnalyzer.analyzeCompressionType(ImmutableMap.of())));
+        Assert.assertEquals(TCompressionType.LZ4_FRAME, (PropertyAnalyzer.analyzeCompressionType(ImmutableMap.of()).first));
 
         // Set in the session
         ctx.getSessionVariable().setDefaultTableCompression("zstd");
-        Assert.assertEquals(TCompressionType.ZSTD, (PropertyAnalyzer.analyzeCompressionType(ImmutableMap.of())));
+        Assert.assertEquals(TCompressionType.ZSTD, (PropertyAnalyzer.analyzeCompressionType(ImmutableMap.of()).first));
 
         // Set in the property
         Map<String, String> property = new HashMap<>();
         property.put(PropertyAnalyzer.PROPERTIES_COMPRESSION, "zlib");
-        Assert.assertEquals(TCompressionType.ZLIB, (PropertyAnalyzer.analyzeCompressionType(property)));
+        Assert.assertEquals(TCompressionType.ZLIB, (PropertyAnalyzer.analyzeCompressionType(property).first));
     }
 
     @Test

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -192,6 +192,7 @@ message ColumnMetaPB {
     optional JsonMetaPB json_meta = 32;
     // for json flat column only
     optional bytes name = 33;
+    optional int32 compression_level = 34;
 }
 
 message SegmentFooterPB {

--- a/gensrc/proto/tablet_schema.proto
+++ b/gensrc/proto/tablet_schema.proto
@@ -85,6 +85,7 @@ message TabletSchemaPB {
     optional int32 schema_version = 12;
     repeated uint32 sort_key_unique_ids = 13;
     repeated TabletIndexPB table_indices = 14;
+    optional int32 compression_level = 15 [default=-1];
     optional int64 id = 50;
 }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -120,6 +120,7 @@ struct TCreateTabletReq {
     19: optional i32 primary_index_cache_expire_sec;
     // Whether or not need to create a separate file to hold schema information.
     20: optional bool create_schema_file = true;
+    21: optional i32 compression_level = -1;
 }
 
 struct TDropTabletReq {

--- a/test/sql/test_compression_level/R/test_zstd_level
+++ b/test/sql/test_compression_level/R/test_zstd_level
@@ -1,0 +1,1027 @@
+-- name: test_error_handling
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(0)"
+);
+-- result:
+E: (1064, 'Invalid level for zstd compression type')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(23)"
+);
+-- result:
+E: (1064, 'Invalid level for zstd compression type')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(-1)"
+);
+-- result:
+E: (1064, 'unknown compression type: zstd(-1)')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(dfsdfff)"
+);
+-- result:
+E: (1064, 'unknown compression type: zstd(dfsdfff)')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(2aa0)"
+);
+-- result:
+E: (1064, 'unknown compression type: zstd(2aa0)')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "lz4(3)"
+);
+-- result:
+E: (1064, 'unknown compression type: lz4(3)')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zlib(3)"
+);
+-- result:
+E: (1064, 'unknown compression type: zlib(3)')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "snappy(3)"
+);
+-- result:
+E: (1064, 'unknown compression type: snappy(3)')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(10)(1)"
+);
+-- result:
+E: (1064, 'unknown compression type: zstd(10)(1)')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd((10))"
+);
+-- result:
+E: (1064, 'unknown compression type: zstd((10))')
+-- !result
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(--2)"
+);
+-- result:
+E: (1064, 'unknown compression type: zstd(--2)')
+-- !result
+-- name: test_normal
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd (  1  )"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(1)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd ( 2)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(2)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd( 3 )"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(3)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd (4 )"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(4)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(5)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(5)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(6)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(6)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(7)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(7)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(8)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(8)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(9)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(9)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(10)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(10)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(11)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(11)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(12)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(12)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(13)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(13)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(14)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(14)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(15)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(15)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(16)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(16)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(17)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(17)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(18)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(18)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(19)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(19)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(20)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(20)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(21)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(21)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(22)"
+);
+-- result:
+-- !result
+INSERT INTO test_normal VALUES (1, "ABC");
+-- result:
+-- !result
+SELECT * FROM test_normal;
+-- result:
+1	ABC
+-- !result
+SHOW CREATE TABLE test_normal;
+-- result:
+test_normal	CREATE TABLE `test_normal` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "ZSTD(22)",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE test_normal;
+-- result:
+-- !result
+-- name: test_char_case
+CREATE TABLE `t_char_case` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zStD(3)"
+);
+-- result:
+-- !result
+DROP TABLE t_char_case;
+-- result:
+-- !result
+CREATE TABLE `t_char_case` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "ZSTD(3)"
+);
+-- result:
+-- !result
+DROP TABLE t_char_case;
+-- result:
+-- !result

--- a/test/sql/test_compression_level/T/test_zstd_level
+++ b/test/sql/test_compression_level/T/test_zstd_level
@@ -1,0 +1,515 @@
+-- name: test_error_handling
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(0)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(23)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(-1)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(dfsdfff)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(2aa0)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "lz4(3)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zlib(3)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "snappy(3)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(10)(1)"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd((10))"
+);
+
+CREATE TABLE `t_error_handling` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(--2)"
+);
+
+-- name: test_normal
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd (  1  )"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd ( 2)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd( 3 )"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd (4 )"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(5)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(6)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(7)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(8)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(9)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(10)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(11)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(12)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(13)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(14)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(15)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(16)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(17)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(18)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(19)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(20)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(21)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+CREATE TABLE `test_normal` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zstd(22)"
+);
+
+INSERT INTO test_normal VALUES (1, "ABC");
+SELECT * FROM test_normal;
+SHOW CREATE TABLE test_normal;
+DROP TABLE test_normal;
+
+-- name: test_char_case
+CREATE TABLE `t_char_case` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "zStD(3)"
+);
+DROP TABLE t_char_case;
+
+CREATE TABLE `t_char_case` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` string COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "ZSTD(3)"
+);
+DROP TABLE t_char_case;


### PR DESCRIPTION
In this pr, we introduce configable compression level for ZSTD compression type.
Valid level is 1-22, default level is 3 (which is same as before)

How to use:
CREATE TABLE t ( k BIGINT NOT NULL, v string COMMENT) ENGINE=OLAP 
DUPLICATE KEY(k)
DISTRIBUTED BY HASH(k) BUCKETS 1
PROPERTIES ( \"compression\" = \"zstd(1)\" );

We can define the compression level for zstd using zstd(level) in CREATE TABLE STATEMENT

We load 10000000row from Clickbench dataset, using different level of zstd compression, result as following:
| level | show data |
|----------|----------|
| 1  | 103.477 MB   |
| 3 (defualt)   | 100.557 MB  |
| 5   | 98.896 MB |
| 10   | 96.549 MB   |
| 15   | 95.890 MB   |
| 20   | 91.921 MB  |
| 22   | 91.921 MB   |

Fixes https://github.com/StarRocks/starrocks/issues/46839

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
