### PR TITLE
[Feature] Cache select support ttl + priority (#47151)

### DIFF
--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -47,6 +47,7 @@ struct CacheOptions {
 };
 
 struct WriteCacheOptions {
+    int8_t priority = 0;
     // If ttl_seconds=0 (default), no ttl restriction will be set. If an old one exists, remove it.
     uint64_t ttl_seconds = 0;
     // If overwrite=true, the cache value will be replaced if it already exists.

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -50,6 +50,7 @@ Status StarCacheWrapper::write_buffer(const std::string& key, const IOBuffer& bu
     }
 
     starcache::WriteOptions opts;
+    opts.priority = options->priority;
     opts.ttl_seconds = options->ttl_seconds;
     opts.overwrite = options->overwrite;
     opts.async = options->async;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -111,6 +111,12 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.datacache_evict_probability) {
         _datacache_evict_probability = state->query_options().datacache_evict_probability;
     }
+    if (state->query_options().__isset.datacache_priority) {
+        _datacache_priority = state->query_options().datacache_priority;
+    }
+    if (state->query_options().__isset.datacache_ttl_seconds) {
+        _datacache_ttl_seconds = state->query_options().datacache_ttl_seconds;
+    }
     if (state->query_options().__isset.enable_dynamic_prune_scan_range) {
         _enable_dynamic_prune_scan_range = state->query_options().enable_dynamic_prune_scan_range;
     }
@@ -417,6 +423,8 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     if (_use_datacache) {
         static const char* prefix = "DataCache";
         ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
+        _profile.runtime_profile->add_info_string("DataCachePriority", std::to_string(_datacache_priority));
+        _profile.runtime_profile->add_info_string("DataCacheTTLSeconds", std::to_string(_datacache_ttl_seconds));
         _profile.datacache_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
         _profile.datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
@@ -567,6 +575,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.enable_datacache_async_populate_mode = _enable_datacache_aync_populate_mode;
     scanner_params.enable_datacache_io_adaptor = _enable_datacache_io_adaptor;
     scanner_params.datacache_evict_probability = _datacache_evict_probability;
+    scanner_params.datacache_priortiy = _datacache_priority;
+    scanner_params.datacache_ttl_seconds = _datacache_ttl_seconds;
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.can_use_min_max_count_opt = _can_use_min_max_count_opt;
     scanner_params.use_file_metacache = _use_file_metacache;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -575,7 +575,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.enable_datacache_async_populate_mode = _enable_datacache_aync_populate_mode;
     scanner_params.enable_datacache_io_adaptor = _enable_datacache_io_adaptor;
     scanner_params.datacache_evict_probability = _datacache_evict_probability;
-    scanner_params.datacache_priortiy = _datacache_priority;
+    scanner_params.datacache_priority = _datacache_priority;
     scanner_params.datacache_ttl_seconds = _datacache_ttl_seconds;
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.can_use_min_max_count_opt = _can_use_min_max_count_opt;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -114,6 +114,8 @@ private:
     bool _enable_datacache_aync_populate_mode = false;
     bool _enable_datacache_io_adaptor = false;
     int32_t _datacache_evict_probability = 0;
+    int8_t _datacache_priority = 0;
+    int64_t _datacache_ttl_seconds = 0;
     bool _enable_dynamic_prune_scan_range = true;
     bool _use_file_metacache = false;
     bool _enable_split_tasks = false;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -236,7 +236,7 @@ Status HdfsScanner::open_random_access_file() {
         _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_datacache);
         _cache_input_stream->set_enable_async_populate_mode(_scanner_params.enable_datacache_async_populate_mode);
         _cache_input_stream->set_enable_cache_io_adaptor(_scanner_params.enable_datacache_io_adaptor);
-        _cache_input_stream->set_priority(_scanner_params.datacache_priortiy);
+        _cache_input_stream->set_priority(_scanner_params.datacache_priority);
         _cache_input_stream->set_ttl_seconds(_scanner_params.datacache_ttl_seconds);
         _cache_input_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
         _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -236,6 +236,8 @@ Status HdfsScanner::open_random_access_file() {
         _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_datacache);
         _cache_input_stream->set_enable_async_populate_mode(_scanner_params.enable_datacache_async_populate_mode);
         _cache_input_stream->set_enable_cache_io_adaptor(_scanner_params.enable_datacache_io_adaptor);
+        _cache_input_stream->set_priority(_scanner_params.datacache_priortiy);
+        _cache_input_stream->set_ttl_seconds(_scanner_params.datacache_ttl_seconds);
         _cache_input_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
         _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
         input_stream = _cache_input_stream;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -216,6 +216,8 @@ struct HdfsScannerParams {
     bool enable_datacache_async_populate_mode = false;
     bool enable_datacache_io_adaptor = false;
     int32_t datacache_evict_probability = 0;
+    int8_t datacache_priortiy = 0;
+    int64_t datacache_ttl_seconds = 0;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool can_use_any_column = false;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -216,7 +216,7 @@ struct HdfsScannerParams {
     bool enable_datacache_async_populate_mode = false;
     bool enable_datacache_io_adaptor = false;
     int32_t datacache_evict_probability = 0;
-    int8_t datacache_priortiy = 0;
+    int8_t datacache_priority = 0;
     int64_t datacache_ttl_seconds = 0;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -237,6 +237,8 @@ Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t 
         WriteCacheOptions options{};
         options.async = _enable_async_populate_mode;
         options.evict_probability = _datacache_evict_probability;
+        options.priority = _priority;
+        options.ttl_seconds = _ttl_seconds;
         const int64_t write_size = std::min(_block_size, write_end_offset - write_offset_cursor);
 
         SharedBufferPtr sb = nullptr;
@@ -431,6 +433,8 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
         WriteCacheOptions options;
         options.async = _enable_async_populate_mode;
         options.evict_probability = _datacache_evict_probability;
+        options.priority = _priority;
+        options.ttl_seconds = _ttl_seconds;
         if (options.async) {
             auto cb = [sb](int code, const std::string& msg) {
                 // We only need to keep the shared buffer pointer

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -73,6 +73,10 @@ public:
 
     void set_datacache_evict_probability(int32_t v) { _datacache_evict_probability = v; }
 
+    void set_priority(const int8_t priority) { _priority = priority; }
+
+    void set_ttl_seconds(const uint64_t ttl_seconds) { _ttl_seconds = ttl_seconds; }
+
     int64_t get_align_size() const;
 
     StatusOr<std::string_view> peek(int64_t count) override;
@@ -114,6 +118,8 @@ private:
     BlockCache* _cache = nullptr;
     int64_t _block_size = 0;
     std::unordered_map<int64_t, BlockBuffer> _block_map;
+    int8_t _priority = 0;
+    uint64_t _ttl_seconds = 0;
 };
 
 } // namespace starrocks::io

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -48,6 +48,8 @@ public class DataCacheSelectExecutor {
         tmpSessionVariable.setEnableDataCacheAsyncPopulateMode(false);
         tmpSessionVariable.setEnableDataCacheIOAdaptor(false);
         tmpSessionVariable.setDataCacheEvictProbability(100);
+        tmpSessionVariable.setDataCachePriority(statement.getPriority());
+        tmpSessionVariable.setDatacacheTTLSeconds(statement.getTTLSeconds());
         connectContext.setSessionVariable(tmpSessionVariable);
 
         InsertStmt insertStmt = statement.getInsertStmt();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1625,6 +1625,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = DATACACHE_EVICT_PROBABILITY, flag = VariableMgr.INVISIBLE)
     private int datacacheEvictProbability = 100;
 
+    private int datacachePriority = 0;
+
+    private long datacacheTTLSeconds = 0L;
+
     @VariableMgr.VarAttr(name = ENABLE_DYNAMIC_PRUNE_SCAN_RANGE)
     private boolean enableDynamicPruneScanRange = true;
 
@@ -2265,6 +2269,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setDataCacheEvictProbability(int datacacheEvictProbability) {
         this.datacacheEvictProbability = datacacheEvictProbability;
+    }
+
+    public void setDataCachePriority(int dataCachePriority) {
+        this.datacachePriority = dataCachePriority;
+    }
+
+    public void setDatacacheTTLSeconds(long datacacheTTLSeconds) {
+        this.datacacheTTLSeconds = datacacheTTLSeconds;
     }
 
     public boolean isCboUseDBLock() {
@@ -4028,6 +4040,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_datacache_async_populate_mode(enableDataCacheAsyncPopulateMode);
         tResult.setEnable_datacache_io_adaptor(enableDataCacheIOAdaptor);
         tResult.setDatacache_evict_probability(datacacheEvictProbability);
+        tResult.setDatacache_priority(datacachePriority);
+        tResult.setDatacache_ttl_seconds(datacacheTTLSeconds);
         tResult.setEnable_file_metacache(enableFileMetaCache);
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
@@ -38,6 +38,8 @@ import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRelation;
 
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,7 +141,28 @@ public class DataCacheStmtAnalyzer {
 
             Map<String, String> properties = statement.getProperties();
             statement.setVerbose(Boolean.parseBoolean(properties.getOrDefault("verbose", "false")));
-            // todo analyze ttl, priority later
+
+            int priority = Integer.parseInt(properties.getOrDefault("priority", "0"));
+            if (priority != 0 && priority != 1) {
+                throw new SemanticException("DataCache's priority can only be set to 0 or 1");
+            }
+            statement.setPriority(priority);
+
+            // Duration for cache remains active.
+            // Use PT0M to prevent expiration of the rule.
+            // Use duration specified in ISO-8601 duration format (PnDTnHnMn).
+            long ttlSeconds = 0L;
+            try {
+                ttlSeconds = Duration.parse(properties.getOrDefault("ttl", "PT0M")).toSeconds();
+            } catch (DateTimeParseException e) {
+                throw new SemanticException(String.format(
+                        "Illegal ttl format, use duration specified in ISO-8601 duration format (PnDTnHnMn). Error msg: %s",
+                        e.getMessage()));
+            }
+            if (priority > 0 && ttlSeconds == 0) {
+                throw new SemanticException("TTL must be specified when priority > 0");
+            }
+            statement.setTTLSeconds(ttlSeconds);
 
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataCacheSelectStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataCacheSelectStatement.java
@@ -28,11 +28,14 @@ public class DataCacheSelectStatement extends DdlStmt {
 
     private final Map<String, String> properties;
 
-    // Set after DataCacheAnalyzer analyze properties
+    // =================================================================================
+    // Below properties will set after DataCacheAnalyzer analyze properties
     private boolean isVerbose = false;
     // real catalog of cache select table
     private String catalog = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
-    // TODO Support priority, ttl later
+    private long ttlSeconds = 0;
+    private int priority = 0;
+    // =================================================================================
 
     public DataCacheSelectStatement(InsertStmt insertStmt, Map<String, String> properties, NodePosition pos) {
         super(pos);
@@ -64,6 +67,22 @@ public class DataCacheSelectStatement extends DdlStmt {
 
     public String getCatalog() {
         return this.catalog;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setTTLSeconds(long ttlSeconds) {
+        this.ttlSeconds = ttlSeconds;
+    }
+
+    public long getTTLSeconds() {
+        return ttlSeconds;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
@@ -128,5 +128,23 @@ public class DataCacheStmtAnalyzerTest {
         DataCacheSelectStatement stmt = (DataCacheSelectStatement) analyzeSuccess(
                 "cache select * from hive0.datacache_db.multi_partition_table properties(\"verBose\"=\"true\")");
         Assert.assertTrue(stmt.isVerbose());
+        Assert.assertEquals(0, stmt.getPriority());
+        Assert.assertEquals(0, stmt.getTTLSeconds());
+
+        analyzeFail("cache select * from hive0.datacache_db.multi_partition_table properties(\"priority\"=\"1\")",
+                "TTL must be specified when priority > 0");
+
+        analyzeFail(
+                "cache select * from hive0.datacache_db.multi_partition_table properties(\"priority\"=\"1\", \"TTL\"=\"P1Y\")");
+
+        stmt = (DataCacheSelectStatement) analyzeSuccess(
+                "cache select * from hive0.datacache_db.multi_partition_table properties(\"priority\"=\"1\", \"TTL\"=\"P1d\")");
+        Assert.assertEquals(1, stmt.getPriority());
+        Assert.assertEquals(24 * 3600, stmt.getTTLSeconds());
+
+        stmt = (DataCacheSelectStatement) analyzeSuccess(
+                "cache select * from hive0.datacache_db.multi_partition_table properties(\"priority\"=\"1\", \"TTL\"=\"P1DT1S\")");
+        Assert.assertEquals(1, stmt.getPriority());
+        Assert.assertEquals(24 * 3600 + 1, stmt.getTTLSeconds());
     }
 }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -312,6 +312,8 @@ struct TQueryOptions {
 
   132: optional bool enable_datacache_async_populate_mode;
   133: optional bool enable_datacache_io_adaptor;
+  134: optional i32 datacache_priority;
+  135: optional i64 datacache_ttl_seconds;
 
   140: optional string catalog;
 


### PR DESCRIPTION
## Why I'm doing:
Support specific datacache ttl and priority in cache select

## What I'm doing:
Do it.

Grammar:

```sql
CACHE SELECT * FROM table PROPERTIES("priority"="1", "ttl"="PT1H");
```

Priority can only use 0 or 1.
TTL use  ISO-8601 duration format (PnDTnHnMn). https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm
If priority is set 1, user must specific ttl also.

Fix: #47151

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
