### PR TITLE
[BugFix] Primary key vertical compaction maybe failed.

### DIFF
--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -558,7 +558,7 @@ private:
 
             CHECK_EQ(rowsets.size(), iterators.size());
             // If iterators only has one union_iterator, new_mask_merge_iterator will return a union_iterator directly.
-            // And in the following function `get_next`, the `source_masks` does not work actually because we only need 
+            // And in the following function `get_next`, the `source_masks` does not work actually because we only need
             // to fetch data in order of segment.
             std::shared_ptr<ChunkIterator> iter = new_mask_merge_iterator(iterators, mask_buffer.get());
             RETURN_IF_ERROR(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -557,6 +557,9 @@ private:
             }
 
             CHECK_EQ(rowsets.size(), iterators.size());
+            // If iterators only has one union_iterator, new_mask_merge_iterator will return a union_iterator directly.
+            // And in the following function `get_next`, the `source_masks` does not work actually because we only need 
+            // to fetch data in order of segment.
             std::shared_ptr<ChunkIterator> iter = new_mask_merge_iterator(iterators, mask_buffer.get());
             RETURN_IF_ERROR(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
 

--- a/be/src/storage/union_iterator.cpp
+++ b/be/src/storage/union_iterator.cpp
@@ -61,6 +61,7 @@ protected:
     Status do_get_next(Chunk* chunk) override;
     Status do_get_next(Chunk* chunk, std::vector<uint32_t>* rowid) override;
     Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override;
+    Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override { return do_get_next(chunk); }
 
 private:
     std::vector<ChunkIteratorPtr> _children;

--- a/be/src/storage/union_iterator.cpp
+++ b/be/src/storage/union_iterator.cpp
@@ -61,6 +61,8 @@ protected:
     Status do_get_next(Chunk* chunk) override;
     Status do_get_next(Chunk* chunk, std::vector<uint32_t>* rowid) override;
     Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override;
+    // Union Iterator will read data in order of segment and we don't need to record the read segment record
+    // Add this function for compatibility
     Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override { return do_get_next(chunk); }
 
 private:


### PR DESCRIPTION
## Why I'm doing:
During the vertical compaction of a PK table, if the input rowset contains only one non-overlapping rowset, we will create a `union_iterator` to read data. However, we will create `source_mask` to support vertical compaction but `union_iterator` does not support read data with `source_mask`, so the compaction task will fail and the output error is as follow:
```
W0618 20:10:32.126293 15920 rowset_merger.cpp:573] reader get next error. tablet=9720982, err=Not supported: get chunk with sources not supported
```

## What I'm doing:
Support `union_iterator` read data with `source_masks`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
