### PR TITLE
[BugFix]  Check the BE service exit status code before launching the be process

### DIFF
--- a/docker/dockerfiles/be/be_entrypoint.sh
+++ b/docker/dockerfiles/be/be_entrypoint.sh
@@ -132,7 +132,9 @@ while true; do
       tail -n $nol $STARROCKS_HOME/log/be.out
   fi
 
-  if [[ "$COREDUMP_ENABLED" != "true" ]]; then
+  # If coredump is enabled, only catch SIGABRT (6), SIGSEGV(11) and repeat launching be process,
+  # should still exit for rest error codes.
+  if [[ "$COREDUMP_ENABLED" != "true" || ($ret -ne 134 && $ret -ne 139) ]]; then
     exit $ret
   fi
 


### PR DESCRIPTION
## Why I'm doing:

BE should exit when BE service exits with status 0. This commit fixes this issue by adding a check for the exit status of BE service.

## What I'm doing:

Fixes #46482

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
