### PR TITLE
[BugFix] Fix not found dict expr when enable lowcardinality V2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -648,6 +648,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                     stringRefToDefineExprMap.put(key.getId(), value);
                     expressionStringRefCounter.putIfAbsent(key.getId(), 0);
                     info.outputStringColumns.union(key.getId());
+                } else {
+                    info.usedStringColumns.union(c);
                 }
             });
             matchChildren.union(dictExpressionCollector.matchChildren);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
@@ -33,6 +33,9 @@ class DecodeInfo {
     // operator's output string columns
     ColumnRefSet outputStringColumns = new ColumnRefSet();
 
+    // operator used string column but not output to downstream operator
+    ColumnRefSet usedStringColumns = new ColumnRefSet();
+
     public DecodeInfo createOutputInfo() {
         if (this.outputStringColumns.isEmpty()) {
             return EMPTY;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -93,6 +93,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         DecodeInfo decodeInfo = context.operatorDecodeInfo.getOrDefault(optExpression.getOp(), DecodeInfo.EMPTY);
 
         fragmentUsedDictExprs.union(decodeInfo.outputStringColumns);
+        fragmentUsedDictExprs.union(decodeInfo.usedStringColumns);
         ColumnRefSet childFragmentUsedDictExpr = optExpression.getOp() instanceof PhysicalDistributionOperator ?
                 new ColumnRefSet() : fragmentUsedDictExprs;
 

--- a/test/sql/test_low_cardinality/R/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality2
@@ -307,11 +307,11 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_72538010da2a11eebf99c1cb78b81852.s1	analyze	status	OK
+test_db_597f05742dee11efbc9b7b0d31512d80.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_72538010da2a11eebf99c1cb78b81852.s2	analyze	status	OK
+test_db_597f05742dee11efbc9b7b0d31512d80.s2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('v3', 's1')
 -- result:
@@ -484,7 +484,7 @@ FROM
 -- !result
 [UC] analyze full table supplier;
 -- result:
-test_db_72538010da2a11eebf99c1cb78b81852.supplier	analyze	status	OK
+test_db_597f05742dee11efbc9b7b0d31512d80.supplier	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('s_region', 'supplier')
 -- result:
@@ -507,4 +507,16 @@ select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier 
 2	2
 3	3
 4	4
+-- !result
+ with a as ( select s_region, S_NAME from supplier where S_SUPPKEY < 10 limit 10 ), b as ( select max(upper(s_region)) as mx from a group by S_NAME ), c as ( select lower(mx) = lower('lw') from b )select *from c;
+-- result:
+0
+0
+0
+0
+0
+0
+0
+0
+0
 -- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality2
@@ -420,3 +420,4 @@ agged_supplier_2 as ( select S_NAME, if(mx_addr = 'key', 'key2', S_NAME) mx_addr
 as ( select S_NAME, mx_addr from agged_supplier_2 l group by S_NAME,mx_addr ), 
 agged_supplier_5 as ( select l.S_NAME, l.mx_addr from agged_supplier_4 l join supplier r where r.s_suppkey=10 ) 
 select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier z on l.S_NAME = z.S_NAME and l.mx_addr = z.s_region order by 2 nulls last,1 limit 10;
+ with a as ( select s_region, S_NAME from supplier where S_SUPPKEY < 10 limit 10 ), b as ( select max(upper(s_region)) as mx from a group by S_NAME ), c as ( select lower(mx) = lower('lw') from b )select *from c;


### PR DESCRIPTION
## Why I'm doing:
reproduce case:
```

with a as (
    select
        lo_shipmode,
        lo_tax
    from
        lineorder l
    where lo_orderkey < 10
    limit 10
),
b as (
    select
        max(upper(lo_shipmode)) as mx
    from
        a
    group by
        lo_tax
),
c as (
    select
        lower(mx) = lower('lw')
    from
        b
)
select
    *
from
    c;
```
```
ERROR 1064 (HY000): couldn't found dict cid:23 
```

## What I'm doing:

if a new string column generated by AGG it was not used in outputColumns (only used in project). BE won't have the dict define.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
