### PR TITLE
[BugFix] Fix missing setttings for warehouse in MetadataCollectJob and DictionaryMgr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -55,6 +55,7 @@ import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.ast.CreateDictionaryStmt;
 import com.starrocks.sql.ast.QueryStatement;
@@ -67,6 +68,7 @@ import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.warehouse.Warehouse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -541,6 +543,9 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             context.setExecutionId(UUIDUtil.toTUniqueId(context.getQueryId()));
             context.setStartTime();
             context.setThreadLocalInfo();
+            WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            Warehouse warehouse = manager.getBackgroundWarehouse();
+            context.setCurrentWarehouse(warehouse.getName());
             return context;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
@@ -124,6 +124,7 @@ public abstract class MetadataCollectJob {
         context.setQueryId(UUIDUtil.genUUID());
         context.setExecutionId(UUIDUtil.toTUniqueId(context.getQueryId()));
         context.setStartTime();
+        context.setCurrentWarehouse(originSessionVariable.getWarehouseName());
 
         return context;
     }


### PR DESCRIPTION
## Why I'm doing:

```
2024-06-14 15:56:19.477+08:00 ERROR (resource_mapping_inside_catalog_iceberg_iceberg_resource_957aae26_2a23_11ef_b0a4_00163e0e489a-iceberg_ssb_1g_orc_snappy-lineorder-1718351779418-fetch_result|267) [StmtExecutor.e
xecuteStmtWithResultQueue():2512] Failed to execute metadata collection job
com.starrocks.common.ErrorReportException: No alive backend or compute node in warehouse default_warehouse.
        at com.starrocks.common.ErrorReportException.report(ErrorReportException.java:38) ~[starrocks-fe.jar:?]
        at com.starrocks.lake.qe.scheduler.DefaultSharedDataWorkerProvider$Factory.captureAvailableWorkers(DefaultSharedDataWorkerProvider.java:88) ~[starrocks-fe.jar:?]
        at com.starrocks.lake.qe.scheduler.DefaultSharedDataWorkerProvider$Factory.captureAvailableWorkers(DefaultSharedDataWorkerProvider.java:67) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.CoordinatorPreprocessor.<init>(CoordinatorPreprocessor.java:92) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.<init>(DefaultCoordinator.java:275) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator$Factory.createQueryScheduler(DefaultCoordinator.java:165) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator$Factory.createQueryScheduler(DefaultCoordinator.java:157) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.executeStmtWithResultQueue(StmtExecutor.java:2498) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.metadata.MetadataExecutor.asyncExecuteSQL(MetadataExecutor.java:52) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.metadata.MetadataCollectJob.asyncCollectMetadata(MetadataCollectJob.java:68) ~[starrocks-fe.jar:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

## What I'm doing:

Pass the correct warehouse id

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
