### PR TITLE
[BugFix] Ngram index fix

### DIFF
--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -213,14 +213,28 @@ bool VectorizedFunctionCallExpr::ngram_bloom_filter(ExprContext* context, const 
     std::unique_ptr<NgramBloomFilterState>& ngram_state = fn_ctx->get_ngram_state();
 
     // initialize ngram_state: determine whether this index useful or not, split needle into ngram_set if useful
+    // this is not thread-safe, but every scan thread will has its own ExprContext, so it's ok
     if (ngram_state == nullptr) {
         ngram_state = std::make_unique<NgramBloomFilterState>();
-        std::vector<Slice>& ngram_set = ngram_state->ngram_set;
+        std::vector<std::string>& ngram_set = ngram_state->ngram_set;
         bool index_useful;
-        if (_fn_desc->name == "LIKE") {
-            index_useful = split_like_string_to_ngram(fn_ctx, reader_options, ngram_set);
+
+        // checked in support_ngram_bloom_filter(size_t gram_num), so it 's safe to get const column's value
+        Slice needle;
+        const auto& needle_column = fn_ctx->get_constant_column(1);
+
+        if (reader_options.index_case_sensitive) {
+            needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column);
         } else {
-            index_useful = split_normal_string_to_ngram(fn_ctx, reader_options, ngram_state.get(), _fn_desc->name);
+            // for case_insensitive, we need to convert needle to lower case
+            std::string& buf = ngram_state->buffer;
+            needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column).tolower(buf);
+        }
+
+        if (_fn_desc->name == "LIKE") {
+            index_useful = split_like_string_to_ngram(needle, reader_options, ngram_set);
+        } else {
+            index_useful = split_normal_string_to_ngram(needle, fn_ctx, reader_options, ngram_set, _fn_desc->name);
         }
         ngram_state->initialized = true;
         ngram_state->index_useful = index_useful;
@@ -239,7 +253,7 @@ bool VectorizedFunctionCallExpr::ngram_bloom_filter(ExprContext* context, const 
     if (_fn_desc->name == "LIKE") {
         for (auto& ngram : ngram_state->ngram_set) {
             // if any ngram in needle doesn't hit bf, this page has nothing to do with target,so filter it
-            if (!bf->test_bytes(ngram.get_data(), ngram.get_size())) {
+            if (!bf->test_bytes(ngram.data(), ngram.size())) {
                 return false;
             }
         }
@@ -248,7 +262,7 @@ bool VectorizedFunctionCallExpr::ngram_bloom_filter(ExprContext* context, const 
     } else {
         for (auto& ngram : ngram_state->ngram_set) {
             // if any ngram in needle hit bf, this page may have something to do with needle, so don't filter it
-            if (bf->test_bytes(ngram.get_data(), ngram.get_size())) {
+            if (bf->test_bytes(ngram.data(), ngram.size())) {
                 return true;
             }
         }
@@ -269,13 +283,12 @@ bool VectorizedFunctionCallExpr::support_ngram_bloom_filter(ExprContext* context
 }
 
 // return false if this index can not be used, otherwise set ngram_set and return true
-bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(FunctionContext* fn_ctx,
+bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(const Slice& needle, FunctionContext* fn_ctx,
                                                               const NgramBloomFilterReaderOptions& reader_options,
-                                                              NgramBloomFilterState* ngram_state,
-                                                              const string& func_name) const {
+                                                              std::vector<std::string>& ngram_set,
+                                                              const std::string& func_name) const {
     size_t index_gram_num = reader_options.index_gram_num;
     bool index_case_sensitive = reader_options.index_case_sensitive;
-    std::vector<Slice>& ngram_set = ngram_state->ngram_set;
 
     auto gram_num_column = fn_ctx->get_constant_column(2);
     if (gram_num_column != nullptr) {
@@ -291,18 +304,6 @@ bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(FunctionContext* f
         return false;
     }
 
-    // checked in support_ngram_bloom_filter(size_t gram_num), so it 's safe to get const column's value
-    Slice needle;
-    const auto& needle_column = fn_ctx->get_constant_column(1);
-
-    if (index_case_sensitive) {
-        needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column);
-    } else {
-        // for case_insensitive, we need to convert needle to lower case
-        std::string& buf = ngram_state->buffer;
-        needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column).tolower(buf);
-    }
-
     std::vector<size_t> index;
     size_t slice_gram_num = get_utf8_index(needle, &index);
     // case like "ngram_search
@@ -316,59 +317,71 @@ bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(FunctionContext* f
         // find next ngram
         size_t cur_ngram_length = j + index_gram_num < slice_gram_num ? index[j + index_gram_num] - index[j]
                                                                       : needle.get_size() - index[j];
-        Slice cur_ngram = Slice(needle.data + index[j], cur_ngram_length);
-
-        ngram_set.push_back(cur_ngram);
+        ngram_set.emplace_back(needle.data + index[j], cur_ngram_length);
     }
     // case like "ngram_search(col, "nee", 3) when col has a 4gram bloom filter, don't use this index
     if (ngram_set.empty()) return false;
     return true;
 }
 
-bool VectorizedFunctionCallExpr::split_like_string_to_ngram(FunctionContext* fn_ctx,
+bool VectorizedFunctionCallExpr::split_like_string_to_ngram(const Slice& needle,
                                                             const NgramBloomFilterReaderOptions& reader_options,
-                                                            std::vector<Slice>& ngram_set) const {
+                                                            std::vector<std::string>& ngram_set) const {
     size_t index_gram_num = reader_options.index_gram_num;
-    auto needle_column = fn_ctx->get_constant_column(1);
-    if (needle_column == nullptr) {
-        return false;
-    }
 
-    Slice needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column);
-
-    size_t cur_valid_grams_num = 0;
+    // below is a window sliding algorithm which consider escaped character
+    // cur_grams_begin_index is window's left site, i is window's right site
+    // in each iteration of while loop, we will keep moving window's right site until we find a valid ngram and save it into  ngram_set
+    // then move window's left site to the next utf-8 gram
     size_t cur_grams_begin_index = 0;
-    bool escaped = false;
-
-    // when iteration begin,[cur_grams_begin_index, i) is the current ngram
-    // cur_valid_grams_num is the number of utf-8 gram in slice[cur_grams_begin_index, i)
-    // escaped means needle[i - 1] is '\\'
-    for (size_t i = 0; i < needle.size;) {
-        if (escaped && (needle[i] == '%' || needle[i] == '_' || needle[i] == '\\')) {
-            ++cur_valid_grams_num;
-            escaped = false;
-            ++i;
-        } else if (!escaped && (needle[i] == '%' || needle[i] == '_')) {
-            cur_valid_grams_num = 0;
-            escaped = false;
-            ++i;
-            cur_grams_begin_index = i;
-        } else if (!escaped && needle[i] == '\\') {
-            escaped = true;
-            ++i;
-        } else {
-            size_t cur_gram_length = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(needle.data[i])];
-            i += cur_gram_length;
-            ++cur_valid_grams_num;
-            escaped = false;
+    while (cur_grams_begin_index < needle.size()) {
+        // we stop here when there is not enough grams left
+        if (needle.size() - cur_grams_begin_index + 1 < index_gram_num) {
+            break;
         }
+        size_t cur_valid_grams_num = 0;
+        size_t cur_grams_begin_index = 0;
+        bool escaped = false;
+        std::string cur_valid_grams;
+        // when iteration begin,[cur_grams_begin_index, i) is the current ngram
+        // cur_valid_grams contains the number of utf-8 gram in needle[cur_grams_begin_index, i) without '\\'
+        // cur_valid_grams_num is the number of utf-8 gram in needle[cur_grams_begin_index, i)
+        // escaped means needle[i - 1] is '\\'
+        for (size_t i = cur_grams_begin_index; i < needle.size;) {
+            if (escaped && (needle[i] == '%' || needle[i] == '_' || needle[i] == '\\')) {
+                cur_valid_grams += needle[i];
+                ++cur_valid_grams_num;
+                escaped = false;
+                ++i;
+            } else if (!escaped && (needle[i] == '%' || needle[i] == '_')) {
+                // not enough grams, so move left site of window to need[i+1]
+                cur_valid_grams_num = 0;
+                escaped = false;
+                ++i;
+                cur_grams_begin_index = i;
+            } else if (!escaped && needle[i] == '\\') {
+                escaped = true;
+                ++i;
+            } else {
+                size_t cur_gram_length = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(needle.data[i])];
+                cur_valid_grams.append(needle[cur_grams_begin_index], cur_gram_length);
+                i += cur_gram_length;
+                ++cur_valid_grams_num;
+                escaped = false;
+            }
 
-        if (cur_valid_grams_num == index_gram_num) {
-            ngram_set.emplace_back(needle.data + cur_grams_begin_index, i - cur_grams_begin_index);
-            cur_valid_grams_num = 0;
-            cur_grams_begin_index = i;
+            if (cur_valid_grams_num == index_gram_num) {
+                // got enough grams, add them to ngram_set and move window's left site(cur_grams_begin_index) to the next utf-8 gram
+                ngram_set.push_back(std::move(cur_valid_grams));
+                cur_valid_grams.clear();
+                cur_valid_grams_num = 0;
+                cur_grams_begin_index +=
+                        UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(needle.data[cur_grams_begin_index])];
+                break;
+            }
         }
     }
+
     // case like "like(col, "nee") when col has a 4gram bloom filter, don't use this index
     if (ngram_set.empty()) return false;
     return true;

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -331,12 +331,12 @@ bool VectorizedFunctionCallExpr::split_like_string_to_ngram(const Slice& needle,
 
     // below is a window sliding algorithm which consider escaped character
     // cur_grams_begin_index is window's left site, i is window's right site
-    // in each iteration of while loop, we will keep moving window's right site until we find a valid ngram and save it into  ngram_set
-    // then move window's left site to the next utf-8 gram
+    // in each iteration of while loop, we will keep moving window's right site i from cur_grams_begin_index until we find a valid ngram and save it into  ngram_set
+    // then move window's left site cur_grams_begin_index to the next utf-8 gram
     size_t cur_grams_begin_index = 0;
-    while (cur_grams_begin_index < needle.size()) {
+    while (cur_grams_begin_index < needle.size) {
         // we stop here when there is not enough grams left
-        if (needle.size() - cur_grams_begin_index + 1 < index_gram_num) {
+        if (needle.size - cur_grams_begin_index < index_gram_num) {
             break;
         }
         size_t cur_valid_grams_num = 0;
@@ -355,10 +355,8 @@ bool VectorizedFunctionCallExpr::split_like_string_to_ngram(const Slice& needle,
                 ++i;
             } else if (!escaped && (needle[i] == '%' || needle[i] == '_')) {
                 // not enough grams, so move left site of window to need[i+1]
-                cur_valid_grams_num = 0;
-                escaped = false;
-                ++i;
-                cur_grams_begin_index = i;
+                cur_grams_begin_index = i + 1;
+                break;
             } else if (!escaped && needle[i] == '\\') {
                 escaped = true;
                 ++i;

--- a/be/src/exprs/function_call_expr.h
+++ b/be/src/exprs/function_call_expr.h
@@ -49,11 +49,12 @@ protected:
     [[nodiscard]] StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
 private:
-    bool split_normal_string_to_ngram(FunctionContext* fn_ctx, const NgramBloomFilterReaderOptions& reader_options,
-                                      NgramBloomFilterState* ngram_state, const std::string& func_name) const;
+    bool split_normal_string_to_ngram(const Slice& needle, FunctionContext* fn_ctx,
+                                      const NgramBloomFilterReaderOptions& reader_options,
+                                      std::vector<std::string>& ngram_set, const std::string& func_name) const;
 
-    bool split_like_string_to_ngram(FunctionContext* fn_ctx, const NgramBloomFilterReaderOptions& reader_options,
-                                    std::vector<Slice>& ngram_set) const;
+    bool split_like_string_to_ngram(const Slice& needle, const NgramBloomFilterReaderOptions& reader_options,
+                                    std::vector<std::string>& ngram_set) const;
 
     const FunctionDescriptor* _fn_desc{nullptr};
 

--- a/be/src/exprs/function_call_expr.h
+++ b/be/src/exprs/function_call_expr.h
@@ -35,6 +35,12 @@ public:
     bool support_ngram_bloom_filter(ExprContext* context) const override;
     bool ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
                             const NgramBloomFilterReaderOptions& reader_options) const override;
+    static bool split_normal_string_to_ngram(const Slice& needle, FunctionContext* fn_ctx,
+                                             const NgramBloomFilterReaderOptions& reader_options,
+                                             std::vector<std::string>& ngram_set, const std::string& func_name);
+
+    static bool split_like_string_to_ngram(const Slice& needle, const NgramBloomFilterReaderOptions& reader_options,
+                                           std::vector<std::string>& ngram_set);
 
 protected:
     [[nodiscard]] Status prepare(RuntimeState* state, ExprContext* context) override;
@@ -49,13 +55,6 @@ protected:
     [[nodiscard]] StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
 private:
-    bool split_normal_string_to_ngram(const Slice& needle, FunctionContext* fn_ctx,
-                                      const NgramBloomFilterReaderOptions& reader_options,
-                                      std::vector<std::string>& ngram_set, const std::string& func_name) const;
-
-    bool split_like_string_to_ngram(const Slice& needle, const NgramBloomFilterReaderOptions& reader_options,
-                                    std::vector<std::string>& ngram_set) const;
-
     const FunctionDescriptor* _fn_desc{nullptr};
 
     bool _is_returning_random_value = false;

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -212,8 +212,7 @@ private:
             DCHECK(needle_not_overlap_with_haystack <= needle_gram_count);
 
             // now get the result
-            double row_result =
-                    1.0f - (needle_not_overlap_with_haystack) * 1.0f / std::max(needle_gram_count, (size_t)1);
+            double row_result = 1.0f - (needle_not_overlap_with_haystack)*1.0f / std::max(needle_gram_count, (size_t)1);
 
             res->get_data()[i] = row_result;
         }
@@ -247,7 +246,7 @@ private:
         size_t needle_gram_count = state->needle_gram_count;
         size_t needle_not_overlap_with_haystack = calculateDistanceWithHaystack<false>(
                 map, cur_haystack, map_restore_helper, needle_gram_count, gram_num);
-        float result = 1.0f - (needle_not_overlap_with_haystack) * 1.0f / std::max(needle_gram_count, (size_t)1);
+        float result = 1.0f - (needle_not_overlap_with_haystack)*1.0f / std::max(needle_gram_count, (size_t)1);
         DCHECK(needle_not_overlap_with_haystack <= needle_gram_count);
         return result;
     }

--- a/be/src/storage/rowset/bloom_filter.h
+++ b/be/src/storage/rowset/bloom_filter.h
@@ -71,7 +71,7 @@ struct NgramBloomFilterState {
     bool initialized = false;
     // whether this index can be used for predicate or not
     bool index_useful = false;
-    std::vector<Slice> ngram_set;
+    std::vector<std::string> ngram_set;
     // when index is case_insensitive, buffer is used to store the lower case of ngram_set
     std::string buffer;
 };

--- a/be/src/storage/rowset/bloom_filter.h
+++ b/be/src/storage/rowset/bloom_filter.h
@@ -72,8 +72,6 @@ struct NgramBloomFilterState {
     // whether this index can be used for predicate or not
     bool index_useful = false;
     std::vector<std::string> ngram_set;
-    // when index is case_insensitive, buffer is used to store the lower case of ngram_set
-    std::string buffer;
 };
 
 // Base class for bloom filter

--- a/be/test/exprs/like_test.cpp
+++ b/be/test/exprs/like_test.cpp
@@ -16,9 +16,9 @@
 #include <gtest/gtest.h>
 
 #include "butil/time.h"
+#include "exprs/function_call_expr.h"
 #include "exprs/like_predicate.h"
 #include "exprs/mock_vectorized_expr.h"
-#include "exprs/function_call_expr.h"
 #include "storage/rowset/bloom_filter.h"
 
 namespace starrocks {
@@ -664,8 +664,8 @@ TEST_F(LikeTest, splitLikePatternIntoNgramSet) {
     // pattern contains special characters
     std::string pattern = "abc%_abccc\\%e\\\\\\\\";
     std::vector<std::string> ngram_set;
-    NgramBloomFilterReaderOptions options(4,false);
-    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern,options, ngram_set);
+    NgramBloomFilterReaderOptions options(4, false);
+    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern, options, ngram_set);
     ASSERT_EQ(6, ngram_set.size());
     ASSERT_EQ("abcc", ngram_set[0]);
     ASSERT_EQ("bccc", ngram_set[1]);
@@ -677,7 +677,7 @@ TEST_F(LikeTest, splitLikePatternIntoNgramSet) {
     // normal case
     pattern = "abccd";
     ngram_set.clear();
-    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern,options, ngram_set);
+    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern, options, ngram_set);
     ASSERT_EQ(2, ngram_set.size());
     ASSERT_EQ("abcc", ngram_set[0]);
     ASSERT_EQ("bccd", ngram_set[1]);
@@ -685,13 +685,13 @@ TEST_F(LikeTest, splitLikePatternIntoNgramSet) {
     // pattern is empty
     pattern = "";
     ngram_set.clear();
-    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern,options, ngram_set);
+    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern, options, ngram_set);
     ASSERT_EQ(0, ngram_set.size());
 
     // pattern is too short
     pattern = "abc";
     ngram_set.clear();
-    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern,options, ngram_set);
+    VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern, options, ngram_set);
     ASSERT_EQ(0, ngram_set.size());
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
@@ -74,6 +74,18 @@ public class BloomFilterIndexUtil {
         }
     }
 
+    private static void addDefaultProperties(Map<String, String> properties) {
+        if (!properties.containsKey(FPP_KEY)) {
+            properties.put(FPP_KEY, NgramBfIndexParamsKey.BLOOM_FILTER_FPP.defaultValue());
+        }
+        if (!properties.containsKey(GRAM_NUM_KEY)) {
+            properties.put(GRAM_NUM_KEY, NgramBfIndexParamsKey.GRAM_NUM.defaultValue());
+        }
+        if (!properties.containsKey(CASE_SENSITIVE_KEY)) {
+            properties.put(CASE_SENSITIVE_KEY, NgramBfIndexParamsKey.CASE_SENSITIVE.defaultValue());
+        }
+    }
+
     public static void checkNgramBloomFilterIndexValid(Column column, Map<String, String> properties, KeysType keysType)
             throws SemanticException {
         Type type = column.getType();
@@ -94,6 +106,8 @@ public class BloomFilterIndexUtil {
         analyzeBloomFilterFpp(properties);
         analyzeBloomFilterGramNum(properties);
         analyzeBloomFilterCaseSensitive(properties);
+        // prefer add default values here instead of Index::toThrift
+        addDefaultProperties(properties);
     }
 
     public static void analyseBfWithNgramBf(Set<Index> newIndexs, Set<String> bfColumns) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
@@ -75,15 +75,9 @@ public class BloomFilterIndexUtil {
     }
 
     private static void addDefaultProperties(Map<String, String> properties) {
-        if (!properties.containsKey(FPP_KEY)) {
-            properties.put(FPP_KEY, NgramBfIndexParamsKey.BLOOM_FILTER_FPP.defaultValue());
-        }
-        if (!properties.containsKey(GRAM_NUM_KEY)) {
-            properties.put(GRAM_NUM_KEY, NgramBfIndexParamsKey.GRAM_NUM.defaultValue());
-        }
-        if (!properties.containsKey(CASE_SENSITIVE_KEY)) {
-            properties.put(CASE_SENSITIVE_KEY, NgramBfIndexParamsKey.CASE_SENSITIVE.defaultValue());
-        }
+        properties.computeIfAbsent(FPP_KEY, k -> NgramBfIndexParamsKey.BLOOM_FILTER_FPP.defaultValue());
+        properties.computeIfAbsent(GRAM_NUM_KEY, k -> NgramBfIndexParamsKey.GRAM_NUM.defaultValue());
+        properties.computeIfAbsent(CASE_SENSITIVE_KEY, k -> NgramBfIndexParamsKey.CASE_SENSITIVE.defaultValue());
     }
 
     public static void checkNgramBloomFilterIndexValid(Column column, Map<String, String> properties, KeysType keysType)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
@@ -281,6 +281,7 @@ public class Index implements Writable {
                 searchIndexParamKeySet = Collections.emptySet();
             }
 
+            // only keep valid properties
             for (Entry<String, String> propEntry : properties.entrySet()) {
                 String key = propEntry.getKey();
                 String value = propEntry.getValue();
@@ -296,15 +297,20 @@ public class Index implements Writable {
                 }
             }
 
-            Arrays.stream(CommonIndexParamKey.values())
-                    .filter(k -> !commonProperties.containsKey(k.name().toLowerCase(Locale.ROOT)) && k.needDefault())
-                    .forEach(k -> commonProperties.put(k.name().toLowerCase(Locale.ROOT), k.defaultValue()));
-            Arrays.stream(IndexParamsKey.values())
-                    .filter(k -> !indexProperties.containsKey(k.name().toLowerCase(Locale.ROOT)) && k.needDefault())
-                    .forEach(k -> indexProperties.put(k.name().toLowerCase(Locale.ROOT), k.defaultValue()));
-            Arrays.stream(SearchParamsKey.values())
-                    .filter(k -> !searchProperties.containsKey(k.name().toLowerCase(Locale.ROOT)) && k.needDefault())
-                    .forEach(k -> searchProperties.put(k.name().toLowerCase(Locale.ROOT), k.defaultValue()));
+            // Add default values for missing properties
+            if (indexType == IndexType.GIN) {
+                Arrays.stream(CommonIndexParamKey.values())
+                        .filter(k -> !commonProperties.containsKey(k.name().toLowerCase(Locale.ROOT)) &&
+                                k.needDefault())
+                        .forEach(k -> commonProperties.put(k.name().toLowerCase(Locale.ROOT), k.defaultValue()));
+                Arrays.stream(IndexParamsKey.values())
+                        .filter(k -> !indexProperties.containsKey(k.name().toLowerCase(Locale.ROOT)) && k.needDefault())
+                        .forEach(k -> indexProperties.put(k.name().toLowerCase(Locale.ROOT), k.defaultValue()));
+                Arrays.stream(SearchParamsKey.values())
+                        .filter(k -> !searchProperties.containsKey(k.name().toLowerCase(Locale.ROOT)) &&
+                                k.needDefault())
+                        .forEach(k -> searchProperties.put(k.name().toLowerCase(Locale.ROOT), k.defaultValue()));
+            }
 
             tIndex.setCommon_properties(commonProperties);
             tIndex.setIndex_properties(indexProperties);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -450,5 +450,11 @@ public class AnalyzeCreateTableTest {
                 "INDEX INDEX1(COL2) USING NGRAMBF ('BLOOM_FILTER_FPP' = '0.01', 'GRAM_NUM' = '2', 'CASE_SENSITIVE' = 'false'))" +
                 "AGGREGATE KEY(COL1, COL2) DISTRIBUTED BY HASH(COL1) BUCKETS 10;";
         analyzeSuccess(sql);
+
+        // create index with default valus
+        sql = "CREATE TABLE TABLE1 (COL1 INT, COL2 VARCHAR(10)," +
+                "INDEX INDEX1(COL2) USING NGRAMBF)" +
+                "AGGREGATE KEY(COL1, COL2) DISTRIBUTED BY HASH(COL1) BUCKETS 10;";
+        analyzeSuccess(sql);
     }
 }

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -15,7 +15,7 @@ CREATE TABLE ngram_index(
 -- !result
 show index from ngram_index;
 -- result:
-ngram_bloom_filter_db_1.ngram_index		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "gram_num" = "4")	
+ngram_bloom_filter_db_1.ngram_index		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "true", "gram_num" = "4")	
 -- !result
 insert into ngram_index values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaaaaaaaaaaab",4),('2023-01-03',"我爱吃烤全羊yangyangchin",4),('2023-01-04',"tonightisgreadnight",4);
 -- result:
@@ -46,7 +46,7 @@ None
 -- !result
 show index from ngram_index;
 -- result:
-ngram_bloom_filter_db_1.ngram_index		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.01", "gram_num" = "4")	
+ngram_bloom_filter_db_1.ngram_index		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.01", "case_sensitive" = "true", "gram_num" = "4")	
 -- !result
 select * from ngram_index order by  ngram_search(username, 'chinese',4) desc;
 -- result:
@@ -75,7 +75,7 @@ CREATE TABLE ngram_index_default_1(
 -- !result
 show index from ngram_index_default_1;
 -- result:
-ngram_bloom_filter_db_2.ngram_index_default_1		idx_name1		username						NGRAMBF("gram_num" = "4")	
+ngram_bloom_filter_db_2.ngram_index_default_1		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "true", "gram_num" = "4")	
 -- !result
 CREATE TABLE ngram_index_default_2(
     timestamp DATETIME NOT NULL,
@@ -87,7 +87,12 @@ CREATE TABLE ngram_index_default_2(
 -- !result
 show index from ngram_index_default_2;
 -- result:
-ngram_bloom_filter_db_2.ngram_index_default_2		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05")	
+ngram_bloom_filter_db_2.ngram_index_default_2		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "true", "gram_num" = "2")	
+-- !result
+// if default value of gram_num is not set, be will crash when insert data
+insert into ngram_index_default_2 values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaaaaaaaaaaab",4),('2023-01-03',"我爱吃烤全羊yangyangchin",4),('2023-01-04',"tonightisgreadnight",4);
+-- result:
+E: (1064, "Getting syntax error at line 1, column 0. Detail message: Unexpected input '/', the most similar input is {'ADD', 'ADMIN', 'ALTER', 'ANALYZE', 'BACKUP', '(', ';'}.")
 -- !result
 CREATE TABLE ngram_index_default_3(
     timestamp DATETIME NOT NULL,
@@ -99,7 +104,7 @@ CREATE TABLE ngram_index_default_3(
 -- !result
 show index from ngram_index_default_3;
 -- result:
-ngram_bloom_filter_db_2.ngram_index_default_3		idx_name1		username						NGRAMBF	
+ngram_bloom_filter_db_2.ngram_index_default_3		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "true", "gram_num" = "2")	
 -- !result
 -- name: test_ngram_bloom_filter_like
 CREATE TABLE ngram_index_like(
@@ -151,6 +156,10 @@ select ngram_search_case_insensitive(Username,"aabaa",4) as order_col from ngram
 1.0
 0.5
 -- !result
+select * from ngram_index_case_in_sensitive where Username like "AaBA_";
+-- result:
+2023-01-01 00:00:00	AaBAa	3
+-- !result
 ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username) USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.01");
 -- result:
 -- !result
@@ -165,6 +174,10 @@ select * from ngram_index_case_in_sensitive order by ngram_search_case_insensiti
 -- result:
 2023-01-01 00:00:00	AaBAa	3
 2023-01-01 00:00:00	aAbac	3
+-- !result
+select * from ngram_index_case_in_sensitive where Username like "AaBA_";
+-- result:
+2023-01-01 00:00:00	AaBAa	3
 -- !result
 drop index idx_name1 on ngram_index_case_in_sensitive;
 -- result:
@@ -207,7 +220,7 @@ CREATE TABLE ngram_index_char(
 -- !result
 show index from ngram_index_char;
 -- result:
-ngram_bloom_filter_db_3.ngram_index_char		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "gram_num" = "4")	
+ngram_bloom_filter_db_3.ngram_index_char		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "true", "gram_num" = "4")	
 -- !result
 insert into ngram_index_char values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaa",4),('2023-01-03',"我爱chin",4),('2023-01-04',"toniggrht",4);
 -- result:

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -89,10 +89,8 @@ show index from ngram_index_default_2;
 -- result:
 ngram_bloom_filter_db_2.ngram_index_default_2		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "true", "gram_num" = "2")	
 -- !result
-// if default value of gram_num is not set, be will crash when insert data
 insert into ngram_index_default_2 values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaaaaaaaaaaab",4),('2023-01-03',"我爱吃烤全羊yangyangchin",4),('2023-01-04',"tonightisgreadnight",4);
 -- result:
-E: (1064, "Getting syntax error at line 1, column 0. Detail message: Unexpected input '/', the most similar input is {'ADD', 'ADMIN', 'ALTER', 'ANALYZE', 'BACKUP', '(', ';'}.")
 -- !result
 CREATE TABLE ngram_index_default_3(
     timestamp DATETIME NOT NULL,

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -41,7 +41,7 @@ CREATE TABLE ngram_index_default_2(
     INDEX idx_name1(username) USING NGRAMBF ("bloom_filter_fpp" = "0.05")
 )PROPERTIES ("replication_num" = "1");
 show index from ngram_index_default_2;
-// if default value of gram_num is not set, be will crash when insert data
+-- if default value of gram_num is not set, be will crash when insert data
 insert into ngram_index_default_2 values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaaaaaaaaaaab",4),('2023-01-03',"我爱吃烤全羊yangyangchin",4),('2023-01-04',"tonightisgreadnight",4);
 
 

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -41,6 +41,9 @@ CREATE TABLE ngram_index_default_2(
     INDEX idx_name1(username) USING NGRAMBF ("bloom_filter_fpp" = "0.05")
 )PROPERTIES ("replication_num" = "1");
 show index from ngram_index_default_2;
+// if default value of gram_num is not set, be will crash when insert data
+insert into ngram_index_default_2 values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaaaaaaaaaaab",4),('2023-01-03',"我爱吃烤全羊yangyangchin",4),('2023-01-04',"tonightisgreadnight",4);
+
 
 CREATE TABLE ngram_index_default_3(
     timestamp DATETIME NOT NULL,
@@ -81,6 +84,8 @@ select ngram_search(Username,"aabaa",4) as order_col from ngram_index_case_in_se
 
 select ngram_search_case_insensitive(Username,"aabaa",4) as order_col from ngram_index_case_in_sensitive order by order_col desc;
 
+select * from ngram_index_case_in_sensitive where Username like "AaBA_";
+
 
 ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username) USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.01");
 function: wait_alter_table_finish()
@@ -89,6 +94,8 @@ function: wait_alter_table_finish()
 select * from ngram_index_case_in_sensitive order by ngram_search(Username,"aabaa",4) desc;
 -- function is case insensitive, index is sensitive, so index doesn't filter any data
 select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+-- when index is case insensitve, like should behave correctly instead of return empty set
+select * from ngram_index_case_in_sensitive where Username like "AaBA_";
 
 drop index idx_name1 on ngram_index_case_in_sensitive;
 function: wait_alter_table_finish()

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -494,7 +494,7 @@ select ngram_search(rowkey, "e6249ba1-5b54-46bf-bfaf-89d69094b757",4) as a from 
 -- !result
 select ngram_search("000073a7-274f-46bf-bfaf-678868cc26cd",rowkey,4) from string_table;
 -- result:
-E: (1064, "ngram search's second parameter must be const")
+E: (1064, "Getting analyzing error from line 1, column 7 to line 1, column 67. Detail message: ngram_search function 's second parameter and third parameter must be constant.")
 -- !result
 select ngram_search("chi","chi",0);
 -- result:

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -494,7 +494,15 @@ select ngram_search(rowkey, "e6249ba1-5b54-46bf-bfaf-89d69094b757",4) as a from 
 -- !result
 select ngram_search("000073a7-274f-46bf-bfaf-678868cc26cd",rowkey,4) from string_table;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 7 to line 1, column 67. Detail message: ngram_search function 's second parameter and third parameter must be constant.")
+E: (1064, "ngram search's second parameter must be const")
+-- !result
+select ngram_search("chi","chi",0);
+-- result:
+E: (1064, "ngram search's third parameter must be a positive number")
+-- !result
+select ngram_search("chi","chi",-1);
+-- result:
+E: (1064, "ngram search's third parameter must be a positive number")
 -- !result
 select ngram_search(date('2020-06-23'), "2020", 4);
 -- result:

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -187,8 +187,13 @@ select ngram_search(rowkey, "e6249ba1-5b54-46bf-bfaf-89d69094b757",4) as a from 
 -- case4: only support (column,const) and (const,const)
 select ngram_search("000073a7-274f-46bf-bfaf-678868cc26cd",rowkey,4) from string_table;
 
+-- case5: gram_num is 0
+select ngram_search("chi","chi",0);
+select ngram_search("chi","chi",-1);
+
 -- only support string,string
 select ngram_search(date('2020-06-23'), "2020", 4);
 
 -- const value with two chunk
 select sum(result) from ( select ngram_search("normal_string", "normal_string", 5) as result from (   select generate_series    from TABLE(generate_series(0, 4097 - 1)) ) as t1) as t2;
+


### PR DESCRIPTION
## Why I'm doing:
fix ngram index's some problems

## What I'm doing:
1. add default values from ngram index's fpp, case_sensitive and gram_num. if there is no default value for gram_num, be will crash
2. when ngram bloom filter is case insensitive, like predicate has to convert all characters to lowercase, otherwise it will filter out data that should not be filtered. see sql test "select * from ngram_index_case_in_sensitive where Username like "AaBA_";" 
3. function split_like_string_to_ngram's logic is totally wrong,reimplement it and add test case for it. 
4. ngram_search's gram num should be positive

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
