### PR TITLE
[BugFix] Fix wrong delimiter in show routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1600,8 +1600,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         if (getFormat().equalsIgnoreCase("json")) {
             jobProperties.put("dataFormat", "json");
         } else {
-            jobProperties.put("columnSeparator", columnSeparator == null ? "\t" : columnSeparator.toString());
-            jobProperties.put("rowDelimiter", rowDelimiter == null ? "\t" : rowDelimiter.toString());
+            jobProperties.put("columnSeparator", columnSeparator == null ? "\t" : columnSeparator.getOriSeparator());
+            jobProperties.put("rowDelimiter", rowDelimiter == null ? "\n" : rowDelimiter.getOriDelimiter());
         }
         jobProperties.put("maxErrorNum", String.valueOf(maxErrorNum));
         jobProperties.put("maxFilterRatio", String.valueOf(maxFilterRatio));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnSeparator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnSeparator.java
@@ -37,6 +37,11 @@ public class ColumnSeparator implements ParseNode {
         this.separator = Delimiter.convertDelimiter(oriSeparator);
     }
 
+    // for show
+    public String getOriSeparator() {
+        return oriSeparator;
+    }
+
     public String getColumnSeparator() {
         return separator;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RowDelimiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RowDelimiter.java
@@ -35,6 +35,11 @@ public class RowDelimiter implements ParseNode {
         this.delimiter = Delimiter.convertDelimiter(oriDelimiter);
     }
 
+    // for show
+    public String getOriDelimiter() {
+        return oriDelimiter;
+    }
+
     public String getRowDelimiter() {
         return delimiter;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnSeparatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnSeparatorTest.java
@@ -47,24 +47,29 @@ public class ColumnSeparatorTest {
         ColumnSeparator separator = new ColumnSeparator("\t");
         Assert.assertEquals("'\t'", separator.toSql());
         Assert.assertEquals("\t", separator.getColumnSeparator());
+        Assert.assertEquals("\t", separator.getOriSeparator());
 
         // \x01
         separator = new ColumnSeparator("\\x01");
         Assert.assertEquals("'\\x01'", separator.toSql());
         Assert.assertEquals("\1", separator.getColumnSeparator());
+        Assert.assertEquals("\\x01", separator.getOriSeparator());
 
         // \x00 \x01
         separator = new ColumnSeparator("\\x0001");
         Assert.assertEquals("'\\x0001'", separator.toSql());
         Assert.assertEquals("\0\1", separator.getColumnSeparator());
+        Assert.assertEquals("\\x0001", separator.getOriSeparator());
 
         separator = new ColumnSeparator("|");
         Assert.assertEquals("'|'", separator.toSql());
         Assert.assertEquals("|", separator.getColumnSeparator());
+        Assert.assertEquals("|", separator.getOriSeparator());
 
         separator = new ColumnSeparator("\\|");
         Assert.assertEquals("'\\|'", separator.toSql());
         Assert.assertEquals("\\|", separator.getColumnSeparator());
+        Assert.assertEquals("\\|", separator.getOriSeparator());
     }
 
     @Test(expected = SemanticException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RowDelimiterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RowDelimiterTest.java
@@ -47,24 +47,29 @@ public class RowDelimiterTest {
         RowDelimiter delimiter = new RowDelimiter("\n");
         Assert.assertEquals("'\n'", delimiter.toSql());
         Assert.assertEquals("\n", delimiter.getRowDelimiter());
+        Assert.assertEquals("\n", delimiter.getOriDelimiter());
 
         // \x01
         delimiter = new RowDelimiter("\\x01");
         Assert.assertEquals("'\\x01'", delimiter.toSql());
         Assert.assertEquals("\1", delimiter.getRowDelimiter());
+        Assert.assertEquals("\\x01", delimiter.getOriDelimiter());
 
         // \x00 \x01
         delimiter = new RowDelimiter("\\x0001");
         Assert.assertEquals("'\\x0001'", delimiter.toSql());
         Assert.assertEquals("\0\1", delimiter.getRowDelimiter());
+        Assert.assertEquals("\\x0001", delimiter.getOriDelimiter());
 
         delimiter = new RowDelimiter("|");
         Assert.assertEquals("'|'", delimiter.toSql());
         Assert.assertEquals("|", delimiter.getRowDelimiter());
+        Assert.assertEquals("|", delimiter.getOriDelimiter());
 
         delimiter = new RowDelimiter("\\|");
         Assert.assertEquals("'\\|'", delimiter.toSql());
         Assert.assertEquals("\\|", delimiter.getRowDelimiter());
+        Assert.assertEquals("\\|", delimiter.getOriDelimiter());
     }
 
     @Test(expected = SemanticException.class)


### PR DESCRIPTION
## Why I'm doing:

```
mysql> show routine load\G                                                                                                                                                                                                                                                                                                                                                  
*************************** 1. row ***************************                                                                                                                                                                                                                            
      DataSourceType: KAFKA
      CurrentTaskNum: 1
       JobProperties: {"columnSeparator":"','", "rowDelimiter":"\t"}
```

## What I'm doing:

```
mysql> show routine load\G                                                                                                                                                                                                                                                                                                                                                  
*************************** 1. row ***************************                                                                                                                                                                                                                           
      DataSourceType: KAFKA
      CurrentTaskNum: 1
       JobProperties: {"columnSeparator":",", "rowDelimiter":"\n"}
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
