### PR TITLE
[Enhancement] Retry apply after apply failed.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -525,6 +525,11 @@ CONF_String(consistency_max_memory_limit, "10G");
 CONF_Int32(consistency_max_memory_limit_percent, "20");
 CONF_Int32(update_memory_limit_percent, "60");
 
+// if `enable_retry_apply`, it apply failed due to some tolerable error(e.g. memory exceed limit)
+// the failed apply task will retry after `retry_apply_interval_second`
+CONF_mBool(enable_retry_apply, "true");
+CONF_mInt32(retry_apply_interval_second, "30");
+
 // Update interval of tablet stat cache.
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -262,6 +262,9 @@ public:
 
     Status clone_and_append_context(const char* filename, int line, const char* expr) const;
 
+    Status(TStatusCode::type code, std::string_view msg) : Status(code, msg, {}) {}
+    Status(TStatusCode::type code, std::string_view msg, std::string_view ctx);
+
 private:
     static const char* copy_state(const char* state);
     static const char* copy_state_with_extra_ctx(const char* state, std::string_view ctx);
@@ -269,9 +272,6 @@ private:
     // Indicates whether this Status was the rhs of a move operation.
     static bool is_moved_from(const char* state);
     static const char* moved_from_state();
-
-    Status(TStatusCode::type code, std::string_view msg) : Status(code, msg, {}) {}
-    Status(TStatusCode::type code, std::string_view msg, std::string_view ctx);
 
 private:
     // OK status has a nullptr _state.  Otherwise, _state is a new[] array

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -254,11 +254,15 @@ Status StorageEngine::start_bg_threads() {
         Thread::set_thread_name(_adjust_cache_thread, "adjust_cache");
     }
 
-    _schedule_apply_thread = std::thread([this] { _schedule_apply_thread_callback(nullptr); });
-    Thread::set_thread_name(_schedule_apply_thread, "schedule_apply");
+    start_schedule_apply_thread();
 
     LOG(INFO) << "All backgroud threads of storage engine have started.";
     return Status::OK();
+}
+
+void StorageEngine::start_schedule_apply_thread() {
+    _schedule_apply_thread = std::thread([this] { _schedule_apply_thread_callback(nullptr); });
+    Thread::set_thread_name(_schedule_apply_thread, "schedule_apply");
 }
 
 void evict_pagecache(StoragePageCache* cache, int64_t bytes_to_dec, std::atomic<bool>& stoped) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -631,6 +631,7 @@ void StorageEngine::stop() {
     wake_finish_publish_vesion_thread();
     wake_schedule_apply_thread();
     JOIN_THREAD(_finish_publish_version_thread)
+    JOIN_THREAD(_schedule_apply_thread)
 
     JOIN_THREADS(_base_compaction_threads)
     JOIN_THREADS(_cumulative_compaction_threads)
@@ -1610,6 +1611,7 @@ void StorageEngine::decommission_disks(const std::vector<string>& decommission_d
 }
 
 void StorageEngine::add_schedule_apply_task(int64_t tablet_id, std::chrono::steady_clock::time_point time_point) {
+    LOG(INFO) << "add tablet:" << tablet_id << ", next apply time:";
     {
         std::unique_lock<std::mutex> wl(_schedule_apply_mutex);
         _schedule_apply_tasks.emplace(std::make_pair(time_point, tablet_id));

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1609,10 +1609,10 @@ void StorageEngine::decommission_disks(const std::vector<string>& decommission_d
     }
 }
 
-void StorageEngine::add_schedule_apply_task(int64_t tablet_id, int64_t time) {
+void StorageEngine::add_schedule_apply_task(int64_t tablet_id, std::chrono::steady_clock::time_point time_point) {
     {
         std::unique_lock<std::mutex> wl(_schedule_apply_mutex);
-        _schedule_apply_tasks.emplace(time, tablet_id);
+        _schedule_apply_tasks.emplace(std::make_pair(time_point, tablet_id));
     }
     _apply_tablet_changed_cv.notify_one();
 }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -312,6 +312,8 @@ public:
         _apply_tablet_changed_cv.notify_one();
     }
 
+    void start_schedule_apply_thread();
+
     bool is_as_cn() { return !_options.need_write_cluster_id; }
 
     bool enable_light_pk_compaction_publish();

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -304,6 +304,13 @@ public:
         _finish_publish_version_cv.notify_one();
     }
 
+    void add_schedule_apply_task(int64_t tablet_id, int64_t time);
+
+    void wake_schedule_apply_thread() {
+        std::unique_lock<std::mutex> wl(_schedule_apply_mutex);
+        _apply_tablet_changed_cv.notify_one();
+    }
+
     bool is_as_cn() { return !_options.need_write_cluster_id; }
 
     bool enable_light_pk_compaction_publish();
@@ -507,6 +514,13 @@ private:
     std::mutex _delta_column_group_cache_lock;
     std::map<DeltaColumnGroupKey, DeltaColumnGroupList> _delta_column_group_cache;
     std::unique_ptr<MemTracker> _delta_column_group_cache_mem_tracker;
+
+    mutable std::mutex _schedule_apply_mutex;
+    std::condition_variable _apply_tablet_changed_cv;
+    std::thread _schedule_apply_thread;
+    std::priority_queue<std::pair<std::chrono::steady_clock::time_point, int64_t>>,
+            std::vector<std::pair<std::chrono::steady_clock::time_point, int64_t>> >,
+            std::greater<> > _schedule_apply_tasks;
 
 #ifdef USE_STAROS
     std::unique_ptr<lake::LocalPkIndexManager> _local_pk_index_manager;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2381,6 +2381,10 @@ Status TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_in
         for (auto& delvec_pair : delvecs) {
             tsid.segment_id = delvec_pair.first;
             st = manager->set_cached_del_vec(tsid, delvec_pair.second);
+            FAIL_POINT_TRIGGER_EXECUTE(tablet_apply_cache_del_vec_failed, {
+                st = Status::InternalError("inject tablet_apply_cache_del_vec_failed");
+                manager->clear_cached_del_vec({tsid});
+            });
             if (!st.ok()) {
                 std::string msg = strings::Substitute("_apply_compaction_commit error: set cached delvec failed: $0 $1",
                                                       st.to_string(), _debug_string(false));

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -951,7 +951,6 @@ void TabletUpdates::do_apply() {
             LOG(ERROR) << msg;
             _set_error(msg);
         }
-        LOG(INFO) << "apply status:" << apply_st;
         first = false;
         // submit a delay apply task to storage_engine
         if (config::enable_retry_apply && _is_tolerable(apply_st) && !apply_st.ok()) {
@@ -5622,7 +5621,7 @@ void TabletUpdates::_reset_apply_status(const EditVersionInfo& version_info_appl
             _rowset_stats.emplace(rsid, std::move(stats));
         }
     }
-    _update_total_stats(_edit_version_infos[_apply_version_idx]->rowsets, nullptr, nullptr);
+    _update_total_stats(version_info_apply.rowsets, nullptr, nullptr);
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -954,14 +954,14 @@ void TabletUpdates::do_apply() {
         first = false;
         // submit a delay apply task to storage_engine
         if (config::enable_retry_apply && _is_tolerable(apply_st) && !apply_st.ok()) {
+            //reset pk index, reset rowset_update_states, reset compaction_state
+            _reset_apply_status(*version_info_apply);
             auto time_point =
                     std::chrono::steady_clock::now() + std::chrono::seconds(config::retry_apply_interval_second);
             StorageEngine::instance()->add_schedule_apply_task(_tablet.tablet_id(), time_point);
             std::string msg = strings::Substitute("apply tablet: $0 failed and retry later, status: $1",
                                                   _tablet.tablet_id(), apply_st.to_string());
             LOG(WARNING) << msg;
-            //reset pk index, reset rowset_update_states, reset compaction_state
-            _reset_apply_status(*version_info_apply);
             break;
         } else {
             if (!apply_st.ok()) {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -364,7 +364,10 @@ public:
 
     RowsetSharedPtr get_rowset(uint32_t rowset_id);
 
-    void check_for_apply() { _check_for_apply(); }
+    void check_for_apply() {
+        _apply_schedule.store(false);
+        _check_for_apply();
+    }
 
     // just for ut
     void reset_update_state() {
@@ -576,6 +579,8 @@ private:
     std::string _error_msg;
 
     std::atomic<double> _pk_index_write_amp_score{0.0};
+
+    std::atomic<bool> _apply_schedule{false};
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -400,14 +400,14 @@ private:
 
     void _ignore_rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
 
-    void _apply_rowset_commit(const EditVersionInfo& version_info);
+    Status _apply_rowset_commit(const EditVersionInfo& version_info);
 
     // used for normal update or row-mode partial update
-    void _apply_normal_rowset_commit(const EditVersionInfo& version_info, const RowsetSharedPtr& rowset);
+    Status _apply_normal_rowset_commit(const EditVersionInfo& version_info, const RowsetSharedPtr& rowset);
     // used for column-mode partial update
-    void _apply_column_partial_update_commit(const EditVersionInfo& version_info, const RowsetSharedPtr& rowset);
+    Status _apply_column_partial_update_commit(const EditVersionInfo& version_info, const RowsetSharedPtr& rowset);
 
-    void _apply_compaction_commit(const EditVersionInfo& version_info);
+    Status _apply_compaction_commit(const EditVersionInfo& version_info);
 
     // wait a version to be applied, so reader can read this version
     // assuming _lock already hold

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -366,6 +366,19 @@ public:
 
     void check_for_apply() { _check_for_apply(); }
 
+    // just for ut
+    void reset_update_state() {
+        const EditVersionInfo* version_info_apply = nullptr;
+        {
+            std::lock_guard rl(_lock);
+            if (_edit_version_infos.empty()) {
+                return;
+            }
+            version_info_apply = _edit_version_infos[_apply_version_idx + 1].get();
+            _reset_apply_status(*version_info_apply);
+        }
+    }
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -486,6 +499,8 @@ private:
             _last_compaction_time_ms = UnixMillis();
         }
     }
+
+    bool compaction_running() { return _compaction_running; }
 
     std::shared_timed_mutex* get_index_lock() { return &_index_lock; }
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -364,6 +364,8 @@ public:
 
     RowsetSharedPtr get_rowset(uint32_t rowset_id);
 
+    void check_for_apply() { _check_for_apply(); }
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -485,8 +487,6 @@ private:
         }
     }
 
-    void check_for_apply() { _check_for_apply(); }
-
     std::shared_timed_mutex* get_index_lock() { return &_index_lock; }
 
     StatusOr<ExtraFileSize> _get_extra_file_size() const;
@@ -496,6 +496,10 @@ private:
     Status _light_apply_compaction_commit(const EditVersion& version, Rowset* output_rowset, PrimaryIndex* index,
                                           size_t* total_deletes, size_t* total_rows,
                                           vector<std::pair<uint32_t, DelVectorPtr>>* delvecs);
+
+    bool _is_tolerable(Status& status);
+
+    void _reset_apply_status(const EditVersionInfo& version_info_apply);
 
 private:
     Tablet& _tablet;

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -150,6 +150,9 @@ public:
     bool TEST_primary_index_refcnt(int64_t tablet_id, uint32_t expected_cnt);
 
 private:
+    void* _schedule_apply_thread_callback(void* arg);
+
+private:
     // default 6min
     int64_t _cache_expire_ms = 360000;
 

--- a/be/src/testutil/init_test_env.h
+++ b/be/src/testutil/init_test_env.h
@@ -92,6 +92,7 @@ int init_test_env(int argc, char** argv) {
                 s.to_string().c_str());
         return -1;
     }
+    engine->start_schedule_apply_thread();
     auto* global_env = GlobalEnv::GetInstance();
     config::disable_storage_page_cache = true;
     auto st = global_env->init();

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3648,9 +3648,22 @@ TEST_F(TabletUpdatesTest, test_compaction_apply_retry) {
     test_fail_point("tablet_apply_index_replace_failed", "tablet_apply_index_commit_failed");
     _tablet->updates()->reset_update_state();
 
-    // 10. normal apply
-    fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("tablet_apply_index_commit_failed");
+    // 10. write meta failed
+    test_fail_point("tablet_apply_index_commit_failed", "tablet_meta_manager_apply_rowset_manager_internal_error");
+
+    // 11. cache del vec failed
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    fp_name = "tablet_meta_manager_apply_rowset_manager_fake_ok";
+    fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(fp_name);
+    fp->setMode(trigger_mode);
+    test_fail_point("tablet_meta_manager_apply_rowset_manager_internal_error", "tablet_apply_cache_del_vec_failed");
+
+    // 12. normal apply
+    fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("tablet_apply_cache_del_vec_failed");
     trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+
+    fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(fp_name);
     fp->setMode(trigger_mode);
 
     _tablet->updates()->reset_error();


### PR DESCRIPTION
## Why I'm doing:
The tablet will be set to error state if apply fails and the tablet in error state cannot be read or written and can only be recovered by restarting the BE process. However, not all apply failures require setting the tablet to an error state. Some apply failure scenarios can be retried.

BTW, apply failed always return internal error right now and we need to categorize return value in the future.

## What I'm doing:
Retry apply if apply failures is tolerable.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
