### PR TITLE
[BugFix] Fix ranger can't work

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1009,10 +1009,6 @@ under the License.
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-client</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Fix https://github.com/StarRocks/StarRocksTest/issues/7878
```bash
2024-06-19 10:39:45.846+08:00 ERROR (PolicyRefresher(serviceName=starrocks)-158|158) [PolicyRefresher.loadPolicyfromPolicyAdmin():332] PolicyRefresher(serviceName=starrocks): failed to refresh policies. Will continue
 to use last known version of policies (-1)
javax.ws.rs.WebApplicationException: com.sun.xml.bind.v2.runtime.IllegalAnnotationsException: 2 counts of IllegalAnnotationExceptions
java.util.Map is an interface, and JAXB can't handle interfaces.
        this problem is related to the following location:
                at java.util.Map
                at private java.util.List org.apache.ranger.plugin.model.RangerPolicy.additionalResources
                at org.apache.ranger.plugin.model.RangerPolicy
                at private java.util.List org.apache.ranger.plugin.util.ServicePolicies.policies
                at org.apache.ranger.plugin.util.ServicePolicies
java.util.Map does not have a no-arg default constructor.
        this problem is related to the following location:
                at java.util.Map
                at private java.util.List org.apache.ranger.plugin.model.RangerPolicy.additionalResources
                at org.apache.ranger.plugin.model.RangerPolicy
                at private java.util.List org.apache.ranger.plugin.util.ServicePolicies.policies
                at org.apache.ranger.plugin.util.ServicePolicies

        at com.sun.jersey.core.provider.jaxb.AbstractRootElementProvider.readFrom(AbstractRootElementProvider.java:115) ~[jersey-core-1.19.4.jar:1.19.4]
        at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:634) ~[jersey-client-1.19.4.jar:1.19.4]
                at org.apache.ranger.plugin.util.ServicePolicies
java.util.Map does not have a no-arg default constructor.
        this problem is related to the following location:
                at java.util.Map
                at private java.util.List org.apache.ranger.plugin.model.RangerPolicy.additionalResources
                at org.apache.ranger.plugin.model.RangerPolicy
                at private java.util.List org.apache.ranger.plugin.util.ServicePolicies.policies
                at org.apache.ranger.plugin.util.ServicePolicies

        at com.sun.jersey.core.provider.jaxb.AbstractRootElementProvider.readFrom(AbstractRootElementProvider.java:115) ~[jersey-core-1.19.4.jar:1.19.4]
        at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:634) ~[jersey-client-1.19.4.jar:1.19.4]
        at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:586) ~[jersey-client-1.19.4.jar:1.19.4]
        at org.apache.ranger.admin.client.RangerAdminRESTClient.getServicePoliciesIfUpdatedWithCred(RangerAdminRESTClient.java:858) ~[ranger-plugins-common-2.4.0.jar:2.4.0]
        at org.apache.ranger.admin.client.RangerAdminRESTClient.getServicePoliciesIfUpdated(RangerAdminRESTClient.java:146) ~[ranger-plugins-common-2.4.0.jar:2.4.0]
        at org.apache.ranger.plugin.util.PolicyRefresher.loadPolicyfromPolicyAdmin(PolicyRefresher.java:308) ~[ranger-plugins-common-2.4.0.jar:2.4.0]
        at org.apache.ranger.plugin.util.PolicyRefresher.loadPolicy(PolicyRefresher.java:247) ~[ranger-plugins-common-2.4.0.jar:2.4.0]
        at org.apache.ranger.plugin.util.PolicyRefresher.run(PolicyRefresher.java:209) ~[ranger-plugins-common-2.4.0.jar:2.4.0]
Caused by: com.sun.xml.bind.v2.runtime.IllegalAnnotationsException: 2 counts of IllegalAnnotationExceptions
        at com.sun.xml.bind.v2.runtime.IllegalAnnotationsException$Builder.check(IllegalAnnotationsException.java:106) ~[jaxb-impl-2.2.3-1.jar:2.2.3]
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.getTypeInfoSet(JAXBContextImpl.java:489) ~[jaxb-impl-2.2.3-1.jar:2.2.3]
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:319) ~[jaxb-impl-2.2.3-1.jar:2.2.3]
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl$JAXBContextBuilder.build(JAXBContextImpl.java:1170) ~[jaxb-impl-2.2.3-1.jar:2.2.3]
        at com.sun.xml.bind.v2.ContextFactory.createContext(ContextFactory.java:145) ~[jaxb-impl-2.2.3-1.jar:2.2.3]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:297) ~[paimon-s3-0.8.1.jar:0.8.1]
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:286) ~[paimon-s3-0.8.1.jar:0.8.1]
        at javax.xml.bind.ContextFinder.find(ContextFinder.java:409) ~[paimon-s3-0.8.1.jar:0.8.1]
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:721) ~[paimon-s3-0.8.1.jar:0.8.1]
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:662) ~[paimon-s3-0.8.1.jar:0.8.1]
        at com.sun.jersey.core.provider.jaxb.AbstractJAXBProvider.getStoredJAXBContext(AbstractJAXBProvider.java:196) ~[jersey-core-1.19.4.jar:1.19.4]
        at com.sun.jersey.core.provider.jaxb.AbstractJAXBProvider.getJAXBContext(AbstractJAXBProvider.java:188) ~[jersey-core-1.19.4.jar:1.19.4]
        at com.sun.jersey.core.provider.jaxb.AbstractJAXBProvider.getUnmarshaller(AbstractJAXBProvider.java:140) ~[jersey-core-1.19.4.jar:1.19.4]
        at com.sun.jersey.core.provider.jaxb.AbstractJAXBProvider.getUnmarshaller(AbstractJAXBProvider.java:123) ~[jersey-core-1.19.4.jar:1.19.4]
        at com.sun.jersey.core.provider.jaxb.AbstractRootElementProvider.readFrom(AbstractRootElementProvider.java:111) ~[jersey-core-1.19.4.jar:1.19.4]
        ... 7 more
```

bug was introduced by https://github.com/StarRocks/starrocks/pull/46327

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
