### PR TITLE
[Enhancement] Add tablet_sched_colocate_balance_after_system_stable_time_s to avoid unnecessary colocate balance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -90,7 +90,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
 
     private static ColocateTableBalancer INSTANCE = null;
 
-    private Set<Long> availableBackendIds = new HashSet<>();
+    private Set<Long> aliveBackendIds = new HashSet<>();
     private long systemStableStartTime = -1L;
 
     /**
@@ -258,13 +258,13 @@ public class ColocateTableBalancer extends FrontendDaemon {
     }
 
     /**
-     * If the availableBackendIds can maintain consistency within
-     * tablet_sched_colocate_balance_after_system_stable_time_s, the system is considered stable.
+     * If the availableBackendIds can maintain unchanged within
+     * tablet_sched_colocate_balance_wait_system_stable_time_s, the system is considered stable.
      */
     protected boolean isSystemStable(SystemInfoService infoService) {
-        Set<Long> currentAvailableBackendIds = new HashSet<>(infoService.getAvailableBackendIds());
-        if (!currentAvailableBackendIds.equals(availableBackendIds)) {
-            availableBackendIds = currentAvailableBackendIds;
+        Set<Long> currentAliveBackendIds = new HashSet<>(infoService.getBackendIds(true));
+        if (!currentAliveBackendIds.equals(aliveBackendIds)) {
+            aliveBackendIds = currentAliveBackendIds;
             systemStableStartTime = -1L;
             return false;
         }
@@ -274,7 +274,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
         }
 
         return System.currentTimeMillis() - systemStableStartTime
-                > Config.tablet_sched_colocate_balance_after_system_stable_time_s * 1000;
+                > Config.tablet_sched_colocate_balance_wait_system_stable_time_s * 1000;
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -90,6 +90,9 @@ public class ColocateTableBalancer extends FrontendDaemon {
 
     private static ColocateTableBalancer INSTANCE = null;
 
+    private Set<Long> availableBackendIds = new HashSet<>();
+    private long systemStableStartTime = -1L;
+
     /**
      * Only for unit test purpose.
      */
@@ -246,11 +249,32 @@ public class ColocateTableBalancer extends FrontendDaemon {
      */
     @Override
     protected void runAfterCatalogReady() {
-        if (!Config.tablet_sched_disable_colocate_balance) {
+        if (!Config.tablet_sched_disable_colocate_balance && isSystemStable(GlobalStateMgr
+                .getCurrentState().getNodeMgr().getClusterInfo())) {
             relocateAndBalancePerGroup();
             relocateAndBalanceAllGroups();
         }
         matchGroups();
+    }
+
+    /**
+     * If the availableBackendIds can maintain consistency within
+     * tablet_sched_colocate_balance_after_system_stable_time_s, the system is considered stable.
+     */
+    protected boolean isSystemStable(SystemInfoService infoService) {
+        Set<Long> currentAvailableBackendIds = new HashSet<>(infoService.getAvailableBackendIds());
+        if (!currentAvailableBackendIds.equals(availableBackendIds)) {
+            availableBackendIds = currentAvailableBackendIds;
+            systemStableStartTime = -1L;
+            return false;
+        }
+        if (systemStableStartTime == -1L) {
+            systemStableStartTime = System.currentTimeMillis();
+            return false;
+        }
+
+        return System.currentTimeMillis() - systemStableStartTime
+                > Config.tablet_sched_colocate_balance_after_system_stable_time_s * 1000;
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1432,6 +1432,7 @@ public class Config extends ConfigBase {
      * To avoid this situation, we introduced the tablet_sched_colocate_balance_after_system_stable_time_s parameter.
      * If the status(alive and decommissioned) of all backend can maintain consistency within
      * tablet_sched_colocate_balance_after_system_stable_time_s, then the colocate balance will be triggered.
+     * Default value is 15min.
      */
     @ConfField(mutable = true)
     public static long tablet_sched_colocate_balance_after_system_stable_time_s = 15 * 60;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1426,7 +1426,7 @@ public class Config extends ConfigBase {
     /**
      * Colocate balance is a very time-consuming operation,
      * and our system should try to avoid triggering colocate balance.
-     * In the BYOC environment, customers will stop all machines when the cluster is not in use to save machine resources.
+     * In the some situation, customers will stop all machines when the cluster is not in use to save machine resources.
      * When the machine is started again, unnecessary colocate balance
      * will be triggered due to the inconsistent start time of the machines.
      * To avoid this situation, we introduced the tablet_sched_colocate_balance_after_system_stable_time_s parameter.
@@ -1435,7 +1435,7 @@ public class Config extends ConfigBase {
      * Default value is 15min.
      */
     @ConfField(mutable = true)
-    public static long tablet_sched_colocate_balance_after_system_stable_time_s = 15 * 60;
+    public static long tablet_sched_colocate_balance_wait_system_stable_time_s = 15 * 60;
 
     /**
      * When setting to true, disable the overall balance behavior for colocate groups which treats all the groups

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1384,7 +1384,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean disable_load_job = false;
 
-    /*
+    /**
      * One master daemon thread will update database used data quota for db txn manager
      * every db_used_data_quota_update_interval_secs
      */
@@ -1422,6 +1422,19 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, aliases = {"disable_colocate_balance"})
     public static boolean tablet_sched_disable_colocate_balance = false;
+
+    /**
+     * Colocate balance is a very time-consuming operation,
+     * and our system should try to avoid triggering colocate balance.
+     * In the BYOC environment, customers will stop all machines when the cluster is not in use to save machine resources.
+     * When the machine is started again, unnecessary colocate balance
+     * will be triggered due to the inconsistent start time of the machines.
+     * To avoid this situation, we introduced the tablet_sched_colocate_balance_after_system_stable_time_s parameter.
+     * If the status(alive and decommissioned) of all backend can maintain consistency within
+     * tablet_sched_colocate_balance_after_system_stable_time_s, then the colocate balance will be triggered.
+     */
+    @ConfField(mutable = true)
+    public static long tablet_sched_colocate_balance_after_system_stable_time_s = 15 * 60;
 
     /**
      * When setting to true, disable the overall balance behavior for colocate groups which treats all the groups
@@ -1476,8 +1489,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long tablet_sched_colocate_be_down_tolerate_time_s = 12L * 3600L;
 
-    // if the number of balancing tablets in TabletScheduler exceed max_balancing_tablets,
-    // no more balance check
+    /**
+     * If the number of balancing tablets in TabletScheduler exceed max_balancing_tablets,
+     * no more balance check
+     */
     @ConfField(mutable = true, aliases = {"max_balancing_tablets"})
     public static int tablet_sched_max_balancing_tablets = 500;
 
@@ -1724,8 +1739,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static String authentication_ldap_simple_bind_root_pwd = "";
 
-    // For forward compatibility, will be removed later.
-    // check token when download image file.
+    /**
+     * For forward compatibility, will be removed later.
+     * check token when download image file.
+     */
     @ConfField
     public static boolean enable_token_check = true;
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -1060,7 +1060,7 @@ public class ColocateTableBalancerTest {
         Assert.assertFalse(balancer.isSystemStable(infoService));
         Assert.assertFalse(balancer.isSystemStable(infoService));
         // set stable last time to 1s, and sleep 1s, the system becomes to stable
-        Config.tablet_sched_colocate_balance_after_system_stable_time_s = 1;
+        Config.tablet_sched_colocate_balance_wait_system_stable_time_s = 1;
         Thread.sleep(1001L);
         Assert.assertTrue(balancer.isSystemStable(infoService));
         Assert.assertTrue(balancer.isSystemStable(infoService));
@@ -1071,12 +1071,5 @@ public class ColocateTableBalancerTest {
         Assert.assertFalse(balancer.isSystemStable(infoService));
         Thread.sleep(1001L);
         Assert.assertTrue(balancer.isSystemStable(infoService));
-
-        // one backend is changed to decommissioned, the system becomes to unstable
-        backend2.setDecommissioned(true);
-        Assert.assertFalse(balancer.isSystemStable(infoService));
-        Assert.assertFalse(balancer.isSystemStable(infoService));
-        Thread.sleep(1001L);
-        Assert.assertTrue(balancer.isSystemStable(infoService));
-    }
+   }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -1071,5 +1071,5 @@ public class ColocateTableBalancerTest {
         Assert.assertFalse(balancer.isSystemStable(infoService));
         Thread.sleep(1001L);
         Assert.assertTrue(balancer.isSystemStable(infoService));
-   }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -1045,4 +1045,38 @@ public class ColocateTableBalancerTest {
                 Lists.newArrayList(5L, 8L, 7L, 8L, 6L, 5L, 6L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
     }
+
+    @Test
+    public void testSystemStable() throws Exception {
+        ColocateTableBalancer balancer = ColocateTableBalancer.getInstance();
+        Backend backend1 = new Backend(100001L, "192.168.0.1", 9050);
+        backend1.setAlive(true);
+        Backend backend2 = new Backend(100002L, "192.168.0.2", 9050);
+        backend2.setAlive(true);
+        SystemInfoService infoService = new SystemInfoService();
+        infoService.replayAddBackend(backend1);
+        infoService.replayAddBackend(backend2);
+
+        Assert.assertFalse(balancer.isSystemStable(infoService));
+        Assert.assertFalse(balancer.isSystemStable(infoService));
+        // set stable last time to 1s, and sleep 1s, the system becomes to stable
+        Config.tablet_sched_colocate_balance_after_system_stable_time_s = 1;
+        Thread.sleep(1001L);
+        Assert.assertTrue(balancer.isSystemStable(infoService));
+        Assert.assertTrue(balancer.isSystemStable(infoService));
+
+        // one backend is changed to not alive, the system becomes to unstable
+        backend1.setAlive(false);
+        Assert.assertFalse(balancer.isSystemStable(infoService));
+        Assert.assertFalse(balancer.isSystemStable(infoService));
+        Thread.sleep(1001L);
+        Assert.assertTrue(balancer.isSystemStable(infoService));
+
+        // one backend is changed to decommissioned, the system becomes to unstable
+        backend2.setDecommissioned(true);
+        Assert.assertFalse(balancer.isSystemStable(infoService));
+        Assert.assertFalse(balancer.isSystemStable(infoService));
+        Thread.sleep(1001L);
+        Assert.assertTrue(balancer.isSystemStable(infoService));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Colocate balance is a very time-consuming operation,
and our system should try to avoid triggering colocate balance.
In the BYOC environment, customers will stop all machines when the cluster is not in use to save machine resources.
When the machine is started again, unnecessary colocate balance
will be triggered due to the inconsistent start time of the machines.
To avoid this situation, we introduced the tablet_sched_colocate_balance_after_system_stable_time_s parameter.
If the status(alive and decommissioned) of all backend can maintain consistency within
tablet_sched_colocate_balance_after_system_stable_time_s, then the colocate balance will be triggered.
Default value is 15min.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
