### PR TITLE
[Enhancement] optimize the process of updating local latest offsets in routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -42,6 +42,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.KafkaUtil;
 import com.starrocks.load.streamload.StreamLoadTask;
 import com.starrocks.server.GlobalStateMgr;
@@ -122,7 +123,15 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 ImmutableMap.copyOf(kafkaRoutineLoadJob.getConvertedCustomProperties()),
                 new ArrayList<>(partitionIdToOffset.keySet()), warehouseId);
         for (Map.Entry<Integer, Long> entry : latestOffsets.entrySet()) {
-            kafkaRoutineLoadJob.setPartitionOffset(entry.getKey(), entry.getValue());
+            Long cachedPartitionOffset = kafkaRoutineLoadJob.getPartitionOffset(entry.getKey());
+            Long localLatestOffset = cachedPartitionOffset == null ? KafkaProgress.OFFSET_END_VAL : cachedPartitionOffset;
+            if (entry.getValue() >= localLatestOffset) {
+                kafkaRoutineLoadJob.setPartitionOffset(entry.getKey(), entry.getValue());
+            } else {
+                LOG.warn("there is a brief offset fallback in partition: {}." +
+                        " local latest offset: {}, get latest offset: {}, task id: {}",
+                        entry.getKey(), localLatestOffset, entry.getValue(), DebugUtil.printId(id));
+            }
         }
 
         for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {


### PR DESCRIPTION
## Why I'm doing:

- There may be a brief `high watermark` fallback in Kafka when the partition is in the process of leader election or recovery (e.g. upgrade or encounter unforeseen error).
- The routine load processing lag may be negative when the number of records consumed during loading process is larger than the max offset fetched from Kafka before task scheduling.

## What I'm doing:

Fixes above issues:
- Deal with the potential offset fallback when checking `readyToExecute`.
- Acquire the max offset during transaction submission in order to avoid negative lag and reduce possible rpc requests to Kafka.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5