### PR TITLE
[BugFix] Disable header validation in netty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -697,7 +697,7 @@ public class Config extends ConfigBase {
     // so the validation is turned off here to be compatible with old users
     // https://github.com/netty/netty/pull/12760
     @ConfField
-    public static boolean http_validate_headers = false;
+    public static boolean enable_http_validate_headers = false;
 
     /**
      * If a request takes longer than the configured time, a log will be generated to trace it.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -693,6 +693,12 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_max_chunk_size = 8192;
 
+    // Because the new version of netty has a stricter headers validation,
+    // so the validation is turned off here to be compatible with old users
+    // https://github.com/netty/netty/pull/12760
+    @ConfField
+    public static boolean http_validate_headers = false;
+
     /**
      * If a request takes longer than the configured time, a log will be generated to trace it.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -233,7 +233,7 @@ public class HttpServer {
                             Config.http_max_initial_line_length,
                             Config.http_max_header_size,
                             Config.http_max_chunk_size,
-                            Config.http_validate_headers))
+                            Config.enable_http_validate_headers))
                     .addLast(new StarRocksHttpPostObjectAggregator(100 * 65536))
                     .addLast(new ChunkedWriteHandler())
                     // add content compressor

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -232,7 +232,8 @@ public class HttpServer {
             ch.pipeline().addLast(new HttpServerCodec(
                             Config.http_max_initial_line_length,
                             Config.http_max_header_size,
-                            Config.http_max_chunk_size))
+                            Config.http_max_chunk_size,
+                            Config.http_validate_headers))
                     .addLast(new StarRocksHttpPostObjectAggregator(100 * 65536))
                     .addLast(new ChunkedWriteHandler())
                     // add content compressor


### PR DESCRIPTION
## Why I'm doing:
Because in #46557 we bump netty-all to `4.1.100.Final`, it introduce more strict HTTP header validation.  Occur https://github.com/StarRocks/StarRocksTest/issues/7769 test case failed.

## What I'm doing:

Disable header validation.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
