### PR TITLE
[BugFix] Fix usage of LOG.warn to ensure stack trace is printed when an error occurs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2031,7 +2031,7 @@ public class SchemaChangeHandler extends AlterHandler {
                             TTabletMetaType.BINLOG_CONFIG);
                 }
             } catch (DdlException e) {
-                LOG.warn(e);
+                LOG.warn("Failed to execute updateBinlogPartitionTabletMeta", e);
                 return isModifiedSuccess;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/binlog/BinlogManager.java
@@ -183,7 +183,7 @@ public class BinlogManager {
                         tableIdToPartitions.remove(table.getId());
                     }
                 } catch (AnalysisException e) {
-                    LOG.warn(e);
+                    LOG.warn("Failed to execute", e);
                 } finally {
                     locker.unLockDatabase(db, LockType.WRITE);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -899,7 +899,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             eraseDatabase(currentTimeMs);
             removeInvalidateReference();
         } catch (InterruptedException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute runAfterCatalogReady", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -334,7 +334,7 @@ public class TabletScheduler extends FrontendDaemon {
                 }
             } while (true);
         } catch (InterruptedException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute blockingAddTabletCtxToScheduler", e);
             locker.lockDatabase(db, LockType.READ);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
@@ -153,7 +153,7 @@ public class TabletSchedulerStat {
                 ((AtomicLong) field.get(lastSnapshot)).set(((AtomicLong) field.get(this)).get());
             }
         } catch (ClassNotFoundException | IllegalArgumentException | IllegalAccessException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute snapshot", e);
             lastSnapshot = null;
         }
     }
@@ -178,7 +178,7 @@ public class TabletSchedulerStat {
                 result.add(info);
             }
         } catch (ClassNotFoundException | IllegalArgumentException | IllegalAccessException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute getBrief", e);
             return Lists.newArrayList();
         }
         return result;
@@ -204,7 +204,7 @@ public class TabletSchedulerStat {
                 sb.append(current).append(" (+").append(current - last).append(")\n");
             }
         } catch (ClassNotFoundException | IllegalArgumentException | IllegalAccessException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute incrementalBrief", e);
             return "";
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
@@ -122,7 +122,7 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient> {
         try {
             pool.invalidateObject(address, object);
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute invalidateObject", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/io/Text.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/io/Text.java
@@ -177,7 +177,7 @@ public class Text implements Writable {
             return -1; // not found
         } catch (CharacterCodingException e) {
             // can't get here
-            LOG.warn(e);
+            LOG.warn("Failed to execute find", e);
             return -1;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -281,7 +281,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         try {
             metastore.addPartitions(dbName, tableName, partitions);
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute metastore.addPartitions", e);
             throw e;
         } finally {
             if (!(metastore instanceof CachingHiveMetastore)) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/HaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/HaAction.java
@@ -147,7 +147,7 @@ public class HaAction extends WebBaseAction {
             buffer.append("<p>last checkpoint time: " + date + "</p>");
             buffer.append("</pre>");
         } catch (IOException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute appendImageInfo", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -81,7 +81,7 @@ public class LoadAction extends RestBaseAction {
             TransactionResult resp = new TransactionResult();
             resp.status = ActionStatus.FAILED;
             resp.msg = e.getClass() + ": " + e.getMessage();
-            LOG.warn(e);
+            LOG.warn("Failed to execute executeWithoutPasswordInternal", e);
 
             sendResult(request, response, resp);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBTool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBTool.java
@@ -80,8 +80,9 @@ public class BDBTool {
         try {
             env = new Environment(new File(metaPath), envConfig);
         } catch (DatabaseException e) {
-            LOG.warn(e);
-            System.err.println("Failed to open BDBJE env: " + metaPath + ". exit");
+            String msg = "Failed to open BDBJE env: " + metaPath + ". exit";
+            LOG.warn(msg, e);
+            System.err.println(msg);
             return false;
         }
         Preconditions.checkNotNull(env);
@@ -148,8 +149,9 @@ public class BDBTool {
                 }
             }
         } catch (Exception e) {
-            LOG.warn(e);
-            System.err.println("Failed to run bdb tools");
+            String msg = "Failed to run bdb tools";
+            LOG.warn(msg, e);
+            System.err.println(msg);
             return false;
         }
         return true;
@@ -170,8 +172,9 @@ public class BDBTool {
             try {
                 entity.readFields(in);
             } catch (Exception e) {
-                LOG.warn(e);
-                System.err.println("Fail to read journal entity for key: " + key + ". reason: " + e.getMessage());
+                String msg = "Fail to read journal entity for key: " + key + ". reason: " + e.getMessage();
+                LOG.warn(msg, e);
+                System.err.println(msg);
                 System.exit(-1);
             }
             System.out.println("key: " + key);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -520,7 +520,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
-                LOG.warn(e);
+                LOG.warn("Failed to execute submitTask", e);
             }
         }
     }
@@ -537,7 +537,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
-                LOG.warn(e);
+                LOG.warn("Failed to execute sleep", e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -802,8 +802,7 @@ public class ConnectContext {
                         break;
                     }
                 } catch (InterruptedException e) {
-                    LOG.warn(e);
-                    LOG.warn("sleep exception, ignore.");
+                    LOG.warn("sleep exception, ignore.", e);
                     break;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1088,7 +1088,7 @@ public class DDLStmtExecutor {
             try {
                 metrics = DataCacheSelectExecutor.cacheSelect(statement, context);
             } catch (Exception e) {
-                LOG.warn(e);
+                LOG.warn("Failed to execute cacheSelect", e);
                 throw new RuntimeException(e.getMessage());
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2382,7 +2382,7 @@ public class StmtExecutor {
                 }
             } while (!batch.isEos());
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute executeStmtWithExecPlan", e);
             coord.getExecStatus().setInternalErrorStatus(e.getMessage());
         } finally {
             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MaterializedViewMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MaterializedViewMgr.java
@@ -111,7 +111,7 @@ public class MaterializedViewMgr {
             LOG.info("Replay MV maintenance jobs: {}", job);
         } catch (Exception e) {
             LOG.warn("Replay MV maintenance job failed: {}", job);
-            LOG.warn(e);
+            LOG.warn("Failed to replay MV maintenance job", e);
         }
     }
 
@@ -128,7 +128,7 @@ public class MaterializedViewMgr {
             LOG.info("Replay MV epoch: {}", job);
         } catch (Exception e) {
             LOG.warn("Replay MV epoch failed: {}", epoch);
-            LOG.warn(e);
+            LOG.warn("Failed to replay MV epoch", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2079,7 +2079,7 @@ public class LocalMetastore implements ConnectorMetadata {
                     table.getName(), System.currentTimeMillis() - start);
 
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute buildPartitionsConcurrently", e);
             countDownLatch.countDownToZero(new Status(TStatusCode.UNKNOWN, e.getMessage()));
             throw new DdlException(e.getMessage());
         } finally {
@@ -2245,7 +2245,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 throw new DdlException(userErrorMsg);
             }
         } catch (InterruptedException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute waitForFinished", e);
             countDownLatch.countDownToZero(new Status(TStatusCode.CANCELLED, "cancelled"));
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -338,7 +338,7 @@ public class NodeMgr {
                         Thread.sleep(5000);
                         continue;
                     } catch (InterruptedException e) {
-                        LOG.warn(e);
+                        LOG.warn("Failed to execute sleep", e);
                         System.exit(-1);
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -239,7 +239,7 @@ public class ListPartitionPruner implements PartitionPruner {
         try {
             result = LiteralExpr.create(value, type);
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute LiteralExpr.create", e);
             throw new StarRocksConnectorException("can not cast literal value " + literalExpr.getStringValue() +
                     " to target type " + type.prettyPrint());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -106,10 +106,10 @@ public class CachedStatisticStorage implements StatisticStorage {
                         k -> data.getOrDefault(k, Optional.empty()).orElse(TableStatistic.unknown())));
             }
         } catch (InterruptedException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute tableStatsCache.getAll", e);
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Faied to execute tableStatsCache.getAll", e);
         }
         return partitions.stream().collect(Collectors.toMap(Partition::getId, p -> TableStatistic.unknown()));
     }
@@ -128,10 +128,10 @@ public class CachedStatisticStorage implements StatisticStorage {
                 completableFuture.get();
             }
         } catch (InterruptedException e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute refreshTableStatistic", e);
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute refreshTableStatistic", e);
         }
     }
 
@@ -184,7 +184,7 @@ public class CachedStatisticStorage implements StatisticStorage {
                 return getDefaultConnectorTableStatistics(columns);
             }
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute connectorTableCachedStatistics.getAll", e);
             return getDefaultConnectorTableStatistics(columns);
         }
     }
@@ -218,7 +218,7 @@ public class CachedStatisticStorage implements StatisticStorage {
             }
             return columnStatistics;
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute getConnectorTableStatisticsSync", e);
             return getDefaultConnectorTableStatistics(columns);
         }
     }
@@ -259,7 +259,7 @@ public class CachedStatisticStorage implements StatisticStorage {
                 return ColumnStatistic.unknown();
             }
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute getColumnStatistic", e);
             return ColumnStatistic.unknown();
         }
     }
@@ -304,7 +304,7 @@ public class CachedStatisticStorage implements StatisticStorage {
                 return getDefaultColumnStatisticList(columns);
             }
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute getColumnStatistics", e);
             return getDefaultColumnStatisticList(columns);
         }
     }
@@ -407,7 +407,7 @@ public class CachedStatisticStorage implements StatisticStorage {
                 return Maps.newHashMap();
             }
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute getHistogramStatistics", e);
             return Maps.newHashMap();
         }
     }
@@ -438,7 +438,7 @@ public class CachedStatisticStorage implements StatisticStorage {
                 return Maps.newHashMap();
             }
         } catch (Exception e) {
-            LOG.warn(e);
+            LOG.warn("Failed to execute getConnectorHistogramStatistics", e);
             return Maps.newHashMap();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1088,8 +1088,7 @@ public class PlanFragmentBuilder {
                 prepareMinMaxExpr(scanNodePredicates, predicates, context);
 
             } catch (Exception e) {
-                LOG.warn("Hudi scan node get scan range locations failed : " + e);
-                LOG.warn(e);
+                LOG.warn("Hudi scan node get scan range locations failed : ", e);
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -178,7 +178,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
-                LOG.warn(e);
+                LOG.warn("Failed to execute submitSubTask", e);
             }
         }
         return true;

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/SparkEtlJob.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/SparkEtlJob.java
@@ -254,8 +254,9 @@ public class SparkEtlJob {
         try {
             new SparkEtlJob(args[0]).run();
         } catch (Exception e) {
-            System.err.println("spark etl job run failed");
-            LOG.warn(e);
+            String msg = "spark etl job run failed";
+            System.err.println(msg);
+            LOG.warn(msg, e);
             System.exit(-1);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

Fix usage of LOG.warn to ensure stack trace is printed when an error occurs

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
