### PR TITLE
[Enhancement] optimize analyze large partitions table FE oom

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1004,6 +1004,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_CTE_REUSE)
     private boolean cboCteReuse = true;
 
+    // -1 (< 0): disable cte, force inline. 0: force cte; other (> 0): compute by costs * ratio
     @VarAttr(name = CBO_CTE_REUSE_RATE_V2, flag = VariableMgr.INVISIBLE, alias = CBO_CTE_REUSE_RATE,
             show = CBO_CTE_REUSE_RATE)
     private double cboCTERuseRatio = 1.15;
@@ -3141,6 +3142,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return singleNodeExecPlan;
     }
 
+    // -1 (< 0): disable cte, force inline. 0: force cte; other (> 0): compute by costs * ratio
     public double getCboCTERuseRatio() {
         return cboCTERuseRatio;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -14,12 +14,12 @@
 
 package com.starrocks.sql.optimizer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -131,28 +131,22 @@ public class CTEContext {
     }
 
     public boolean needPushPredicate() {
-        for (Map.Entry<Integer, Integer> entry : consumeNums.entrySet()) {
-            int cteId = entry.getKey();
-            int nums = entry.getValue();
-
-            if (consumePredicates.getOrDefault(cteId, Collections.emptyList()).size() >= nums) {
+        for (Integer cteId : consumePredicates.keySet()) {
+            Preconditions.checkState(consumeNums.containsKey(cteId));
+            if (consumePredicates.get(cteId).size() >= consumeNums.get(cteId)) {
                 return true;
             }
         }
-
         return false;
     }
 
     public boolean needPushLimit() {
-        for (Map.Entry<Integer, Integer> entry : consumeNums.entrySet()) {
-            int cteId = entry.getKey();
-            int num = entry.getValue();
-
-            if (consumeLimits.getOrDefault(cteId, Collections.emptyList()).size() >= num) {
+        for (Integer cteId : consumeLimits.keySet()) {
+            Preconditions.checkState(consumeNums.containsKey(cteId));
+            if (consumeLimits.get(cteId).size() >= consumeNums.get(cteId)) {
                 return true;
             }
         }
-
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
@@ -37,10 +37,13 @@ import java.util.stream.Collectors;
 
 public class SampleStatisticsCollectJob extends StatisticsCollectJob {
 
+    private static final String INSERT_SELECT_WITH_TEMPLATE =
+            "WITH base_cte_table as (SELECT $columnNames from `$dbName`.`$tableName` $hints) ";
+
     private static final String INSERT_SELECT_METRIC_SAMPLE_TEMPLATE =
             "SELECT $tableId, '$columnNameStr', $dbId, '$dbNameStr.$tableNameStr', '$dbNameStr', COUNT(1) * $ratio, "
                     + "$dataSize * $ratio, 0, 0, '', '', NOW() "
-                    + "FROM (SELECT $columnName as column_key FROM `$dbName`.`$tableName` $hints ) as t ";
+                    + "FROM (SELECT 1 as column_key FROM `base_cte_table` ) as t ";
 
     private static final String INSERT_SELECT_TYPE_SAMPLE_TEMPLATE =
             "SELECT $tableId, '$columnNameStr', $dbId, '$dbNameStr.$tableNameStr', '$dbNameStr', "
@@ -50,7 +53,7 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
                     + "       $maxFunction, $minFunction, NOW() "
                     + "FROM ( "
                     + "    SELECT t0.`column_key`, COUNT(1) as count "
-                    + "    FROM (SELECT $columnName as column_key FROM `$dbName`.`$tableName` $hints) as t0 "
+                    + "    FROM (SELECT $columnName as column_key FROM `base_cte_table`) as t0 "
                     + "    GROUP BY t0.column_key "
                     + ") as t1 ";
 
@@ -79,9 +82,9 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
                 splitSize = columnNames.size();
             }
         }
-        // Supports a maximum of 256 tasks for a union,
+        // Supports a maximum of 64 tasks for a union,
         // preventing unexpected situations caused by too many tasks being executed at one time
-        return (int) Math.min(256, splitSize);
+        return (int) Math.min(64, splitSize);
     }
 
     @Override
@@ -173,6 +176,27 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
 
         Set<String> lowerDistributeColumns =
                 table.getDistributionColumnNames().stream().map(String::toLowerCase).collect(Collectors.toSet());
+
+        {
+            VelocityContext cteContext = new VelocityContext();
+            cteContext.put("dbName", db.getFullName());
+            cteContext.put("tableName", table.getName());
+            cteContext.put("hints", hintTablets);
+            List<String> collectNames = Lists.newArrayList();
+            for (int i = 0; i < columnNames.size(); i++) {
+                Type columnType = columnTypes.get(i);
+                if (columnType.canStatistic()) {
+                    collectNames.add(StatisticUtils.quoting(columnNames.get(i)));
+                }
+            }
+            if (collectNames.isEmpty()) {
+                collectNames.add(StatisticUtils.quoting(columnNames.get(0)));
+            }
+            cteContext.put("columnNames", String.join(", ", collectNames));
+            StringWriter sw = new StringWriter();
+            DEFAULT_VELOCITY_ENGINE.evaluate(cteContext, sw, "", INSERT_SELECT_WITH_TEMPLATE);
+            builder.append(sw).append(" ");
+        }
 
         for (int i = 0; i < columnNames.size(); i++) {
             VelocityContext context = new VelocityContext();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -103,6 +103,8 @@ public class StatisticUtils {
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setEnablePipelineEngine(true);
+        context.getSessionVariable().setCboCteReuse(true);
+        context.getSessionVariable().setCboCTERuseRatio(0);
         WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         Warehouse warehouse = manager.getBackgroundWarehouse();
         context.getSessionVariable().setWarehouseName(warehouse.getName());


### PR DESCRIPTION
## Why I'm doing:

when we create 35k partitions * 40 buckets table, and execute sample analzye.

we will get a sql like:
```
insert statistics......
select column_1, row_count, min, max from table 
union all
select column_2, row_count, min, max from table 
union all
select column_3, row_count, min, max from table
```

in `PlanFragmentBuilder.visitPhysicalOlapScan`, need compute scanRangeLocations for each table.

it's meanings need copy 35k * 40 * the num of tables tabletInfo...

update sample analyze sql to
```
insert statistics......
with xxx (select * from table)
select column_1, row_count, min, max from xxx 
union all
select column_2, row_count, min, max from xxx 
union all
select column_3, row_count, min, max from xxx
```

and force use cte reuse, let table process only once...

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
