### PR TITLE
[BugFix]lazy decode is adaptive but it changed subfield column of struct

### DIFF
--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -131,7 +131,7 @@ public:
         return Status::OK();
     }
 
-    virtual Status fill_dst_column(ColumnPtr& dst, const ColumnPtr& src) {
+    virtual Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
         dst->swap_column(*src);
         return Status::OK();
     }

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -264,7 +264,7 @@ Status StructColumnReader::filter_dict_column(const ColumnPtr& column, Filter* f
                                                          layer + 1);
 }
 
-Status StructColumnReader::fill_dst_column(ColumnPtr& dst, const ColumnPtr& src) {
+Status StructColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     StructColumn* struct_column_src = nullptr;
     StructColumn* struct_column_dst = nullptr;
     if (src->is_nullable()) {

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -187,7 +187,7 @@ public:
     Status filter_dict_column(const ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
                               const size_t& layer) override;
 
-    Status fill_dst_column(ColumnPtr& dst, const ColumnPtr& src) override;
+    Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
     void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOType type, bool active) override {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -435,7 +435,7 @@ StatusOr<bool> GroupReader::_filter_chunk_with_dict_filter(ChunkPtr* chunk, Filt
     return true;
 }
 
-Status GroupReader::_fill_dst_chunk(const ChunkPtr& read_chunk, ChunkPtr* chunk) {
+Status GroupReader::_fill_dst_chunk(ChunkPtr& read_chunk, ChunkPtr* chunk) {
     read_chunk->check_or_die();
     for (const auto& column : _param.read_cols) {
         SlotId slot_id = column.slot_id();

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -127,7 +127,7 @@ public:
     Status _rewrite_conjunct_ctxs_to_predicates(bool* is_group_filtered);
 
     StatusOr<bool> _filter_chunk_with_dict_filter(ChunkPtr* chunk, Filter* filter);
-    Status _fill_dst_chunk(const ChunkPtr& read_chunk, ChunkPtr* chunk);
+    Status _fill_dst_chunk(ChunkPtr& read_chunk, ChunkPtr* chunk);
 
     Status _init_column_readers();
     Status _create_column_reader(const GroupReaderParam::Column& column);

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -33,6 +33,7 @@ Status ScalarColumnReader::read_range(const Range<uint64_t>& range, const Filter
             _dict_code = ColumnHelper::create_column(
                     TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
         }
+        _ori_column = dst;
         dst = _dict_code;
         dst->reserve(range.span_size());
     }
@@ -74,7 +75,7 @@ bool ScalarColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decode
     }
 }
 
-Status ScalarColumnReader::fill_dst_column(ColumnPtr& dst, const ColumnPtr& src) {
+Status ScalarColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     if (!_need_lazy_decode) {
         dst->swap_column(*src);
     } else {
@@ -102,6 +103,7 @@ Status ScalarColumnReader::fill_dst_column(ColumnPtr& dst, const ColumnPtr& src)
         }
 
         src->reset_column();
+        src = _ori_column;
     }
     return Status::OK();
 }

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -63,7 +63,7 @@ public:
         return _dict_filter_ctx->predicate->evaluate_and(column.get(), filter->data());
     }
 
-    Status fill_dst_column(ColumnPtr& dst, const ColumnPtr& src) override;
+    Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
     void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOType type, bool active) override;
@@ -114,6 +114,7 @@ private:
     bool _need_lazy_decode = false;
     // dict code
     ColumnPtr _dict_code = nullptr;
+    ColumnPtr _ori_column = nullptr;
 };
 
 } // namespace starrocks::parquet

--- a/test/sql/test_external_file/R/test_parquet_struct_in_struct
+++ b/test/sql/test_external_file/R/test_parquet_struct_in_struct
@@ -65,6 +65,17 @@ select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 in ('55'
 -- result:
 200
 -- !result
+select * from struct_in_struct where (c0 in (101, 1000)) or (c0 > 5000 and c0 < 5005) or (c0 in (9001, 10000));
+-- result:
+101	9900	{"c0":"1","c1":"0"}	{"c0":"1","c_struct":{"c0":"1","c1":"0"}}
+1000	9001	None	None
+5001	5000	{"c0":"1","c1":"0"}	{"c0":"1","c_struct":{"c0":"1","c1":"0"}}
+5002	4999	{"c0":"2","c1":"99"}	{"c0":"2","c_struct":{"c0":"2","c1":"99"}}
+5003	4998	{"c0":"3","c1":"98"}	{"c0":"3","c_struct":{"c0":"3","c1":"98"}}
+5004	4997	{"c0":"4","c1":"97"}	{"c0":"4","c_struct":{"c0":"4","c1":"97"}}
+9001	1000	{"c0":"1","c1":"0"}	{"c0":"1","c_struct":{"c0":"1","c1":"0"}}
+10000	1	None	None
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_struct_in_struct/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_external_file/T/test_parquet_struct_in_struct
+++ b/test/sql/test_external_file/T/test_parquet_struct_in_struct
@@ -38,4 +38,7 @@ select * from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56')
 -- filed is not output column but in conjunct of multi-slot, decode is needed
 select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56') and c_struct_struct.c_struct.c0 = c_struct.c0;
 
+-- string in struct, lazy_decode -> normal_decode -> lazy_decode
+select * from struct_in_struct where (c0 in (101, 1000)) or (c0 > 5000 and c0 < 5005) or (c0 in (9001, 10000));
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_struct_in_struct/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
lazy decode is adaptive, but when we read dict_code from the file we changed the 
subfield column of read_chunk, but later we may read dict_value from the file, so
we need set back the ori column.
the root cause is that shared_ptr is not deep copy, for flat type, it's ok, but not for 
nested column. 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
