### PR TITLE
[Feature] Support evicting old cache items with a given probability option to avoid frequent cache replacement. (backport #44810)

### DIFF
--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -55,6 +55,11 @@ struct WriteCacheOptions {
     bool allow_zero_copy = false;
     std::function<void(int, const std::string&)> callback = nullptr;
 
+    // The probability to evict other items if the cache space is full, which can help avoid frequent cache replacement
+    // and improve cache hit rate sometimes.
+    // It is expressed as a percentage. If evict_probability is 10, it means the probability to evict other data is 10%.
+    int32_t evict_probability = 100;
+
     struct Stats {
         int64_t write_mem_bytes = 0;
         int64_t write_disk_bytes = 0;

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -59,6 +59,7 @@ Status StarCacheWrapper::write_buffer(const std::string& key, const IOBuffer& bu
     opts.callback = options->callback;
     opts.mode = _enable_tiered_cache ? starcache::WriteOptions::WriteMode::WRITE_BACK
                                      : starcache::WriteOptions::WriteMode::WRITE_THROUGH;
+    opts.evict_probability = options->evict_probability;
     Status st;
     {
         // The memory when writing starcache is no longer recorded to the query memory.
@@ -84,6 +85,7 @@ Status StarCacheWrapper::write_object(const std::string& key, const void* ptr, s
     starcache::WriteOptions opts;
     opts.ttl_seconds = options->ttl_seconds;
     opts.overwrite = options->overwrite;
+    opts.evict_probability = options->evict_probability;
     Status st;
     {
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -74,6 +74,8 @@ inline Status to_status(const butil::Status& st) {
         return Status::IOError(st.error_str());
     case ENOMEM:
         return Status::MemoryLimitExceeded(st.error_str());
+    case ENOSPC:
+        return Status::CapacityLimitExceed(st.error_str());
     case EBUSY:
         return Status::ResourceBusy(st.error_str());
     default:

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -197,6 +197,8 @@ public:
 
     static Status RemoteFileNotFound(const Slice& msg) { return Status(TStatusCode::REMOTE_FILE_NOT_FOUND, msg); }
 
+    static Status CapacityLimitExceed(const Slice& msg) { return Status(TStatusCode::CAPACITY_LIMIT_EXCEED, msg); }
+
     bool ok() const {
         mark_checked();
         return _state == nullptr;
@@ -210,6 +212,11 @@ public:
     bool is_mem_limit_exceeded() const {
         mark_checked();
         return code() == TStatusCode::MEM_LIMIT_EXCEEDED;
+    }
+
+    bool is_capacity_limit_exceeded() const {
+        mark_checked();
+        return code() == TStatusCode::CAPACITY_LIMIT_EXCEED;
     }
 
     bool is_thrift_rpc_error() const {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -103,6 +103,9 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.enable_datacache_io_adaptor) {
         _enable_datacache_io_adaptor = state->query_options().enable_datacache_io_adaptor;
     }
+    if (state->query_options().__isset.datacache_evict_probability) {
+        _datacache_evict_probability = state->query_options().datacache_evict_probability;
+    }
     if (state->query_options().__isset.enable_file_metacache) {
         _use_file_metacache = state->query_options().enable_file_metacache;
     }
@@ -528,6 +531,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.enable_populate_datacache = _enable_populate_datacache;
     scanner_params.enable_datacache_async_populate_mode = _enable_datacache_aync_populate_mode;
     scanner_params.enable_datacache_io_adaptor = _enable_datacache_io_adaptor;
+    scanner_params.datacache_evict_probability = _datacache_evict_probability;
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.can_use_min_max_count_opt = _can_use_min_max_count_opt;
     scanner_params.use_file_metacache = _use_file_metacache;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -108,6 +108,7 @@ private:
     bool _enable_populate_datacache = false;
     bool _enable_datacache_aync_populate_mode = false;
     bool _enable_datacache_io_adaptor = false;
+    int32_t _datacache_evict_probability = 0;
     bool _use_file_metacache = false;
     bool _enable_split_tasks = false;
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -135,6 +135,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.can_use_min_max_count_opt = _scanner_params.can_use_min_max_count_opt;
     ctx.use_file_metacache = _scanner_params.use_file_metacache;
+    ctx.datacache_evict_probability = _scanner_params.datacache_evict_probability;
     ctx.timezone = _runtime_state->timezone();
     ctx.iceberg_schema = _scanner_params.iceberg_schema;
     ctx.stats = &_app_stats;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -65,6 +65,7 @@ struct HdfsScanStats {
     int64_t footer_cache_read_count = 0;
     int64_t footer_cache_write_count = 0;
     int64_t footer_cache_write_bytes = 0;
+    int64_t footer_cache_write_fail_count = 0;
     int64_t column_reader_init_ns = 0;
     // dict filter
     int64_t group_chunk_read_ns = 0;
@@ -209,6 +210,7 @@ struct HdfsScannerParams {
     bool enable_populate_datacache = false;
     bool enable_datacache_async_populate_mode = false;
     bool enable_datacache_io_adaptor = false;
+    int32_t datacache_evict_probability = 0;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool can_use_any_column = false;
@@ -280,6 +282,8 @@ struct HdfsScannerContext {
     bool return_count_column = false;
 
     bool use_file_metacache = false;
+
+    int32_t datacache_evict_probability = 0;
 
     std::string timezone;
 

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -58,6 +58,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* footer_read_timer = nullptr;
     RuntimeProfile::Counter* footer_cache_write_counter = nullptr;
     RuntimeProfile::Counter* footer_cache_write_bytes = nullptr;
+    RuntimeProfile::Counter* footer_cache_write_fail_counter = nullptr;
     RuntimeProfile::Counter* footer_cache_read_counter = nullptr;
     RuntimeProfile::Counter* footer_cache_read_timer = nullptr;
     RuntimeProfile::Counter* column_reader_init_timer = nullptr;
@@ -88,6 +89,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
             ADD_CHILD_COUNTER(root, "FooterCacheWriteCount", TUnit::UNIT, kParquetProfileSectionPrefix);
     footer_cache_write_bytes =
             ADD_CHILD_COUNTER(root, "FooterCacheWriteBytes", TUnit::BYTES, kParquetProfileSectionPrefix);
+    footer_cache_write_fail_counter =
+            ADD_CHILD_COUNTER(root, "FooterCacheWriteFailCount", TUnit::UNIT, kParquetProfileSectionPrefix);
     footer_cache_read_counter =
             ADD_CHILD_COUNTER(root, "FooterCacheReadCount", TUnit::UNIT, kParquetProfileSectionPrefix);
     footer_cache_read_timer = ADD_CHILD_TIMER(root, "FooterCacheReadTimer", kParquetProfileSectionPrefix);
@@ -122,6 +125,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     COUNTER_UPDATE(footer_read_timer, _app_stats.footer_read_ns);
     COUNTER_UPDATE(footer_cache_write_counter, _app_stats.footer_cache_write_count);
     COUNTER_UPDATE(footer_cache_write_bytes, _app_stats.footer_cache_write_bytes);
+    COUNTER_UPDATE(footer_cache_write_fail_counter, _app_stats.footer_cache_write_fail_count);
     COUNTER_UPDATE(footer_cache_read_counter, _app_stats.footer_cache_read_count);
     COUNTER_UPDATE(footer_cache_read_timer, _app_stats.footer_cache_read_ns);
     COUNTER_UPDATE(column_reader_init_timer, _app_stats.column_reader_init_ns);

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -236,6 +236,7 @@ Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t 
         DCHECK(write_offset_cursor % _block_size == 0);
         WriteCacheOptions options{};
         options.async = _enable_async_populate_mode;
+        options.evict_probability = _datacache_evict_probability;
         const int64_t write_size = std::min(_block_size, write_end_offset - write_offset_cursor);
 
         SharedBufferPtr sb = nullptr;
@@ -250,16 +251,15 @@ Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t 
             options.allow_zero_copy = true;
         }
         Status r = _cache->write_buffer(_cache_key, write_offset_cursor, write_size, src_cursor, &options);
-        if (r.ok()) {
+        if (r.ok() || r.is_already_exist()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += write_size;
             _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
             _stats.write_disk_cache_bytes += options.stats.write_disk_bytes;
-        } else if (!r.is_already_exist() && !r.is_resource_busy()) {
+        } else if (!_can_ignore_populate_error(r)) {
             _stats.write_cache_fail_count += 1;
             _stats.write_cache_fail_bytes += write_size;
-            LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
-            // Failed to write cache, but we can keep processing query.
+            LOG(WARNING) << "write block cache failed, errmsg: " << r.message();
         }
         src_cursor += write_size;
         write_offset_cursor += write_size;
@@ -426,10 +426,11 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
     int64_t begin = offset / _block_size * _block_size;
     int64_t end = std::min((offset + count + _block_size - 1) / _block_size * _block_size, _size);
     p -= (offset - begin);
-    auto f = [cache, sb, this](const char* buf, size_t offset, size_t size) {
+    auto f = [cache, sb, this](const char* buf, size_t off, size_t size) {
         SCOPED_RAW_TIMER(&_stats.write_cache_ns);
         WriteCacheOptions options;
         options.async = _enable_async_populate_mode;
+        options.evict_probability = _datacache_evict_probability;
         if (options.async) {
             auto cb = [sb](int code, const std::string& msg) {
                 // We only need to keep the shared buffer pointer
@@ -438,16 +439,13 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
             options.callback = cb;
             options.allow_zero_copy = true;
         }
-        Status r = cache->write_buffer(_cache_key, offset, size, buf, &options);
-        if (r.ok()) {
+        Status r = _cache->write_buffer(_cache_key, off, size, buf, &options);
+        if (r.ok() || r.is_already_exist()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += size;
             _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
             _stats.write_disk_cache_bytes += options.stats.write_disk_bytes;
-        } else if (r.is_cancelled()) {
-            _stats.skip_write_cache_count += 1;
-            _stats.skip_write_cache_bytes += size;
-        } else if (!r.is_already_exist() && !r.is_resource_busy()) {
+        } else if (!_can_ignore_populate_error(r)) {
             _stats.write_cache_fail_count += 1;
             _stats.write_cache_fail_bytes += size;
             LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
@@ -461,6 +459,13 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
         p += size;
     }
     return;
+}
+
+bool CacheInputStream::_can_ignore_populate_error(const Status& status) const {
+    if (status.is_resource_busy() || status.is_mem_limit_exceeded() || status.is_capacity_limit_exceeded()) {
+        return true;
+    }
+    return false;
 }
 
 } // namespace starrocks::io

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -71,6 +71,8 @@ public:
 
     void set_enable_cache_io_adaptor(bool v) { _enable_cache_io_adaptor = v; }
 
+    void set_datacache_evict_probability(int32_t v) { _datacache_evict_probability = v; }
+
     int64_t get_align_size() const;
 
     StatusOr<std::string_view> peek(int64_t count) override;
@@ -94,6 +96,7 @@ private:
     Status _populate_to_cache(const int64_t offset, const int64_t size, char* src);
     void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count, const SharedBufferPtr& sb);
     void _deduplicate_shared_buffer(const SharedBufferPtr& sb);
+    bool _can_ignore_populate_error(const Status& status) const;
 
     std::string _cache_key;
     std::string _filename;
@@ -107,6 +110,7 @@ private:
     bool _enable_async_populate_mode = false;
     bool _enable_block_buffer = false;
     bool _enable_cache_io_adaptor = false;
+    int32_t _datacache_evict_probability = 100;
     BlockCache* _cache = nullptr;
     int64_t _block_size = 0;
     std::unordered_map<int64_t, BlockBuffer> _block_map;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -430,6 +430,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_POPULATE_DATACACHE = "enable_populate_datacache";
     public static final String ENABLE_DATACACHE_ASYNC_POPULATE_MODE = "enable_datacache_async_populate_mode";
     public static final String ENABLE_DATACACHE_IO_ADAPTOR = "enable_datacache_io_adaptor";
+    public static final String DATACACHE_EVICT_PROBABILITY = "datacache_evict_probability";
 
     // The following configurations will be deprecated, and we use the `datacache` suffix instead.
     // But it is temporarily necessary to keep them for a period of time to be compatible with
@@ -1421,6 +1422,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_DATACACHE_IO_ADAPTOR)
     private boolean enableDataCacheIOAdaptor = false;
 
+    @VariableMgr.VarAttr(name = DATACACHE_EVICT_PROBABILITY, flag = VariableMgr.INVISIBLE)
+    private int datacacheEvictProbability = 100;
+
+
     @VariableMgr.VarAttr(name = IO_TASKS_PER_SCAN_OPERATOR)
     private int ioTasksPerScanOperator = 4;
 
@@ -1965,6 +1970,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_STRICT_TYPE, flag = VariableMgr.INVISIBLE)
     private boolean enableStrictType = false;
+
+    public void setDataCacheEvictProbability(int datacacheEvictProbability) {
+        this.datacacheEvictProbability = datacacheEvictProbability;
+    }
 
     public boolean isCboUseDBLock() {
         return cboUseDBLock;
@@ -3546,6 +3555,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_populate_datacache(enablePopulateDataCache);
         tResult.setEnable_datacache_async_populate_mode(enableDataCacheAsyncPopulateMode);
         tResult.setEnable_datacache_io_adaptor(enableDataCacheIOAdaptor);
+        tResult.setDatacache_evict_probability(datacacheEvictProbability);
         tResult.setEnable_file_metacache(enableFileMetaCache);
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -264,6 +264,8 @@ struct TQueryOptions {
 
   132: optional bool enable_datacache_async_populate_mode;
   133: optional bool enable_datacache_io_adaptor;
+
+  141: optional i32 datacache_evict_probability;
 }
 
 

--- a/gensrc/thrift/StatusCode.thrift
+++ b/gensrc/thrift/StatusCode.thrift
@@ -104,6 +104,8 @@ enum TStatusCode {
 
     SR_EAGAIN = 54,
 
-    REMOTE_FILE_NOT_FOUND = 55 // for hive external table
+    REMOTE_FILE_NOT_FOUND = 55, // for hive external table
+
+    CAPACITY_LIMIT_EXCEED = 58
 }
 


### PR DESCRIPTION
## Why I'm doing:
Sometimes when the datacache quota is smaller than the query io bytes, evicting the old cache item and populate a new one may cause too much CPU overhead and a lower cache hit rate.

For example, for a large query that read 500G data, while the cache quota is only 300G. If we always replace the cache data during the query, it may trigger the bad case of LRU policy, which result in a very low cache hit rate.

## What I'm doing:
We support an evict probability option to control the probability to replace the old cache items when the cache space is full.  In some cases, this can help avoid the hit rate problem caused by frequent cache replacement.

Fixes [#46970](https://github.com/StarRocks/starrocks/issues/46970)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

