### PR TITLE
[Enhancement] Enable spill by default for connector sink

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -161,6 +161,9 @@ public class ConnectContext {
     protected MysqlSerializer serializer;
     // Variables belong to this session.
     protected SessionVariable sessionVariable;
+    // Variables belong to this session
+    // used to back up `sessionVariable` after query start, and restore `sessionVariable` before query end
+    protected SessionVariable backupSessionVariable = null;
     // all the modified session variables, will forward to leader
     protected Map<String, SystemVariable> modifiedSessionVariables = new HashMap<>();
     // user define variable in this session
@@ -442,6 +445,18 @@ public class ConnectContext {
 
     public void setSessionVariable(SessionVariable sessionVariable) {
         this.sessionVariable = sessionVariable;
+    }
+
+    public SessionVariable getBackupSessionVariable() {
+        return this.backupSessionVariable;
+    }
+
+    public void setBackupSessionVariable(SessionVariable sessionVariable) {
+        this.backupSessionVariable = sessionVariable;
+    }
+
+    public void clearBackupSessionVariable() {
+        this.setBackupSessionVariable(null);
     }
 
     public ConnectScheduler getConnectScheduler() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -161,9 +161,6 @@ public class ConnectContext {
     protected MysqlSerializer serializer;
     // Variables belong to this session.
     protected SessionVariable sessionVariable;
-    // Variables belong to this session
-    // used to back up `sessionVariable` after query start, and restore `sessionVariable` before query end
-    protected SessionVariable backupSessionVariable = null;
     // all the modified session variables, will forward to leader
     protected Map<String, SystemVariable> modifiedSessionVariables = new HashMap<>();
     // user define variable in this session
@@ -445,18 +442,6 @@ public class ConnectContext {
 
     public void setSessionVariable(SessionVariable sessionVariable) {
         this.sessionVariable = sessionVariable;
-    }
-
-    public SessionVariable getBackupSessionVariable() {
-        return this.backupSessionVariable;
-    }
-
-    public void setBackupSessionVariable(SessionVariable sessionVariable) {
-        this.backupSessionVariable = sessionVariable;
-    }
-
-    public void clearBackupSessionVariable() {
-        this.setBackupSessionVariable(null);
     }
 
     public ConnectScheduler getConnectScheduler() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -426,6 +426,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String HIVE_PARTITION_STATS_SAMPLE_SIZE = "hive_partition_stats_sample_size";
 
     public static final String ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE = "enable_connector_sink_global_shuffle";
+
+    public static final String CONNECTOR_SINK_ENABLE_SPILL = "connector_sink_enable_spill";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
@@ -1047,6 +1049,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Add a global shuffle between the connector sink fragment and its child fragment.
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
+
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_ENABLE_SPILL, flag = VariableMgr.INVISIBLE)
+    private boolean connectorSinkEnableSpill = true;
 
     // execute sql don't return result, for performance test
     @VarAttr(name = ENABLE_EXECUTION_ONLY, flag = VariableMgr.INVISIBLE)
@@ -2987,6 +2993,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableConnectorSinkGlobalShuffle() {
         return enableConnectorSinkGlobalShuffle;
+    }
+
+    public boolean isConnectorSinkEnableSpill() {
+        return connectorSinkEnableSpill;
     }
 
     public void setPipelineSinkDop(int pipelineSinkDop) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -427,7 +427,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE = "enable_connector_sink_global_shuffle";
 
-    public static final String CONNECTOR_SINK_ENABLE_SPILL = "connector_sink_enable_spill";
+    public static final String ENABLE_CONNECTOR_SINK_SPILL = "enable_connector_sink_spill";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
@@ -1051,8 +1051,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableConnectorSinkGlobalShuffle = true;
 
 
-    @VariableMgr.VarAttr(name = CONNECTOR_SINK_ENABLE_SPILL, flag = VariableMgr.INVISIBLE)
-    private boolean connectorSinkEnableSpill = true;
+    @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
+    private boolean enableConnectorSinkSpill = true;
 
     // execute sql don't return result, for performance test
     @VarAttr(name = ENABLE_EXECUTION_ONLY, flag = VariableMgr.INVISIBLE)
@@ -2995,8 +2995,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableConnectorSinkGlobalShuffle;
     }
 
-    public boolean isConnectorSinkEnableSpill() {
-        return connectorSinkEnableSpill;
+    public boolean isEnableConnectorSinkSpill() {
+        return enableConnectorSinkSpill;
     }
 
     public void setPipelineSinkDop(int pipelineSinkDop) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -428,6 +428,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE = "enable_connector_sink_global_shuffle";
 
     public static final String ENABLE_CONNECTOR_SINK_SPILL = "enable_connector_sink_spill";
+    public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
@@ -1053,6 +1054,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD, flag = VariableMgr.INVISIBLE)
+    private double connectorSinkSpillMemLimitThreshold = 0.5;
 
     // execute sql don't return result, for performance test
     @VarAttr(name = ENABLE_EXECUTION_ONLY, flag = VariableMgr.INVISIBLE)
@@ -2644,6 +2648,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public double getSpillMemLimitThreshold() {
         return this.spillMemLimitThreshold;
+    }
+
+    public void setSpillMemLimitThreshold(double spillMemLimitThreshold) {
+        this.spillMemLimitThreshold = spillMemLimitThreshold;
+    }
+
+    public double getConnectorSinkSpillMemLimitThreshold() {
+        return this.connectorSinkSpillMemLimitThreshold;
     }
 
     public long getSpillOperatorMinBytes() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -452,7 +452,7 @@ public class StmtExecutor {
         // Try to use query id as execution id when execute first time.
         UUID uuid = context.getQueryId();
         context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
-        SessionVariable sessionVariableBackup = context.getSessionVariable();
+        context.setBackupSessionVariable(context.getSessionVariable());
 
         // if use http protocal, use httpResultSender to send result to netty channel
         if (context instanceof HttpConnectContext) {
@@ -741,14 +741,16 @@ public class StmtExecutor {
             }
 
             if (parsedStmt != null && parsedStmt.isExistQueryScopeHint()) {
-                clearQueryScopeHintContext(sessionVariableBackup);
+                clearQueryScopeHintContext();
             }
 
+            // restore session variable in connect context
+            context.setSessionVariable(context.getBackupSessionVariable());
+            context.clearBackupSessionVariable();
         }
     }
 
-    private void clearQueryScopeHintContext(SessionVariable sessionVariableBackup) {
-        context.setSessionVariable(sessionVariableBackup);
+    private void clearQueryScopeHintContext() {
         Iterator<Map.Entry<String, UserVariable>> iterator = context.userVariables.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<String, UserVariable> entry = iterator.next();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -452,7 +452,7 @@ public class StmtExecutor {
         // Try to use query id as execution id when execute first time.
         UUID uuid = context.getQueryId();
         context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
-        context.setBackupSessionVariable(context.getSessionVariable());
+        SessionVariable sessionVariableBackup = context.getSessionVariable();
 
         // if use http protocal, use httpResultSender to send result to netty channel
         if (context instanceof HttpConnectContext) {
@@ -745,8 +745,7 @@ public class StmtExecutor {
             }
 
             // restore session variable in connect context
-            context.setSessionVariable(context.getBackupSessionVariable());
-            context.clearBackupSessionVariable();
+            context.setSessionVariable(sessionVariableBackup);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -415,7 +415,7 @@ public class InsertPlanner {
             }
 
             // enable spill for connector sink
-            if (session.getSessionVariable().isConnectorSinkEnableSpill() && (targetTable instanceof IcebergTable
+            if (session.getSessionVariable().isEnableConnectorSinkSpill() && (targetTable instanceof IcebergTable
                     || targetTable instanceof HiveTable || targetTable instanceof TableFunctionTable)) {
                 session.setSessionVariable((SessionVariable) session.getSessionVariable().clone());
                 session.getSessionVariable().setEnableSpill(true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -417,8 +417,12 @@ public class InsertPlanner {
             // enable spill for connector sink
             if (session.getSessionVariable().isEnableConnectorSinkSpill() && (targetTable instanceof IcebergTable
                     || targetTable instanceof HiveTable || targetTable instanceof TableFunctionTable)) {
-                session.setSessionVariable((SessionVariable) session.getSessionVariable().clone());
-                session.getSessionVariable().setEnableSpill(true);
+                SessionVariable sessionVariable = (SessionVariable) session.getSessionVariable().clone();
+                sessionVariable.setEnableSpill(true);
+                if (sessionVariable.getConnectorSinkSpillMemLimitThreshold() < sessionVariable.getSpillMemLimitThreshold()) {
+                    sessionVariable.setSpillMemLimitThreshold(sessionVariable.getConnectorSinkSpillMemLimitThreshold());
+                }
+                session.setSessionVariable(sessionVariable);
             }
 
             PlanFragment sinkFragment = execPlan.getFragments().get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -403,11 +403,14 @@ public class InsertPlanner {
                 descriptorTable.addReferencedTable(targetTable);
                 dataSink = new IcebergTableSink((IcebergTable) targetTable, tupleDesc,
                         isKeyPartitionStaticInsert(insertStmt, queryRelation), session.getSessionVariable());
+                session.getSessionVariable().setEnableSpill(true);
             } else if (targetTable instanceof HiveTable) {
                 dataSink = new HiveTableSink((HiveTable) targetTable, tupleDesc,
                         isKeyPartitionStaticInsert(insertStmt, queryRelation), session.getSessionVariable());
+                session.getSessionVariable().setEnableSpill(true);
             } else if (targetTable instanceof TableFunctionTable) {
                 dataSink = new TableFunctionTableSink((TableFunctionTable) targetTable);
+                session.getSessionVariable().setEnableSpill(true);
             } else if (targetTable.isBlackHoleTable()) {
                 dataSink = new BlackHoleTableSink();
             } else {


### PR DESCRIPTION
## Why I'm doing:

Enable spill by default for connector sink. 

## What I'm doing:

Add a new session variable `enable_connector_sink_spill`, whose default value is true.

If enable_connector_sink_spill is true, set enable_spill to true for connector sink(hive/iceberg/files).



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
