### PR TITLE
[BugFix] disable lowcardinality optimize on join predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -146,6 +146,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
         return physicalOlapScanColumns.containsAll(matchChildren);
     }
+
     private void fillDisableStringColumns() {
         // build string dependency
         // a = upper(b) b = upper(c)
@@ -203,7 +204,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         // for each relation group if any element in group is disable then disable all group
         for (Set<Integer> relationSet : relationSets) {
             for (Integer cid : relationSet) {
-                if (disableRewriteStringColumns.contains(cid)){
+                if (disableRewriteStringColumns.contains(cid)) {
                     unionAll(disableRewriteStringColumns, relationSet);
                     break;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -62,6 +62,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -121,6 +122,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     private final List<Integer> scanStringColumns = Lists.newArrayList();
 
+    // For these columns we need to disable the associated rewrites.
+    private ColumnRefSet disableRewriteStringColumns = new ColumnRefSet();
+
     // operators which are the children of Match operator
     private final ColumnRefSet matchChildren = new ColumnRefSet();
 
@@ -142,10 +146,85 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
         return physicalOlapScanColumns.containsAll(matchChildren);
     }
+    private void fillDisableStringColumns() {
+        // build string dependency
+        // a = upper(b) b = upper(c)
+        // if disable b, disable a & c
+        // build dependencies
+        // a = upper(b) b = upper(c)
+        // a -> set(b, c)
+
+        Map<Integer, Set<Integer>> dependencyStringIds = Maps.newHashMap();
+        // build dependencies from project exprs
+        this.stringRefToDefineExprMap.forEach((k, v) -> {
+            for (ColumnRefOperator columnRef : v.getColumnRefs()) {
+                dependencyStringIds.computeIfAbsent(columnRef.getId(), x -> Sets.newHashSet());
+                final int cid = columnRef.getId();
+                if (!k.equals(cid)) {
+                    dependencyStringIds.get(cid).add(k);
+                }
+            }
+        });
+        // build dependencies from aggregate exprs
+        this.stringAggregateExpressions.forEach((k, v) -> {
+            for (CallOperator callOperator : v) {
+                for (ColumnRefOperator columnRef : callOperator.getColumnRefs()) {
+                    dependencyStringIds.computeIfAbsent(columnRef.getId(), x -> Sets.newHashSet());
+                    final int cid = columnRef.getId();
+                    if (!k.equals(cid)) {
+                        dependencyStringIds.get(cid).add(k);
+                    }
+                }
+            }
+        });
+        // build relation groups. The same closure is built into the same group
+        // eg:
+        // 1 -> (2, 3)
+        // 2 -> (3)
+        // 3 -> 3
+        // 4 -> 4
+        // will generate result:
+        // 1 -> (1,2,3)
+        // 2 -> (1,2,3)
+        // 3 -> (1,2,3)
+        // 4 -> (4)
+        Map<Integer, Set<Integer>> relations = Maps.newHashMap();
+        dependencyStringIds.forEach((k, v) -> {
+            relations.computeIfAbsent(k, x -> Sets.newHashSet());
+            final Set<Integer> relation = relations.get(k);
+            relation.addAll(v);
+            relation.add(k);
+            for (Integer dependency : v) {
+                relations.put(dependency, relation);
+            }
+        });
+
+        final Set<Set<Integer>> relationSets = new HashSet<>(relations.values());
+        // for each relation group if any element in group is disable then disable all group
+        for (Set<Integer> relationSet : relationSets) {
+            for (Integer cid : relationSet) {
+                if (disableRewriteStringColumns.contains(cid)){
+                    unionAll(disableRewriteStringColumns, relationSet);
+                    break;
+                }
+            }
+        }
+    }
+
+    private void unionAll(ColumnRefSet columnRefSet, Set<Integer> cids) {
+        for (Integer cid : cids) {
+            columnRefSet.union(cid);
+        }
+    }
 
     private void initContext(DecodeContext context) {
+        fillDisableStringColumns();
+
         // choose the profitable string columns
         for (Integer cid : scanStringColumns) {
+            if (disableRewriteStringColumns.contains(cid)) {
+                continue;
+            }
             if (matchChildren.contains(cid)) {
                 continue;
             }
@@ -173,6 +252,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             if (context.allStringColumns.contains(cid)) {
                 continue;
             }
+            if (disableRewriteStringColumns.contains(cid)) {
+                continue;
+            }
             if (!checkDependOnExpr(cid, context.allStringColumns)) {
                 continue;
             }
@@ -196,6 +278,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
         // add string column's all aggregate expression(1st & 2nd stage)
         for (Integer aggregateId : stringAggregateExpressions.keySet()) {
+            if (disableRewriteStringColumns.contains(aggregateId)) {
+                continue;
+            }
             List<CallOperator> aggregateExprs = stringAggregateExpressions.get(aggregateId);
             for (CallOperator agg : aggregateExprs) {
                 if (agg.getColumnRefs().stream().map(ColumnRefOperator::getId)
@@ -307,12 +392,13 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         result.outputStringColumns.clear();
         result.inputStringColumns.getStream().forEach(c -> {
             if (onColumns.contains(c)) {
-                result.decodeStringColumns.union(c);
+                disableRewriteStringColumns.union(c);
             } else {
                 result.outputStringColumns.union(c);
             }
         });
-        result.inputStringColumns.except(result.decodeStringColumns);
+        result.decodeStringColumns.except(disableRewriteStringColumns);
+        result.inputStringColumns.except(disableRewriteStringColumns);
         return result;
     }
 
@@ -425,13 +511,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         if (context.outputStringColumns.isEmpty()) {
             return DecodeInfo.EMPTY;
         }
-        DecodeInfo result = context.createOutputInfo();
-        // 1. join on-predicate don't support low-cardinality optimization, must decode before shuffle
-        // 2. if parent don't need dict column, `parent` will null, it's unlikely, but to check is better
-        if (context.parent != null && context.parent.getOp() instanceof PhysicalJoinOperator) {
-            return visitPhysicalJoin(context.parent, context);
-        }
-        return result;
+        return context.createOutputInfo();
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
If a lowcardinality column is a shuffle column, it cannot be using lowcardinality optimized. hash(A, string) is different from hash(A, int). So we disable such cases first.

## What I'm doing:

Fixes #47108

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
