### PR TITLE
[BugFix] Fix usage of LOG.warn and LOG.error to ensure stack trace is printed when an error occurs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -233,7 +233,7 @@ public class StarRocksFE {
         try {
             cmd = commandLineParser.parse(options, args);
         } catch (final ParseException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             System.err.println("Failed to parse command line. exit now");
             System.exit(-1);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
@@ -78,7 +78,7 @@ public class CastExpr extends Expr {
         try {
             analyze();
         } catch (AnalysisException ex) {
-            LOG.warn(ex);
+            LOG.warn(ex.getMessage(), ex);
             Preconditions.checkState(false,
                     "Implicit casts should never throw analysis exception.");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -345,7 +345,7 @@ public class ColocateTableIndex implements Writable {
                     GlobalStateMgr.getCurrentState().getStarOSAgent().updateMetaGroup(groupId.grpId, shardGroupIds,
                             false /* isJoin */);
                 } catch (DdlException e) {
-                    LOG.error(e.getMessage());
+                    LOG.error(e.getMessage(), e);
                 }
             }
 
@@ -621,7 +621,7 @@ public class ColocateTableIndex implements Writable {
             addTableToGroup(info.getGroupId().dbId, tbl, tbl.getColocateGroup(), info.getGroupId(), true /* isReplay */);
         } catch (DdlException e) {
             // should not happen, just log an error here
-            LOG.error(e.getMessage());
+            LOG.error(e.getMessage(), e);
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DomainResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DomainResolver.java
@@ -190,7 +190,7 @@ public class DomainResolver extends FrontendDaemon {
                     bufferedReader.close();
                 }
             } catch (IOException e) {
-                LOG.error("Close bufferedReader error! " + e);
+                LOG.error("Close bufferedReader error! ", e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
@@ -87,7 +87,7 @@ public class CurrentQueryInfoProvider {
                     brpcNetAddress = SystemInfoService.toBrpcHost(instanceInfo.getAddress());
                     brpcAddresses.put(instanceInfo.getAddress(), brpcNetAddress);
                 } catch (Exception e) {
-                    LOG.warn(e.getMessage());
+                    LOG.warn(e.getMessage(), e);
                     throw new AnalysisException(e.getMessage());
                 }
             }
@@ -124,10 +124,10 @@ public class CurrentQueryInfoProvider {
                     statisticsMap.put(host, statistics);
                 }
             } catch (InterruptedException e) {
-                LOG.warn("Thread interrupted! " + e.getCause());
+                LOG.warn("Thread interrupted! ", e);
                 Thread.currentThread().interrupt();
             } catch (ExecutionException | TimeoutException e) {
-                LOG.warn("fail to receive result " + e.getCause());
+                LOG.warn("fail to receive result ", e);
                 throw new AnalysisException(e.getMessage());
             }
         }
@@ -146,7 +146,7 @@ public class CurrentQueryInfoProvider {
                         brpcNetAddress = SystemInfoService.toBrpcHost(instanceInfo.getAddress());
                         brpcAddresses.put(instanceInfo.getAddress(), brpcNetAddress);
                     } catch (Exception e) {
-                        LOG.warn(e.getMessage());
+                        LOG.warn(e.getMessage(), e);
                         throw new AnalysisException(e.getMessage());
                     }
                 }
@@ -208,10 +208,10 @@ public class CurrentQueryInfoProvider {
                     }
                 }
             } catch (InterruptedException e) {
-                LOG.warn("Thread interrupt! " + e.getCause());
+                LOG.warn("Thread interrupt! ", e);
                 Thread.currentThread().interrupt();
             } catch (ExecutionException | TimeoutException e) {
-                LOG.warn("fail to receive result" + e.getCause());
+                LOG.warn("fail to receive result", e);
                 throw new AnalysisException(e.getMessage());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PulsarUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PulsarUtil.java
@@ -187,11 +187,11 @@ public class PulsarUtil {
                     return result;
                 }
             } catch (InterruptedException ie) {
-                LOG.warn("got interrupted exception when sending proxy request to " + address);
+                LOG.warn("got interrupted exception when sending proxy request to " + address, ie);
                 Thread.currentThread().interrupt();
                 throw new LoadException("got interrupted exception when sending proxy request to " + address);
             } catch (Exception e) {
-                LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
+                LOG.warn("failed to send proxy request to " + address, e);
                 throw new LoadException("failed to send proxy request to " + address + " err " + e.getMessage());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
@@ -224,7 +224,7 @@ public class LockManager {
                 removeFromWaiterList(rid, currentLocker, lockType);
                 /* Failure to acquire lock within the timeout ms */
                 DeadlockException exception = DeadlockException.makeDeadlockException(dc, currentLocker, false);
-                LOG.warn(exception.getMessage());
+                LOG.warn(exception.getMessage(), exception);
                 throw exception;
             }
 
@@ -409,7 +409,7 @@ public class LockManager {
                     removeFromWaiterList(rid, locker, lockType);
                     DeadlockException exception =
                             DeadlockException.makeDeadlockException(deadLockChecker, victim, true);
-                    LOG.warn(exception.getMessage());
+                    LOG.warn(exception.getMessage(), exception);
                     throw exception;
                 }
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -400,7 +400,7 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
                     }
                 } catch (Exception e) {
                     // Ignore, exception would not have affection on Diskcache
-                    LOG.warn("Encountered exception when loading disk metadata " + e.getMessage());
+                    LOG.warn("Encountered exception when loading disk metadata ", e);
                 }
             });
             executor.shutdown();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -71,7 +71,7 @@ public class JDBCMetadata implements ConnectorMetadata {
             String driverName = getDriverName();
             Class.forName(driverName);
         } catch (ClassNotFoundException e) {
-            LOG.warn(e.getMessage());
+            LOG.warn(e.getMessage(), e);
             throw new StarRocksConnectorException("doesn't find class: " + e.getMessage());
         }
         if (properties.get(JDBCResource.DRIVER_CLASS).toLowerCase().contains("mysql")) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/LogAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/LogAction.java
@@ -96,7 +96,7 @@ public class LogAction extends WebBaseAction {
             appendUpdateVerboseButton(buffer, "add_verbose");
             appendUpdateVerboseButton(buffer, "del_verbose");
         } catch (IOException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/WebBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/WebBaseAction.java
@@ -354,7 +354,7 @@ public class WebBaseAction extends BaseAction {
                 node = instance.open(path);
             }
         } catch (AnalysisException e) {
-            LOG.warn(e.getMessage());
+            LOG.warn(e.getMessage(), e);
             return null;
         }
         return node;

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -370,7 +370,7 @@ public class MetaService {
                 Storage storage = new Storage(imageDir.getAbsolutePath());
                 response.updateHeader(MetaBaseAction.TOKEN, storage.getToken());
             } catch (IOException e) {
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
             }
             writeResponse(request, response);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
@@ -110,7 +110,7 @@ public class QueryDumpAction extends RestBaseAction {
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             executor.execute();
         } catch (Exception e) {
-            LOG.warn("execute query failed. " + e);
+            LOG.warn("execute query failed. ", e);
             response.getContent().append("execute query failed. " + e.getMessage());
             sendResult(request, response, HttpResponseStatus.BAD_REQUEST);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -203,7 +203,7 @@ public class RestBaseAction extends BaseAction {
             resultUriObj = new URI("http", null, addr.getHostname(),
                     addr.getPort(), urlObj.getPath(), urlObj.getQuery(), null);
         } catch (URISyntaxException e) {
-            LOG.warn(e.getMessage());
+            LOG.warn(e.getMessage(), e);
             throw new DdlException(e.getMessage());
         }
         response.updateHeader(HttpHeaderNames.LOCATION.toString(), resultUriObj.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
@@ -162,7 +162,7 @@ public class ShowMetaInfoAction extends RestBaseAction {
             long lastCheckpointTime = storage.getCurrentImageFile().lastModified();
             feInfo.put("last_checkpoint_time", String.valueOf(lastCheckpointTime));
         } catch (IOException e) {
-            LOG.warn(e.getMessage());
+            LOG.warn(e.getMessage(), e);
         }
         return feInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
@@ -130,7 +130,7 @@ public class ShowProcAction extends RestBaseAction {
                     procNode = instance.open(path);
                 }
             } catch (AnalysisException e) {
-                LOG.warn(e.getMessage());
+                LOG.warn(e.getMessage(), e);
                 response.getContent().append("[]");
             }
 
@@ -144,7 +144,7 @@ public class ShowProcAction extends RestBaseAction {
                     response.setContentType("application/json");
                     response.getContent().append(formatResultToJson(columnNames, rows));
                 } catch (AnalysisException e) {
-                    LOG.warn(e.getMessage());
+                    LOG.warn(e.getMessage(), e);
                     response.getContent().append("[]");
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -192,7 +192,7 @@ public class LakeTable extends OlapTable {
             shardIds = globalStateMgr.getStarOSAgent().createShards(tabletNum, fsInfo, cacheInfo, shardGroupId, null, properties,
                     StarOSAgent.DEFAULT_WORKER_GROUP_ID);
         } catch (DdlException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.getMessage(), e);
             return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
         }
         for (long shardId : shardIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -129,7 +129,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                     response.failedTablets.forEach(shards::remove);
                 }
             } catch (Throwable e) {
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
@@ -124,7 +124,7 @@ public class LakeBackupJob extends BackupJob {
             lockRequests.put(snapshotInfo, request);
             unfinishedTaskIds.put(tablet.getId(), 1L);
         } catch (Exception e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.getMessage(), e);
             status = new Status(Status.ErrCode.COMMON_ERROR,
                     "failed to choose replica to make snapshot for tablet " + tablet.getId()
                             + ". visible version: " + visibleVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -136,7 +136,7 @@ public class LakeRestoreJob extends RestoreJob {
                         computeNodeId, tbl.getSchemaHashByIndexId(index.getId()), -1);
                 snapshotInfos.put(idChain.getTabletId(), computeNodeId, info);
             } catch (Exception e) {
-                LOG.error(e.getMessage());
+                LOG.error(e.getMessage(), e);
                 status = new Status(Status.ErrCode.COMMON_ERROR,
                         "failed to choose replica to make snapshot for tablet " + tablet.getId());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -310,7 +310,7 @@ public class CompactionScheduler extends Daemon {
             job.setTasks(tasks);
             return job;
         } catch (Exception e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             partition.setMinRetainVersion(0);
             nextCompactionInterval = MIN_COMPACTION_INTERVAL_MS_ON_FAILURE;
             abortTransactionIgnoreError(job, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -286,7 +286,7 @@ public class InsertOverwriteJobRunner {
         try {
             addPartitionClause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(olapTable, partitionValues);
         } catch (AnalysisException ex) {
-            LOG.warn(ex);
+            LOG.warn(ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
         GlobalStateMgr state = GlobalStateMgr.getCurrentState();
@@ -296,7 +296,7 @@ public class InsertOverwriteJobRunner {
         try {
             state.getLocalMetastore().addPartitions(context, db, olapTable.getName(), addPartitionClause);
         } catch (Exception ex) {
-            LOG.warn(ex);
+            LOG.warn(ex.getMessage(), ex);
             throw new RuntimeException(ex);
         }
         PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
@@ -103,11 +103,11 @@ public class RoutineLoadScheduler extends FrontendDaemon {
             } catch (MetaNotFoundException e) {
                 errorJobState = RoutineLoadJob.JobState.CANCELLED;
                 userException = e;
-                LOG.warn(userException.getMessage());
+                LOG.warn(userException.getMessage(), userException);
             } catch (UserException e) {
                 errorJobState = RoutineLoadJob.JobState.PAUSED;
                 userException = e;
-                LOG.warn(userException.getMessage());
+                LOG.warn(userException.getMessage(), userException);
             }
 
             if (errorJobState != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
@@ -162,7 +162,7 @@ public class PartitionColumnFilter {
                 upperKey = PartitionKey.createPartitionKey(
                         Lists.newArrayList(new PartitionValue(upperBound.getStringValue())), columns);
             } catch (AnalysisException e) {
-                LOG.warn(e.getMessage());
+                LOG.warn(e.getMessage(), e);
                 return null;
             }
             return Range.range(lowerKey, lowerType, upperKey, upperType);

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -631,7 +631,7 @@ public class NodeMgr {
                 System.exit(-1);
             }
         } catch (UnknownHostException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             System.exit(-1);
         }
         LOG.debug("get self node: {}", selfNode);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -444,7 +444,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 try {
                     tbl = metadataMgr.getTable(catalogName, params.db, tableName);
                 } catch (Exception e) {
-                    LOG.warn(e.getMessage());
+                    LOG.warn(e.getMessage(), e);
                 }
 
                 if (tbl == null) {
@@ -1977,7 +1977,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         try {
             result = updateImmutablePartitionInternal(request);
         } catch (Throwable t) {
-            LOG.warn(t);
+            LOG.warn(t.getMessage(), t);
             result = new TImmutablePartitionResult();
             TStatus errorStatus = new TStatus(RUNTIME_ERROR);
             errorStatus.setError_msgs(Lists.newArrayList(String.format("txn_id=%d failed. %s",

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -413,7 +413,7 @@ public class InformationSchemaDataSource {
                     try {
                         table = metadataMgr.getBasicTable(catalogName, dbName, tableName);
                     } catch (Exception e) {
-                        LOG.warn(e.getMessage());
+                        LOG.warn(e.getMessage(), e);
                     }
                     if (table == null) {
                         continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterRoutineLoadAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterRoutineLoadAnalyzer.java
@@ -58,7 +58,7 @@ public class AlterRoutineLoadAnalyzer {
             statement.checkJobProperties();
             statement.checkDataSourceProperties();
         } catch (UserException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             throw new SemanticException(e.getMessage());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateRoutineLoadAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateRoutineLoadAnalyzer.java
@@ -54,7 +54,7 @@ public class CreateRoutineLoadAnalyzer {
             statement.checkJobProperties();
             statement.checkDataSourceProperties();
         } catch (UserException e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
             throw new SemanticException(e.getMessage());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpDeserializer.java
@@ -101,7 +101,7 @@ public class QueryDumpDeserializer implements JsonDeserializer<QueryDumpInfo> {
             try {
                 dumpInfo.getSessionVariable().replayFromJson(dumpJsonObject.get("session_variables").getAsString());
             } catch (IOException e) {
-                LOG.warn("deserialize from json failed. " + e);
+                LOG.warn("deserialize from json failed. ", e);
             }
         }
         // column statistics

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
@@ -57,7 +57,7 @@ public class QueryDumpSerializer implements JsonSerializer<QueryDumpInfo> {
         try {
             dumpJson.addProperty("session_variables", dumpInfo.getSessionVariable().getJsonString());
         } catch (IOException e) {
-            LOG.warn("serialize session variables failed. " + e);
+            LOG.warn("serialize session variables failed. ", e);
         }
 
         // BE number

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CsvFileStatisticsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CsvFileStatisticsStorage.java
@@ -80,7 +80,7 @@ public class CsvFileStatisticsStorage implements StatisticStorage {
                 columnStatisticMap.put(new Pair<>(entry.tableName.split("\\.")[1], entry.columnName), entry);
             }
         } catch (Exception e) {
-            LOG.warn("parse csv file failed, " + e);
+            LOG.warn("parse csv file failed, ", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1130,7 +1130,7 @@ public class PlanFragmentBuilder {
                 prepareCommonExpr(scanNodePredicates, predicates, context);
                 prepareMinMaxExpr(scanNodePredicates, predicates, context);
             } catch (Exception e) {
-                LOG.warn("Hdfs scan node get scan range locations failed : " + e);
+                LOG.warn("Hdfs scan node get scan range locations failed : ", e);
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
@@ -1215,7 +1215,7 @@ public class PlanFragmentBuilder {
                 prepareCommonExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
                 prepareMinMaxExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
             } catch (AnalysisException e) {
-                LOG.warn("Delta lake scan node get scan range locations failed : " + e);
+                LOG.warn("Delta lake scan node get scan range locations failed : ", e);
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
@@ -1259,7 +1259,7 @@ public class PlanFragmentBuilder {
                 prepareMinMaxExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
                 prepareCommonExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
             } catch (Exception e) {
-                LOG.warn("Paimon scan node get scan range locations failed : " + e);
+                LOG.warn("Paimon scan node get scan range locations failed : ", e);
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
@@ -1352,7 +1352,7 @@ public class PlanFragmentBuilder {
                 prepareMinMaxExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
                 prepareCommonExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
             } catch (Exception e) {
-                LOG.warn("Kudu scan node get scan range locations failed : " + e);
+                LOG.warn("Kudu scan node get scan range locations failed : ", e);
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
@@ -1402,7 +1402,7 @@ public class PlanFragmentBuilder {
                 HDFSScanNodePredicates scanNodePredicates = icebergScanNode.getScanNodePredicates();
                 prepareMinMaxExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
             } catch (UserException e) {
-                LOG.warn("Iceberg scan node get scan range locations failed : " + e);
+                LOG.warn("Iceberg scan node get scan range locations failed : ", e);
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -70,7 +70,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
         try {
             GlobalStateMgr.getCurrentState().getMetadata().createDb(dbStmt.getFullDbName());
         } catch (UserException e) {
-            LOG.warn("Failed to create database " + e.getMessage());
+            LOG.warn("Failed to create database ", e);
             return false;
         }
         LOG.info("create statistics db down");
@@ -162,7 +162,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             Analyzer.analyze(stmt, context);
             GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
         } catch (UserException e) {
-            LOG.warn("Failed to create sample statistics, " + e.getMessage());
+            LOG.warn("Failed to create sample statistics, ", e);
             return false;
         }
         LOG.info("create sample statistics table done");
@@ -194,7 +194,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             Analyzer.analyze(stmt, context);
             GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
         } catch (UserException e) {
-            LOG.warn("Failed to create full statistics table, " + e.getMessage());
+            LOG.warn("Failed to create full statistics table", e);
             return false;
         }
         LOG.info("create full statistics table done");
@@ -225,7 +225,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             Analyzer.analyze(stmt, context);
             GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
         } catch (UserException e) {
-            LOG.warn("Failed to create histogram statistics table, " + e.getMessage());
+            LOG.warn("Failed to create histogram statistics table", e);
             return false;
         }
         LOG.info("create histogram statistics table done");
@@ -263,7 +263,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             Analyzer.analyze(stmt, context);
             GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
         } catch (UserException e) {
-            LOG.warn("Failed to create full statistics table, " + e.getMessage());
+            LOG.warn("Failed to create full statistics table", e);
             return false;
         }
         LOG.info("create external full statistics table done");
@@ -293,7 +293,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             Analyzer.analyze(stmt, context);
             GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
         } catch (UserException e) {
-            LOG.warn("Failed to create external histogram statistics table, " + e.getMessage());
+            LOG.warn("Failed to create external histogram statistics table", e);
             return false;
         }
         LOG.info("create external histogram statistics table done");
@@ -332,7 +332,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(stmt);
         } catch (DdlException e) {
-            LOG.warn("Failed to drop table" + e.getMessage());
+            LOG.warn("Failed to drop table", e);
             return false;
         }
         LOG.info("drop statistics table done");
@@ -343,7 +343,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
         try {
             Thread.sleep(millis);
         } catch (InterruptedException e) {
-            LOG.warn(e.getMessage());
+            LOG.warn(e.getMessage(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -272,7 +272,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
         try {
             BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort()).abortTxn(request);
         } catch (Throwable e) {
-            LOG.error(e);
+            LOG.error(e.getMessage(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -162,7 +162,6 @@ import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.layered.TFramedTransport;
 
-import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -182,6 +181,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.security.auth.login.LoginException;
 
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
 
@@ -362,7 +362,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
                         JavaUtils.getClassLoader());
                 return (URIResolverHook) ReflectionUtils.newInstance(uriResolverClass, null);
             } catch (Exception e) {
-                LOG.error("Exception loading uri resolver hook" + e);
+                LOG.error("Exception loading uri resolver hook", e);
                 return null;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
@@ -144,7 +144,7 @@ public class MetadataParser {
                 try {
                     Thread.sleep(50);
                 } catch (InterruptedException e) {
-                    LOG.error(e);
+                    LOG.error(e.getMessage(), e);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -424,7 +424,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             AlterTableStmt addValColStmt2 = (AlterTableStmt) parseAndAnalyzeStmt(addValColStmtStr2);
             GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(addValColStmt2);
         } catch (Exception e) {
-            LOG.warn(e.getMessage());
+            LOG.warn(e.getMessage(), e);
             Assert.assertTrue(e.getMessage().contains("Property primary_index_cache_expire_sec must not be less than 0"));
         }
 
@@ -433,7 +433,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             AlterTableStmt addValColStmt3 = (AlterTableStmt) parseAndAnalyzeStmt(addValColStmtStr3);
             GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(addValColStmt3);
         } catch (Exception e) {
-            LOG.warn(e.getMessage());
+            LOG.warn(e.getMessage(), e);
             Assert.assertTrue(e.getMessage().contains("Property primary_index_cache_expire_sec must be integer"));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -330,7 +330,7 @@ public class PseudoCluster {
                     System.out.println("retry execute " + sql);
                     continue;
                 }
-                LOG.error(e);
+                LOG.error(e.getMessage(), e);
                 throw e;
             }
         }

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
@@ -290,7 +290,7 @@ class BitmapUnionAggregator extends SparkRDDAggregator<BitmapValue> {
             ((BitmapValue) value).serialize(outputStream);
             return bos.toByteArray();
         } catch (IOException ioException) {
-            LOG.warn(ioException);
+            LOG.warn(ioException.getMessage(), ioException);
             throw new RuntimeException(ioException);
         }
     }
@@ -334,7 +334,7 @@ class HllUnionAggregator extends SparkRDDAggregator<Hll> {
             ((Hll) value).serialize(outputStream);
             return bos.toByteArray();
         } catch (IOException ioException) {
-            LOG.warn(ioException);
+            LOG.warn(ioException.getMessage(), ioException);
             throw new RuntimeException(ioException);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

Fix usage of LOG.warn and LOG.error to ensure stack trace is printed when an error occurs.

## What I'm doing:

Identify common logging patterns in LOG.warn or LOG.error, where these patterns only print the message information without printing the stack trace.

Including:
```
LOG.warn(e)
LOG.warn(e.getMessage())
LOG.warn("Close bufferedReader error! " + e)
LOG.warn("Thread interrupted! " + e.getCause());
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
