### PR TITLE
[Enhancement] Reduce the memory usage during data ingestion

### DIFF
--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -131,6 +131,8 @@ void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest
         }
     }
     channel->open(cntl, request, response, done_guard.release());
+    LOG(INFO) << "local channels open, sleep 3600s";
+    sleep(3600);
 }
 
 void LoadChannelMgr::add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -131,8 +131,6 @@ void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest
         }
     }
     channel->open(cntl, request, response, done_guard.release());
-    LOG(INFO) << "local channels open, sleep 3600s";
-    sleep(3600);
 }
 
 void LoadChannelMgr::add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response) {

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -655,7 +655,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         options.timeout_ms = params.timeout_ms();
         options.write_quorum = params.write_quorum();
         options.miss_auto_increment_column = params.miss_auto_increment_column();
-        options.ptable_schema_param = params.schema();
+        options.ptable_schema_param = &(params.schema());
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);
@@ -854,6 +854,7 @@ Status LocalTabletsChannel::incremental_open(const PTabletWriterOpenRequest& par
         options.timeout_ms = params.timeout_ms();
         options.write_quorum = params.write_quorum();
         options.miss_auto_increment_column = params.miss_auto_increment_column();
+        options.ptable_schema_param = &(params.schema());
         options.immutable_tablet_size = params.immutable_tablet_size();
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -632,7 +632,7 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
                 ASSIGN_OR_RETURN(_tablet_schema,
                                  TabletSchema::create(*ori_tablet_schema, ptable_schema_param->indexes(i).schema_id(),
                                                       ptable_schema_param->version(),
-                                                      ptable_schema_param->indexpes(i).column_param()));
+                                                      ptable_schema_param->indexes(i).column_param()));
                 if (_tablet_schema->schema_version() > ori_tablet_schema->schema_version()) {
                     _tablet->update_max_version_schema(_tablet_schema);
                 }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -365,6 +365,8 @@ Status DeltaWriter::_init() {
     VLOG(2) << "DeltaWriter [tablet_id=" << _opt.tablet_id << ", load_id=" << print_id(_opt.load_id)
             << ", replica_state=" << _replica_state_name(_replica_state) << "] open success.";
 
+    // no need after initialization.
+    _opt.ptable_schema_param = nullptr;
     return Status::OK();
 }
 
@@ -630,7 +632,7 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
                 ASSIGN_OR_RETURN(_tablet_schema,
                                  TabletSchema::create(*ori_tablet_schema, ptable_schema_param->indexes(i).schema_id(),
                                                       ptable_schema_param->version(),
-                                                      ptable_schema_param->indexes(i).column_param()));
+                                                      ptable_schema_param->indexpes(i).column_param()));
                 if (_tablet_schema->schema_version() > ori_tablet_schema->schema_version()) {
                     _tablet->update_max_version_schema(_tablet_schema);
                 }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -613,27 +613,29 @@ Status DeltaWriter::_flush_memtable() {
     return st;
 }
 
-Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTableSchemaParam& ptable_schema_param,
+Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTableSchemaParam* ptable_schema_param,
                                                  const TabletSchemaCSPtr& ori_tablet_schema) {
     // new tablet schema if new table
     // find the right index id
     int i = 0;
-    for (; i < ptable_schema_param.indexes_size(); i++) {
-        if (ptable_schema_param.indexes(i).id() == index_id) break;
-    }
-    if (i < ptable_schema_param.indexes_size()) {
-        if (ptable_schema_param.indexes_size() > 0 && ptable_schema_param.indexes(i).has_column_param() &&
-            ptable_schema_param.indexes(i).column_param().columns_desc_size() != 0 &&
-            ptable_schema_param.indexes(i).column_param().columns_desc(0).unique_id() >= 0 &&
-            ptable_schema_param.version() != ori_tablet_schema->schema_version()) {
-            ASSIGN_OR_RETURN(
-                    _tablet_schema,
-                    TabletSchema::create(*ori_tablet_schema, ptable_schema_param.indexes(i).schema_id(),
-                                         ptable_schema_param.version(), ptable_schema_param.indexes(i).column_param()));
-            if (_tablet_schema->schema_version() > ori_tablet_schema->schema_version()) {
-                _tablet->update_max_version_schema(_tablet_schema);
+    if (ptable_schema_param != nullptr) {
+        for (; i < ptable_schema_param->indexes_size(); i++) {
+            if (ptable_schema_param->indexes(i).id() == index_id) break;
+        }
+        if (i < ptable_schema_param->indexes_size()) {
+            if (ptable_schema_param->indexes_size() > 0 && ptable_schema_param->indexes(i).has_column_param() &&
+                ptable_schema_param->indexes(i).column_param().columns_desc_size() != 0 &&
+                ptable_schema_param->indexes(i).column_param().columns_desc(0).unique_id() >= 0 &&
+                ptable_schema_param->version() != ori_tablet_schema->schema_version()) {
+                ASSIGN_OR_RETURN(_tablet_schema,
+                                 TabletSchema::create(*ori_tablet_schema, ptable_schema_param->indexes(i).schema_id(),
+                                                      ptable_schema_param->version(),
+                                                      ptable_schema_param->indexes(i).column_param()));
+                if (_tablet_schema->schema_version() > ori_tablet_schema->schema_version()) {
+                    _tablet->update_max_version_schema(_tablet_schema);
+                }
+                return Status::OK();
             }
-            return Status::OK();
         }
     }
     _tablet_schema = ori_tablet_schema;

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -65,7 +65,9 @@ struct DeltaWriterOptions {
     ReplicaState replica_state;
     bool miss_auto_increment_column = false;
     PartialUpdateMode partial_update_mode = PartialUpdateMode::UNKNOWN_MODE;
-    POlapTableSchemaParam ptable_schema_param;
+    // `ptable_schema_param` is valid during initialization.
+    // And it may become invalid after initialization, so please do not access it afterward.
+    const POlapTableSchemaParam* ptable_schema_param = nullptr;
     int64_t immutable_tablet_size = 0;
 };
 
@@ -172,7 +174,7 @@ private:
 
     Status _init();
     Status _flush_memtable();
-    Status _build_current_tablet_schema(int64_t index_id, const POlapTableSchemaParam& table_schema_param,
+    Status _build_current_tablet_schema(int64_t index_id, const POlapTableSchemaParam* table_schema_param,
                                         const TabletSchemaCSPtr& ori_tablet_schema);
 
     const char* _state_name(State state) const;

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -67,7 +67,7 @@ struct DeltaWriterOptions {
     PartialUpdateMode partial_update_mode = PartialUpdateMode::UNKNOWN_MODE;
     // `ptable_schema_param` is valid during initialization.
     // And it will be set to nullptr because we only need to access it during intialization.
-    // If you need to access it after intialization, please make sure the point is valid.
+    // If you need to access it after intialization, please make sure the pointer is valid.
     const POlapTableSchemaParam* ptable_schema_param = nullptr;
     int64_t immutable_tablet_size = 0;
 };

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -66,7 +66,8 @@ struct DeltaWriterOptions {
     bool miss_auto_increment_column = false;
     PartialUpdateMode partial_update_mode = PartialUpdateMode::UNKNOWN_MODE;
     // `ptable_schema_param` is valid during initialization.
-    // And it may become invalid after initialization, so please do not access it afterward.
+    // And it will be set to nullptr because we only need to access it during intialization.
+    // If you need to access it after intialization, please make sure the point is valid.
     const POlapTableSchemaParam* ptable_schema_param = nullptr;
     int64_t immutable_tablet_size = 0;
 };


### PR DESCRIPTION
## Why I'm doing:
FE will send full schema to BE during data ingestion and each tablet may generate the new tablet schema according to the schema from FE and each `delta_writer` will keep a full schema until ingestion finished. If there are a lot of ingestion task and tablets, it maybe use a lot of memory.

## What I'm doing:
The full schema for each `delta_writer` is no need to hold during the whole ingestion. We only need it during initialization, so we can release memory in advance. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
