### PR TITLE
[Enhancement] Remove files property from BackupJobInfo to save memory

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
@@ -241,8 +241,6 @@ public class BackupJobInfo implements Writable {
     public static class BackupTabletInfo {
         @SerializedName(value = "id")
         public long id;
-        @SerializedName(value = "files")
-        public List<String> files = Lists.newArrayList();
     }
 
     // eg: __db_10001/__tbl_10002/__part_10003/__idx_10002/__10004
@@ -328,9 +326,6 @@ public class BackupJobInfo implements Writable {
                         for (Tablet tablet : index.getTablets()) {
                             BackupTabletInfo tabletInfo = new BackupTabletInfo();
                             tabletInfo.id = tablet.getId();
-                            if (tbl.isOlapTable()) {
-                                tabletInfo.files.addAll(snapshotInfos.get(tablet.getId()).getFiles());
-                            }
                             idxInfo.tablets.add(tabletInfo);
                         }
                     }
@@ -349,9 +344,6 @@ public class BackupJobInfo implements Writable {
                             for (Tablet tablet : index.getTablets()) {
                                 BackupTabletInfo tabletInfo = new BackupTabletInfo();
                                 tabletInfo.id = tablet.getId();
-                                if (tbl.isOlapTable()) {
-                                    tabletInfo.files.addAll(snapshotInfos.get(tablet.getId()).getFiles());
-                                }
                                 idxInfo.tablets.add(tabletInfo);
                             }
                         }
@@ -487,10 +479,6 @@ public class BackupJobInfo implements Writable {
                         for (String tabletId : orderedTabletIds) {
                             BackupTabletInfo tabletInfo = new BackupTabletInfo();
                             tabletInfo.id = Long.valueOf(tabletId);
-                            JSONArray files = tablets.getJSONArray(tabletId);
-                            for (Object object : files) {
-                                tabletInfo.files.add((String) object);
-                            }
                             indexInfo.tablets.add(tabletInfo);
                         }
                         partInfo.indexes.put(indexInfo.name, indexInfo);
@@ -527,10 +515,6 @@ public class BackupJobInfo implements Writable {
                                 for (String tabletId : orderedTabletIds) {
                                     BackupTabletInfo tabletInfo = new BackupTabletInfo();
                                     tabletInfo.id = Long.valueOf(tabletId);
-                                    JSONArray files = tablets.getJSONArray(tabletId);
-                                    for (Object object : files) {
-                                        tabletInfo.files.add((String) object);
-                                    }
                                     indexInfo.tablets.add(tabletInfo);
                                 }
                                 subPartInfo.indexes.put(indexInfo.name, indexInfo);
@@ -627,9 +611,6 @@ public class BackupJobInfo implements Writable {
                         for (BackupTabletInfo tabletInfo : idxInfo.tablets) {
                             JSONArray files = new JSONArray();
                             tablets.put(String.valueOf(tabletInfo.id), files);
-                            for (String fileName : tabletInfo.files) {
-                                files.put(fileName);
-                            }
                             // to save the order of tablets
                             tabletsOrder.put(String.valueOf(tabletInfo.id));
                         }
@@ -654,9 +635,6 @@ public class BackupJobInfo implements Writable {
                             for (BackupTabletInfo tabletInfo : idxInfo.tablets) {
                                 JSONArray files = new JSONArray();
                                 tablets.put(String.valueOf(tabletInfo.id), files);
-                                for (String fileName : tabletInfo.files) {
-                                    files.put(fileName);
-                                }
                                 // to save the order of tablets
                                 tabletsOrder.put(String.valueOf(tabletInfo.id));
                             }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobInfoTest.java
@@ -209,10 +209,6 @@ public class BackupJobInfoTest {
         Assert.assertEquals(2,
                 jobInfo.getTableInfo("table1").getPartInfo("partition1").getIdx("rollup1").tablets.size());
 
-        Assert.assertEquals(2,
-                jobInfo.getTableInfo("table1").getPartInfo("partition1")
-                        .getIdx("rollup1").getTablet(10007L).files.size());
-
         File tmpFile = new File("./tmp");
         try {
             DataOutputStream out = new DataOutputStream(new FileOutputStream(tmpFile));

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -284,9 +284,6 @@ public class RestoreJobMaterializedViewTest {
                 for (Tablet tablet : index.getTablets()) {
                     BackupTabletInfo tabletInfo = new BackupTabletInfo();
                     tabletInfo.id = tablet.getId();
-                    tabletInfo.files.add(tabletInfo.id + ".dat");
-                    tabletInfo.files.add(tabletInfo.id + ".idx");
-                    tabletInfo.files.add(tabletInfo.id + ".hdr");
                     idxInfo.tablets.add(tabletInfo);
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -252,8 +252,6 @@ public class RestoreJobPrimaryKeyTest {
                 for (Tablet tablet : index.getTablets()) {
                     BackupTabletInfo tabletInfo = new BackupTabletInfo();
                     tabletInfo.id = tablet.getId();
-                    tabletInfo.files.add(tabletInfo.id + ".dat");
-                    tabletInfo.files.add("meta");
                     idxInfo.tablets.add(tabletInfo);
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -288,9 +288,6 @@ public class RestoreJobTest {
                     for (Tablet tablet : index.getTablets()) {
                         BackupTabletInfo tabletInfo = new BackupTabletInfo();
                         tabletInfo.id = tablet.getId();
-                        tabletInfo.files.add(tabletInfo.id + ".dat");
-                        tabletInfo.files.add(tabletInfo.id + ".idx");
-                        tabletInfo.files.add(tabletInfo.id + ".hdr");
                         idxInfo.tablets.add(tabletInfo);
                     }
                 }
@@ -469,9 +466,6 @@ public class RestoreJobTest {
                 for (Tablet tablet : index.getTablets()) {
                     BackupTabletInfo tabletInfo = new BackupTabletInfo();
                     tabletInfo.id = tablet.getId();
-                    tabletInfo.files.add(tabletInfo.id + ".dat");
-                    tabletInfo.files.add(tabletInfo.id + ".idx");
-                    tabletInfo.files.add(tabletInfo.id + ".hdr");
                     idxInfo.tablets.add(tabletInfo);
                 }
             }


### PR DESCRIPTION
## Why I'm doing:
The files is not used, remove it to save memory. A lot of memory is wasted when there are many snapshot files for one tablet.
![img_v3_02at_be8ec2e4-0ca2-4e73-b8fd-3e30a33e83eg](https://github.com/StarRocks/starrocks/assets/54172532/d293c4a8-5bcd-4a30-b3fd-80ee3da517cb)

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
