### PR TITLE
[BugFix] split_part fuction should not return null when delimiter is not matched

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -126,6 +126,7 @@ set(EXEC_FILES
         ./exprs/math_functions_test.cpp
         ./exprs/null_if_expr_test.cpp
         ./exprs/percentile_functions_test.cpp
+        ./exprs/split_part_test.cpp
         ./exprs/string_fn_concat_test.cpp
         ./exprs/string_fn_locate_test.cpp
         ./exprs/string_fn_pad_test.cpp

--- a/be/test/exprs/split_part_test.cpp
+++ b/be/test/exprs/split_part_test.cpp
@@ -1,0 +1,54 @@
+#include <memory>
+
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "exprs/string_functions.h"
+#include "gtest/gtest.h"
+
+namespace starrocks {
+class SplitPartTest : public ::testing::Test {};
+
+void split_part_test(const std::string& haystack, const std::string& delimiter, int part_number,
+                     const std::string& expected) {
+    auto context = std::make_unique<FunctionContext>();
+
+    auto haystack_column = BinaryColumn::create();
+    auto delimiter_column = BinaryColumn::create();
+    haystack_column->append(haystack);
+    delimiter_column->append(delimiter);
+
+    size_t chunk_size = haystack_column->size();
+    auto part_number_column = ColumnHelper::create_const_column<TYPE_INT>(part_number, chunk_size);
+
+    Columns columns;
+    columns.emplace_back(std::move(haystack_column));
+    columns.emplace_back(std::move(delimiter_column));
+    columns.emplace_back(std::move(part_number_column));
+
+    auto result = StringFunctions::split_part(context.get(), columns);
+
+    ASSERT_TRUE(result.ok());
+    auto result_column = std::move(result).value();
+    ASSERT_EQ(result_column->size(), 1);
+    ASSERT_EQ(result_column->get(0).get_slice().to_string(), expected);
+}
+
+TEST_F(SplitPartTest, splitPartTest) {
+    split_part_test("hello world", "|", 1, "hello world");
+    split_part_test("hello world", "|", 100, "");
+    split_part_test("hello world", " ", 1, "hello");
+    split_part_test("hello world", " ", 2, "world");
+    split_part_test("hello world", " ", -1, "world");
+    split_part_test("hello world", " ", -2, "hello");
+    split_part_test("abca", "a", 1, "");
+    split_part_test("abca", "a", -1, "");
+    split_part_test("abca", "a", -2, "bc");
+    split_part_test("hello", "", 1, "h");
+    split_part_test("hello", "", 0, "");
+    split_part_test("hello", "", 10, "");
+    split_part_test("hello world", " ", 0, "");
+    split_part_test("hello world", " ", 100, "");
+    split_part_test("hello world", "z", 1, "hello world");
+    split_part_test("hello world", "z", 2, "");
+}
+} // namespace starrocks

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -1042,7 +1042,7 @@ PARALLEL_TEST(VecStringFunctionsTest, splitPart) {
 
     ASSERT_EQ("hello", v->get(0).get<Slice>().to_string());
     ASSERT_EQ("word", v->get(1).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(2).is_null());
+    ASSERT_TRUE(v->get(2).get<Slice>().empty());
     ASSERT_EQ("", v->get(3).get<Slice>().to_string());
     ASSERT_EQ(" word", v->get(4).get<Slice>().to_string());
     ASSERT_EQ("", v->get(5).get<Slice>().to_string());
@@ -1054,20 +1054,20 @@ PARALLEL_TEST(VecStringFunctionsTest, splitPart) {
     ASSERT_EQ("#123", v->get(11).get<Slice>().to_string());
     ASSERT_EQ("#234", v->get(12).get<Slice>().to_string());
     ASSERT_EQ("b", v->get(13).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(14).is_null());
-    ASSERT_TRUE(v->get(15).is_null());
-    ASSERT_TRUE(v->get(16).is_null());
-    ASSERT_TRUE(v->get(17).is_null());
-    ASSERT_TRUE(v->get(18).is_null());
-    ASSERT_TRUE(v->get(19).is_null());
+    ASSERT_TRUE(v->get(14).get<Slice>().empty());
+    ASSERT_TRUE(v->get(15).get<Slice>().empty());
+    ASSERT_TRUE(v->get(16).get<Slice>().empty());
+    ASSERT_TRUE(v->get(17).get<Slice>().empty());
+    ASSERT_TRUE(v->get(18).get<Slice>().empty());
+    ASSERT_TRUE(v->get(19).get<Slice>().empty());
     ASSERT_EQ("9", v->get(20).get<Slice>().to_string());
     ASSERT_EQ("年", v->get(21).get<Slice>().to_string());
     ASSERT_EQ("9", v->get(22).get<Slice>().to_string());
     ASSERT_EQ("日", v->get(23).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(24).is_null());
+    ASSERT_TRUE(v->get(24).get<Slice>().empty());
     ASSERT_EQ("word", v->get(25).get<Slice>().to_string());
     ASSERT_EQ("hello", v->get(26).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(27).is_null());
+    ASSERT_TRUE(v->get(24).get<Slice>().empty());
     ASSERT_EQ("8日", v->get(28).get<Slice>().to_string());
 }
 


### PR DESCRIPTION


## Why I'm doing:

![image](https://github.com/StarRocks/starrocks/assets/81925277/ee9a2837-b966-4040-9aca-b7d15aaf1266)

## What I'm doing:

![image](https://github.com/StarRocks/starrocks/assets/81925277/7849420b-24a4-424f-92d5-a120488dbeb1)


Fixes #46774 

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
