### PR TITLE
[Tool] Create symlink for gensrc at runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ be/output
 be/build
 be/build_Release
 be/ut_build
+be/src/gen_cpp/build
 output
 docs/contents
 docs/.temp

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -71,6 +71,23 @@ set(OUTPUT_DIR "${BASE_DIR}/output")
 set(CONTRIB_DIR "${BASE_DIR}/../contrib/")
 set(CMAKE_EXPORT_COMPILECOMMANDS ON)
 
+set(REAL_GENSRC_DIR "${BASE_DIR}/../gensrc/build/")
+if(EXISTS ${GENSRC_DIR})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${GENSRC_DIR})
+    message(STATUS "Existing symlink or file ${GENSRC_DIR} removed.")
+endif()
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${REAL_GENSRC_DIR} ${GENSRC_DIR}
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+)
+if(result)
+    message(FATAL_ERROR "Failed to create symlink: ${error}")
+else()
+    message(STATUS "Symbolic link created: ${REAL_GENSRC_DIR} -> ${GENSRC_DIR}")
+endif()
+
 if (APPLE)
     set(MAKE_TEST "ON")
 else()

--- a/be/src/gen_cpp/build
+++ b/be/src/gen_cpp/build
@@ -1,1 +1,0 @@
-../../../gensrc/build/


### PR DESCRIPTION
## Why I'm doing:

When cloning this repository on macOS after https://github.com/StarRocks/starrocks/pull/46030 merged, because of the difference between Linux and macOS, the symbolic path 'starrocks/be/src/gen_cpp/build' will look like the below:
![image](https://github.com/StarRocks/starrocks/assets/45445803/ce28e40f-61b0-4e64-834b-6eeff7c9479c). 

The different behaviors will influence the developer under the macOS Platform.

## What I'm doing:

Create a symbolic path for 'gensrc' when CMake is running.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
