### PR TITLE
[BugFix] Disable mv rewrite for only group by keys rollup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -725,13 +725,6 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             Preconditions.checkState(targetColumn instanceof CallOperator);
             return (CallOperator) targetColumn;
         } else {
-            if (targetColumn instanceof CallOperator) {
-                // if it's aggregate function, it should be rewritten by group by keys, return it directly.
-                CallOperator targetCall = (CallOperator) targetColumn;
-                if (targetCall.isAggregate()) {
-                    return targetCall;
-                }
-            }
             if (!targetColumn.isColumnRef()) {
                 OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext.getMVName(),
                         "Rewrite aggregate rollup {} failed: only column-ref is supported after rewrite",

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -353,47 +353,26 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 " as select t1a, t1b, sum(t1f) as total from test.test_all_type group by t1a, t1b;", () -> {
             {
                 String query = "select t1a, sum(if(t1b=0, t1f, 0)) as total from test.test_all_type group by t1a;";
-                // TODO: fix this later.
                 sql(query).notContain("mv0");
             }
             {
                 String query = "select t1a, sum(if(t1b=0, t1b, 0)) as total from test.test_all_type group by t1a;";
-                sql(query)
-                        .contains("mv0")
-                        .contains("  1:AGGREGATE (update serialize)\n" +
-                                "  |  STREAMING\n" +
-                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
-                                "  |  group by: 13: t1a");
+                sql(query).notContain("mv0");
             }
             {
                 String query = "select t1a, sum(if(murmur_hash3_32(t1b %3) = 0, t1b, 0)) as total from test.test_all_type group" +
                         " by t1a;";
-                sql(query)
-                        .contains("mv0")
-                        .contains("  1:AGGREGATE (update serialize)\n" +
-                                "  |  STREAMING\n" +
-                                "  |  output: sum(if(murmur_hash3_32(CAST(14: t1b % 3 AS VARCHAR)) = 0, 14: t1b, 0))\n" +
-                                "  |  group by: 13: t1a");
+                sql(query).notContain("mv0");
             }
             {
                 String query = "select t1a, sum(case when(t1b=0) then t1b else 0 end) as total from test.test_all_type " +
                         "group by t1a;";
-                sql(query)
-                        .contains("mv0")
-                        .contains("  1:AGGREGATE (update serialize)\n" +
-                                "  |  STREAMING\n" +
-                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
-                                "  |  group by: 13: t1a");
+                sql(query).notContain("mv0");
             }
             {
                 String query = "select t1a, sum(case when(t1b=0) then t1b else 0 end) as total from test.test_all_type " +
                         "group by t1a;";
-                sql(query)
-                        .contains("mv0")
-                        .contains("  1:AGGREGATE (update serialize)\n" +
-                                "  |  STREAMING\n" +
-                                "  |  output: sum(if(14: t1b = 0, 14: t1b, 0))\n" +
-                                "  |  group by: 13: t1a");
+                sql(query).notContain("mv0");
             }
         });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -384,22 +384,11 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 " as select sum(t1f) as total, t1a, t1b from test.test_all_type group by t1a, t1b;", () -> {
             {
                 String query = "select t1a, sum(t1b) as total from test.test_all_type group by t1a;";
-                sql(query)
-                        .contains("mv0")
-                        .contains("  1:AGGREGATE (update serialize)\n" +
-                                "  |  STREAMING\n" +
-                                "  |  output: sum(14: t1b)\n" +
-                                "  |  group by: 12: t1a\n" +
-                                "  |  ");
+                sql(query).nonMatch("mv0");
             }
             {
                 String query = "select t1a, sum(t1b + 1) as total from test.test_all_type group by t1a;";
-                sql(query)
-                        .contains("mv0")
-                        .contains("  1:AGGREGATE (update serialize)\n" +
-                                "  |  STREAMING\n" +
-                                "  |  output: sum(CAST(15: t1b AS INT) + 1)\n" +
-                                "  |  group by: 13: t1a");
+                sql(query).nonMatch("mv0");
             }
         });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -755,13 +755,9 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteFail(mv, "select empid, deptno,\n" +
                 " sum(salary) as total, count(1)  as cnt\n" +
                 " from emps group by empid, deptno");
-        testRewriteOK(mv, "select empid,\n" +
+        testRewriteFail(mv, "select empid,\n" +
                 " sum(salary) as total, count(1)  as cnt\n" +
-                " from emps group by empid")
-                .contains("  1:AGGREGATE (update serialize)\n" +
-                        "  |  STREAMING\n" +
-                        "  |  output: sum(11: total), count(1)\n" +
-                        "  |  group by: 9: empid");
+                " from emps group by empid");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -168,19 +168,7 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
 
         String query9 = "select sum(c3) from test_base_part";
         String plan9 = getFragmentPlan(query9);
-        PlanTestBase.assertContains(plan9, "UNION");
-        PlanTestBase.assertContains(plan9, "  1:OlapScanNode\n" +
-                "     TABLE: partial_mv_5\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=5/5");
-        PlanTestBase.assertContains(plan9, "  4:AGGREGATE (update finalize)\n" +
-                "  |  output: sum(13: c2)\n" +
-                "  |  group by: 12: c1, 14: c3\n" +
-                "  |  \n" +
-                "  3:OlapScanNode\n" +
-                "     TABLE: test_base_part\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=1/6");
+        PlanTestBase.assertNotContains(plan9, "partial_mv_5");
         dropMv("test", "partial_mv_5");
     }
 

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite_with_case_when
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite_with_case_when
@@ -24,7 +24,11 @@ DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
 -- !result
 insert into t1 values 
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
-    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  2, 2, 2, 2, 2, 2.0, 2.0, 1.0),
+    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  1, 2, 2, 2, 2, 2.0, 2.0, 1.0),
+    ('2023-06-16', '2023-06-16 00:00:00', 'c', 'a', false, 3, 1, 3, 3, 3, 3.0, 3.0, 1.0),
+    ('2023-06-17', '2023-06-17 00:00:00', 'd', 'a', true,  4, 1, 4, 4, 4, 4.0, 4.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  1, 2, 2, 2, 2, 2.0, 2.0, 1.0),
     ('2023-06-16', '2023-06-16 00:00:00', 'c', 'a', false, 3, 1, 3, 3, 3, 3.0, 3.0, 1.0),
     ('2023-06-17', '2023-06-17 00:00:00', 'd', 'a', true,  4, 1, 4, 4, 4, 4.0, 4.0, 1.0)
 ;
@@ -64,39 +68,39 @@ None
 -- !result
 SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
-2023-06-16	3
-2023-06-17	4
+2023-06-15	0
+2023-06-16	6
+2023-06-17	8
 -- !result
 SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	3
-2023-06-16	4
-2023-06-17	5
+2023-06-15	0
+2023-06-16	7
+2023-06-17	9
 -- !result
 SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	1
+2023-06-15	6
 2023-06-16	0
 2023-06-17	0
 -- !result
 SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
+2023-06-15	8
 2023-06-16	0
 2023-06-17	0
 -- !result
 SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;
 -- result:
-2023-06-15	3	0	1	2
-2023-06-16	3	0	0	0
-2023-06-17	4	0	0	0
+2023-06-15	6	0	6	0
+2023-06-16	6	0	0	0
+2023-06-17	8	0	0	0
 -- !result
 SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
-2023-06-16	3
-2023-06-17	4
+2023-06-15	0
+2023-06-16	6
+2023-06-17	8
 -- !result
 DROP MATERIALIZED VIEW test_mv1;
 -- result:
@@ -135,39 +139,39 @@ None
 -- !result
 SELECT k1, sum(case when k6 > 1 then k9 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
-2023-06-16	3
-2023-06-17	4
+2023-06-15	0
+2023-06-16	6
+2023-06-17	8
 -- !result
 SELECT k1, sum(case when k6 > 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	3
-2023-06-16	4
-2023-06-17	5
+2023-06-15	0
+2023-06-16	8
+2023-06-17	10
 -- !result
 SELECT k1, sum(case when k6 = 1 then k9 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	1
+2023-06-15	6
 2023-06-16	0
 2023-06-17	0
 -- !result
 SELECT k1, sum(case when k6 = 1 then k9 + 1 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
+2023-06-15	10
 2023-06-16	0
 2023-06-17	0
 -- !result
 SELECT k1, sum(k9), sum(if(k6=0, k9, 0)) as cnt0, sum(if(k6=1, k9, 0)) as cnt1,  sum(if(k6=2, k9, 0)) as cnt2 from t1 group by k1 order by k1;
 -- result:
-2023-06-15	3	0	1	2
-2023-06-16	3	0	0	0
-2023-06-17	4	0	0	0
+2023-06-15	6	0	6	0
+2023-06-16	6	0	0	0
+2023-06-17	8	0	0	0
 -- !result
 SELECT k1, sum(if(k6 > 1, k9, 0)) as cnt0 from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
-2023-06-16	3
-2023-06-17	4
+2023-06-15	0
+2023-06-16	6
+2023-06-17	8
 -- !result
 DROP MATERIALIZED VIEW test_mv1;
 -- result:
@@ -178,55 +182,79 @@ AS SELECT k1, k6, SUM(k7) as sum1, SUM(k9) as sum2, SUM(k8) as sum3 FROM t1 GROU
 -- result:
 -- !result
 refresh materialized view test_mv1 with sync mode;
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT count(1) from t1;", "test_mv1")
 -- result:
 None
 -- !result
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT count(*) from t1;", "test_mv1")
 -- result:
 None
 -- !result
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT count(k6) from t1;", "test_mv1")
 -- result:
 None
 -- !result
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
 -- result:
 None
 -- !result
-function: check_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
 -- result:
 None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT count(1) from t1;
+-- result:
+8
+-- !result
+SELECT count(*) from t1;
+-- result:
+8
+-- !result
+SELECT count(k6) from t1;
+-- result:
+8
 -- !result
 SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
-2023-06-16	3
-2023-06-17	4
+2023-06-15	0
+2023-06-16	6
+2023-06-17	8
 -- !result
 SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	3
-2023-06-16	4
-2023-06-17	5
+2023-06-15	0
+2023-06-16	8
+2023-06-17	10
 -- !result
 SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	1
+2023-06-15	4
 2023-06-16	0
 2023-06-17	0
 -- !result
 SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
+2023-06-15	8
 2023-06-16	0
 2023-06-17	0
 -- !result
 SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;
 -- result:
-2023-06-15	2
-2023-06-16	3
-2023-06-17	4
+2023-06-15	0
+2023-06-16	6
+2023-06-17	8
 -- !result
 drop table t1;
 -- result:

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite_with_case_when
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite_with_case_when
@@ -21,9 +21,14 @@ CREATE TABLE `t1` (
 DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
 DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
 
+-- add duplicated rows
 insert into t1 values 
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
-    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  2, 2, 2, 2, 2, 2.0, 2.0, 1.0),
+    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  1, 2, 2, 2, 2, 2.0, 2.0, 1.0),
+    ('2023-06-16', '2023-06-16 00:00:00', 'c', 'a', false, 3, 1, 3, 3, 3, 3.0, 3.0, 1.0),
+    ('2023-06-17', '2023-06-17 00:00:00', 'd', 'a', true,  4, 1, 4, 4, 4, 4.0, 4.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 01:00:00', 'b', 'a', true,  1, 2, 2, 2, 2, 2.0, 2.0, 1.0),
     ('2023-06-16', '2023-06-16 00:00:00', 'c', 'a', false, 3, 1, 3, 3, 3, 3.0, 3.0, 1.0),
     ('2023-06-17', '2023-06-17 00:00:00', 'd', 'a', true,  4, 1, 4, 4, 4, 4.0, 4.0, 1.0)
 ;
@@ -74,12 +79,18 @@ AS SELECT k1, k6, SUM(k7) as sum1, SUM(k9) as sum2, SUM(k8) as sum3 FROM t1 GROU
 
 refresh materialized view test_mv1 with sync mode;
 
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
-function: check_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
-function: check_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT count(1) from t1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT count(*) from t1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT count(k6) from t1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(case when k6 = 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT k1, sum(if(k6 > 1, k6, 0)) as cnt0 from t1 group by k1 order by k1;", "test_mv1")
 
+SELECT count(1) from t1;
+SELECT count(*) from t1;
+SELECT count(k6) from t1;
 SELECT k1, sum(case when k6 > 1 then k6 else 0 end) from t1 group by k1 order by k1;
 SELECT k1, sum(case when k6 > 1 then k6 + 1 else 0 end) from t1 group by k1 order by k1;
 SELECT k1, sum(case when k6 = 1 then k6 else 0 end) from t1 group by k1 order by k1;


### PR DESCRIPTION
## Why I'm doing:
- MV should not rewrite for rollup with only group by keys, otherwise result may not be right.


## What I'm doing:
- Disable mv rewrite for only group by keys rollup 

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/7839)

TODO: https://github.com/StarRocks/starrocks/issues/46750

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
