### PR TITLE
[Enhancement] Optimize multiple like predicates (backport #46914)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -681,6 +681,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CONNECTOR_HUGE_FILE_SIZE = "connector_huge_file_size";
     public static final String ENABLE_HYPERSCAN_VEC = "enable_hyperscan_vec";
 
+    // A group of like predicates with the same column and concatenated by OR, can be consolidated into
+    // regexp predicate, only the number of like predicates is not less that `like_predicate_consolidate_min`
+    // would be consolidated, since when the number of like predicates is too small, its corresponding
+    // regexp predicate is less efficient than like predicates.
+    public static final String LIKE_PREDICATE_CONSOLIDATE_MIN = "like_predicate_consolidate_min";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1888,6 +1894,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return Optional.of(followerForwardMode.equalsIgnoreCase(FollowerQueryForwardMode.LEADER.toString()));
     }
 
+    @VarAttr(name = LIKE_PREDICATE_CONSOLIDATE_MIN)
+    private int likePredicateConsolidateMin = 2;
     public int getExprChildrenLimit() {
         return exprChildrenLimit;
     }
@@ -3468,6 +3476,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableConnectorSplitIoTasks() {
         return enableConnectorSplitIoTasks;
+    }
+
+    public int getLikePredicateConsolidateMin() {
+        return likePredicateConsolidateMin;
+    }
+
+    public void setLikePredicateConsolidateMin(int value) {
+        this.likePredicateConsolidateMin = value;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -92,6 +92,7 @@ import com.starrocks.sql.optimizer.rule.tree.PruneSubfieldsForComplexType;
 import com.starrocks.sql.optimizer.rule.tree.PushDownAggregateRule;
 import com.starrocks.sql.optimizer.rule.tree.PushDownDistinctAggregateRule;
 import com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuseRule;
+import com.starrocks.sql.optimizer.rule.tree.SimplifyCaseWhenPredicateRule;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.PruneSubfieldRule;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule;
 import com.starrocks.sql.optimizer.task.OptimizeGroupTask;
@@ -552,6 +553,8 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, new GroupByCountDistinctRewriteRule());
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, new DeriveRangeJoinPredicateRule());
+        tree = SimplifyCaseWhenPredicateRule.INSTANCE.rewrite(tree, rootTaskContext);
+        deriveLogicalProperty(tree);
         return tree.getInputs().get(0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -793,4 +793,19 @@ public class Utils {
 
         expr.setStatistics(expressionContext.getStatistics());
     }
+
+    @SuppressWarnings("unchecked")
+    public static <T, S extends T> Optional<S> downcast(T obj, Class<S> klass) {
+        Preconditions.checkArgument(obj != null);
+        if (obj.getClass().equals(Objects.requireNonNull(klass))) {
+            return Optional.of((S) obj);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public static <T, S extends T> S mustCast(T obj, Class<S> klass) {
+        return downcast(obj, klass)
+                .orElseThrow(() -> new IllegalArgumentException("Cannot cast " + obj.getClass() + " to " + klass));
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
@@ -74,5 +75,13 @@ public class ScalarOperatorUtil {
                     ((ScalarType) argTypes[0]).getScalarScale()));
         }
         return newFn;
+    }
+
+    public static boolean isSimpleLike(ScalarOperator op) {
+        return Utils.downcast(op, LikePredicateOperator.class)
+                .map(likeOp -> !likeOp.isRegexp() &&
+                        likeOp.getChild(0).isColumnRef() &&
+                        likeOp.getChild(1).isConstantRef())
+                .orElse(false);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -21,13 +21,16 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ArithmeticCommutativeRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.ConsolidateLikesRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ExtractCommonPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.MvNormalizePredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.NormalizePredicateRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.PruneTediousPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedCaseWhenRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
 
@@ -48,7 +51,13 @@ public class ScalarOperatorRewriter {
             new FoldConstantsRule(),
             new SimplifiedPredicateRule(),
             new ExtractCommonPredicateRule(),
-            new ArithmeticCommutativeRule()
+            new ArithmeticCommutativeRule(),
+            ConsolidateLikesRule.INSTANCE
+    );
+
+    private static final List<ScalarOperatorRewriteRule> CASE_WHEN_PREDICATE_RULE = Lists.newArrayList(
+            SimplifiedCaseWhenRule.INSTANCE,
+            PruneTediousPredicateRule.INSTANCE
     );
 
     public static final List<ScalarOperatorRewriteRule> DEFAULT_REWRITE_SCAN_PREDICATE_RULES = Lists.newArrayList(
@@ -61,7 +70,8 @@ public class ScalarOperatorRewriter {
             new SimplifiedScanColumnRule(),
             new SimplifiedPredicateRule(),
             new ExtractCommonPredicateRule(),
-            new ArithmeticCommutativeRule()
+            new ArithmeticCommutativeRule(),
+            ConsolidateLikesRule.INSTANCE
     );
 
     public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = DEFAULT_REWRITE_SCAN_PREDICATE_RULES.stream()
@@ -140,5 +150,10 @@ public class ScalarOperatorRewriter {
             op.setChild(i, applyRuleTopDown(op.getChild(i), rule));
         }
         return op;
+    }
+
+    public static ScalarOperator simplifyCaseWhen(ScalarOperator predicates) {
+        // simplify case-when
+        return new ScalarOperatorRewriter().rewrite(predicates, CASE_WHEN_PREDICATE_RULE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ConsolidateLikesRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ConsolidateLikesRule.java
@@ -1,0 +1,226 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ConsolidateLikesRule extends TopDownScalarOperatorRewriteRule {
+
+    public static final ConsolidateLikesRule INSTANCE = new ConsolidateLikesRule();
+    private static final Set<Character> REGEX_META_CHARS = "^$.*+?|(){}[]".chars()
+            .mapToObj(c -> (char) c).collect(ImmutableSet.toImmutableSet());
+    private static final char LIKE_META_DASH = '_';
+    private static final char LIKE_META_PERCENT = '%';
+    private static final char BACKSLASH = '\\';
+    private static final String REGEX_META_DOT = ".";
+    private static final String REGEX_META_DOT_ASTERISK = ".*";
+    private static final char C_ESCAPED_NL = '\n';
+    private static final char C_ESCAPED_CR = '\r';
+    private static final char C_ESCAPED_TAB = '\t';
+    private static final String C_ESCAPED_NL_S = "\\n";
+    private static final String C_ESCAPED_CR_S = "\\r";
+    private static final String C_ESCAPED_TAB_S = "\\t";
+
+    private ConsolidateLikesRule() {
+    }
+
+    private static boolean isPrintableChar(char c) {
+        Character.UnicodeBlock block = Character.UnicodeBlock.of(c);
+        return (!Character.isISOControl(c)) &&
+                c != KeyEvent.CHAR_UNDEFINED &&
+                block != null &&
+                block != Character.UnicodeBlock.SPECIALS;
+    }
+
+    private static Optional<String> toRegexPattern(String likePattern) {
+        // '' like '' return 1;
+        // '' regexp '' return 0 in SR, report Illegal regex expression in MySQL,
+        // so we convert like pattern '' to regex '^$'
+        if (likePattern.isEmpty()) {
+            return Optional.of("^$");
+        }
+        char[] chars = likePattern.toCharArray();
+        char lastChar = chars[chars.length - 1];
+        String prefix = likePattern.substring(0, likePattern.length() - 1);
+        // column like "prefix%" has performance regression, so do not optimize it.
+        if ((lastChar == LIKE_META_DASH || lastChar == LIKE_META_PERCENT) &&
+                prefix.chars().noneMatch(ch -> ch == LIKE_META_DASH || ch == LIKE_META_PERCENT)) {
+            return Optional.empty();
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < chars.length; ++i) {
+            char ch = chars[i];
+            if (ch == BACKSLASH) {
+                sb.append(ch);
+                ++i;
+                if (i < chars.length) {
+                    char ch1 = chars[i];
+                    if (ch1 == BACKSLASH || ch1 == LIKE_META_DASH || ch1 == LIKE_META_PERCENT) {
+                        sb.append(chars[i]);
+                    } else {
+                        // TODO(by satanson): \c may be a regex meta char, it is error-prone, so
+                        //  do not convert it into regex.
+                        return Optional.empty();
+                    }
+                } else {
+                    sb.append(BACKSLASH);
+                }
+            } else if (ch == LIKE_META_DASH) {
+                sb.append(REGEX_META_DOT);
+            } else if (ch == LIKE_META_PERCENT) {
+                sb.append(REGEX_META_DOT_ASTERISK);
+            } else if (ch == C_ESCAPED_NL) {
+                sb.append(C_ESCAPED_NL_S);
+            } else if (ch == C_ESCAPED_CR) {
+                sb.append(C_ESCAPED_CR_S);
+            } else if (ch == C_ESCAPED_TAB) {
+                sb.append(C_ESCAPED_TAB_S);
+            } else if (REGEX_META_CHARS.contains(ch)) {
+                sb.append(BACKSLASH).append(ch);
+            } else if (isPrintableChar(ch)) {
+                sb.append(ch);
+            } else {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(sb.toString());
+    }
+
+    private static Optional<List<ScalarOperator>> consolidate(List<LikePredicateOperator> likeOps, int consolidateMin) {
+        if (likeOps.size() < consolidateMin) {
+            return Optional.empty();
+        }
+        ColumnRefOperator columnRef = Utils.mustCast(likeOps.get(0).getChild(0), ColumnRefOperator.class);
+        List<Pair<LikePredicateOperator, Optional<String>>> likeAndRegexLists =
+                likeOps.stream()
+                        .map(likeOp -> Pair.create(likeOp,
+                                Utils.mustCast(likeOp.getChild(1), ConstantOperator.class).getVarchar()))
+                        .map(p -> Pair.create(p.first, toRegexPattern(p.second)))
+                        .collect(Collectors.toList());
+
+        Map<Boolean, List<Pair<LikePredicateOperator, Optional<String>>>> likeAndRegexGroups =
+                likeAndRegexLists.stream().collect(Collectors.partitioningBy(p -> p.second.isPresent()));
+
+        List<Pair<LikePredicateOperator, Optional<String>>> regexList = likeAndRegexGroups.get(true);
+        if (regexList.size() < consolidateMin) {
+            return Optional.empty();
+        }
+        String regexp = regexList.stream()
+                .map(p -> Objects.requireNonNull(p.second.orElse(null)))
+                .map(re -> "(" + re + ")")
+                .collect(Collectors.joining("|"));
+
+        ConstantOperator regexPattern = ConstantOperator.createVarchar("^(" + regexp + ")$");
+
+        ScalarOperator regexOp =
+                new LikePredicateOperator(LikePredicateOperator.LikeType.REGEXP, columnRef, regexPattern);
+        List<ScalarOperator> newDisjuncts = Stream.concat(
+                Stream.of(regexOp),
+                likeAndRegexGroups.get(false).stream().map(p -> p.first)
+        ).collect(Collectors.toList());
+        return Optional.of(newDisjuncts);
+    }
+
+    private static Optional<List<ScalarOperator>> handleDisjuncts(
+            List<ScalarOperator> disjuncts, int consolidateMin) {
+        if (disjuncts.size() < consolidateMin) {
+            return Optional.empty();
+        }
+        if (disjuncts.stream().filter(ScalarOperatorUtil::isSimpleLike).count() < consolidateMin) {
+            return Optional.empty();
+        }
+
+        Map<Boolean, List<ScalarOperator>> disjunctGroups = disjuncts.stream()
+                .collect(Collectors.partitioningBy(ScalarOperatorUtil::isSimpleLike));
+        List<ScalarOperator> likeOps = disjunctGroups.get(true);
+        List<ScalarOperator> otherDisjuncts = disjunctGroups.get(false);
+
+        Map<ColumnRefOperator, List<LikePredicateOperator>> likeOpGroups = likeOps.stream()
+                .map(disj -> Utils.mustCast(disj, LikePredicateOperator.class))
+                .collect(Collectors.groupingBy(likeOp ->
+                        Utils.mustCast(likeOp.getChild(0), ColumnRefOperator.class)));
+
+        List<Pair<List<LikePredicateOperator>, Optional<List<ScalarOperator>>>> consolidatedDisjuncts =
+                likeOpGroups.values()
+                        .stream()
+                        .map(likePredicateOperators -> Pair.create(
+                                likePredicateOperators,
+                                consolidate(likePredicateOperators, consolidateMin)))
+                        .collect(Collectors.toList());
+        if (consolidatedDisjuncts.stream().noneMatch(p -> p.second.isPresent())) {
+            return Optional.empty();
+        }
+        consolidatedDisjuncts.stream()
+                .map(p -> p.second.orElseGet(() -> new ArrayList<ScalarOperator>(p.first)));
+
+        List<ScalarOperator> newDisjuncts = Stream.concat(
+                        otherDisjuncts.stream(),
+                        consolidatedDisjuncts
+                                .stream()
+                                .map(p -> p.second.orElseGet(() -> new ArrayList<ScalarOperator>(p.first)))
+                                .flatMap(Collection::stream))
+                .collect(Collectors.toList());
+        return Optional.of(newDisjuncts);
+    }
+
+    @Override
+    public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator predicate,
+                                                 ScalarOperatorRewriteContext context) {
+        int consolidateMin = Optional.ofNullable(ConnectContext.get())
+                .map(ConnectContext::getSessionVariable)
+                .map(SessionVariable::getLikePredicateConsolidateMin)
+                .orElse(0);
+        if (consolidateMin < 1) {
+            return predicate;
+        }
+        if (predicate.isOr()) {
+            List<ScalarOperator> disjuncts = Utils.extractDisjunctive(predicate);
+            return handleDisjuncts(disjuncts, consolidateMin).map(Utils::compoundOr).orElse(predicate);
+        } else if (predicate.isAnd()) {
+            NegateFilterShuttle negateShuttle = NegateFilterShuttle.getInstance();
+            List<ScalarOperator> disjuncts = Utils.extractConjuncts(predicate).stream()
+                    .map(negateShuttle::negateFilter)
+                    .collect(Collectors.toList());
+            return handleDisjuncts(disjuncts, consolidateMin)
+                    .map(Utils::compoundOr)
+                    .map(negateShuttle::negateFilter)
+                    .orElse(predicate);
+        } else {
+            return predicate;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -30,8 +30,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
-import com.starrocks.sql.optimizer.rewrite.scalar.PruneTediousPredicateRule;
-import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedCaseWhenRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -82,13 +80,8 @@ public class PushDownPredicateScanRule extends TransformationRule {
 
         ScalarOperatorRewriter scalarOperatorRewriter = new ScalarOperatorRewriter();
         ScalarOperator predicates = Utils.compoundAnd(lfo.getPredicate(), logicalScanOperator.getPredicate());
-        // simplify case-when
-        if (context.getSessionVariable().isEnableSimplifyCaseWhen()) {
-            predicates = scalarOperatorRewriter.rewrite(predicates, Lists.newArrayList(
-                    SimplifiedCaseWhenRule.INSTANCE,
-                    PruneTediousPredicateRule.INSTANCE
-            ));
-        }
+
+        predicates = ScalarOperatorRewriter.simplifyCaseWhen(predicates);
 
         ScalarRangePredicateExtractor rangeExtractor = new ScalarRangePredicateExtractor();
         predicates = rangeExtractor.rewriteOnlyColumn(Utils.compoundAnd(Utils.extractConjuncts(predicates)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SimplifyCaseWhenPredicateRule.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class SimplifyCaseWhenPredicateRule implements TreeRewriteRule {
+    public static final SimplifyCaseWhenPredicateRule INSTANCE = new SimplifyCaseWhenPredicateRule();
+
+    private SimplifyCaseWhenPredicateRule() {
+    }
+
+    private static final class Rewriter extends OptExpressionVisitor<Optional<OptExpression>, Void> {
+        public static final Rewriter INSTANCE = new Rewriter();
+
+        private Rewriter() {
+        }
+
+        @Override
+        public Optional<OptExpression> visit(OptExpression optExpression, Void context) {
+            ScalarOperator predicate = optExpression.getOp().getPredicate();
+            if (predicate == null) {
+                return Optional.empty();
+            }
+            ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate);
+            if (newPredicate == predicate) {
+                return Optional.empty();
+            }
+            Operator newOperator = OperatorBuilderFactory.build(optExpression.getOp())
+                    .withOperator(optExpression.getOp())
+                    .setPredicate(newPredicate).build();
+            return Optional.of(OptExpression.create(newOperator, optExpression.getInputs()));
+        }
+
+        @Override
+        public Optional<OptExpression> visitLogicalJoin(OptExpression optExpression, Void context) {
+            LogicalJoinOperator joinOperator = optExpression.getOp().cast();
+            Optional<ScalarOperator> optNewOnPredicate =
+                    Optional.ofNullable(joinOperator.getOnPredicate()).map(predicate -> {
+                        ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate);
+                        return newPredicate == predicate ? null : newPredicate;
+                    });
+            Optional<ScalarOperator> optNewPredicate =
+                    Optional.ofNullable(joinOperator.getPredicate()).map(predicate -> {
+                        ScalarOperator newPredicate = ScalarOperatorRewriter.simplifyCaseWhen(predicate);
+                        return newPredicate == predicate ? null : newPredicate;
+                    });
+            if (!optNewOnPredicate.isPresent() && !optNewPredicate.isPresent()) {
+                return Optional.empty();
+            }
+            Operator newOperator = LogicalJoinOperator.builder().withOperator(joinOperator)
+                    .setOnPredicate(optNewOnPredicate.orElse(joinOperator.getOnPredicate()))
+                    .setPredicate(optNewPredicate.orElse(joinOperator.getPredicate()))
+                    .build();
+            return Optional.of(OptExpression.create(newOperator, optExpression.getInputs()));
+        }
+
+        private Optional<OptExpression> processImpl(OptExpression optExpression) {
+            List<Optional<OptExpression>> optNewInputs =
+                    optExpression.getInputs().stream()
+                            .map(this::processImpl)
+                            .collect(Collectors.toList());
+            List<OptExpression> newInputs = IntStream.range(0, optNewInputs.size())
+                    .mapToObj(i -> optNewInputs.get(i).orElse(optExpression.getInputs().get(i)))
+                    .collect(Collectors.toList());
+
+            OptExpression newExpression = OptExpression.create(optExpression.getOp(), newInputs);
+            return optExpression.getOp().accept(this, newExpression, null);
+        }
+
+        public OptExpression process(OptExpression optExpression) {
+            return processImpl(optExpression).orElse(optExpression);
+        }
+    }
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        if (taskContext.getOptimizerContext().getSessionVariable().isEnableSimplifyCaseWhen()) {
+            return Rewriter.INSTANCE.process(root);
+        } else {
+            return root;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
@@ -1,0 +1,285 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Stream;
+
+public class SelectStmtWithMultiLikeTest {
+
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp()
+            throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        String createTblStmtStr = " CREATE TABLE `t0` (\n" +
+                "  `region` varchar(128) NOT NULL COMMENT \"\",\n" +
+                "  `order_date` date NOT NULL COMMENT \"\",\n" +
+                "  `site` varchar(128) NOT NULL COMMENT \"\",\n" +
+                "  `income` decimal(7, 0) NOT NULL COMMENT \"\",\n" +
+                "  `ship_mode` int NOT NULL COMMENT \"\",\n" +
+                "  `ship_code` int" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`region`, `order_date`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`region`, `order_date`) BUCKETS 10 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\" " +
+                ");";
+
+        starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        starRocksAssert.withTable(createTblStmtStr);
+        FeConstants.enablePruneEmptyOutputScan = false;
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("multiLikeTestCases")
+    void testMultiLikeClause(String sql, List<String> patterns) throws Exception {
+        test(sql, patterns);
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("joinOnMultiLikeTestCases")
+    void testJoinOnMultiLikeClause(String sql, List<String> patterns) throws Exception {
+        test(sql, patterns);
+    }
+
+    private static Stream<Arguments> multiLikeTestCases() {
+        String sqlFormat = "select count(1) from t0 where %s";
+        String[][] testCases = new String[][] {
+                {"region like '%ABC' or region like 'DEF_G'",
+                        "Predicates: " +
+                                "1: region REGEXP '^((.*ABC)|(DEF.G))$'"},
+                {"region like '%ABC'",
+                        "Predicates: " +
+                                "1: region LIKE '%ABC'"},
+                {"region like '%ABC' or order_date between '2012-01-01' and '2023-01-01'",
+                        "region LIKE '%ABC'"
+                },
+                {"region like '%ABC' and order_date between '2012-01-01' and '2023-01-01'",
+                        "region LIKE '%ABC'"
+                },
+                {"region like '%ABC' or region like 'DEF_G' or order_date between '2012-01-01' and '2023-01-01'",
+                        "region REGEXP '^((.*ABC)|(DEF.G))$'"
+                },
+                {"region like '%ABC' or region like 'DEF_G' and order_date between '2012-01-01' and '2023-01-01'",
+                        "region LIKE '%ABC'"
+                },
+                {"(region like '%ABC' or region like 'DEF_G') and order_date between '2012-01-01' and '2023-01-01'",
+                        "region REGEXP '^((.*ABC)|(DEF.G))$'"
+                },
+                {"region not like '%ABC' and region not like 'DEF_G'",
+                        "Predicates: " +
+                                "NOT (1: region REGEXP '^((.*ABC)|(DEF.G))$')"
+                },
+                {"region like '^$%ABC\n' or region like '%BC[]\r' or region like '\t%AC{}' ",
+                        "Predicates: " +
+                                "1: region REGEXP " +
+                                "'^((\\\\^\\\\$.*ABC\\\\n)|(.*BC\\\\[\\\\]\\\\r)|(\\\\t.*AC\\\\{\\\\}))$'"
+                },
+                {"region not like '^$%ABC\n' and region not like '%BC[]\r' and region not like '\t%AC{}' ",
+                        "Predicates: " +
+                                "NOT (1: region REGEXP " +
+                                "'^((\\\\^\\\\$.*ABC\\\\n)|(.*BC\\\\[\\\\]\\\\r)|(\\\\t.*AC\\\\{\\\\}))$')"
+                },
+                {"region like '甲乙.子丑%' or " +
+                        "region like '丙丁.寅卯%' or " +
+                        "region like '戊己.辰巳%' or " +
+                        "region like '庚辛.午未%'",
+                        "region LIKE '甲乙.子丑%'"
+                },
+                {"region not like '甲乙.%子丑' and " +
+                        "region not like '丙丁.%寅卯' and " +
+                        "region not like '戊己.%辰巳' and " +
+                        "region not like '庚辛.午未%'",
+                        "region REGEXP '^((甲乙\\\\..*子丑)|(丙丁\\\\..*寅卯)|(戊己\\\\..*辰巳))$'",
+                        "region LIKE '庚辛.午未%'"
+                },
+                {"region like '甲乙.%子丑' or " +
+                        "site like '东*青?%木' or " +
+                        "region like '丙丁.%寅卯' or " +
+                        "site like '南*赤?%火' or " +
+                        "region like '戊己.%辰巳' or " +
+                        "site like '西*白?%金' or " +
+                        "region like '庚辛.午未%'",
+                        "region REGEXP '^((甲乙\\\\..*子丑)|(丙丁\\\\..*寅卯)|(戊己\\\\..*辰巳))$'",
+                        "region LIKE '庚辛.午未%')) OR (3: site REGEXP '^((东\\\\*青\\\\?.*木)|" +
+                                "(南\\\\*赤\\\\?.*火)|(西\\\\*白\\\\?.*金))$'",
+                },
+                {"region not like '甲乙.%子丑' and " +
+                        "site not like '东*青?木%' and " +
+                        "region not like '丙丁.%寅卯' and " +
+                        "site not like '南*%赤?火' and " +
+                        "region not like '戊己.%辰巳' and " +
+                        "site not like '西*%白?金' and " +
+                        "region not like '庚辛.%午未'",
+                        "region REGEXP '^((甲乙\\\\..*子丑)|(丙丁\\\\..*寅卯)|(戊己\\\\..*辰巳)|(庚辛\\\\..*午未))$'"
+                },
+                {"order_date = '2023-01-01' or region like '甲乙.%子丑' or " +
+                        "site like '东*%青?木' or " +
+                        "region like '丙丁%.寅卯' or " +
+                        "site like '南*赤%?火' or " +
+                        "region like '戊己.%辰巳' or " +
+                        "site like '西*白%?金' or " +
+                        "region like '庚辛.%午未'",
+                        "region REGEXP '^((甲乙\\\\..*子丑)|(丙丁.*\\\\.寅卯)|(戊己\\\\..*辰巳)|(庚辛\\\\..*午未))$'"
+                },
+                {"region not like '甲乙.子丑%' and " +
+                        "site not like '东*青?木%' and " +
+                        "region not like '丙丁.寅卯%' and " +
+                        "site not like '南*%赤?火' and " +
+                        "region not like '戊己.辰巳%' and " +
+                        "site not like '西*%白?金' and " +
+                        "region not like '庚辛.午未%'",
+                        "site REGEXP '^((南\\\\*.*赤\\\\?火)|(西\\\\*.*白\\\\?金))$'"
+                },
+                {"(case when ship_mode in (1,2,3,4)\n" +
+                        " and (region like '甲乙.%子丑'\n" +
+                        "      or region like '丙丁.%寅卯' \n" +
+                        "      or region like '戊己.%辰巳' \n" +
+                        "      or region like '庚辛.%午未'\n" +
+                        "      or region like '壬癸.%申酉' )\n" +
+                        " then  '01'\n" +
+                        " when ship_mode in (5,6,7,8)\n" +
+                        " and (region like '中央.%黄土'\n" +
+                        "      or region like '东方.%青木%' \n" +
+                        "      or region like '南方.%赤火%' \n" +
+                        "      or region like '北方.%黑水%'\n" +
+                        "      or region like '西方.%白金%' )\n" +
+                        " then  '02'\n" +
+                        " when ship_mode in (9,10,11,12)\n" +
+                        " and (region like '天.地.玄.%黄%'\n" +
+                        "      or region like '宇.宙.%洪.荒%' \n" +
+                        "      or region like '日.月.%盈.昃%' \n" +
+                        "      or region like '辰.宿.%列.张%'\n" +
+                        "      or region like '寒.来.%暑.往%' )\n" +
+                        " then  '03'\n" +
+                        " when ship_mode in (13,14,15,16)\n" +
+                        " and (region like 'Α.Β.Γ.%Δ%'\n" +
+                        "      or region like 'α.β.%γ.δ%' \n" +
+                        "      or region like 'A.B.%C.D%' \n" +
+                        "      or region like 'a.b.%c.d%'\n" +
+                        "      or region like '一.二.%三.四%' )\n" +
+                        " then  '04'\n" +
+                        " else  '00'\n" +
+                        " end) = '02'\n",
+                        "region REGEXP '^((中央\\\\..*黄土)|" +
+                                "(东方\\\\..*青木.*)|" +
+                                "(南方\\\\..*赤火.*)|" +
+                                "(北方\\\\..*黑水.*)|" +
+                                "(西方\\\\..*白金.*))$'",
+                        "region REGEXP '^((甲乙\\\\..*子丑)|" +
+                                "(丙丁\\\\..*寅卯)|" +
+                                "(戊己\\\\..*辰巳)|" +
+                                "(庚辛\\\\..*午未)|" +
+                                "(壬癸\\\\..*申酉))$'",
+                },
+                {"region like '\\\\b%' or region like '\\\\d%' or region like '\\\\S+'",
+                        "region LIKE '\\\\b%'",
+                        "region LIKE '\\\\d%'",
+                        "region = '\\\\S+'"
+                }
+        };
+
+        List<Arguments> argumentsList = Lists.newArrayList();
+        for (String[] tc : testCases) {
+            String sql = String.format(sqlFormat, tc[0]);
+            argumentsList.add(Arguments.of(sql, Arrays.asList(tc).subList(1, tc.length)));
+        }
+        return argumentsList.stream();
+    }
+
+    private static Stream<Arguments> joinOnMultiLikeTestCases() {
+        String sqlFormat = "select count(1) from t0 ta join t0 tb on " +
+                "ta.order_date = days_add(tb.order_date, 1) and %s";
+        String[][] testCases = new String[][] {
+                {"(case when ta.ship_mode in (1,2,3,4)\n" +
+                        " and (tb.region like '甲乙.子丑%'\n" +
+                        "      or tb.region like '丙丁.寅卯%' \n" +
+                        "      or tb.region like '戊己.辰巳%' \n" +
+                        "      or tb.region like '庚辛.午未%'\n" +
+                        "      or tb.region like '壬癸.申酉%' )\n" +
+                        " then  '01'\n" +
+                        " when ta.ship_mode in (5,6,7,8)\n" +
+                        " and (tb.region like '中央.黄土%'\n" +
+                        "      or tb.region like '东方.青木%' \n" +
+                        "      or tb.region like '南方.赤火%' \n" +
+                        "      or tb.region like '北方.黑水%'\n" +
+                        "      or tb.region like '西方.白金%' )\n" +
+                        " then  '02'\n" +
+                        " when ta.ship_mode in (9,10,11,12)\n" +
+                        " and (tb.region like '天.地.玄.黄%'\n" +
+                        "      or tb.region like '宇.宙.洪.荒%' \n" +
+                        "      or tb.region like '日.月.盈.昃%' \n" +
+                        "      or tb.region like '辰.宿.列.张%'\n" +
+                        "      or tb.region like '寒.来.暑.往%' )\n" +
+                        " then  '03'\n" +
+                        " when ta.ship_mode in (13,14,15,16)\n" +
+                        " and (tb.region like 'Α.Β.Γ.Δ%'\n" +
+                        "      or tb.region like 'α.β.γ.δ%' \n" +
+                        "      or tb.region like 'A.B.C.D%' \n" +
+                        "      or tb.region like 'a.b.c.d%'\n" +
+                        "      or tb.region like '一.二.三.四%' )\n" +
+                        " then  '04'\n" +
+                        " else  '00'\n" +
+                        " end) = '02'\n",
+                        "5: ship_mode IN (5, 6, 7, 8), " +
+                                "((((7: region LIKE '中央.黄土%') OR " +
+                                "(7: region LIKE '东方.青木%')) OR " +
+                                "(7: region LIKE '南方.赤火%')) OR " +
+                                "(7: region LIKE '北方.黑水%')) OR " +
+                                "(7: region LIKE '西方.白金%'), " +
+                                "NOT ((5: ship_mode IN (1, 2, 3, 4)) AND " +
+                                "(((((7: region LIKE '甲乙.子丑%') OR " +
+                                "(7: region LIKE '丙丁.寅卯%')) OR " +
+                                "(7: region LIKE '戊己.辰巳%')) OR " +
+                                "(7: region LIKE '庚辛.午未%')) OR " +
+                                "(7: region LIKE '壬癸.申酉%')))\n"
+                }
+        };
+
+        List<Arguments> argumentsList = Lists.newArrayList();
+        for (String[] tc : testCases) {
+            String sql = String.format(sqlFormat, tc[0]);
+            argumentsList.add(Arguments.of(sql, Arrays.asList(tc).subList(1, tc.length)));
+        }
+        return argumentsList.stream();
+    }
+
+    private void test(String sql, List<String> patterns) throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setOptimizerExecuteTimeout(3000000);
+        starRocksAssert.getCtx().getSessionVariable().setLikePredicateConsolidateMin(2);
+        String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+        StringJoiner joiner = new StringJoiner("\n");
+        joiner.add(sql);
+        joiner.add(patterns.toString());
+        joiner.add(plan);
+        Assert.assertTrue(joiner.toString(), patterns.stream().allMatch(plan::contains));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -474,12 +474,13 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/correlated_subquery_with_equals_expression"), null,
                         TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains(" 22:NESTLOOP JOIN\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("  22:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other join predicates: if(19: c_0_0 != 1: c_0_0, 4: c_0_3, 20: c_0_3) = '1969-12-28', " +
-                "CASE WHEN (21: countRows IS NULL) OR (21: countRows = 0) THEN FALSE WHEN 1: c_0_0 IS NULL THEN NULL " +
-                "WHEN 16: c_0_0 IS NOT NULL THEN TRUE WHEN 22: countNotNulls < 21: countRows THEN NULL ELSE FALSE END IS NULL"));
+                "if(((1: c_0_0 IS NULL) AND (NOT ((21: countRows IS NULL) OR (21: countRows = 0)))) OR " +
+                "((22: countNotNulls < 21: countRows) AND (((NOT ((21: countRows IS NULL) OR (21: countRows = 0))) " +
+                "AND (1: c_0_0 IS NOT NULL)) AND (16: c_0_0 IS NULL))), TRUE, FALSE)\n"));
         Assert.assertTrue(replayPair.second, replayPair.second.contains("  20:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -34,12 +34,13 @@ public class SubqueryTest extends PlanTestBase {
     public void testCorrelatedSubqueryWithEqualsExpressions() throws Exception {
         String sql = "select t0.v1 from t0 where (t0.v2 in (select t1.v4 from t1 where t0.v3 + t1.v5 = 1)) is NULL";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan, plan.contains("15:NESTLOOP JOIN\n" +
+        Assert.assertTrue(plan, plan.contains("  15:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  other join predicates: 3: v3 + 11: v5 = 1, CASE WHEN (12: countRows IS NULL) " +
-                "OR (12: countRows = 0) THEN FALSE WHEN 2: v2 IS NULL THEN NULL WHEN 8: v4 IS NOT NULL " +
-                "THEN TRUE WHEN 13: countNotNulls < 12: countRows THEN NULL ELSE FALSE END IS NULL"));
+                "  |  other join predicates: 3: v3 + 11: v5 = 1, if(((2: v2 IS NULL) AND " +
+                "(NOT ((12: countRows IS NULL) OR (12: countRows = 0)))) OR " +
+                "((13: countNotNulls < 12: countRows) AND (((NOT ((12: countRows IS NULL) OR " +
+                "(12: countRows = 0))) AND (2: v2 IS NOT NULL)) AND (8: v4 IS NULL))), TRUE, FALSE)"));
         assertContains(plan, "8:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +

--- a/test/sql/test_consolidate_multi_likes/R/test_consolidate_multi_likes
+++ b/test/sql/test_consolidate_multi_likes/R/test_consolidate_multi_likes
@@ -1,0 +1,44 @@
+-- name: test_consolidate_multi_likes
+ DROP TABLE if exists t0;
+-- result:
+-- !result
+ CREATE TABLE if not exists t0
+ (
+ c0 INT NOT NULL,
+ c1 VARCHAR(2048) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 1
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+-- result:
+-- !result
+INSERT INTO t0
+(c0, c1)
+VALUES
+('1', 'ABC\t\n \r{}[]()^$.?+*|%_\\'),
+('2', '\t\n \rABC{}[]()^$.?+*|%_\\'),
+('3', '\t\n \r{}[]()^$.?+*|%_\\ABC'),
+('4', 'DEFG\t\n \r{}[]()^$.?+*|%_\\'),
+('5', '\t\n \rDEFG{}[]()^$.?+*|%_\\'),
+('6', '\t\n \r{}[]()^$.?+*|%_\\DEFG');
+-- result:
+-- !result
+set like_predicate_consolidate_min='3';
+-- result:
+-- !result
+select count(*) from t0 where c1 like 'AB%\t\n \r{}[]()^$.?+*|\\%\\_\\\\'  or c1 like '\t\n \rAB%{}[]()^$.?+*|\\%\\_\\\\'  or c1 like '\t\n \r{}[]()^$.?+*|\\%\\_\\\\AB%';
+-- result:
+3
+-- !result
+set like_predicate_consolidate_min='3';
+-- result:
+-- !result
+select count(*) from t0 where c1 not like 'DEF%\t\n \r{}[]()^$.?+*|\\%\\_\\\\'  and c1 not like '\t\n \rDEF%{}[]()^$.?+*|\\%\\_\\\\'  and c1 not like '\t\n \r{}[]()^$.?+*|\\%\\_\\\\DEF%';
+-- result:
+3
+-- !result

--- a/test/sql/test_consolidate_multi_likes/T/test_consolidate_multi_likes
+++ b/test/sql/test_consolidate_multi_likes/T/test_consolidate_multi_likes
@@ -1,0 +1,29 @@
+-- name: test_consolidate_multi_likes
+ DROP TABLE if exists t0;
+
+ CREATE TABLE if not exists t0
+ (
+ c0 INT NOT NULL,
+ c1 VARCHAR(2048) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 1
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+INSERT INTO t0
+(c0, c1)
+VALUES
+('1', 'ABC\t\n \r{}[]()^$.?+*|%_\\'),
+('2', '\t\n \rABC{}[]()^$.?+*|%_\\'),
+('3', '\t\n \r{}[]()^$.?+*|%_\\ABC'),
+('4', 'DEFG\t\n \r{}[]()^$.?+*|%_\\'),
+('5', '\t\n \rDEFG{}[]()^$.?+*|%_\\'),
+('6', '\t\n \r{}[]()^$.?+*|%_\\DEFG');
+set like_predicate_consolidate_min='3';
+select count(*) from t0 where c1 like 'AB%\t\n \r{}[]()^$.?+*|\\%\\_\\\\'  or c1 like '\t\n \rAB%{}[]()^$.?+*|\\%\\_\\\\'  or c1 like '\t\n \r{}[]()^$.?+*|\\%\\_\\\\AB%';
+set like_predicate_consolidate_min='3';
+select count(*) from t0 where c1 not like 'DEF%\t\n \r{}[]()^$.?+*|\\%\\_\\\\'  and c1 not like '\t\n \rDEF%{}[]()^$.?+*|\\%\\_\\\\'  and c1 not like '\t\n \r{}[]()^$.?+*|\\%\\_\\\\DEF%';


### PR DESCRIPTION
## Why I'm doing:

1. Multiple like predicates with the same column can converted into a regex predicate.
e.g: 
```SQL
region like '%ABC' or region like 'DEF_G'
```
can converted to 
```SQL
region REGEXP '^((.*ABC)|(DEF.G))$'
```
The latter would be more efficient.

2. Case-when simplification in previous versions is only applied to scan operator, it can applied to predicates of other operators, too.

## What I'm doing:
1. Introduce a ScalarOparatorRewriteRule to optimize multiple like predicate;
2. Introduce a SimplifyCaseWhenPredicateRule to travel the plan tree to process prediates of each logical operator. 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
<hr>This is an automatic backport of pull request #46914 done by [Mergify](https://mergify.com).
## Why I'm doing:

1. Multiple like predicates with the same column can converted into a regex predicate.
e.g: 
```SQL
region like '%ABC' or region like 'DEF_G'
```
can converted to 
```SQL
region REGEXP '^((.*ABC)|(DEF.G))$'
```
The latter would be more efficient.

2. Case-when simplification in previous versions is only applied to scan operator, it can applied to predicates of other operators, too.

## What I'm doing:
1. Introduce a ScalarOparatorRewriteRule to optimize multiple like predicate;
2. Introduce a SimplifyCaseWhenPredicateRule to travel the plan tree to process prediates of each logical operator. 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


