### PR TITLE
[BugFix]keep connector/catalog map in consistent as much as possible

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalCatalog.java
@@ -15,15 +15,12 @@
 
 package com.starrocks.catalog;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Map;
 
 public class ExternalCatalog extends Catalog {
 
     public ExternalCatalog(long id, String name, String comment, Map<String, String> config) {
         super(id, name, config, comment);
-        Preconditions.checkNotNull(config.get(CATALOG_TYPE));
     }
 
     // old database uuid format: external_catalog_name.db_name

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
@@ -37,9 +37,9 @@ public class ConnectorMgr {
         CatalogConnector connector = null;
         readLock();
         try {
-            connector = ConnectorFactory.createConnector(context);
             Preconditions.checkState(!connectors.containsKey(catalogName),
                     "Connector of catalog '%s' already exists", catalogName);
+            connector = ConnectorFactory.createConnector(context);
             if (connector == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -116,15 +116,6 @@ public class CatalogMgr {
         writeLock();
         try {
             Preconditions.checkState(!catalogs.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
-            CatalogConnector connector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, properties));
-            if (null == connector) {
-                LOG.error("{} connector [{}] create failed", type, catalogName);
-                throw new DdlException("connector create failed");
-            }
-            long id = isResourceMappingCatalog(catalogName) ?
-                    ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt() :
-                    GlobalStateMgr.getCurrentState().getNextId();
-            Catalog catalog = new ExternalCatalog(id, catalogName, comment, properties);
             String serviceName = properties.get("ranger.plugin.hive.service.name");
             if (serviceName == null || serviceName.isEmpty()) {
                 if (Config.access_control.equals("ranger")) {
@@ -136,6 +127,16 @@ public class CatalogMgr {
                 Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
             }
 
+            // TODO：please keep connector and catalog create together, they need keep in consistent asap.
+            CatalogConnector connector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, properties));
+            if (null == connector) {
+                LOG.error("{} connector [{}] create failed", type, catalogName);
+                throw new DdlException("connector create failed");
+            }
+            long id = isResourceMappingCatalog(catalogName) ?
+                    ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt() :
+                    GlobalStateMgr.getCurrentState().getNextId();
+            Catalog catalog = new ExternalCatalog(id, catalogName, comment, properties);
             catalogs.put(catalogName, catalog);
 
             if (!isResourceMappingCatalog(catalogName)) {
@@ -262,17 +263,6 @@ public class CatalogMgr {
             readUnlock();
         }
 
-        try {
-            CatalogConnector catalogConnector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, config));
-            if (catalogConnector == null) {
-                LOG.error("{} connector [{}] create failed.", type, catalogName);
-                throw new DdlException("connector create failed");
-            }
-        } catch (StarRocksConnectorException e) {
-            LOG.error("connector create failed [{}], reason {}", catalogName, e.getMessage());
-            throw new DdlException(String.format("connector create failed: %s", e.getMessage()));
-        }
-
         Map<String, String> properties = catalog.getConfig();
         String serviceName = properties.get("ranger.plugin.hive.service.name");
         if (serviceName == null || serviceName.isEmpty()) {
@@ -283,6 +273,18 @@ public class CatalogMgr {
             }
         } else {
             Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
+        }
+
+        // TODO：please keep connector and catalog create together, they need keep in consistent asap.
+        try {
+            CatalogConnector catalogConnector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, config));
+            if (catalogConnector == null) {
+                LOG.error("{} connector [{}] create failed.", type, catalogName);
+                throw new DdlException("connector create failed");
+            }
+        } catch (StarRocksConnectorException e) {
+            LOG.error("connector create failed [{}], reason {}", catalogName, e.getMessage());
+            throw new DdlException(String.format("connector create failed: %s", e.getMessage()));
         }
 
         writeLock();

--- a/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
@@ -118,6 +118,12 @@ public class CatalogMgrTest {
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("Missing"));
         }
+
+        config.put("type", "test_unsupported");
+
+        Assert.assertThrows(DdlException.class, () -> {
+            catalogMgr.createCatalog("test_unsupported", "b", "", config);
+        });
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
There are three maps for createcatalog, which are connectors, catalogs, catalogToAccessControl.
when we create a new catalog, we put new items into these three maps one by one, but there may
be some exception, and only one or two successed, when we create the catalog again, we get 
exception that the item has already exist.

## What I'm doing:
keep consistent of connector/catalog asap.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
