### PR TITLE
[Enhancement] add memory usage check for pk table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1333,5 +1333,6 @@ CONF_Strings(python_envs, "");
 CONF_Bool(report_python_worker_error, "true");
 CONF_Bool(python_worker_reuse, "true");
 CONF_Int32(python_worker_expire_time_sec, "300");
+CONF_mBool(enable_pk_strict_memcheck, "true");
 
 } // namespace starrocks::config

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -43,6 +43,10 @@ starrocks::MemTracker* CurrentThread::operator_mem_tracker() {
     return tls_operator_mem_tracker;
 }
 
+starrocks::MemTracker* CurrentThread::singleton_check_mem_tracker() {
+    return tls_singleton_check_mem_tracker;
+}
+
 CurrentThread& CurrentThread::current() {
     return tls_thread_status;
 }

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -298,6 +298,17 @@ public:
 
     bool limit_exceeded_by_ratio(int64_t ratio) const { return _limit >= 0 && (_limit * ratio / 100) < consumption(); }
 
+    bool limit_exceeded_precheck(int64_t consume) const { return _limit >= 0 && _limit < consumption() + consume; }
+
+    bool any_limit_exceeded_precheck(int64_t consume) const {
+        for (auto& _limit_tracker : _limit_trackers) {
+            if (_limit_tracker->limit_exceeded_precheck(consume)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void set_limit(int64_t limit) { _limit = limit; }
 
     int64_t limit() const { return _limit; }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -82,11 +82,13 @@ Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateSt
         _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
                                                -1 /*unused*/, params.tablet_schema);
     }
-    _upserts.resize(_rowset_ptr->num_segments());
-    _base_versions.resize(_rowset_ptr->num_segments());
-    _partial_update_states.resize(_rowset_ptr->num_segments());
-    _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
-    _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
+    TRY_CATCH_BAD_ALLOC({
+        _upserts.resize(_rowset_ptr->num_segments());
+        _base_versions.resize(_rowset_ptr->num_segments());
+        _partial_update_states.resize(_rowset_ptr->num_segments());
+        _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
+        _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
+    });
 
     if (_upserts.size() == 0) {
         // Empty rowset
@@ -192,6 +194,7 @@ void RowsetUpdateState::plan_read_by_rssid(const std::vector<uint64_t>& rowids, 
 }
 
 Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpdateStateParams& params) {
+    CHECK_MEM_LIMIT("RowsetUpdateState::_do_load_upserts");
     vector<uint32_t> pk_columns;
     for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
@@ -205,7 +208,8 @@ Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpda
     }
     RETURN_ERROR_IF_FALSE(_segment_iters.size() == _rowset_ptr->num_segments());
     // only hold pkey, so can use larger chunk size
-    auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
+    ChunkUniquePtr chunk_shared_ptr;
+    TRY_CATCH_BAD_ALLOC(chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096));
     auto chunk = chunk_shared_ptr.get();
 
     auto itr = _segment_iters[segment_id].get();
@@ -220,13 +224,13 @@ Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpda
             } else if (!st.ok()) {
                 return st;
             } else {
-                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get()));
             }
         }
         itr->close();
     }
     dest = std::move(col);
-    dest->raw_data();
+    TRY_CATCH_BAD_ALLOC(dest->raw_data());
     _memory_usage += dest->memory_usage();
 
     return Status::OK();
@@ -254,6 +258,7 @@ static std::vector<ColumnId> get_read_columns_ids(const TxnLogPB_OpWrite& op_wri
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t segment_id,
                                                                         const RowsetUpdateStateParams& params,
                                                                         bool need_lock) {
+    CHECK_MEM_LIMIT("RowsetUpdateState::_prepare_auto_increment_partial_update_states");
     const auto& txn_meta = params.op_write.txn_meta();
 
     uint32_t auto_increment_column_id = 0;
@@ -329,8 +334,8 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t
                                                                    &read_column,
                                                                    &_auto_increment_partial_update_states[segment_id]));
 
-    _auto_increment_partial_update_states[segment_id].write_column->append_selective(*read_column[0], idxes.data(), 0,
-                                                                                     idxes.size());
+    TRY_CATCH_BAD_ALLOC(_auto_increment_partial_update_states[segment_id].write_column->append_selective(
+            *read_column[0], idxes.data(), 0, idxes.size()));
     _memory_usage += _auto_increment_partial_update_states[segment_id].write_column->memory_usage();
     /*
         * Suppose we have auto increment ids for the rows which are not exist in the previous version.
@@ -347,8 +352,9 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t
     _auto_increment_delete_pks[segment_id].reset();
     _auto_increment_delete_pks[segment_id] = _upserts[segment_id]->clone_empty();
     std::vector<uint32_t> delete_idxes;
-    const int64* data =
-            reinterpret_cast<const int64*>(_auto_increment_partial_update_states[segment_id].write_column->raw_data());
+    const int64* data = nullptr;
+    TRY_CATCH_BAD_ALLOC(data = reinterpret_cast<const int64*>(
+                                _auto_increment_partial_update_states[segment_id].write_column->raw_data()));
 
     // just check the rows which are not exist in the previous version
     // because the rows exist in the previous version may contain 0 which are specified by the user
@@ -359,8 +365,8 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t
     }
 
     if (delete_idxes.size() != 0) {
-        _auto_increment_delete_pks[segment_id]->append_selective(*_upserts[segment_id], delete_idxes.data(), 0,
-                                                                 delete_idxes.size());
+        TRY_CATCH_BAD_ALLOC(_auto_increment_delete_pks[segment_id]->append_selective(
+                *_upserts[segment_id], delete_idxes.data(), 0, delete_idxes.size()));
         _memory_usage += _auto_increment_delete_pks[segment_id]->memory_usage();
     }
     return Status::OK();
@@ -368,6 +374,7 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t
 
 Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, const RowsetUpdateStateParams& params,
                                                          bool need_lock) {
+    CHECK_MEM_LIMIT("RowsetUpdateState::_prepare_partial_update_states");
     std::vector<ColumnId> read_column_ids = get_read_columns_ids(params.op_write, params.tablet_schema);
 
     auto read_column_schema = ChunkHelper::convert_schema(params.tablet_schema, read_column_ids);
@@ -396,8 +403,8 @@ Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, co
     RETURN_IF_ERROR(params.tablet->update_mgr()->get_column_values(params, read_column_ids, num_default > 0,
                                                                    rowids_by_rssid, &read_columns));
     for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
-        _partial_update_states[segment_id].write_columns[col_idx]->append_selective(*read_columns[col_idx],
-                                                                                    idxes.data(), 0, idxes.size());
+        TRY_CATCH_BAD_ALLOC(_partial_update_states[segment_id].write_columns[col_idx]->append_selective(
+                *read_columns[col_idx], idxes.data(), 0, idxes.size()));
         _memory_usage += _partial_update_states[segment_id].write_columns[col_idx]->memory_usage();
     }
     TRACE_COUNTER_INCREMENT("partial_upt_total_rows", total_rows);
@@ -421,6 +428,7 @@ StatusOr<bool> RowsetUpdateState::file_exist(const std::string& full_path) {
 Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, const RowsetUpdateStateParams& params,
                                           std::map<int, FileInfo>* replace_segments,
                                           std::vector<std::string>* orphan_files) {
+    CHECK_MEM_LIMIT("RowsetUpdateState::rewrite_segment");
     TRACE_COUNTER_SCOPE_LATENCY_US("rewrite_segment_latency_us");
     const RowsetMetadata& rowset_meta = params.op_write.rowset();
     auto root_path = params.tablet->metadata_root_location();
@@ -510,6 +518,7 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, const RowsetUpdat
 
 Status RowsetUpdateState::_resolve_conflict(uint32_t segment_id, const RowsetUpdateStateParams& params,
                                             int64_t base_version) {
+    CHECK_MEM_LIMIT("RowsetUpdateState::_resolve_conflict");
     // There are two cases that we must resolve conflict here:
     // 1. Current transaction's base version isn't equal latest base version, which means that conflict happens.
     // 2. We use batch publish here. This transaction may conflict with a transaction in the same batch.
@@ -591,7 +600,8 @@ Status RowsetUpdateState::_resolve_conflict_partial_update(const RowsetUpdateSta
         for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
             std::unique_ptr<Column> new_write_column =
                     _partial_update_states[segment_id].write_columns[col_idx]->clone_empty();
-            new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
+            TRY_CATCH_BAD_ALLOC(new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0,
+                                                                   read_idxes.size()));
             RETURN_IF_EXCEPTION(_partial_update_states[segment_id].write_columns[col_idx]->update_rows(
                     *new_write_column, conflict_idxes.data()));
         }
@@ -669,7 +679,8 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const RowsetUpdateSta
 
         std::unique_ptr<Column> new_write_column =
                 _auto_increment_partial_update_states[segment_id].write_column->clone_empty();
-        new_write_column->append_selective(*auto_increment_read_column[0], idxes.data(), 0, idxes.size());
+        TRY_CATCH_BAD_ALLOC(
+                new_write_column->append_selective(*auto_increment_read_column[0], idxes.data(), 0, idxes.size()));
         RETURN_IF_EXCEPTION(_auto_increment_partial_update_states[segment_id].write_column->update_rows(
                 *new_write_column, conflict_idxes.data()));
 
@@ -677,8 +688,9 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const RowsetUpdateSta
         _auto_increment_delete_pks[segment_id].reset();
         _auto_increment_delete_pks[segment_id] = _upserts[segment_id]->clone_empty();
         std::vector<uint32_t> delete_idxes;
-        const int64* data = reinterpret_cast<const int64*>(
-                _auto_increment_partial_update_states[segment_id].write_column->raw_data());
+        const int64* data = nullptr;
+        TRY_CATCH_BAD_ALLOC(data = reinterpret_cast<const int64*>(
+                                    _auto_increment_partial_update_states[segment_id].write_column->raw_data()));
 
         // just check the rows which are not exist in the previous version
         // because the rows exist in the previous version may contain 0 which are specified by the user
@@ -689,8 +701,8 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const RowsetUpdateSta
         }
 
         if (delete_idxes.size() != 0) {
-            _auto_increment_delete_pks[segment_id]->append_selective(*_upserts[segment_id], delete_idxes.data(), 0,
-                                                                     delete_idxes.size());
+            TRY_CATCH_BAD_ALLOC(_auto_increment_delete_pks[segment_id]->append_selective(
+                    *_upserts[segment_id], delete_idxes.data(), 0, delete_idxes.size()));
         }
     }
     return Status::OK();
@@ -709,6 +721,7 @@ void RowsetUpdateState::release_segment(uint32_t segment_id) {
 }
 
 Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStateParams& params) {
+    CHECK_MEM_LIMIT("RowsetUpdateState::load_delete");
     // always one file for now.
     TRACE_COUNTER_SCOPE_LATENCY_US("load_delete_us");
     _deletes.resize(params.op_write.dels_size());

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -92,6 +92,9 @@ public:
     }
 
     Status apply(const TxnLogPB& log) override {
+        SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
+        SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
+                config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
         _max_txn_id = std::max(_max_txn_id, log.txn_id());
         if (log.has_op_write()) {
             RETURN_IF_ERROR(check_and_recover([&]() { return apply_write_log(log.op_write(), log.txn_id()); }));
@@ -114,6 +117,9 @@ public:
     }
 
     Status finish() override {
+        SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
+        SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
+                config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
         // still need prepre primary index even there is an empty compaction
         if (_index_entry == nullptr && _has_empty_compaction) {
             // get lock to avoid gc

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -33,6 +33,7 @@ CompactionState::~CompactionState() {
 
 Status CompactionState::load_segments(Rowset* rowset, UpdateManager* update_manager,
                                       const TabletSchemaCSPtr& tablet_schema, uint32_t segment_id) {
+    CHECK_MEM_LIMIT("CompactionState::load_segments");
     TRACE_COUNTER_SCOPE_LATENCY_US("load_segments_latency_us");
     std::lock_guard<std::mutex> lg(_state_lock);
     if (pk_cols.empty() && rowset->num_segments() > 0) {
@@ -88,13 +89,13 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
             } else if (!st.ok()) {
                 return st;
             } else {
-                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get()));
             }
         }
         itr->close();
     }
     dest = std::move(col);
-    dest->raw_data();
+    TRY_CATCH_BAD_ALLOC(dest->raw_data());
     _memory_usage += dest->memory_usage();
     _update_manager->compaction_state_mem_tracker()->consume(dest->memory_usage());
     return Status::OK();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -918,6 +918,9 @@ void UpdateManager::try_remove_cache(uint32_t tablet_id, int64_t txn_id) {
 }
 
 void UpdateManager::preload_update_state(const TxnLog& txnlog, Tablet* tablet) {
+    SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
+    SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(config::enable_pk_strict_memcheck ? _update_mem_tracker
+                                                                                             : nullptr);
     // use tabletid-txnid as update state cache's key, so it can retry safe.
     auto state_entry = _update_state_cache.get_or_create(cache_key(tablet->id(), txnlog.txn_id()));
     state_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
@@ -970,6 +973,9 @@ void UpdateManager::preload_update_state(const TxnLog& txnlog, Tablet* tablet) {
 
 void UpdateManager::preload_compaction_state(const TxnLog& txnlog, const Tablet& tablet,
                                              const TabletSchemaCSPtr& tablet_schema) {
+    SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
+    SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(config::enable_pk_strict_memcheck ? _update_mem_tracker
+                                                                                             : nullptr);
     // no need to preload if using light compaction publish
     if (StorageEngine::instance()->enable_light_pk_compaction_publish()) {
         return;

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -176,6 +176,8 @@ public:
 
     MemTracker* index_mem_tracker() const { return _index_cache_mem_tracker.get(); }
 
+    MemTracker* mem_tracker() const { return _update_mem_tracker; }
+
     // get or create primary index, and prepare primary index state
     StatusOr<IndexEntry*> prepare_primary_index(const TabletMetadataPtr& metadata, MetaFileBuilder* builder,
                                                 int64_t base_version, int64_t new_version,

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -422,6 +422,35 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     }
 }
 
+TEST_P(LakePrimaryKeyPublishTest, test_publish_with_oom) {
+    auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+    auto txns = std::vector<int64_t>();
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    const int64_t old_limit = _update_mgr->mem_tracker()->limit();
+    _update_mgr->mem_tracker()->set_limit(1);
+    ASSERT_TRUE(_update_mgr->mem_tracker()->any_limit_exceeded_precheck(2));
+    for (int i = 0; i < 3; i++) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // Publish version fail because of oom
+        ASSERT_ERROR(publish_single_version(tablet_id, version + 1, txn_id).status());
+        EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_absent(tablet_id, txn_id));
+    }
+    _update_mgr->mem_tracker()->set_limit(old_limit);
+}
+
 TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
     auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
     auto version = 1;


### PR DESCRIPTION
## Why I'm doing:
In current implementation, we only track pk table memory usage in `update` memory tracker, but we don't do any limit check when publish & apply, so when pk table use too much memory, it can lead to BE crash because of OOM.

## What I'm doing:
To avoid BE crash, I add check limit tracker fo pk table and call `TRY_CATCH_BAD_ALLOC` and `CHECK_MEM_LIMIT` to check limit exceed.
I also add `tls_singleton_check_mem_tracker` because we can't support trace alloc and free object size on different thread (because of statistical errors in object size), so we need to separate memory tracker and limit check tracker.

Use `SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER` to set up a separate check tracker.

Notice: This PR is only about cloud native pk table, and no include `primary index` usage check. we will do these on next PR.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
