### PR TITLE
[BugFix] Fix spill buffer read cost too much memory

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1033,6 +1033,8 @@ CONF_Int64(spill_max_log_block_container_bytes, "10737418240"); // 10GB
 // be the same with storage path. Spill will return with error when used size has exceeded
 // the limit.
 CONF_mDouble(spill_max_dir_bytes_ratio, "0.8"); // 80%
+// min bytes size of spill read buffer. if the buffer size is less than this value, we will disable buffer read
+CONF_Int64(spill_read_buffer_min_bytes, "1048576");
 
 CONF_Int32(internal_service_query_rpc_thread_num, "-1");
 

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -36,6 +36,7 @@
 
 #include <cstring>
 #include <string>
+#include <string_view>
 
 #include "column/column.h"
 #include "common/logging.h"
@@ -147,8 +148,8 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         // parse body and footer
         Slice page_slice = handle->data();
         uint32_t footer_size = decode_fixed32_le((uint8_t*)page_slice.data + page_slice.size - 4);
-        std::string footer_buf(page_slice.data + page_slice.size - 4 - footer_size, footer_size);
-        if (!footer->ParseFromString(footer_buf)) {
+        std::string_view footer_buf{page_slice.data + page_slice.size - 4 - footer_size, footer_size};
+        if (!footer->ParseFromArray(footer_buf.data(), footer_buf.size())) {
             return Status::Corruption(
                     strings::Substitute("Bad page: invalid footer, read from page cache, file=$0, footer_size=$1",
                                         opts.read_file->filename(), footer_size));


### PR DESCRIPTION
## Why I'm doing:
Now spill buffer read will allocate 16M for each block.

before this patch enable buffer read:

![img_v3_02c0_6d3d709d-6145-4966-b228-b24430e6304g](https://github.com/StarRocks/starrocks/assets/34912776/a3e05a02-2a96-4650-8212-50a08e366a7b)
fixed 
![JKnW3VkmpE](https://github.com/StarRocks/starrocks/assets/34912776/f01a50e3-6cf1-434e-9baf-369eec9eeb53)


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
