### PR TITLE
[Enhancement] optimize lookup for dictionary

### DIFF
--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -277,9 +277,7 @@ public:
 
 private:
     // Avoid creating Datum
-    inline void _append_value(Column* dest, const ValueCppType& v) {
-        down_cast<ValueColumnType*>(dest)->append(v);
-    }
+    inline void _append_value(Column* dest, const ValueCppType& v) { down_cast<ValueColumnType*>(dest)->append(v); }
 
     template <class KeyCppType, class ValueCppType>
     inline size_t _get_element_memory_usage(const KeyCppType& k, const ValueCppType& v) {

--- a/test/sql/test_dictionary/R/test_dictionary
+++ b/test/sql/test_dictionary/R/test_dictionary
@@ -1168,3 +1168,79 @@ DROP DICTIONARY test_dictionary_common_expression;
 DROP TABLE t_dictionary_common_expression;
 -- result:
 -- !result
+-- name: test_dictionary_multiple_row
+CREATE TABLE `t_dictionary_multiple_row` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT "",
+  `id4` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t_dictionary_multiple_row_fact` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT "",
+  `id4` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t_dictionary_multiple_row select generate_series, generate_series, generate_series, generate_series from Table(generate_series(1, 20000));
+-- result:
+-- !result
+[UC]DROP DICTIONARY test_dictionary_multiple_row_multi_value;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: dictionary: test_dictionary_multiple_row_multi_value does not exist.')
+-- !result
+CREATE DICTIONARY test_dictionary_multiple_row_multi_value USING t_dictionary_multiple_row (id1 KEY, id2 VALUE, id3 VALUE, id4 VALUE);
+-- result:
+-- !result
+function: wait_refresh_dictionary_finish("test_dictionary_multiple_row_multi_value", "FINISHED")
+-- result:
+None
+-- !result
+[UC]DROP DICTIONARY test_dictionary_multiple_row_single_value;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: dictionary: test_dictionary_multiple_row_single_value does not exist.')
+-- !result
+CREATE DICTIONARY test_dictionary_multiple_row_single_value USING t_dictionary_multiple_row (id1 KEY, id2 VALUE);
+-- result:
+-- !result
+function: wait_refresh_dictionary_finish("test_dictionary_multiple_row_single_value", "FINISHED")
+-- result:
+None
+-- !result
+insert into t_dictionary_multiple_row_fact SELECT id1, dictionary_get("test_dictionary_multiple_row_multi_value", id1)[1], dictionary_get("test_dictionary_multiple_row_multi_value", id1)[2], dictionary_get("test_dictionary_multiple_row_multi_value", id1)[3] FROM t_dictionary_multiple_row;
+-- result:
+-- !result
+insert into t_dictionary_multiple_row_fact SELECT id1, dictionary_get("test_dictionary_multiple_row_single_value", id1)[1], 1, 1 FROM t_dictionary_multiple_row;
+-- result:
+-- !result
+DROP TABLE t_dictionary_multiple_row;
+-- result:
+-- !result
+DROP TABLE t_dictionary_multiple_row_fact;
+-- result:
+-- !result
+DROP DICTIONARY test_dictionary_multiple_row_multi_value;
+-- result:
+-- !result
+DROP DICTIONARY test_dictionary_multiple_row_single_value;
+-- result:
+-- !result

--- a/test/sql/test_dictionary/R/test_dictionary
+++ b/test/sql/test_dictionary/R/test_dictionary
@@ -1201,7 +1201,7 @@ PROPERTIES (
 );
 -- result:
 -- !result
-insert into t_dictionary_multiple_row select generate_series, generate_series, generate_series, generate_series from Table(generate_series(1, 20000));
+insert into t_dictionary_multiple_row select generate_series, generate_series, generate_series, generate_series from Table(generate_series(1, 20001));
 -- result:
 -- !result
 [UC]DROP DICTIONARY test_dictionary_multiple_row_multi_value;

--- a/test/sql/test_dictionary/T/test_dictionary
+++ b/test/sql/test_dictionary/T/test_dictionary
@@ -539,3 +539,52 @@ SELECT dictionary_get("test_dictionary_common_expression", id1)[1],dictionary_ge
 
 DROP DICTIONARY test_dictionary_common_expression;
 DROP TABLE t_dictionary_common_expression;
+
+-- name: test_dictionary_multiple_row
+CREATE TABLE `t_dictionary_multiple_row` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT "",
+  `id4` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t_dictionary_multiple_row_fact` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT "",
+  `id4` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t_dictionary_multiple_row select generate_series, generate_series, generate_series, generate_series from Table(generate_series(1, 20000));
+
+[UC]DROP DICTIONARY test_dictionary_multiple_row_multi_value;
+CREATE DICTIONARY test_dictionary_multiple_row_multi_value USING t_dictionary_multiple_row (id1 KEY, id2 VALUE, id3 VALUE, id4 VALUE);
+function: wait_refresh_dictionary_finish("test_dictionary_multiple_row_multi_value", "FINISHED")
+
+[UC]DROP DICTIONARY test_dictionary_multiple_row_single_value;
+CREATE DICTIONARY test_dictionary_multiple_row_single_value USING t_dictionary_multiple_row (id1 KEY, id2 VALUE);
+function: wait_refresh_dictionary_finish("test_dictionary_multiple_row_single_value", "FINISHED")
+
+insert into t_dictionary_multiple_row_fact SELECT dictionary_get("test_dictionary_multiple_row_multi_value", id1)[1], dictionary_get("test_dictionary_multiple_row_multi_value", id1)[2], dictionary_get("test_dictionary_multiple_row_multi_value", id1)[3] FROM t_dictionary_multiple_row;
+insert into t_dictionary_multiple_row_fact SELECT dictionary_get("test_dictionary_multiple_row_single_value", id1)[1], 1, 1 FROM t_dictionary_multiple_row;
+
+DROP TABLE t_dictionary_multiple_row;
+DROP TABLE t_dictionary_multiple_row_fact;
+DROP DICTIONARY test_dictionary_multiple_row_multi_value;
+DROP DICTIONARY test_dictionary_multiple_row_single_value;

--- a/test/sql/test_dictionary/T/test_dictionary
+++ b/test/sql/test_dictionary/T/test_dictionary
@@ -571,7 +571,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
-insert into t_dictionary_multiple_row select generate_series, generate_series, generate_series, generate_series from Table(generate_series(1, 20000));
+insert into t_dictionary_multiple_row select generate_series, generate_series, generate_series, generate_series from Table(generate_series(1, 20001));
 
 [UC]DROP DICTIONARY test_dictionary_multiple_row_multi_value;
 CREATE DICTIONARY test_dictionary_multiple_row_multi_value USING t_dictionary_multiple_row (id1 KEY, id2 VALUE, id3 VALUE, id4 VALUE);


### PR DESCRIPTION
[Enhancement] optimize lookup for dictionary
    
This pr introduce some optimization for looking up dictionary:
1. reserve the memory for the dest column which using for saving the result
   to avoid the memory reallocation.
2. Using _append_value instead of creating Datum for appending.
3. If the value type is Slice, save the slice first and append when to loop
   is finished. Avoid polluting the cpu cache for the prefetched content.

In our test case, for 1BE(16cpu, 128GB) + 1FE, here is the expression computation time:
key: int -> value: (int) : 572ms(before optimization) vs. 268ms(after optimization)
key: int -> value: (int, int) : 732ms(before optimization) vs. 395ms(after optimization)
key: int -> value: (int, int, varchar(length 128)) : 1s211ms(before optimization) vs. 744ms(after optimization)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
