### PR TITLE
[Enhancement] improve cloud native pk index rebuild and compaction strategy

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -987,7 +987,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
-CONF_mInt32(lake_pk_index_sst_max_compaction_bytes, /*1GB*/ "1073741824");
+CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -988,6 +988,8 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
+// When the ratio of cumulative level to base level is greater than this config, use base merge.
+CONF_mDouble(lake_pk_index_cumulative_base_compaction_ratio, "0.1");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -67,12 +67,18 @@ void KeyValueMerger::flush() {
 
     IndexValuesWithVerPB index_value_pb;
     for (const auto& index_value_with_ver : _index_value_vers) {
+        if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
+            // deleted
+            continue;
+        }
         auto* value = index_value_pb.add_values();
         value->set_version(index_value_with_ver.first);
         value->set_rssid(index_value_with_ver.second.get_rssid());
         value->set_rowid(index_value_with_ver.second.get_rowid());
     }
-    _builder->Add(Slice(_key), Slice(index_value_pb.SerializeAsString()));
+    if (index_value_pb.values_size() > 0) {
+        _builder->Add(Slice(_key), Slice(index_value_pb.SerializeAsString()));
+    }
     _index_value_vers.clear();
 }
 
@@ -130,7 +136,7 @@ Status LakePersistentIndex::minor_compact() {
     PersistentIndexSstablePB sstable_pb;
     sstable_pb.set_filename(filename);
     sstable_pb.set_filesize(filesize);
-    sstable_pb.set_version(_immutable_memtable->max_version());
+    sstable_pb.set_max_rss_rowid(_immutable_memtable->max_rss_rowid());
     auto* block_cache = _tablet_mgr->update_mgr()->block_cache();
     if (block_cache == nullptr) {
         return Status::InternalError("Block cache is null.");
@@ -260,10 +266,53 @@ Status LakePersistentIndex::replace(size_t n, const Slice* keys, const IndexValu
     return Status::OK();
 }
 
+void LakePersistentIndex::pick_sstables_for_merge(const PersistentIndexSstableMetaPB& sstable_meta,
+                                                  std::vector<PersistentIndexSstablePB>* sstables,
+                                                  bool* merge_base_level) {
+    // There are two levels in persistent index:
+    //  1) base level. It contains only one sst file.
+    //  2) cumulative level. Sst files that except base level.
+    // And there are two kinds of merge:
+    //  1) base merge. Merge all sst files.
+    //  2) cumulative merge. Only merge cumulative sst files.
+    //
+    // And we use this strategy to decide whether to use base merge or cumulative merge:
+    // 1. When total size of cumulative level sst files reach 1/10 of base level, use base merge.
+    // 2. Otherwise, use cumulative merge.
+    DCHECK(sstable_meta.sstables_size() > 0);
+    int64_t base_level_bytes = 0;
+    int64_t cumulative_level_bytes = 0;
+    std::vector<PersistentIndexSstablePB> cumulative_sstables;
+    for (int i = 0; i < sstable_meta.sstables_size(); i++) {
+        if (i == 0) {
+            base_level_bytes = sstable_meta.sstables(i).filesize();
+        } else {
+            cumulative_level_bytes += sstable_meta.sstables(i).filesize();
+            cumulative_sstables.push_back(sstable_meta.sstables(i));
+        }
+    }
+
+    if (cumulative_level_bytes * 10 < base_level_bytes) {
+        // cumulative merge
+        sstables->swap(cumulative_sstables);
+        *merge_base_level = false;
+    } else {
+        // base merge
+        sstables->push_back(sstable_meta.sstables(0));
+        sstables->insert(sstables->end(), cumulative_sstables.begin(), cumulative_sstables.end());
+        *merge_base_level = true;
+    }
+    // Limit max sstable count that can do merge, to avoid cost too much memory.
+    const int32_t max_limit = config::lake_pk_index_sst_max_compaction_versions;
+    if (sstables->size() > max_limit) {
+        sstables->resize(max_limit);
+    }
+}
+
 Status LakePersistentIndex::prepare_merging_iterator(
         TabletManager* tablet_mgr, const TabletMetadata& metadata, TxnLogPB* txn_log,
         std::vector<std::shared_ptr<PersistentIndexSstable>>* merging_sstables,
-        std::unique_ptr<sstable::Iterator>* merging_iter_ptr) {
+        std::unique_ptr<sstable::Iterator>* merging_iter_ptr, bool* merge_base_level) {
     sstable::ReadOptions read_options;
     // No need to cache input sst's blocks.
     read_options.fill_cache = false;
@@ -274,11 +323,16 @@ Status LakePersistentIndex::prepare_merging_iterator(
         }
     });
 
-    auto max_compaction_bytes = config::lake_pk_index_sst_max_compaction_bytes;
     iters.reserve(metadata.sstable_meta().sstables().size());
-    size_t total_filesize = 0;
     std::stringstream ss_debug;
-    for (const auto& sstable_pb : metadata.sstable_meta().sstables()) {
+    std::vector<PersistentIndexSstablePB> sstables_to_merge;
+    // Pick sstable for merge, decide to use base merge or cumulative merge.
+    pick_sstables_for_merge(metadata.sstable_meta(), &sstables_to_merge, merge_base_level);
+    if (sstables_to_merge.size() <= 1) {
+        // no need to do merge
+        return Status::OK();
+    }
+    for (const auto& sstable_pb : sstables_to_merge) {
         // build sstable from meta, instead of reuse `_sstables`, to keep it thread safe
         ASSIGN_OR_RETURN(auto rf,
                          fs::new_random_access_file(tablet_mgr->sst_location(metadata.id(), sstable_pb.filename())));
@@ -287,14 +341,9 @@ Status LakePersistentIndex::prepare_merging_iterator(
         merging_sstables->push_back(merging_sstable);
         sstable::Iterator* iter = merging_sstable->new_iterator(read_options);
         iters.emplace_back(iter);
-        total_filesize += sstable_pb.filesize();
         // add input sstable.
         txn_log->mutable_op_compaction()->add_input_sstables()->CopyFrom(merging_sstable->sstable_pb());
         ss_debug << sstable_pb.filename() << " | ";
-        if (total_filesize >= max_compaction_bytes &&
-            merging_sstables->size() >= config::lake_pk_index_sst_min_compaction_versions) {
-            break;
-        }
     }
     sstable::Options options;
     (*merging_iter_ptr).reset(sstable::NewMergingIterator(options.comparator, &iters[0], iters.size()));
@@ -304,9 +353,9 @@ Status LakePersistentIndex::prepare_merging_iterator(
     return Status::OK();
 }
 
-Status LakePersistentIndex::merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr,
-                                           sstable::TableBuilder* builder) {
-    auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), builder);
+Status LakePersistentIndex::merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder,
+                                           bool base_level_merge) {
+    auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), builder, base_level_merge);
     while (iter_ptr->Valid()) {
         RETURN_IF_ERROR(merger->merge(iter_ptr->key().to_string(), iter_ptr->value().to_string()));
         iter_ptr->Next();
@@ -324,8 +373,14 @@ Status LakePersistentIndex::major_compact(TabletManager* tablet_mgr, const Table
 
     std::vector<std::shared_ptr<PersistentIndexSstable>> sstable_vec;
     std::unique_ptr<sstable::Iterator> merging_iter_ptr;
+    bool merge_base_level = false;
     // build merge iterator
-    RETURN_IF_ERROR(prepare_merging_iterator(tablet_mgr, metadata, txn_log, &sstable_vec, &merging_iter_ptr));
+    RETURN_IF_ERROR(prepare_merging_iterator(tablet_mgr, metadata, txn_log, &sstable_vec, &merging_iter_ptr,
+                                             &merge_base_level));
+    if (merging_iter_ptr == nullptr) {
+        // no need to do merge
+        return Status::OK();
+    }
     if (!merging_iter_ptr->Valid()) {
         return merging_iter_ptr->status();
     }
@@ -338,7 +393,7 @@ Status LakePersistentIndex::major_compact(TabletManager* tablet_mgr, const Table
     filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
     options.filter_policy = filter_policy.get();
     sstable::TableBuilder builder(options, wf.get());
-    RETURN_IF_ERROR(merge_sstables(std::move(merging_iter_ptr), &builder));
+    RETURN_IF_ERROR(merge_sstables(std::move(merging_iter_ptr), &builder, merge_base_level));
     RETURN_IF_ERROR(wf->close());
 
     // record output sstable pb
@@ -354,7 +409,8 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
 
     PersistentIndexSstablePB sstable_pb;
     sstable_pb.CopyFrom(op_compaction.output_sstable());
-    sstable_pb.set_version(op_compaction.input_sstables(op_compaction.input_sstables().size() - 1).version());
+    sstable_pb.set_max_rss_rowid(
+            op_compaction.input_sstables(op_compaction.input_sstables().size() - 1).max_rss_rowid());
     auto sstable = std::make_unique<PersistentIndexSstable>();
     ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(_tablet_mgr->sst_location(_tablet_id, sstable_pb.filename())));
     auto* block_cache = _tablet_mgr->update_mgr()->block_cache();
@@ -367,24 +423,31 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
     for (const auto& input_sstable : op_compaction.input_sstables()) {
         filenames.insert(input_sstable.filename());
     }
+    // Erase merged sstable from sstable list
     _sstables.erase(std::remove_if(_sstables.begin(), _sstables.end(),
                                    [&](const std::unique_ptr<PersistentIndexSstable>& sstable) {
                                        return filenames.contains(sstable->sstable_pb().filename());
                                    }),
                     _sstables.end());
-    _sstables.insert(_sstables.begin(), std::move(sstable));
+    // Insert sstable to sstable list by `max_rss_rowid` order.
+    auto lower_it = std::lower_bound(
+            _sstables.begin(), _sstables.end(), sstable,
+            [](const std::unique_ptr<PersistentIndexSstable>& a, const std::unique_ptr<PersistentIndexSstable>& b) {
+                return a->sstable_pb().max_rss_rowid() < b->sstable_pb().max_rss_rowid();
+            });
+    _sstables.insert(lower_it, std::move(sstable));
     return Status::OK();
 }
 
 Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
     PersistentIndexSstableMetaPB sstable_meta;
-    int64_t last_version = 0;
+    int64_t last_max_rss_rowid = 0;
     for (auto& sstable : _sstables) {
-        int64_t sstable_version = sstable->sstable_pb().version();
-        if (last_version > sstable_version) {
-            return Status::InternalError("Versions of sstables are not ordered");
+        int64_t max_rss_rowid = sstable->sstable_pb().max_rss_rowid();
+        if (last_max_rss_rowid > max_rss_rowid) {
+            return Status::InternalError("sstables are not ordered");
         }
-        last_version = sstable_version;
+        last_max_rss_rowid = max_rss_rowid;
         auto* sstable_pb = sstable_meta.add_sstables();
         sstable_pb->CopyFrom(sstable->sstable_pb());
     }
@@ -406,13 +469,9 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
 
     const auto& sstables = metadata->sstable_meta().sstables();
-    int64_t max_sstable_version = sstables.empty() ? 0 : sstables.rbegin()->version();
-    if (max_sstable_version > base_version) {
-        return Status::OK();
-    }
-    TRACE_COUNTER_INCREMENT("max_sstable_version", max_sstable_version);
-    TRACE_COUNTER_INCREMENT("new_version", metadata->version());
-
+    // Rebuild persistent index from `rebuild_rss_rowid_point`
+    const uint64_t rebuild_rss_rowid_point = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid();
+    const uint32_t rebuild_rss_id = rebuild_rss_rowid_point >> 32;
     OlapReaderStatistics stats;
     std::unique_ptr<Column> pk_column;
     if (pk_columns.size() > 1) {
@@ -428,18 +487,9 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     auto rowsets = Rowset::get_rowsets(tablet_mgr, metadata);
     // Rowset whose version is between max_sstable_version and base_version should be recovered.
     for (auto& rowset : rowsets) {
-        TRACE_COUNTER_INCREMENT("total_rowsets", 1);
-        TRACE_COUNTER_INCREMENT("total_segments", rowset->num_segments());
-        TRACE_COUNTER_INCREMENT("total_datasize_bytes", rowset->data_size());
+        TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
         TRACE_COUNTER_INCREMENT("total_num_rows", rowset->num_rows());
-        // If it is upgraded from old version of sr, the rowset version will be not set.
-        // The generated rowset version will be treated as base_version.
-        int64_t rowset_version = rowset->version() != 0 ? rowset->version() : base_version;
-        // The data whose version is max_sstable_version in memtable may be not flushed to sstable.
-        // So rowset whose version is max_sstable_version should also be recovered.
-        if (rowset_version < max_sstable_version) {
-            continue;
-        }
+        const int64_t rowset_version = rowset->version() != 0 ? rowset->version() : base_version;
         auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
         if (!res.ok()) {
             return res.status();
@@ -451,6 +501,13 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             if (itr == nullptr) {
                 continue;
             }
+            if (rowset->id() + i < rebuild_rss_id) {
+                // lower than rebuild point, skip
+                // Notice: segment id that equal `rebuild_rss_id` can't be skip because
+                // there are maybe some rows need to rebuild.
+                continue;
+            }
+            TRACE_COUNTER_INCREMENT("rebuild_index_segment_cnt", 1);
             while (true) {
                 chunk->reset();
                 rowids.clear();
@@ -476,6 +533,11 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                     for (uint32_t i = 0; i < pkc->size(); i++) {
                         values.emplace_back(base + rowids[i]);
                     }
+                    if (values.back().get_value() <= rebuild_rss_rowid_point) {
+                        // lower AND equal than rebuild point, skip
+                        continue;
+                    }
+                    TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", pkc->size());
                     Status st;
                     if (pkc->is_binary()) {
                         RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
@@ -495,10 +557,6 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             }
             itr->close();
         }
-        TRACE_COUNTER_INCREMENT("loaded_rowsets", 1);
-        TRACE_COUNTER_INCREMENT("loaded_segments", rowset->num_segments());
-        TRACE_COUNTER_INCREMENT("loaded_datasize_bytes", rowset->data_size());
-        TRACE_COUNTER_INCREMENT("loaded_num_rows", rowset->num_rows());
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -39,8 +39,8 @@ using IndexValueWithVer = std::pair<int64_t, IndexValue>;
 
 class KeyValueMerger {
 public:
-    explicit KeyValueMerger(const std::string& key, sstable::TableBuilder* builder)
-            : _key(std::move(key)), _builder(builder) {}
+    explicit KeyValueMerger(const std::string& key, sstable::TableBuilder* builder, bool merge_base_level)
+            : _key(std::move(key)), _builder(builder), _merge_base_level(merge_base_level) {}
 
     Status merge(const std::string& key, const std::string& value);
 
@@ -53,6 +53,8 @@ private:
     std::string _key;
     sstable::TableBuilder* _builder;
     std::list<IndexValueWithVer> _index_value_vers;
+    // If do merge base level, that means we can delete NullIndexValue items safely.
+    bool _merge_base_level = false;
 };
 
 // LakePersistentIndex is not thread-safe.
@@ -125,6 +127,9 @@ public:
 
     size_t memory_usage() const override;
 
+    static void pick_sstables_for_merge(const PersistentIndexSstableMetaPB& sstable_meta,
+                                        std::vector<PersistentIndexSstablePB>* sstables, bool* merge_base_level);
+
 private:
     Status flush_memtable();
 
@@ -153,9 +158,11 @@ private:
     // get sstable's iterator that need to compact and modify txn_log
     static Status prepare_merging_iterator(TabletManager* tablet_mgr, const TabletMetadata& metadata, TxnLogPB* txn_log,
                                            std::vector<std::shared_ptr<PersistentIndexSstable>>* merging_sstables,
-                                           std::unique_ptr<sstable::Iterator>* merging_iter_ptr);
+                                           std::unique_ptr<sstable::Iterator>* merging_iter_ptr,
+                                           bool* merge_base_level);
 
-    static Status merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder);
+    static Status merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder,
+                                 bool base_level_merge);
 
 private:
     std::unique_ptr<PersistentIndexMemtable> _memtable;

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -44,9 +44,9 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
             nfound += old_value.get_value() != NullIndexValue;
             update_index_value(&old_index_value_vers, version, value);
         }
+        _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
     *num_found = nfound;
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 
@@ -65,8 +65,8 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
             return Status::AlreadyExist(msg);
         }
         _keys_size += key.capacity() + sizeof(std::string);
+        _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 
@@ -90,7 +90,6 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
         }
     }
     *num_found = nfound;
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 
@@ -106,8 +105,8 @@ Status PersistentIndexMemtable::replace(const Slice* keys, const IndexValue* val
         } else {
             _keys_size += key.capacity() + sizeof(std::string);
         }
+        _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
-    _max_version = std::max(_max_version, version);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -58,7 +58,7 @@ public:
 
     void clear();
 
-    const int64_t max_version() const { return _max_version; }
+    const int64_t max_rss_rowid() const { return _max_rss_rowid; }
 
 private:
     static void update_index_value(std::list<IndexValueWithVer>* index_value_info, int64_t version,
@@ -67,8 +67,8 @@ private:
 private:
     // The size can be up to 230K. The performance of std::map may be poor.
     phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>> _map;
-    int64_t _max_version{0};
     int64_t _keys_size{0};
+    uint64_t _max_rss_rowid{0};
 };
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -253,4 +253,51 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 
+TEST_F(LakePersistentIndexTest, test_compaction_strategy) {
+    PersistentIndexSstableMetaPB sstable_meta;
+    std::vector<PersistentIndexSstablePB> sstables;
+    bool merge_base_level = false;
+    auto test_fn = [&](size_t sub_size, size_t N, bool is_base) {
+        sstable_meta.Clear();
+        sstables.clear();
+        auto* sstable_pb = sstable_meta.add_sstables();
+        sstable_pb->set_filesize(1000000);
+        sstable_pb->set_filename("aaa.sst");
+        for (int i = 0; i < N; i++) {
+            sstable_pb = sstable_meta.add_sstables();
+            sstable_pb->set_filesize(sub_size);
+        }
+        LakePersistentIndex::pick_sstables_for_merge(sstable_meta, &sstables, &merge_base_level);
+        if (is_base) {
+            ASSERT_TRUE(merge_base_level);
+            ASSERT_TRUE(sstables.size() == std::min(1 + N, (size_t)config::lake_pk_index_sst_max_compaction_versions));
+            ASSERT_TRUE(sstables[0].filename() == "aaa.sst");
+            for (int i = 1; i < N; i++) {
+                ASSERT_TRUE(sstables[i].filesize() == sub_size);
+            }
+        } else {
+            ASSERT_TRUE(!merge_base_level);
+            ASSERT_TRUE(sstables.size() == std::min(N, (size_t)config::lake_pk_index_sst_max_compaction_versions));
+            for (int i = 0; i < N; i++) {
+                ASSERT_TRUE(sstables[i].filesize() == sub_size);
+            }
+        }
+    };
+    // 1. <1000000, 100>
+    test_fn(100, 1, false);
+    // 2. <1000000>
+    test_fn(100, 0, false);
+    // 3. <1000000, 10000, 10000, 10000, ...(9 items)>
+    test_fn(10000, 9, false);
+    // 4. <1000000, 10000, 10000, 10000, ...(10 items)>
+    test_fn(10000, 10, true);
+    // 4. <1000000, 10000, 10000, 10000, ...(11 items)>
+    test_fn(10000, 11, true);
+    int32_t old = config::lake_pk_index_sst_max_compaction_versions;
+    config::lake_pk_index_sst_max_compaction_versions = 3;
+    // 5. <1000000, 10000, 10000, 10000, ...(11 items)>
+    test_fn(10000, 11, true);
+    config::lake_pk_index_sst_max_compaction_versions = old;
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -682,8 +682,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
         auto sstable_meta = new_tablet_metadata->sstable_meta();
         for (auto& sstable : sstable_meta.sstables()) {
-            EXPECT_GT(sstable.version(), 0);
-            EXPECT_LE(sstable.version(), version);
+            EXPECT_GT(sstable.max_rss_rowid(), 0);
         }
     }
 }

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -707,13 +707,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
-        auto sstable_meta = new_tablet_metadata->sstable_meta();
-        for (auto& sstable : sstable_meta.sstables()) {
-            EXPECT_GT(sstable.version(), 0);
-            EXPECT_LE(sstable.version(), version);
-        }
-    }
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 
@@ -989,6 +982,61 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_with_clear_txnlog) {
         version++;
     }
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_write_with_cloud_native_index_rebuild) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
+    std::vector<ChunkPtr> chunk_vec;
+    std::vector<std::vector<uint32_t>> indexes_vec;
+    auto [chunk0, indexes0] = gen_data_and_index(kChunkSize * 3, 0, true, true);
+    chunk_vec.push_back(chunk0);
+    indexes_vec.push_back(indexes0);
+    auto [chunk1, indexes1] = gen_data_and_index(kChunkSize * 3, 1, true, true);
+    chunk_vec.push_back(chunk1);
+    indexes_vec.push_back(indexes1);
+    auto [chunk2, indexes2] = gen_data_and_index(kChunkSize * 3, 2, true, true);
+    chunk_vec.push_back(chunk2);
+    indexes_vec.push_back(indexes2);
+    auto [chunk3, indexes3] = gen_data_and_index(kChunkSize * 3, 3, true, true);
+    chunk_vec.push_back(chunk3);
+    indexes_vec.push_back(indexes3);
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    auto do_load_func = [&]() {
+        for (int i = 0; i < 4; i++) {
+            int64_t txn_id = next_id();
+            ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(tablet_id)
+                                                       .set_txn_id(txn_id)
+                                                       .set_partition_id(_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_schema_id(_tablet_schema->id())
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(*chunk_vec[i], indexes_vec[i].data(), indexes_vec[i].size()));
+            auto txn_log_st = delta_writer->finish_with_txnlog();
+            ASSERT_OK(txn_log_st);
+            delta_writer->close();
+            // Publish version
+            ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+            version++;
+        }
+    };
+    // 1. first time
+    const auto old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+    do_load_func();
+    config::l0_max_mem_usage = old_val;
+    ASSERT_EQ(kChunkSize * 3 * 4, read_rows(tablet_id, version));
+    // 2. release persistent index and rebuild index
+    _update_mgr->unload_and_remove_primary_index(tablet_id);
+    // 3. second time
+    do_load_func();
+    ASSERT_EQ(kChunkSize * 3 * 4, read_rows(tablet_id, version));
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -184,9 +184,10 @@ message IndexValuesWithVerPB {
 }
 
 message PersistentIndexSstablePB {
-    optional int64 version = 1;
-    optional string filename = 2;
-    optional int64 filesize = 3;
+    optional string filename = 1;
+    optional int64 filesize = 2;
+    // used for rebuild point of persistent index
+    optional uint64 max_rss_rowid = 3;
 }
 
 message PersistentIndexSstableMetaPB {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -184,10 +184,11 @@ message IndexValuesWithVerPB {
 }
 
 message PersistentIndexSstablePB {
-    optional string filename = 1;
-    optional int64 filesize = 2;
+    optional int64 version = 1; // Deprecated
+    optional string filename = 2;
+    optional int64 filesize = 3;
     // used for rebuild point of persistent index
-    optional uint64 max_rss_rowid = 3;
+    optional uint64 max_rss_rowid = 4;
 }
 
 message PersistentIndexSstableMetaPB {


### PR DESCRIPTION
## Why I'm doing:
There are two flaws in current cloud native persistent index implementation.
1. We use Rowset's `version` as index rebuild point, and its recovery granularity is too coarse and can lead to duplicate recovery of large amounts of data during index rebuilds.
2. There is always full compaction happens in current compaction strategy, which is inefficient and lead to large write amplification.

## What I'm doing:
1. Use rss_rowid (rowset + segment id + rowid) as rebuild point instead of version, this is because rss_rowid enables finer-grained index rebuild point, which reduces the time required for cloud native persistent index rebuilds.
2. Separate sst files into two levels : 
     a) base level
     b) cumulative level. Base level contains only one sst file, rest of sst files are included in cumulative level.

    And there are two kinds of merge:
    a) base merge. Merge all sst files.
    b) cumulative merge. Only merge cumulative level's sst files.
    
    And we use this strategy to decide whether to use base merge or cumulative merge:
    a) When total size of cumulative level sst files reach 1/10 of base level, use base merge. The ratio is configurable, controlled by `config::lake_pk_index_base_cumulative_compaction_ratio`.
    b) Otherwise, use cumulative merge.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
