### PR TITLE
[BugFix] Fix rewrite json expr error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -175,7 +175,7 @@ public class PruneSubfieldRule extends TransformationRule {
             visit(cast.getChild(0), context);
             if (cast.getChild(0).getType().isJsonType() && (cast.getChild(0) instanceof CallOperator)) {
                 CallOperator childCall = cast.getChild(0).cast();
-                if (!FunctionSet.JSON_QUERY.equalsIgnoreCase(childCall.getFnName()) &&
+                if (!FunctionSet.JSON_QUERY.equalsIgnoreCase(childCall.getFnName()) ||
                         childCall.getChildren().size() != 2) {
                     return cast;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1107,4 +1107,11 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
     }
+
+    @Test
+    public void testOtherFunctionJson() throws Exception {
+        String sql = "select v1 from js0 where LOWER( COALESCE( j1 -> 'a', j1 -> 'b' ) ) = 'x'";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "lower(CAST(coalesce(json_query(2: j1, 'a'), json_query(2: j1, 'b')) AS VARCHAR)) = 'x'");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

the check condition error

```
lower(CAST(coalesce(json_query(2: j1, 'a'), json_query(2: j1, 'b')) AS VARCHAR)) = 'x'
```

will rewrite to 
```
lower(CAST(get_json_string(json_query(2: j1, 'a'), json_query(2: j1, 'b')) AS VARCHAR)) = 'x'
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
