### PR TITLE
[Enhancement] Support to recognize skip.header.line.count in hive's textfile

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -19,8 +19,8 @@
 #include "fs/hdfs/fs_hdfs.h"
 #include "io/compressed_input_stream.h"
 #include "io/shared_buffered_input_stream.h"
-#include "util/compression/stream_compression.h"
 #include "util/compression/compression_utils.h"
+#include "util/compression/stream_compression.h"
 
 namespace starrocks {
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -20,6 +20,7 @@
 #include "io/compressed_input_stream.h"
 #include "io/shared_buffered_input_stream.h"
 #include "util/compression/stream_compression.h"
+#include "util/compression/compression_utils.h"
 
 namespace starrocks {
 
@@ -625,6 +626,14 @@ void HdfsScanner::move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* s
     if (split_tasks->size() > 0) {
         _scanner_ctx.estimated_mem_usage_per_split_task = 3 * max_split_size / 2;
     }
+}
+
+CompressionTypePB HdfsScanner::get_compression_type_from_path(const std::string& filename) {
+    ssize_t end = filename.size() - 1;
+    while (end >= 0 && filename[end] != '.' && filename[end] != '/') end--;
+    if (end == -1 || filename[end] == '/') return NO_COMPRESSION;
+    const std::string& ext = filename.substr(end + 1);
+    return CompressionUtils::to_compression_pb(ext);
 }
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -355,6 +355,7 @@ public:
 
 protected:
     Status open_random_access_file();
+    static CompressionTypePB get_compression_type_from_path(const std::string& filename);
 
     void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);
 

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -25,14 +25,6 @@
 
 namespace starrocks {
 
-static CompressionTypePB return_compression_type_from_filename(const std::string& filename) {
-    ssize_t end = filename.size() - 1;
-    while (end >= 0 && filename[end] != '.' && filename[end] != '/') end--;
-    if (end == -1 || filename[end] == '/') return NO_COMPRESSION;
-    const std::string& ext = filename.substr(end + 1);
-    return CompressionUtils::to_compression_pb(ext);
-}
-
 class HdfsScannerCSVReader : public CSVReader {
 public:
     // |file| must outlive HdfsScannerCSVReader
@@ -177,8 +169,17 @@ char* HdfsScannerCSVReader::_find_line_delimiter(starrocks::CSVBuffer& buffer, s
 }
 
 Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
-    TTextFileDesc text_file_desc = _scanner_params.scan_range->text_file_desc;
+    const TTextFileDesc& text_file_desc = _scanner_params.scan_range->text_file_desc;
+    RETURN_IF_ERROR(_setup_delimiter(text_file_desc));
+    RETURN_IF_ERROR(_setup_compression_type(text_file_desc));
 
+    if (text_file_desc.__isset.skip_header_line_count) {
+        _skip_header_line_count = text_file_desc.skip_header_line_count;
+    }
+    return Status::OK();
+}
+
+Status HdfsTextScanner::_setup_delimiter(const TTextFileDesc& text_file_desc) {
     // _field_delimiter and _line_delimiter should use std::string,
     // because the CSVReader is using std::string type as delimiter.
     if (text_file_desc.__isset.field_delim) {
@@ -216,6 +217,7 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
     } else {
         _collection_delimiter = DEFAULT_COLLECTION_DELIM.front();
     }
+
     if (text_file_desc.__isset.mapkey_delim) {
         if (text_file_desc.mapkey_delim.empty()) {
             // Just a piece of defense code
@@ -225,29 +227,48 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
     } else {
         _mapkey_delimiter = DEFAULT_MAPKEY_DELIM.front();
     }
+    return Status::OK();
+}
 
+Status HdfsTextScanner::_setup_compression_type(const TTextFileDesc& text_file_desc) {
     // by default it's unknown compression. we will synthesise informaiton from FE and BE(file extension)
     // parse compression type from FE first.
-    _compression_type = CompressionTypePB::UNKNOWN_COMPRESSION;
+    CompressionTypePB compression_type;
     if (text_file_desc.__isset.compression_type) {
-        _compression_type = CompressionUtils::to_compression_pb(text_file_desc.compression_type);
+        compression_type = CompressionUtils::to_compression_pb(text_file_desc.compression_type);
+    } else {
+        // if FE does not specify compress type, we choose it by looking at filename.
+        compression_type = get_compression_type_from_path(_scanner_params.path);
+    }
+    if (compression_type != UNKNOWN_COMPRESSION) {
+        _compression_type = compression_type;
+    } else {
+        _compression_type = NO_COMPRESSION;
     }
 
+    // If it's compressed file, we only handle scan range whose offset == 0.
+    if (_compression_type != NO_COMPRESSION && _scanner_params.scan_range->offset != 0) {
+        _no_data = true;
+    }
     return Status::OK();
 }
 
 Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
-    const std::string& path = _scanner_params.path;
-    // if FE does not specify compress type, we choose it by looking at filename.
-    if (_compression_type == CompressionTypePB::UNKNOWN_COMPRESSION) {
-        _compression_type = return_compression_type_from_filename(path);
-        if (_compression_type == CompressionTypePB::UNKNOWN_COMPRESSION) {
-            _compression_type = CompressionTypePB::NO_COMPRESSION;
-        }
+    if (_no_data) {
+        return Status::OK();
     }
+
     RETURN_IF_ERROR(open_random_access_file());
-    RETURN_IF_ERROR(_create_or_reinit_reader());
+
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
+    // create csv reader eat lines may throw EOF, we need to handle it
+    Status st = _create_csv_reader();
+    if (st.is_end_of_file()) {
+        _no_data = true;
+        return Status::OK();
+    } else if (!st.ok()) {
+        return st;
+    }
 
     // update materialized columns.
     {
@@ -275,6 +296,9 @@ void HdfsTextScanner::do_update_counter(HdfsScanProfile* profile) {
 }
 
 void HdfsTextScanner::do_close(RuntimeState* runtime_state) noexcept {
+    if (_no_data) {
+        return;
+    }
     _reader.reset();
 }
 
@@ -283,7 +307,7 @@ Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
         return Status::EndOfFile("");
     }
     CHECK(chunk != nullptr);
-    RETURN_IF_ERROR(parse_csv(runtime_state->chunk_size(), chunk));
+    RETURN_IF_ERROR(_parse_csv(runtime_state->chunk_size(), chunk));
 
     ChunkPtr ck = *chunk;
     // do stats before we filter rows which does not match.
@@ -299,7 +323,7 @@ Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
     return Status::OK();
 }
 
-Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
+Status HdfsTextScanner::_parse_csv(int chunk_size, ChunkPtr* chunk) {
     DCHECK_EQ(0, chunk->get()->num_rows());
 
     int num_columns = chunk->get()->num_columns();
@@ -378,51 +402,63 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
     return rows_read > 0 ? Status::OK() : Status::EndOfFile("");
 }
 
-Status HdfsTextScanner::_create_or_reinit_reader() {
+Status HdfsTextScanner::_create_csv_reader() {
     const THdfsScanRange* scan_range = _scanner_ctx.scan_range;
 
     if (_compression_type != NO_COMPRESSION) {
-        // Since we can not parse compressed file in pieces, we only handle scan range whose offset == 0.
-        if (scan_range->offset != 0) {
-            _no_data = true;
-            return Status::OK();
-        }
         // we don't know real stream size in adavance, so we set a very large stream size
         auto file_size = static_cast<size_t>(-1);
-        _reader = std::make_unique<HdfsScannerCSVReader>(_file.get(), _line_delimiter, _need_probe_line_delimiter,
+        _reader = std::make_shared<HdfsScannerCSVReader>(_file.get(), _line_delimiter, _need_probe_line_delimiter,
                                                          _field_delimiter, file_size);
-        return Status::OK();
-    }
-
-    // no compressed file, splittable.
-    {
-        _reader = std::make_unique<HdfsScannerCSVReader>(_file.get(), _line_delimiter, _need_probe_line_delimiter,
+    } else {
+        // no compressed file, splittable.
+        _reader = std::make_shared<HdfsScannerCSVReader>(_file.get(), _line_delimiter, _need_probe_line_delimiter,
                                                          _field_delimiter, scan_range->file_length);
-        auto* reader = down_cast<HdfsScannerCSVReader*>(_reader.get());
+    }
+    auto* reader = down_cast<HdfsScannerCSVReader*>(_reader.get());
 
-        // if reading start of file, skipping UTF-8 BOM
-        bool has_bom = false;
-        if (scan_range->offset == 0) {
-            CSVReader::Record first_line;
-            RETURN_IF_ERROR(reader->next_record(&first_line));
-            if (first_line.size >= 3 && (unsigned char)first_line.data[0] == 0xEF &&
-                (unsigned char)first_line.data[1] == 0xBB && (unsigned char)first_line.data[2] == 0xBF) {
-                has_bom = true;
-            }
-        }
-        if (has_bom) {
+    // (TODO) only support uncompressed file to skip utf-8 bom, because compressed input stream didn't support seek() function
+    if (_compression_type == NO_COMPRESSION) {
+        // if reading start of file, try to skipping UTF-8 BOM
+        ASSIGN_OR_RETURN(const bool has_utf8_bom, _has_uft8_bom());
+        if (has_utf8_bom) {
             RETURN_IF_ERROR(reader->reset(scan_range->offset + 3, scan_range->length - 3));
         } else {
+            // reset offset
             RETURN_IF_ERROR(reader->reset(scan_range->offset, scan_range->length));
         }
-        if (scan_range->offset != 0) {
-            // Always skip first record of scan range with non-zero offset.
-            // Notice that the first record will read by previous scan range.
-            CSVReader::Record dummy;
+    }
+
+    if (scan_range->offset != 0) {
+        // Always skip first record of scan range with non-zero offset.
+        // Notice that the first record will read by previous scan range.
+        CSVReader::Record dummy;
+        RETURN_IF_ERROR(reader->next_record(&dummy));
+    }
+
+    // skip header line count only in offset = 0
+    if (scan_range->offset == 0 && _skip_header_line_count > 0) {
+        CSVReader::Record dummy;
+        for (int32_t i = 0; i < _skip_header_line_count; i++) {
             RETURN_IF_ERROR(reader->next_record(&dummy));
         }
     }
     return Status::OK();
+}
+
+StatusOr<bool> HdfsTextScanner::_has_uft8_bom() const {
+    // if reading start of file, skipping UTF-8 BOM
+    if (_scanner_ctx.scan_range->offset == 0) {
+        auto* reader = down_cast<HdfsScannerCSVReader*>(_reader.get());
+        CSVReader::Record first_line;
+        RETURN_IF_ERROR(reader->next_record(&first_line));
+        if (first_line.size >= 3 && static_cast<unsigned char>(first_line.data[0]) == 0xEF &&
+            static_cast<unsigned char>(first_line.data[1]) == 0xBB &&
+            static_cast<unsigned char>(first_line.data[2]) == 0xBF) {
+            return true;
+        }
+    }
+    return false;
 }
 
 Status HdfsTextScanner::_build_hive_column_name_2_index() {

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -420,7 +420,7 @@ Status HdfsTextScanner::_create_csv_reader() {
     // (TODO) only support uncompressed file to skip utf-8 bom, because compressed input stream didn't support seek() function
     if (_compression_type == NO_COMPRESSION) {
         // if reading start of file, try to skipping UTF-8 BOM
-        ASSIGN_OR_RETURN(const bool has_utf8_bom, _has_uft8_bom());
+        ASSIGN_OR_RETURN(const bool has_utf8_bom, _has_utf8_bom());
         if (has_utf8_bom) {
             RETURN_IF_ERROR(reader->reset(scan_range->offset + 3, scan_range->length - 3));
         } else {
@@ -446,7 +446,7 @@ Status HdfsTextScanner::_create_csv_reader() {
     return Status::OK();
 }
 
-StatusOr<bool> HdfsTextScanner::_has_uft8_bom() const {
+StatusOr<bool> HdfsTextScanner::_has_utf8_bom() const {
     // if reading start of file, skipping UTF-8 BOM
     if (_scanner_ctx.scan_range->offset == 0) {
         auto* reader = down_cast<HdfsScannerCSVReader*>(_reader.get());

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -50,7 +50,7 @@ private:
     Status _create_csv_reader();
     Status _setup_compression_type(const TTextFileDesc& text_file_desc);
     Status _setup_delimiter(const TTextFileDesc& text_file_desc);
-    StatusOr<bool> _has_uft8_bom() const;
+    StatusOr<bool> _has_utf8_bom() const;
     Status _build_hive_column_name_2_index();
     Status _parse_csv(int chunk_size, ChunkPtr* chunk);
 

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -44,19 +44,22 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-    Status parse_csv(int chunk_size, ChunkPtr* chunk);
     int64_t estimated_mem_usage() const override;
 
 private:
-    // create a reader or re init reader
-    Status _create_or_reinit_reader();
+    Status _create_csv_reader();
+    Status _setup_compression_type(const TTextFileDesc& text_file_desc);
+    Status _setup_delimiter(const TTextFileDesc& text_file_desc);
+    StatusOr<bool> _has_uft8_bom() const;
     Status _build_hive_column_name_2_index();
+    Status _parse_csv(int chunk_size, ChunkPtr* chunk);
 
     using ConverterPtr = std::unique_ptr<csv::Converter>;
     std::string _line_delimiter;
     std::string _field_delimiter;
     char _collection_delimiter;
     char _mapkey_delimiter;
+    int32_t _skip_header_line_count = 0;
     bool _need_probe_line_delimiter = false;
     // Always set true in data lake now.
     // TODO(SmithCruise) use a hive catalog property to control this behavior
@@ -67,6 +70,7 @@ private:
     // _materialize_slots_index_2_csv_column_index[0] = 5 means materialize_slots[0]->column index 5 in csv
     // materialize_slots is StarRocks' table definition, column index is the actual position in csv
     std::vector<size_t> _materialize_slots_index_2_csv_column_index;
+    // (TODO) move compressed file don't split logic to FE, _no_data is prone to bugs
     bool _no_data = false;
 };
 } // namespace starrocks

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1735,6 +1735,7 @@ TEST_F(HdfsScannerTest, TestCSVCompressed) {
         scanner->close();
     }
     {
+        // compressed file with offset != 0
         auto* range = _create_scan_range(compressed_file, 1, 0);
         auto* tuple_desc = _create_tuple_desc(csv_descs);
         auto* param = _create_param(compressed_file, range, tuple_desc);
@@ -1747,6 +1748,40 @@ TEST_F(HdfsScannerTest, TestCSVCompressed) {
         status = scanner->open(_runtime_state);
         ASSERT_TRUE(status.ok()) << status.message();
         ASSERT_EQ(0, scanner->estimated_mem_usage());
+        scanner->close();
+    }
+    {
+        // compressed file with skip_header_line_count
+        auto* range = _create_scan_range(compressed_file, 0, 0);
+        range->text_file_desc.__set_skip_header_line_count(50);
+        auto* tuple_desc = _create_tuple_desc(csv_descs);
+        auto* param = _create_param(compressed_file, range, tuple_desc);
+        build_hive_column_names(param, tuple_desc);
+        auto scanner = std::make_shared<HdfsTextScanner>();
+
+        status = scanner->init(_runtime_state, *param);
+        ASSERT_TRUE(status.ok()) << status.message();
+
+        status = scanner->open(_runtime_state);
+        ASSERT_TRUE(status.ok()) << status.message();
+        READ_SCANNER_ROWS(scanner, 50);
+        scanner->close();
+    }
+    {
+        // compressed file with skip_header_line_count > total line count
+        auto* range = _create_scan_range(compressed_file, 0, 0);
+        range->text_file_desc.__set_skip_header_line_count(200);
+        auto* tuple_desc = _create_tuple_desc(csv_descs);
+        auto* param = _create_param(compressed_file, range, tuple_desc);
+        build_hive_column_names(param, tuple_desc);
+        auto scanner = std::make_shared<HdfsTextScanner>();
+
+        status = scanner->init(_runtime_state, *param);
+        ASSERT_TRUE(status.ok()) << status.message();
+
+        status = scanner->open(_runtime_state);
+        ASSERT_TRUE(status.ok()) << status.message();
+        READ_SCANNER_ROWS(scanner, 0);
         scanner->close();
     }
     {
@@ -1999,6 +2034,56 @@ TEST_F(HdfsScannerTest, TestCSVWithUTFBOM) {
 
         EXPECT_EQ("['5c3ffda0d1d7']", chunk->debug_row(0));
         EXPECT_EQ("['62ef51eae5d8']", chunk->debug_row(1));
+        scanner->close();
+    }
+
+    {
+        // bom + skip 2 line
+        auto* range = _create_scan_range(bom_file, 0, 0);
+        range->text_file_desc.__set_skip_header_line_count(2);
+        auto* tuple_desc = _create_tuple_desc(csv_descs);
+        auto* param = _create_param(bom_file, range, tuple_desc);
+        build_hive_column_names(param, tuple_desc);
+        auto scanner = std::make_shared<HdfsTextScanner>();
+
+        status = scanner->init(_runtime_state, *param);
+        ASSERT_TRUE(status.ok()) << status.message();
+
+        status = scanner->open(_runtime_state);
+        ASSERT_TRUE(status.ok()) << status.message();
+
+        ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 4096);
+
+        status = scanner->get_next(_runtime_state, &chunk);
+        EXPECT_TRUE(status.ok());
+        EXPECT_EQ(1, chunk->num_rows());
+
+        EXPECT_EQ("['6358db89e73b']", chunk->debug_row(0));
+        scanner->close();
+    }
+
+    {
+        // offset + bom + skip 1 line, but bom and skip_header_line_count will not take effect because of start offset != 0
+        auto* range = _create_scan_range(bom_file, 20, 0);
+        range->text_file_desc.__set_skip_header_line_count(1);
+        auto* tuple_desc = _create_tuple_desc(csv_descs);
+        auto* param = _create_param(bom_file, range, tuple_desc);
+        build_hive_column_names(param, tuple_desc);
+        auto scanner = std::make_shared<HdfsTextScanner>();
+
+        status = scanner->init(_runtime_state, *param);
+        ASSERT_TRUE(status.ok()) << status.message();
+
+        status = scanner->open(_runtime_state);
+        ASSERT_TRUE(status.ok()) << status.message();
+
+        ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 4096);
+
+        status = scanner->get_next(_runtime_state, &chunk);
+        EXPECT_TRUE(status.ok());
+        EXPECT_EQ(2, chunk->num_rows());
+        EXPECT_EQ("['62ef51eae5d8']", chunk->debug_row(0));
+        EXPECT_EQ("['6358db89e73b']", chunk->debug_row(1));
         scanner->close();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -605,6 +605,9 @@ public class HiveMetastoreApiConverter {
         String lineDelim = parameters.getOrDefault(serdeConstants.LINE_DELIM, "");
         String mapkeyDelim = parameters.getOrDefault(serdeConstants.MAPKEY_DELIM, "");
         int skipHeaderLineCount = Integer.parseInt(parameters.getOrDefault(serdeConstants.HEADER_COUNT, "0"));
+        if (skipHeaderLineCount < 0) {
+            skipHeaderLineCount = 0;
+        }
 
         // check delim is empty, if it's empty, we convert it to null
         fieldDelim = fieldDelim.isEmpty() ? null : fieldDelim;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -59,6 +59,8 @@ import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.OpenCSVSerde;
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -347,11 +349,15 @@ public class HiveMetastoreApiConverter {
 
     public static Partition toPartition(StorageDescriptor sd, Map<String, String> params) {
         requireNonNull(sd, "StorageDescriptor is null");
+        Map<String, String> textFileParameters = Maps.newHashMap();
+        textFileParameters.putAll(sd.getSerdeInfo().getParameters());
+        // "skip.header.line.count" is set in TBLPROPERTIES
+        textFileParameters.putAll(params);
         Partition.Builder partitionBuilder = Partition.builder()
                 .setParams(params)
                 .setFullPath(sd.getLocation())
                 .setInputFormat(toRemoteFileInputFormat(sd.getInputFormat()))
-                .setTextFileFormatDesc(toTextFileFormatDesc(sd.getSerdeInfo().getParameters()))
+                .setTextFileFormatDesc(toTextFileFormatDesc(textFileParameters))
                 .setSplittable(RemoteFileInputFormat.isSplittable(sd.getInputFormat()));
 
         return partitionBuilder.build();
@@ -570,7 +576,7 @@ public class HiveMetastoreApiConverter {
         return RemoteFileInputFormat.fromHdfsInputFormatClass(inputFormat);
     }
 
-    public static TextFileFormatDesc toTextFileFormatDesc(Map<String, String> serdeParams) {
+    public static TextFileFormatDesc toTextFileFormatDesc(Map<String, String> parameters) {
         final String DEFAULT_FIELD_DELIM = "\001";
         final String DEFAULT_COLLECTION_DELIM = "\002";
         final String DEFAULT_MAPKEY_DELIM = "\003";
@@ -584,20 +590,21 @@ public class HiveMetastoreApiConverter {
         // There is a typo in Hive 2.x version, and fixed in Hive 3.x version.
         // https://issues.apache.org/jira/browse/HIVE-16922
         String collectionDelim;
-        if (serdeParams.containsKey("colelction.delim")) {
-            collectionDelim = serdeParams.getOrDefault("colelction.delim", "");
+        if (parameters.containsKey("colelction.delim")) {
+            collectionDelim = parameters.getOrDefault("colelction.delim", "");
         } else {
-            collectionDelim = serdeParams.getOrDefault("collection.delim", "");
+            collectionDelim = parameters.getOrDefault(serdeConstants.COLLECTION_DELIM, "");
         }
 
-        String fieldDelim = serdeParams.getOrDefault("field.delim", "");
+        String fieldDelim = parameters.getOrDefault(serdeConstants.FIELD_DELIM, "");
         if (fieldDelim.isEmpty()) {
             // Support for hive org.apache.hadoop.hive.serde2.OpenCSVSerde
             // https://cwiki.apache.org/confluence/display/hive/csv+serde
-            fieldDelim = serdeParams.getOrDefault("separatorChar", "");
+            fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, "");
         }
-        String lineDelim = serdeParams.getOrDefault("line.delim", "");
-        String mapkeyDelim = serdeParams.getOrDefault("mapkey.delim", "");
+        String lineDelim = parameters.getOrDefault(serdeConstants.LINE_DELIM, "");
+        String mapkeyDelim = parameters.getOrDefault(serdeConstants.MAPKEY_DELIM, "");
+        int skipHeaderLineCount = Integer.parseInt(parameters.getOrDefault(serdeConstants.HEADER_COUNT, "0"));
 
         // check delim is empty, if it's empty, we convert it to null
         fieldDelim = fieldDelim.isEmpty() ? null : fieldDelim;
@@ -605,7 +612,7 @@ public class HiveMetastoreApiConverter {
         collectionDelim = collectionDelim.isEmpty() ? null : collectionDelim;
         mapkeyDelim = mapkeyDelim.isEmpty() ? null : mapkeyDelim;
 
-        return new TextFileFormatDesc(fieldDelim, lineDelim, collectionDelim, mapkeyDelim);
+        return new TextFileFormatDesc(fieldDelim, lineDelim, collectionDelim, mapkeyDelim, skipHeaderLineCount);
     }
 
     public static HiveCommonStats toHiveCommonStats(Map<String, String> params) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/TextFileFormatDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/TextFileFormatDesc.java
@@ -30,11 +30,19 @@ public class TextFileFormatDesc {
     // For example, {"smith": age} mapkey_delimiter is ':'.
     private final String mapkeyDelim;
 
+    private final int skipHeaderLineCount;
+
     public TextFileFormatDesc(String fieldDelim, String lineDelim, String collectionDelim, String mapkeyDelim) {
+        this(fieldDelim, lineDelim, collectionDelim, mapkeyDelim, 0);
+    }
+
+    public TextFileFormatDesc(String fieldDelim, String lineDelim, String collectionDelim, String mapkeyDelim,
+                              int skipHeaderLineCount) {
         this.fieldDelim = fieldDelim;
         this.lineDelim = lineDelim;
         this.collectionDelim = collectionDelim;
         this.mapkeyDelim = mapkeyDelim;
+        this.skipHeaderLineCount = skipHeaderLineCount;
     }
 
     public String getFieldDelim() {
@@ -53,6 +61,10 @@ public class TextFileFormatDesc {
         return mapkeyDelim;
     }
 
+    public int getSkipHeaderLineCount() {
+        return skipHeaderLineCount;
+    }
+
     public TTextFileDesc toThrift() {
         TTextFileDesc desc = new TTextFileDesc();
         if (fieldDelim != null) {
@@ -67,6 +79,7 @@ public class TextFileFormatDesc {
         if (mapkeyDelim != null) {
             desc.setMapkey_delim(mapkeyDelim);
         }
+        desc.setSkip_header_line_count(skipHeaderLineCount);
         return desc;
     }
 
@@ -77,6 +90,7 @@ public class TextFileFormatDesc {
         sb.append(", lineDelim='").append(lineDelim).append('\'');
         sb.append(", collectionDelim='").append(collectionDelim).append('\'');
         sb.append(", mapkeyDelim='").append(mapkeyDelim).append('\'');
+        sb.append(", skipHeaderLineCount='").append(skipHeaderLineCount).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -172,6 +172,7 @@ public class HiveMetaClientTest {
         Assert.assertNull(blankDesc.getLineDelim());
         Assert.assertNull(blankDesc.getCollectionDelim());
         Assert.assertNull(blankDesc.getMapkeyDelim());
+        Assert.assertEquals(0, blankDesc.getSkipHeaderLineCount());
 
         // Check is using OpenCSVSerde
         Map<String, String> openCSVParameters = new HashMap<>();
@@ -188,11 +189,13 @@ public class HiveMetaClientTest {
         parameters.put("line.delim", "\004");
         parameters.put("collection.delim", "\006");
         parameters.put("mapkey.delim", ":");
+        parameters.put("skip.header.line.count", "2");
         TextFileFormatDesc customDesc = HiveMetastoreApiConverter.toTextFileFormatDesc(parameters);
         Assert.assertEquals(",", customDesc.getFieldDelim());
         Assert.assertEquals("\004", customDesc.getLineDelim());
         Assert.assertEquals("\006", customDesc.getCollectionDelim());
         Assert.assertEquals(":", customDesc.getMapkeyDelim());
+        Assert.assertEquals(2, customDesc.getSkipHeaderLineCount());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -196,6 +196,9 @@ public class HiveMetaClientTest {
         Assert.assertEquals("\006", customDesc.getCollectionDelim());
         Assert.assertEquals(":", customDesc.getMapkeyDelim());
         Assert.assertEquals(2, customDesc.getSkipHeaderLineCount());
+        parameters.put("skip.header.line.count", "-10");
+        customDesc = HiveMetastoreApiConverter.toTextFileFormatDesc(parameters);
+        Assert.assertEquals(0, customDesc.getSkipHeaderLineCount());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/TextFileFormatDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/TextFileFormatDescTest.java
@@ -27,8 +27,10 @@ public class TextFileFormatDescTest {
         Assert.assertFalse(tTextFileDesc.isSetLine_delim());
         Assert.assertFalse(tTextFileDesc.isSetCollection_delim());
         Assert.assertFalse(tTextFileDesc.isSetMapkey_delim());
+        Assert.assertTrue(tTextFileDesc.isSetSkip_header_line_count());
+        Assert.assertEquals(0, tTextFileDesc.getSkip_header_line_count());
 
-        desc = new TextFileFormatDesc("a", "b", "c", "d");
+        desc = new TextFileFormatDesc("a", "b", "c", "d", 10);
         tTextFileDesc = desc.toThrift();
         Assert.assertTrue(tTextFileDesc.isSetField_delim());
         Assert.assertTrue(tTextFileDesc.isSetLine_delim());
@@ -38,6 +40,7 @@ public class TextFileFormatDescTest {
         Assert.assertEquals("b", tTextFileDesc.getLine_delim());
         Assert.assertEquals("c", tTextFileDesc.getCollection_delim());
         Assert.assertEquals("d", tTextFileDesc.getMapkey_delim());
+        Assert.assertEquals(10, tTextFileDesc.getSkip_header_line_count());
     }
 
 

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -100,6 +100,8 @@ struct TTextFileDesc {
     
     // escape character
     8: optional i8 escape
+
+    9: optional i32 skip_header_line_count
 }
 
 enum TSchemaTableType {


### PR DESCRIPTION
## Why I'm doing:
Support `skip.header.line.count` tblproperties in hive table.

demo:
```sql
create table csv_big_skip
(c1 string, c2 int) stored as textfile tblproperties("skip.header.line.count"="10");
```

## What I'm doing:

Support it

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
