### PR TITLE
[UT] Fix unstable sql test test_load_channel_profile

### DIFF
--- a/test/sql/test_profile/R/test_load_channel_profile
+++ b/test/sql/test_profile/R/test_load_channel_profile
@@ -44,22 +44,9 @@ INSERT INTO `t0` (v1, v2, v3) values
     (2, 4, 12);
 -- result:
 -- !result
-SET enable_profile="true";
+shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_load_channel_profile_analysis.sh
 -- result:
--- !result
-INSERT INTO `t0` SELECT * FROM `t0`;
--- result:
--- !result
-with
-    profile as (
-        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
-    ), result as (
-        select count(*) as value from profile where line like "%LoadChannel%"
-        UNION ALL
-        select count(*) as value from profile where line like "%Index (id=%"
-    )
-select * from result order by value;
--- result:
-1
-3
+0
+Analyze profile succeeded
+Analyze profile succeeded
 -- !result

--- a/test/sql/test_profile/T/test_load_channel_profile
+++ b/test/sql/test_profile/T/test_load_channel_profile
@@ -36,16 +36,4 @@ INSERT INTO `t0` (v1, v2, v3) values
     (2, 4, 11),
     (2, 4, 12);
 
-SET enable_profile="true";
-
-INSERT INTO `t0` SELECT * FROM `t0`;
-
-with
-    profile as (
-        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
-    ), result as (
-        select count(*) as value from profile where line like "%LoadChannel%"
-        UNION ALL
-        select count(*) as value from profile where line like "%Index (id=%"
-    )
-select * from result order by value;
+shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_load_channel_profile_analysis.sh

--- a/test/sql/test_profile/T/test_load_channel_profile_analysis.sh
+++ b/test/sql/test_profile/T/test_load_channel_profile_analysis.sh
@@ -26,7 +26,7 @@ function check_keywords() {
         echo "Analyze profile succeeded"
     else
         echo "Analyze profile failed, keywords: ${keywords}, expect_num: ${expect_num}, actual_num: ${actual_num}"
-        echo -n "${profile}"
+        echo -e "${profile}"
     fi
 }
 

--- a/test/sql/test_profile/T/test_load_channel_profile_analysis.sh
+++ b/test/sql/test_profile/T/test_load_channel_profile_analysis.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function check_keywords() {
+    profile=$1
+    keywords=$2
+    expect_num=$3
+
+    actual_num=$(echo -e "${profile}" | grep -c "${keywords}")
+    if [ "${expect_num}" -eq "${actual_num}" ]; then
+        echo "Analyze profile succeeded"
+    else
+        echo "Analyze profile failed, keywords: ${keywords}, expect_num: ${expect_num}, actual_num: ${actual_num}"
+        echo -n "${profile}"
+    fi
+}
+
+sql=$(cat << EOF
+SET enable_profile=true;
+SET enable_async_profile=false;
+INSERT INTO t0 SELECT * FROM t0;
+SELECT get_query_profile(last_query_id());
+EOF
+)
+
+output=$(${mysql_cmd} -e "$sql")
+check_keywords "$output" "LoadChannel" "1"
+check_keywords "$output" "Index (id=" "3"


### PR DESCRIPTION
## Why I'm doing:
test_load_channel_profile sometimes fails with the following exception, and should fix it
```
======================================================================
FAIL: 454  : sql/test_profile/R/test_load_channel_profile:test_load_channel_profile
----------------------------------------------------------------------
AssertionError: Element counts were not equal:
First has 1, Second has 0:  '1'
First has 1, Second has 0:  '3'
First has 0, Second has 2:  '0' : sql result not match:
- [SQL]: with
    profile as (
        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
    ), result as (
        select count(*) as value from profile where line like "%LoadChannel%"
        UNION ALL
        select count(*) as value from profile where line like "%Index (id=%"
    )
select * from result order by value;
- [exp]: ['1', '3']
- [act]: ['0', '0']
---
```

## What I'm doing:
The reason is that the session variable `enable_async_profile` is true  by default, and there is probability the profile is not ready when executing `get_query_profile(last_query_id())`.  So setting `enable_async_profile` false can fix the problem. At the same time, refactor the test to print more information if it fails.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
