### PR TITLE
[UT] fix unstable be ut vertical_compaction_with_rows_mapper

### DIFF
--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1267,7 +1267,7 @@ void TabletUpdatesTest::test_horizontal_compaction_with_rows_mapper(bool enable_
     std::thread th([&]() { ASSERT_FALSE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
     RowsetSharedPtr output_rs;
     size_t retry_cnt = 0;
-    while (output_rs == nullptr || retry_cnt <= 10) {
+    while (output_rs == nullptr && retry_cnt <= 10) {
         // check rows mapper file
         std::this_thread::sleep_for(std::chrono::seconds(1));
         // read from file
@@ -1571,7 +1571,7 @@ void TabletUpdatesTest::test_vertical_compaction_with_rows_mapper(bool enable_pe
     std::thread th([&]() { ASSERT_FALSE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
     RowsetSharedPtr output_rs;
     size_t retry_cnt = 0;
-    while (output_rs == nullptr || retry_cnt <= 10) {
+    while (output_rs == nullptr && retry_cnt <= 10) {
         // check rows mapper file
         std::this_thread::sleep_for(std::chrono::seconds(1));
         // read from file

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1265,10 +1265,16 @@ void TabletUpdatesTest::test_horizontal_compaction_with_rows_mapper(bool enable_
     // stop apply
     best_tablet->updates()->stop_apply(true);
     std::thread th([&]() { ASSERT_FALSE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
-    // check rows mapper file
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    // read from file
-    auto output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
+    RowsetSharedPtr output_rs;
+    size_t retry_cnt = 0;
+    while (output_rs == nullptr || retry_cnt <= 10) {
+        // check rows mapper file
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        // read from file
+        output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
+        retry_cnt++;
+    }
+    ASSERT_TRUE(output_rs != nullptr);
     RowsMapperIterator iterator;
     ASSERT_OK(iterator.open(local_rows_mapper_filename(best_tablet.get(), output_rs->rowset_id_str())));
     for (uint32_t i = 0; i < 100; i += 20) {
@@ -1563,10 +1569,16 @@ void TabletUpdatesTest::test_vertical_compaction_with_rows_mapper(bool enable_pe
     // stop apply
     best_tablet->updates()->stop_apply(true);
     std::thread th([&]() { ASSERT_FALSE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
-    // check rows mapper file
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    // read from file
-    auto output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
+    RowsetSharedPtr output_rs;
+    size_t retry_cnt = 0;
+    while (output_rs == nullptr || retry_cnt <= 10) {
+        // check rows mapper file
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        // read from file
+        output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
+        retry_cnt++;
+    }
+    ASSERT_TRUE(output_rs != nullptr);
     RowsMapperIterator iterator;
     ASSERT_OK(iterator.open(local_rows_mapper_filename(best_tablet.get(), output_rs->rowset_id_str())));
     for (uint32_t i = 0; i < 100; i += 20) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
fix unstable be UT, current be UT will fail like:
![img_v3_02bv_d1c99c7f-f80f-4b84-babc-9a9a9fb56b5g](https://github.com/StarRocks/starrocks/assets/10725468/2011c180-84d7-4bcd-b0bb-365cee496073)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
