### PR TITLE
[BugFix] [Refactor] Add CachedPartitionTraits to cache partition trait results in mv refresh and rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ThrowingSupplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThrowingSupplier.java
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+/**
+ * ThrowingSupplier is a functional interface that can be used to wrap a supplier that throws a checked exception.
+ * @param <T> get a return type
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T> {
+    T get() throws Exception;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -14,47 +14,32 @@
 
 package com.starrocks.connector;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
-import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.LiteralExpr;
-import com.starrocks.analysis.NullLiteral;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.DeltaLakePartitionKey;
-import com.starrocks.catalog.DeltaLakeTable;
-import com.starrocks.catalog.HiveMetaStoreTable;
-import com.starrocks.catalog.HivePartitionKey;
-import com.starrocks.catalog.HiveTable;
-import com.starrocks.catalog.HudiPartitionKey;
-import com.starrocks.catalog.IcebergPartitionKey;
-import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.JDBCPartitionKey;
-import com.starrocks.catalog.JDBCTable;
-import com.starrocks.catalog.KuduPartitionKey;
-import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.NullablePartitionKey;
-import com.starrocks.catalog.OdpsPartitionKey;
-import com.starrocks.catalog.OdpsTable;
-import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.PaimonPartitionKey;
-import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
-import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.connector.iceberg.IcebergPartitionUtils;
-import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.connector.partitiontraits.CachedPartitionTraits;
+import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
+import com.starrocks.connector.partitiontraits.HivePartitionTraits;
+import com.starrocks.connector.partitiontraits.HudiPartitionTraits;
+import com.starrocks.connector.partitiontraits.IcebergPartitionTraits;
+import com.starrocks.connector.partitiontraits.JDBCPartitionTraits;
+import com.starrocks.connector.partitiontraits.KuduPartitionTraits;
+import com.starrocks.connector.partitiontraits.OdpsPartitionTraits;
+import com.starrocks.connector.partitiontraits.OlapPartitionTraits;
+import com.starrocks.connector.partitiontraits.PaimonPartitionTraits;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +48,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Abstract the partition-related interfaces for different connectors, including Iceberg/Hive/....
@@ -71,9 +55,10 @@ import java.util.stream.Collectors;
 public abstract class ConnectorPartitionTraits {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConnectorPartitionTraits.class);
+
     private static final Map<Table.TableType, Supplier<ConnectorPartitionTraits>> TRAITS_TABLE =
             ImmutableMap.<Table.TableType, Supplier<ConnectorPartitionTraits>>builder()
-                    // Consider all native table as OLAP
+                    // Consider all native tables as OLAP
                     .put(Table.TableType.OLAP, OlapPartitionTraits::new)
                     .put(Table.TableType.MATERIALIZED_VIEW, OlapPartitionTraits::new)
                     .put(Table.TableType.CLOUD_NATIVE, OlapPartitionTraits::new)
@@ -101,44 +86,79 @@ public abstract class ConnectorPartitionTraits {
                 "traits not supported: " + tableType).get();
     }
 
+    /**
+     * Build the partition traits for the table, if the current thread has a ConnectContext, use the cache if possible.
+     * @param ctx the connect context
+     * @param table the table to build partition traits
+     * @return the partition traits
+     */
+    public static ConnectorPartitionTraits buildWithCache(ConnectContext ctx, Table table) {
+        ConnectorPartitionTraits delegate = buildWithoutCache(table);
+        if (ctx != null && ctx.getQueryMVContext() != null) {
+            QueryMaterializationContext queryMVContext = ctx.getQueryMVContext();
+            Cache<Object, Object> cache = queryMVContext.getMvQueryContextCache();
+            return new CachedPartitionTraits(cache, delegate, queryMVContext.getQueryCacheStats());
+        } else {
+            return delegate;
+        }
+    }
+
+    /**
+     * Build the partition traits for the table, if the current thread has a ConnectContext, use the cache if possible.
+     * @param table the table to build partition traits
+     * @return the partition traits
+     */
     public static ConnectorPartitionTraits build(Table table) {
+        ConnectContext ctx = ConnectContext.get();
+        return buildWithCache(ctx, table);
+    }
+
+    private static ConnectorPartitionTraits buildWithoutCache(Table table) {
         ConnectorPartitionTraits res = build(table.getType());
         res.table = table;
         return res;
     }
 
+    public Table getTable() {
+        return this.table;
+    }
+
+    public String getTableName() {
+        return table.getName();
+    }
+
     /**
      * Build a partition key for the table, some of them have specific representations for null values
      */
-    abstract PartitionKey createEmptyKey();
+    public abstract PartitionKey createEmptyKey();
 
-    abstract String getDbName();
+    public abstract String getDbName();
 
     /**
      * Whether this table support partition-granular refresh as ref-table
      */
     public abstract boolean supportPartitionRefresh();
 
-    abstract PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException;
+    public abstract PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException;
 
-    abstract PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)
+    public abstract PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)
             throws AnalysisException;
     /**
      * Get all partitions' name
      */
-    abstract List<String> getPartitionNames();
+    public abstract List<String> getPartitionNames();
 
     /**
      * Get partition columns
      */
-    abstract List<Column> getPartitionColumns();
+    public abstract List<Column> getPartitionColumns();
 
     /**
      * Get partition range map with the specified partition column and expression
      *
      * @apiNote it must be a range-partitioned table
      */
-    abstract Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr)
+    public abstract Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr)
             throws AnalysisException;
 
     /**
@@ -146,11 +166,15 @@ public abstract class ConnectorPartitionTraits {
      *
      * @apiNote it must be a list-partitioned table
      */
-    abstract Map<String, List<List<String>>> getPartitionList(Column partitionColumn) throws AnalysisException;
+    public abstract Map<String, List<List<String>>> getPartitionList(Column partitionColumn) throws AnalysisException;
 
     public abstract Map<String, PartitionInfo> getPartitionNameWithPartitionInfo();
 
     public abstract Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames);
+
+    public List<PartitionInfo> getPartitions(List<String> names) {
+        throw new NotImplementedException("getPartitions is not implemented for this table type: " + table.getType());
+    }
 
     /**
      * The max of refresh ts for all partitions
@@ -163,551 +187,15 @@ public abstract class ConnectorPartitionTraits {
     public abstract Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                          MaterializedView.AsyncRefreshContext context);
 
-    // ========================================= Implementations ==============================================
-
-    public abstract static class DefaultTraits extends ConnectorPartitionTraits {
-
-        @Override
-        public boolean supportPartitionRefresh() {
-            return false;
-        }
-
-        @Override
-        public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException {
-            Preconditions.checkState(values.size() == types.size(),
-                    "columns size is %s, but values size is %s", types.size(), values.size());
-
-            PartitionKey partitionKey = createEmptyKey();
-
-            // change string value to LiteralExpr,
-            for (int i = 0; i < values.size(); i++) {
-                String rawValue = values.get(i);
-                Type type = types.get(i);
-                LiteralExpr exprValue;
-                // rawValue could be null for delta table
-                if (rawValue == null) {
-                    rawValue = "null";
-                }
-                if (((NullablePartitionKey) partitionKey).nullPartitionValueList().contains(rawValue)) {
-                    partitionKey.setNullPartitionValue(rawValue);
-                    exprValue = NullLiteral.create(type);
-                } else {
-                    exprValue = LiteralExpr.create(rawValue, type);
-                }
-                partitionKey.pushColumn(exprValue, type.getPrimitiveType());
-            }
-            return partitionKey;
-        }
-
-        @Override
-        public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)
-                throws AnalysisException {
-            return createPartitionKeyWithType(partitionValues,
-                    partitionColumns.stream().map(Column::getType).collect(Collectors.toList()));
-        }
-
-        protected String getTableName() {
-            return table.getName();
-        }
-
-        @Override
-        public List<String> getPartitionNames() {
-            if (table.isUnPartitioned()) {
-                return Lists.newArrayList(table.getName());
-            }
-
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
-                    table.getCatalogName(), getDbName(), getTableName());
-        }
-
-        @Override
-        public List<Column> getPartitionColumns() {
-            return table.getPartitionColumns();
-        }
-
-        @Override
-        public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr)
-                throws AnalysisException {
-            return PartitionUtil.getRangePartitionMapOfExternalTable(
-                    table, partitionColumn, getPartitionNames(), partitionExpr);
-        }
-
-        @Override
-        public Map<String, List<List<String>>> getPartitionList(Column partitionColumn) throws AnalysisException {
-            return PartitionUtil.getMVPartitionNameWithList(table, partitionColumn, getPartitionNames());
-        }
-
-        @Override
-        public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
-            Map<String, PartitionInfo> partitionNameWithPartition = Maps.newHashMap();
-            List<String> partitionNames = getPartitionNames();
-            List<PartitionInfo> partitions = getPartitions(partitionNames);
-            Preconditions.checkState(partitions.size() == partitionNames.size(), "corrupted partition meta");
-            for (int index = 0; index < partitionNames.size(); ++index) {
-                partitionNameWithPartition.put(partitionNames.get(index), partitions.get(index));
-            }
-            return partitionNameWithPartition;
-        }
-
-        @Override
-        public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames) {
-            Map<String, PartitionInfo> partitionNameWithPartition = Maps.newHashMap();
-            List<PartitionInfo> partitions = getPartitions(partitionNames);
-            Preconditions.checkState(partitions.size() == partitionNames.size(), "corrupted partition meta");
-            for (int index = 0; index < partitionNames.size(); ++index) {
-                partitionNameWithPartition.put(partitionNames.get(index), partitions.get(index));
-            }
-            return partitionNameWithPartition;
-        }
-
-        protected List<PartitionInfo> getPartitions(List<String> names) {
-            throw new NotImplementedException("Only support hive/paimon/jdbc");
-        }
-
-        @Override
-        public Optional<Long> maxPartitionRefreshTs() {
-            throw new NotImplementedException("Not support maxPartitionRefreshTs");
-        }
-
-        @Override
-        public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
-                                                    MaterializedView.AsyncRefreshContext context) {
-            Table baseTable = table;
-            Set<String> result = Sets.newHashSet();
-            Map<String, com.starrocks.connector.PartitionInfo> latestPartitionInfo =
-                    getPartitionNameWithPartitionInfo();
-
-            for (BaseTableInfo baseTableInfo : baseTables) {
-                if (!baseTableInfo.getTableIdentifier().equalsIgnoreCase(baseTable.getTableIdentifier())) {
-                    continue;
-                }
-                Map<String, MaterializedView.BasePartitionInfo> versionMap =
-                        context.getBaseTableRefreshInfo(baseTableInfo);
-
-                // check whether there are partitions added
-                for (Map.Entry<String, com.starrocks.connector.PartitionInfo> entry : latestPartitionInfo.entrySet()) {
-                    if (!versionMap.containsKey(entry.getKey())) {
-                        result.add(entry.getKey());
-                    }
-                }
-
-                for (Map.Entry<String, MaterializedView.BasePartitionInfo> versionEntry : versionMap.entrySet()) {
-                    String basePartitionName = versionEntry.getKey();
-                    if (!latestPartitionInfo.containsKey(basePartitionName)) {
-                        // partitions deleted
-                        return latestPartitionInfo.keySet();
-                    }
-                    long basePartitionVersion = latestPartitionInfo.get(basePartitionName).getModifiedTime();
-
-                    MaterializedView.BasePartitionInfo basePartitionInfo = versionEntry.getValue();
-                    // basePartitionVersion less than 0 is illegal
-                    if ((basePartitionInfo == null || basePartitionVersion != basePartitionInfo.getVersion())
-                            && basePartitionVersion >= 0) {
-                        result.add(basePartitionName);
-                    }
-                }
-            }
-            return result;
-        }
-    }
-
-    // ========================================= Specific Implementations ======================================
-
-    static class OlapPartitionTraits extends DefaultTraits {
-
-        @Override
-        PartitionKey createEmptyKey() {
-            throw new NotImplementedException("not support olap table");
-        }
-
-        @Override
-        String getDbName() {
-            throw new NotImplementedException("not support olap table");
-        }
-
-        @Override
-        public boolean supportPartitionRefresh() {
-            // TODO: check partition types
-            return true;
-        }
-
-        @Override
-        public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
-            if (!((OlapTable) table).getPartitionInfo().isRangePartition()) {
-                throw new IllegalArgumentException("Must be range partitioned table");
-            }
-            return ((OlapTable) table).getRangePartitionMap();
-        }
-
-        @Override
-        public Map<String, List<List<String>>> getPartitionList(Column partitionColumn) {
-            // TODO: check partition type
-            return ((OlapTable) table).getListPartitionMap();
-        }
-
-        @Override
-        public Optional<Long> maxPartitionRefreshTs() {
-            OlapTable olapTable = (OlapTable) table;
-            return olapTable.getPhysicalPartitions().stream().map(PhysicalPartition::getVisibleVersionTime).max(Long::compareTo);
-        }
-
-        @Override
-        public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
-                                                    MaterializedView.AsyncRefreshContext context) {
-            OlapTable baseTable = (OlapTable) table;
-            Map<String, MaterializedView.BasePartitionInfo> mvBaseTableVisibleVersionMap =
-                    context.getBaseTableVisibleVersionMap()
-                            .computeIfAbsent(baseTable.getId(), k -> Maps.newHashMap());
-            if (LOG.isDebugEnabled()) {
-                List<String> baseTablePartitionInfos = Lists.newArrayList();
-                for (String p : baseTable.getVisiblePartitionNames()) {
-                    Partition partition = baseTable.getPartition(p);
-                    baseTablePartitionInfos.add(String.format("%s:%s:%s", p, partition.getVisibleVersion(),
-                            partition.getVisibleVersionTime()));
-                }
-                LOG.debug("baseTable: {}, baseTablePartitions:{}, mvBaseTableVisibleVersionMap: {}",
-                        baseTable.getName(), baseTablePartitionInfos, mvBaseTableVisibleVersionMap);
-            }
-
-            Set<String> result = Sets.newHashSet();
-            // If there are new added partitions, add it into refresh result.
-            for (String partitionName : baseTable.getVisiblePartitionNames()) {
-                if (!mvBaseTableVisibleVersionMap.containsKey(partitionName)) {
-                    Partition partition = baseTable.getPartition(partitionName);
-                    if (partition.getVisibleVersion() != 1) {
-                        result.add(partitionName);
-                    }
-                }
-            }
-
-            for (Map.Entry<String, MaterializedView.BasePartitionInfo> versionEntry : mvBaseTableVisibleVersionMap.entrySet()) {
-                String basePartitionName = versionEntry.getKey();
-                Partition basePartition = baseTable.getPartition(basePartitionName);
-                if (basePartition == null) {
-                    // Once there is a partition deleted, refresh all partitions.
-                    return baseTable.getVisiblePartitionNames();
-                }
-                MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo = versionEntry.getValue();
-                if (mvRefreshedPartitionInfo == null) {
-                    result.add(basePartitionName);
-                } else {
-                    // Ignore partitions if mv's partition is the same with the basic table.
-                    if (mvRefreshedPartitionInfo.getId() == basePartition.getId()
-                            && !isBaseTableChanged(basePartition, mvRefreshedPartitionInfo)) {
-                        continue;
-                    }
-
-                    // others will add into the result.
-                    result.add(basePartitionName);
-                }
-            }
-            return result;
-        }
-
-        public List<Column> getPartitionColumns() {
-            return ((OlapTable) table).getPartitionInfo().getPartitionColumns(table.getIdToColumn());
-        }
-    }
-
     /**
      * Check whether the base table's partition has changed or not.
      * </p>
      * NOTE: If the base table is materialized view, partition is overwritten each time, so we need to compare
      * version and modified time.
      */
-    private static boolean isBaseTableChanged(Partition partition,
-                                              MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo) {
+    public static boolean isBaseTableChanged(Partition partition,
+                                             MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo) {
         return partition.getVisibleVersion() != mvRefreshedPartitionInfo.getVersion()
                 || partition.getVisibleVersionTime() > mvRefreshedPartitionInfo.getLastRefreshTime();
-    }
-
-    static class HivePartitionTraits extends DefaultTraits {
-
-        @Override
-        public boolean supportPartitionRefresh() {
-            return true;
-        }
-
-        @Override
-        public String getDbName() {
-            return ((HiveMetaStoreTable) table).getDbName();
-        }
-
-        @Override
-        public PartitionKey createEmptyKey() {
-            return new HivePartitionKey();
-        }
-
-        @Override
-        public List<PartitionInfo> getPartitions(List<String> partitionNames) {
-            HiveTable hiveTable = (HiveTable) table;
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    getPartitions(hiveTable.getCatalogName(), table, partitionNames);
-        }
-
-        @Override
-        public Optional<Long> maxPartitionRefreshTs() {
-            Map<String, com.starrocks.connector.PartitionInfo> partitionNameWithPartition =
-                    getPartitionNameWithPartitionInfo();
-            return
-                    partitionNameWithPartition.values().stream()
-                            .map(com.starrocks.connector.PartitionInfo::getModifiedTime)
-                            .max(Long::compareTo);
-        }
-    }
-
-    static class HudiPartitionTraits extends DefaultTraits {
-
-        @Override
-        public String getDbName() {
-            return ((HiveMetaStoreTable) table).getDbName();
-        }
-
-        @Override
-        PartitionKey createEmptyKey() {
-            return new HudiPartitionKey();
-        }
-
-        @Override
-        public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
-                                                    MaterializedView.AsyncRefreshContext context) {
-            // TODO: implement
-            return null;
-        }
-    }
-
-    static class IcebergPartitionTraits extends DefaultTraits {
-
-        @Override
-        public boolean supportPartitionRefresh() {
-            // TODO: refine the check
-            return true;
-        }
-
-        @Override
-        public String getDbName() {
-            return ((IcebergTable) table).getRemoteDbName();
-        }
-
-        @Override
-        public String getTableName() {
-            return ((IcebergTable) table).getRemoteTableName();
-        }
-
-        @Override
-        PartitionKey createEmptyKey() {
-            return new IcebergPartitionKey();
-        }
-
-        @Override
-        public List<PartitionInfo> getPartitions(List<String> partitionNames) {
-            IcebergTable icebergTable = (IcebergTable) table;
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    getPartitions(icebergTable.getCatalogName(), table, partitionNames);
-        }
-
-        @Override
-        public Optional<Long> maxPartitionRefreshTs() {
-            IcebergTable icebergTable = (IcebergTable) table;
-            return icebergTable.getSnapshot().map(Snapshot::timestampMillis);
-        }
-
-        @Override
-        public List<String> getPartitionNames() {
-            if (table.isUnPartitioned()) {
-                return Lists.newArrayList(table.getName());
-            }
-
-            IcebergTable icebergTable = (IcebergTable) table;
-            long snapshotId = icebergTable.getSnapshot().isPresent() ? icebergTable.getSnapshot().get().snapshotId() : -1;
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
-                    table.getCatalogName(), getDbName(), getTableName(), snapshotId);
-        }
-
-        @Override
-        public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)
-                throws AnalysisException {
-            Preconditions.checkState(partitionValues.size() == partitionColumns.size(),
-                    "columns size is %s, but values size is %s", partitionColumns.size(),
-                    partitionValues.size());
-
-            IcebergTable icebergTable = (IcebergTable) table;
-            List<PartitionField> partitionFields = Lists.newArrayList();
-            for (Column column : partitionColumns) {
-                for (PartitionField field : icebergTable.getNativeTable().spec().fields()) {
-                    String partitionFieldName = icebergTable.getNativeTable().schema().findColumnName(field.sourceId());
-                    if (partitionFieldName.equalsIgnoreCase(column.getName())) {
-                        partitionFields.add(field);
-                    }
-                }
-            }
-            Preconditions.checkState(partitionFields.size() == partitionColumns.size(),
-                    "columns size is %s, but partitionFields size is %s", partitionColumns.size(), partitionFields.size());
-
-            PartitionKey partitionKey = createEmptyKey();
-
-            // change string value to LiteralExpr,
-            for (int i = 0; i < partitionValues.size(); i++) {
-                String rawValue = partitionValues.get(i);
-                Column column = partitionColumns.get(i);
-                PartitionField field = partitionFields.get(i);
-                LiteralExpr exprValue;
-                // rawValue could be null for delta table
-                if (rawValue == null) {
-                    rawValue = "null";
-                }
-                if (((NullablePartitionKey) partitionKey).nullPartitionValueList().contains(rawValue)) {
-                    partitionKey.setNullPartitionValue(rawValue);
-                    exprValue = NullLiteral.create(column.getType());
-                } else {
-                    // transform year/month/day/hour dedup name is time
-                    if (field.transform().dedupName().equalsIgnoreCase("time")) {
-                        rawValue = IcebergPartitionUtils.normalizeTimePartitionName(rawValue, field,
-                                icebergTable.getNativeTable().schema(), column.getType());
-                        exprValue = LiteralExpr.create(rawValue,  column.getType());
-                    } else {
-                        exprValue = LiteralExpr.create(rawValue,  column.getType());
-                    }
-                }
-                partitionKey.pushColumn(exprValue, column.getType().getPrimitiveType());
-            }
-            return partitionKey;
-        }
-    }
-
-    static class PaimonPartitionTraits extends DefaultTraits {
-
-        @Override
-        public boolean supportPartitionRefresh() {
-            // TODO: refine the check
-            return true;
-        }
-
-        @Override
-        public String getDbName() {
-            return ((PaimonTable) table).getDbName();
-        }
-
-        @Override
-        PartitionKey createEmptyKey() {
-            return new PaimonPartitionKey();
-        }
-
-        @Override
-        public List<PartitionInfo> getPartitions(List<String> partitionNames) {
-            PaimonTable paimonTable = (PaimonTable) table;
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    getPartitions(paimonTable.getCatalogName(), table, partitionNames);
-        }
-
-        @Override
-        public Optional<Long> maxPartitionRefreshTs() {
-            Map<String, com.starrocks.connector.PartitionInfo> partitionNameWithPartition =
-                    getPartitionNameWithPartitionInfo();
-            return partitionNameWithPartition.values().stream()
-                            .map(com.starrocks.connector.PartitionInfo::getModifiedTime)
-                            .max(Long::compareTo);
-        }
-
-    }
-
-    static class OdpsPartitionTraits extends DefaultTraits {
-
-        @Override
-        public String getDbName() {
-            return ((OdpsTable) table).getDbName();
-        }
-
-        @Override
-        PartitionKey createEmptyKey() {
-            return new OdpsPartitionKey();
-        }
-    }
-
-    static class KuduPartitionTraits extends DefaultTraits {
-
-        @Override
-        public String getDbName() {
-            return ((KuduTable) table).getDbName();
-        }
-
-        @Override
-        PartitionKey createEmptyKey() {
-            return new KuduPartitionKey();
-        }
-
-        @Override
-        public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
-                                                    MaterializedView.AsyncRefreshContext context) {
-            // TODO: implement
-            return null;
-        }
-    }
-
-    static class JDBCPartitionTraits extends DefaultTraits {
-
-        @Override
-        public boolean supportPartitionRefresh() {
-            // TODO: refine check
-            return true;
-        }
-
-        @Override
-        public String getDbName() {
-            return ((JDBCTable) table).getDbName();
-        }
-
-        @Override
-        public String getTableName() {
-            return ((JDBCTable) table).getJdbcTable();
-        }
-
-        @Override
-        public List<PartitionInfo> getPartitions(List<String> partitionNames) {
-            JDBCTable jdbcTable = (JDBCTable) table;
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    getPartitions(jdbcTable.getCatalogName(), table, partitionNames);
-        }
-
-        @Override
-        public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr)
-                throws AnalysisException {
-            return PartitionUtil.getRangePartitionMapOfJDBCTable(
-                    table, partitionColumn, getPartitionNames(), partitionExpr);
-        }
-
-        @Override
-        PartitionKey createEmptyKey() {
-            return new JDBCPartitionKey();
-        }
-
-        @Override
-        public Optional<Long> maxPartitionRefreshTs() {
-            Map<String, com.starrocks.connector.PartitionInfo> partitionNameWithPartition =
-                    getPartitionNameWithPartitionInfo();
-            return partitionNameWithPartition.values().stream()
-                    .map(com.starrocks.connector.PartitionInfo::getModifiedTime)
-                    .max(Long::compareTo);
-        }
-    }
-
-    static class DeltaLakePartitionTraits extends DefaultTraits {
-
-        @Override
-        PartitionKey createEmptyKey() {
-            return new DeltaLakePartitionKey();
-        }
-
-        @Override
-        String getDbName() {
-            return ((DeltaLakeTable) table).getDbName();
-        }
-
-        @Override
-        public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
-                                                    MaterializedView.AsyncRefreshContext context) {
-            // TODO: implement
-            return null;
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -165,13 +165,14 @@ public class CachedPartitionTraits extends DefaultTraits {
 
     @Override
     public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames) {
-        return getCache("getPartitionNameWithPartitionInfo2",
-                () -> delegate.getPartitionNameWithPartitionInfo(partitionNames), () -> Maps.newHashMap());
+        // no cache since partition names are not stable.
+        return delegate.getPartitionNameWithPartitionInfo(partitionNames);
     }
 
     @Override
     public List<PartitionInfo> getPartitions(List<String> names) {
-        return getCache("getPartitions", () -> delegate.getPartitions(names), () -> Lists.newArrayList());
+        // no cache since partition names are not stable.
+        return delegate.getPartitions(names);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -1,0 +1,188 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.partitiontraits;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.ThrowingSupplier;
+import com.starrocks.connector.ConnectorPartitionTraits;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * CachedPartitionTraits is a wrapper class for ConnectorPartitionTraits, which is used to cache the partition info once it has
+ * been fetched from the connector.
+ *
+ * NOTE: This class will cache partition info during the query connect context which it's unexpected if the table partition
+ * changes during the query execution. But it can be used in mv refresh since mv refresh will snapshot the base table's partition
+ * info before the refresh.
+ */
+public class CachedPartitionTraits extends DefaultTraits {
+    private final Cache<Object, Object> cache;
+    private final ConnectorPartitionTraits delegate;
+    private final QueryMaterializationContext.QueryCacheStats stats;
+
+    public CachedPartitionTraits(Cache<Object, Object> cache,
+                                 ConnectorPartitionTraits delegate,
+                                 QueryMaterializationContext.QueryCacheStats stats) {
+        Objects.requireNonNull(cache);
+        Objects.requireNonNull(delegate);
+        Objects.requireNonNull(stats);
+        this.cache = cache;
+        this.delegate = delegate;
+        this.table = delegate.getTable();
+        this.stats = stats;
+    }
+
+    /**
+     * Construct the cache key: cache_{prefix}_{tableId}
+     * @param prefix use the prefix to distinguish different cache keys, please check the unique usage of this method
+     * @return the cache key
+     */
+    private String buildCacheKey(String prefix) {
+        return String.format("cache_%s_%s", prefix, table.getId());
+    }
+
+    /**
+     * Get the cache value by key, if the value is not in cache, use the supplier to get the value and put it into cache
+     * @param prefix the cache key prefix
+     * @param supplier the supplier to get the value if the key is not in the cache
+     * @param defaultSupplier  the default supplier to initialize the cache value
+     * @return the cache value
+     * @param <T> the cache result type
+     */
+    private <T> T getCache(String prefix, Supplier<T> supplier, Supplier<T> defaultSupplier) {
+        String cacheKey = buildCacheKey(prefix);
+        T result = (T) cache.get(cacheKey, k -> supplier.get());
+        stats.incr(cacheKey);
+        return Optional.ofNullable(result).map(x -> (T) x).orElse(defaultSupplier.get());
+    }
+
+    /**
+     * it's another version to getCache which the input supplier can be a throwing supplier
+     */
+    private <T> T getCacheWithException(String key, ThrowingSupplier<T> supplier, Supplier<T> defaultSupplier) {
+        String cacheKey = buildCacheKey(key);
+        T result = (T) cache.get(cacheKey, k -> {
+            try {
+                return supplier.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        stats.incr(cacheKey);
+        return Optional.ofNullable(result).map(x -> (T) x).orElse(defaultSupplier.get());
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return delegate.createEmptyKey();
+    }
+
+    @Override
+    public String getDbName() {
+        return delegate.getDbName();
+    }
+
+    @Override
+    public boolean supportPartitionRefresh() {
+        return delegate.supportPartitionRefresh();
+    }
+
+    @Override
+    public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException {
+        return delegate.createPartitionKeyWithType(values, types);
+    }
+
+    @Override
+    public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)
+            throws AnalysisException {
+        return delegate.createPartitionKey(partitionValues, partitionColumns);
+    }
+
+    @Override
+    public String getTableName() {
+        return delegate.getTableName();
+    }
+
+    @Override
+    public List<String> getPartitionNames() {
+        return getCacheWithException("partitionNames", delegate::getPartitionNames, () -> Lists.newArrayList());
+    }
+
+    @Override
+    public List<Column> getPartitionColumns() {
+        return delegate.getPartitionColumns();
+    }
+
+    @Override
+    public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr)
+            throws AnalysisException {
+        return getCacheWithException("getPartitionKeyRange",
+                () -> delegate.getPartitionKeyRange(partitionColumn, partitionExpr), () -> Maps.newHashMap());
+    }
+
+    @Override
+    public Map<String, List<List<String>>> getPartitionList(Column partitionColumn) {
+        return getCacheWithException("getPartitionList",
+                () -> delegate.getPartitionList(partitionColumn), () -> Maps.newHashMap());
+    }
+
+    @Override
+    public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
+        return getCache("getPartitionNameWithPartitionInfo1",
+                () -> delegate.getPartitionNameWithPartitionInfo(), () -> Maps.newHashMap());
+    }
+
+    @Override
+    public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames) {
+        return getCache("getPartitionNameWithPartitionInfo2",
+                () -> delegate.getPartitionNameWithPartitionInfo(partitionNames), () -> Maps.newHashMap());
+    }
+
+    @Override
+    public List<PartitionInfo> getPartitions(List<String> names) {
+        return getCache("getPartitions", () -> delegate.getPartitions(names), () -> Lists.newArrayList());
+    }
+
+    @Override
+    public Optional<Long> maxPartitionRefreshTs() {
+        return getCache("maxPartitionRefreshTs", () -> delegate.maxPartitionRefreshTs(), () -> Optional.empty());
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
+                                                MaterializedView.AsyncRefreshContext context) {
+        return getCache("getUpdatedPartitionNames", () -> delegate.getUpdatedPartitionNames(baseTables, context),
+                () -> Sets.newHashSet());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -1,0 +1,179 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.partitiontraits;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.NullLiteral;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.NullablePartitionKey;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.ConnectorPartitionTraits;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.commons.lang.NotImplementedException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class DefaultTraits extends ConnectorPartitionTraits  {
+    @Override
+    public boolean supportPartitionRefresh() {
+        return false;
+    }
+
+    @Override
+    public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException {
+        Preconditions.checkState(values.size() == types.size(),
+                "columns size is %s, but values size is %s", types.size(), values.size());
+
+        PartitionKey partitionKey = createEmptyKey();
+
+        // change string value to LiteralExpr,
+        for (int i = 0; i < values.size(); i++) {
+            String rawValue = values.get(i);
+            Type type = types.get(i);
+            LiteralExpr exprValue;
+            // rawValue could be null for delta table
+            if (rawValue == null) {
+                rawValue = "null";
+            }
+            if (((NullablePartitionKey) partitionKey).nullPartitionValueList().contains(rawValue)) {
+                partitionKey.setNullPartitionValue(rawValue);
+                exprValue = NullLiteral.create(type);
+            } else {
+                exprValue = LiteralExpr.create(rawValue, type);
+            }
+            partitionKey.pushColumn(exprValue, type.getPrimitiveType());
+        }
+        return partitionKey;
+    }
+
+    @Override
+    public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)
+            throws AnalysisException {
+        return createPartitionKeyWithType(partitionValues,
+                partitionColumns.stream().map(Column::getType).collect(Collectors.toList()));
+    }
+
+    @Override
+    public List<String> getPartitionNames() {
+        if (table.isUnPartitioned()) {
+            return Lists.newArrayList(table.getName());
+        }
+
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
+                table.getCatalogName(), getDbName(), getTableName());
+    }
+
+    @Override
+    public List<Column> getPartitionColumns() {
+        return table.getPartitionColumns();
+    }
+
+    @Override
+    public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr)
+            throws AnalysisException {
+        return PartitionUtil.getRangePartitionMapOfExternalTable(
+                table, partitionColumn, getPartitionNames(), partitionExpr);
+    }
+
+    @Override
+    public Map<String, List<List<String>>> getPartitionList(Column partitionColumn) throws AnalysisException {
+        return PartitionUtil.getMVPartitionNameWithList(table, partitionColumn, getPartitionNames());
+    }
+
+    @Override
+    public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
+        Map<String, PartitionInfo> partitionNameWithPartition = Maps.newHashMap();
+        List<String> partitionNames = getPartitionNames();
+        List<PartitionInfo> partitions = getPartitions(partitionNames);
+        Preconditions.checkState(partitions.size() == partitionNames.size(), "corrupted partition meta");
+        for (int index = 0; index < partitionNames.size(); ++index) {
+            partitionNameWithPartition.put(partitionNames.get(index), partitions.get(index));
+        }
+        return partitionNameWithPartition;
+    }
+
+    @Override
+    public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames) {
+        Map<String, PartitionInfo> partitionNameWithPartition = Maps.newHashMap();
+        List<PartitionInfo> partitions = getPartitions(partitionNames);
+        Preconditions.checkState(partitions.size() == partitionNames.size(), "corrupted partition meta");
+        for (int index = 0; index < partitionNames.size(); ++index) {
+            partitionNameWithPartition.put(partitionNames.get(index), partitions.get(index));
+        }
+        return partitionNameWithPartition;
+    }
+
+    @Override
+    public Optional<Long> maxPartitionRefreshTs() {
+        throw new NotImplementedException("Not support maxPartitionRefreshTs");
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
+                                                MaterializedView.AsyncRefreshContext context) {
+        Table baseTable = table;
+        Set<String> result = Sets.newHashSet();
+        Map<String, PartitionInfo> latestPartitionInfo = getPartitionNameWithPartitionInfo();
+
+        for (BaseTableInfo baseTableInfo : baseTables) {
+            if (!baseTableInfo.getTableIdentifier().equalsIgnoreCase(baseTable.getTableIdentifier())) {
+                continue;
+            }
+            Map<String, MaterializedView.BasePartitionInfo> versionMap =
+                    context.getBaseTableRefreshInfo(baseTableInfo);
+
+            // check whether there are partitions added
+            for (Map.Entry<String, PartitionInfo> entry : latestPartitionInfo.entrySet()) {
+                if (!versionMap.containsKey(entry.getKey())) {
+                    result.add(entry.getKey());
+                }
+            }
+
+            for (Map.Entry<String, MaterializedView.BasePartitionInfo> versionEntry : versionMap.entrySet()) {
+                String basePartitionName = versionEntry.getKey();
+                if (!latestPartitionInfo.containsKey(basePartitionName)) {
+                    // partitions deleted
+                    return latestPartitionInfo.keySet();
+                }
+                long basePartitionVersion = latestPartitionInfo.get(basePartitionName).getModifiedTime();
+
+                MaterializedView.BasePartitionInfo basePartitionInfo = versionEntry.getValue();
+                // basePartitionVersion less than 0 is illegal
+                if ((basePartitionInfo == null || basePartitionVersion != basePartitionInfo.getVersion())
+                        && basePartitionVersion >= 0) {
+                    result.add(basePartitionName);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DeltaLakePartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DeltaLakePartitionTraits.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.partitiontraits;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.DeltaLakePartitionKey;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionKey;
+
+import java.util.List;
+import java.util.Set;
+
+public class DeltaLakePartitionTraits extends DefaultTraits {
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new DeltaLakePartitionKey();
+    }
+
+    @Override
+    public String getDbName() {
+        return ((DeltaLakeTable) table).getDbName();
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
+                                                MaterializedView.AsyncRefreshContext context) {
+        // TODO: implement
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.starrocks.catalog.HiveMetaStoreTable;
+import com.starrocks.catalog.HivePartitionKey;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class HivePartitionTraits extends DefaultTraits {
+
+    @Override
+    public boolean supportPartitionRefresh() {
+        return true;
+    }
+
+    @Override
+    public String getDbName() {
+        return ((HiveMetaStoreTable) table).getDbName();
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new HivePartitionKey();
+    }
+
+    @Override
+    public List<PartitionInfo> getPartitions(List<String> partitionNames) {
+        HiveTable hiveTable = (HiveTable) table;
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().
+                getPartitions(hiveTable.getCatalogName(), table, partitionNames);
+    }
+
+    @Override
+    public Optional<Long> maxPartitionRefreshTs() {
+        Map<String, PartitionInfo> partitionNameWithPartition =
+                getPartitionNameWithPartitionInfo();
+        return
+                partitionNameWithPartition.values().stream()
+                        .map(com.starrocks.connector.PartitionInfo::getModifiedTime)
+                        .max(Long::compareTo);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.HiveMetaStoreTable;
+import com.starrocks.catalog.HudiPartitionKey;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionKey;
+
+import java.util.List;
+import java.util.Set;
+
+public class HudiPartitionTraits extends DefaultTraits {
+
+    @Override
+    public String getDbName() {
+        return ((HiveMetaStoreTable) table).getDbName();
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new HudiPartitionKey();
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
+                                                MaterializedView.AsyncRefreshContext context) {
+        // TODO: implement
+        return null;
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.NullLiteral;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergPartitionKey;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.NullablePartitionKey;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Snapshot;
+
+import java.util.List;
+import java.util.Optional;
+
+public class IcebergPartitionTraits extends DefaultTraits {
+
+    @Override
+    public boolean supportPartitionRefresh() {
+        // TODO: refine the check
+        return true;
+    }
+
+    @Override
+    public String getDbName() {
+        return ((IcebergTable) table).getRemoteDbName();
+    }
+
+    @Override
+    public String getTableName() {
+        return ((IcebergTable) table).getRemoteTableName();
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new IcebergPartitionKey();
+    }
+
+    @Override
+    public List<PartitionInfo> getPartitions(List<String> partitionNames) {
+        IcebergTable icebergTable = (IcebergTable) table;
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().
+                getPartitions(icebergTable.getCatalogName(), table, partitionNames);
+    }
+
+    @Override
+    public Optional<Long> maxPartitionRefreshTs() {
+        IcebergTable icebergTable = (IcebergTable) table;
+        return icebergTable.getSnapshot().map(Snapshot::timestampMillis);
+    }
+
+    @Override
+    public List<String> getPartitionNames() {
+        if (table.isUnPartitioned()) {
+            return Lists.newArrayList(table.getName());
+        }
+
+        IcebergTable icebergTable = (IcebergTable) table;
+        long snapshotId = icebergTable.getSnapshot().isPresent() ? icebergTable.getSnapshot().get().snapshotId() : -1;
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
+                table.getCatalogName(), getDbName(), getTableName(), snapshotId);
+    }
+
+    @Override
+    public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)
+            throws AnalysisException {
+        Preconditions.checkState(partitionValues.size() == partitionColumns.size(),
+                "columns size is %s, but values size is %s", partitionColumns.size(),
+                partitionValues.size());
+
+        IcebergTable icebergTable = (IcebergTable) table;
+        List<PartitionField> partitionFields = Lists.newArrayList();
+        for (Column column : partitionColumns) {
+            for (PartitionField field : icebergTable.getNativeTable().spec().fields()) {
+                String partitionFieldName = icebergTable.getNativeTable().schema().findColumnName(field.sourceId());
+                if (partitionFieldName.equalsIgnoreCase(column.getName())) {
+                    partitionFields.add(field);
+                }
+            }
+        }
+        Preconditions.checkState(partitionFields.size() == partitionColumns.size(),
+                "columns size is %s, but partitionFields size is %s", partitionColumns.size(), partitionFields.size());
+
+        PartitionKey partitionKey = createEmptyKey();
+
+        // change string value to LiteralExpr,
+        for (int i = 0; i < partitionValues.size(); i++) {
+            String rawValue = partitionValues.get(i);
+            Column column = partitionColumns.get(i);
+            PartitionField field = partitionFields.get(i);
+            LiteralExpr exprValue;
+            // rawValue could be null for delta table
+            if (rawValue == null) {
+                rawValue = "null";
+            }
+            if (((NullablePartitionKey) partitionKey).nullPartitionValueList().contains(rawValue)) {
+                partitionKey.setNullPartitionValue(rawValue);
+                exprValue = NullLiteral.create(column.getType());
+            } else {
+                // transform year/month/day/hour dedup name is time
+                if (field.transform().dedupName().equalsIgnoreCase("time")) {
+                    rawValue = IcebergPartitionUtils.normalizeTimePartitionName(rawValue, field,
+                            icebergTable.getNativeTable().schema(), column.getType());
+                    exprValue = LiteralExpr.create(rawValue,  column.getType());
+                } else {
+                    exprValue = LiteralExpr.create(rawValue,  column.getType());
+                }
+            }
+            partitionKey.pushColumn(exprValue, column.getType().getPrimitiveType());
+        }
+        return partitionKey;
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.google.common.collect.Range;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.JDBCPartitionKey;
+import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class JDBCPartitionTraits extends DefaultTraits {
+
+    @Override
+    public boolean supportPartitionRefresh() {
+        // TODO: refine check
+        return true;
+    }
+
+    @Override
+    public String getDbName() {
+        return ((JDBCTable) table).getDbName();
+    }
+
+    @Override
+    public String getTableName() {
+        return ((JDBCTable) table).getJdbcTable();
+    }
+
+    @Override
+    public List<PartitionInfo> getPartitions(List<String> partitionNames) {
+        JDBCTable jdbcTable = (JDBCTable) table;
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().
+                getPartitions(jdbcTable.getCatalogName(), table, partitionNames);
+    }
+
+    @Override
+    public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr)
+            throws AnalysisException {
+        return PartitionUtil.getRangePartitionMapOfJDBCTable(
+                table, partitionColumn, getPartitionNames(), partitionExpr);
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new JDBCPartitionKey();
+    }
+
+    @Override
+    public Optional<Long> maxPartitionRefreshTs() {
+        Map<String, com.starrocks.connector.PartitionInfo> partitionNameWithPartition =
+                getPartitionNameWithPartitionInfo();
+        return partitionNameWithPartition.values().stream()
+                .map(com.starrocks.connector.PartitionInfo::getModifiedTime)
+                .max(Long::compareTo);
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/KuduPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/KuduPartitionTraits.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.KuduPartitionKey;
+import com.starrocks.catalog.KuduTable;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionKey;
+
+import java.util.List;
+import java.util.Set;
+
+public class KuduPartitionTraits extends DefaultTraits {
+
+    @Override
+    public String getDbName() {
+        return ((KuduTable) table).getDbName();
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new KuduPartitionKey();
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
+                                                MaterializedView.AsyncRefreshContext context) {
+        // TODO: implement
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OdpsPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OdpsPartitionTraits.java
@@ -1,0 +1,31 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.starrocks.catalog.OdpsPartitionKey;
+import com.starrocks.catalog.OdpsTable;
+import com.starrocks.catalog.PartitionKey;
+
+public class OdpsPartitionTraits extends DefaultTraits {
+
+    @Override
+    public String getDbName() {
+        return ((OdpsTable) table).getDbName();
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new OdpsPartitionKey();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PhysicalPartition;
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class OlapPartitionTraits extends DefaultTraits {
+    private static final Logger LOG = LogManager.getLogger(OlapPartitionTraits.class);
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        throw new NotImplementedException("not support olap table");
+    }
+
+    @Override
+    public String getDbName() {
+        throw new NotImplementedException("not support olap table");
+    }
+
+    @Override
+    public boolean supportPartitionRefresh() {
+        // TODO: check partition types
+        return true;
+    }
+
+    @Override
+    public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
+        if (!((OlapTable) table).getPartitionInfo().isRangePartition()) {
+            throw new IllegalArgumentException("Must be range partitioned table");
+        }
+        return ((OlapTable) table).getRangePartitionMap();
+    }
+
+    @Override
+    public Map<String, List<List<String>>> getPartitionList(Column partitionColumn) {
+        // TODO: check partition type
+        return ((OlapTable) table).getListPartitionMap();
+    }
+
+    @Override
+    public Optional<Long> maxPartitionRefreshTs() {
+        OlapTable olapTable = (OlapTable) table;
+        return olapTable.getPhysicalPartitions().stream().map(PhysicalPartition::getVisibleVersionTime).max(Long::compareTo);
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
+                                                MaterializedView.AsyncRefreshContext context) {
+        OlapTable baseTable = (OlapTable) table;
+        Map<String, MaterializedView.BasePartitionInfo> mvBaseTableVisibleVersionMap =
+                context.getBaseTableVisibleVersionMap()
+                        .computeIfAbsent(baseTable.getId(), k -> Maps.newHashMap());
+        if (LOG.isDebugEnabled()) {
+            List<String> baseTablePartitionInfos = Lists.newArrayList();
+            for (String p : baseTable.getVisiblePartitionNames()) {
+                Partition partition = baseTable.getPartition(p);
+                baseTablePartitionInfos.add(String.format("%s:%s:%s", p, partition.getVisibleVersion(),
+                        partition.getVisibleVersionTime()));
+            }
+            LOG.debug("baseTable: {}, baseTablePartitions:{}, mvBaseTableVisibleVersionMap: {}",
+                    baseTable.getName(), baseTablePartitionInfos, mvBaseTableVisibleVersionMap);
+        }
+
+        Set<String> result = Sets.newHashSet();
+        // If there are new added partitions, add it into refresh result.
+        for (String partitionName : baseTable.getVisiblePartitionNames()) {
+            if (!mvBaseTableVisibleVersionMap.containsKey(partitionName)) {
+                Partition partition = baseTable.getPartition(partitionName);
+                if (partition.getVisibleVersion() != 1) {
+                    result.add(partitionName);
+                }
+            }
+        }
+
+        for (Map.Entry<String, MaterializedView.BasePartitionInfo> versionEntry : mvBaseTableVisibleVersionMap.entrySet()) {
+            String basePartitionName = versionEntry.getKey();
+            Partition basePartition = baseTable.getPartition(basePartitionName);
+            if (basePartition == null) {
+                // Once there is a partition deleted, refresh all partitions.
+                return baseTable.getVisiblePartitionNames();
+            }
+            MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo = versionEntry.getValue();
+            if (mvRefreshedPartitionInfo == null) {
+                result.add(basePartitionName);
+            } else {
+                // Ignore partitions if mv's partition is the same with the basic table.
+                if (mvRefreshedPartitionInfo.getId() == basePartition.getId()
+                        && !isBaseTableChanged(basePartition, mvRefreshedPartitionInfo)) {
+                    continue;
+                }
+
+                // others will add into the result.
+                result.add(basePartitionName);
+            }
+        }
+        return result;
+    }
+
+    public List<Column> getPartitionColumns() {
+        return ((OlapTable) table).getPartitionInfo().getPartitionColumns(table.getIdToColumn());
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/PaimonPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/PaimonPartitionTraits.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.partitiontraits;
+
+import com.starrocks.catalog.PaimonPartitionKey;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class PaimonPartitionTraits extends DefaultTraits {
+
+    @Override
+    public boolean supportPartitionRefresh() {
+        // TODO: refine the check
+        return true;
+    }
+
+    @Override
+    public String getDbName() {
+        return ((PaimonTable) table).getDbName();
+    }
+
+    @Override
+    public PartitionKey createEmptyKey() {
+        return new PaimonPartitionKey();
+    }
+
+    @Override
+    public List<PartitionInfo> getPartitions(List<String> partitionNames) {
+        PaimonTable paimonTable = (PaimonTable) table;
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().
+                getPartitions(paimonTable.getCatalogName(), table, partitionNames);
+    }
+
+    @Override
+    public Optional<Long> maxPartitionRefreshTs() {
+        Map<String, PartitionInfo> partitionNameWithPartition =
+                getPartitionNameWithPartitionInfo();
+        return partitionNameWithPartition.values().stream()
+                .map(com.starrocks.connector.PartitionInfo::getModifiedTime)
+                .max(Long::compareTo);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -70,6 +70,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.ast.UserVariable;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.sql.parser.SqlParser;
@@ -228,6 +229,10 @@ public class ConnectContext {
     private final Map<String, PrepareStmtContext> preparedStmtCtxs = Maps.newHashMap();
 
     private UUID sessionId;
+
+    // QueryMaterializationContext is different from MaterializationContext that it keeps the context during the query
+    // lifecycle instead of per materialized view.
+    private QueryMaterializationContext queryMVContext;
 
     public StmtExecutor getExecutor() {
         return executor;
@@ -777,6 +782,14 @@ public class ConnectContext {
 
     public UUID getSessionId() {
         return this.sessionId;
+    }
+
+    public QueryMaterializationContext getQueryMVContext() {
+        return queryMVContext;
+    }
+
+    public void setQueryMVContext(QueryMaterializationContext queryMVContext) {
+        this.queryMVContext = queryMVContext;
     }
 
     // kill operation with no protect.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -108,6 +108,7 @@ import com.starrocks.sql.common.MvPartitionDiffResult;
 import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -218,6 +219,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         IMaterializedViewMetricsEntity mvEntity = null;
         ConnectContext connectContext = context.getCtx();
+        QueryMaterializationContext queryMVContext = new QueryMaterializationContext();
+        connectContext.setQueryMVContext(queryMVContext);
         try {
             // prepare
             try (Timer ignored = Tracers.watchScope("MVRefreshPrepare")) {
@@ -241,12 +244,17 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             connectContext.getState().setError(e.getMessage());
             throw e;
         } finally {
-            postProcess();
+            // reset query mv context to avoid affecting other tasks
+            queryMVContext.clear();
+            connectContext.setQueryMVContext(null);
+
             if (FeConstants.runningUnitTest) {
                 runtimeProfile = new RuntimeProfile();
                 Tracers.toRuntimeProfile(runtimeProfile);
             }
+
             Tracers.close();
+            postProcess();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -35,8 +35,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.RangeUtils;
-import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.logging.log4j.LogManager;
@@ -246,9 +244,6 @@ public class PartitionDiffer {
             return Maps.newHashMap();
         }
 
-        // TODO: lock base tables or use snapshot tables to avoid the partition change during the process.
-        Locker locker = new Locker();
-        locker.lockDatabase(db, LockType.READ);
         Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
         try {
             for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
@@ -271,8 +266,6 @@ public class PartitionDiffer {
         } catch (UserException | SemanticException e) {
             LOG.warn("Partition differ collects ref base table partition failed.", e);
             return null;
-        } finally {
-            locker.unLockDatabase(db, LockType.READ);
         }
         return refBaseTablePartitionMap;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/LogicalPlanPrinter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/LogicalPlanPrinter.java
@@ -381,6 +381,11 @@ public class LogicalPlanPrinter {
             return visitScanCommon(optExpression, step, "ICEBERG METADATA SCAN");
         }
 
+        @Override
+        public OperatorStr visitPhysicalPaimonScan(OptExpression optExpression, Integer step) {
+            return visitScanCommon(optExpression, step, "PAIMON SCAN");
+        }
+
         public OperatorStr visitPhysicalProject(OptExpression optExpression, Integer step) {
             return visit(optExpression.getInputs().get(0), step);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -236,7 +236,8 @@ public class MvRewritePreprocessor {
             Set<Table> queryTables = MvUtils.getAllTables(queryOptExpression).stream().collect(Collectors.toSet());
             logMVParams(connectContext, queryTables);
 
-            QueryMaterializationContext queryMaterializationContext = new QueryMaterializationContext();
+            QueryMaterializationContext queryMaterializationContext = connectContext.getQueryMVContext() != null ?
+                    connectContext.getQueryMVContext() : new QueryMaterializationContext();
             try {
                 // 1. get related mvs for all input tables
                 Set<MaterializedView> relatedMVs = getRelatedMVs(queryTables, context.getOptimizerConfig().isRuleBased());
@@ -264,9 +265,11 @@ public class MvRewritePreprocessor {
                             queryColumnRefFactory, requiredColumns);
                 }
 
-                // add queryMaterializationContext into context
+                // To avoid disturbing queries without mv, only initialize materialized view context
+                // when there are candidate mvs.
                 if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
                     context.setQueryMaterializationContext(queryMaterializationContext);
+                    connectContext.setQueryMVContext(queryMaterializationContext);
                 }
 
                 // initialize mv rewrite strategy finally

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -94,6 +94,7 @@ public class OptimizerContext {
         this.candidateMvs = Lists.newArrayList();
         this.queryId = UUID.randomUUID();
         this.allLogicalOlapScanOperators = Collections.emptyList();
+        this.queryMaterializationContext = new QueryMaterializationContext();
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.connector;
 
 import com.starrocks.connector.paimon.Partition;
+import com.starrocks.connector.partitiontraits.DefaultTraits;
+import com.starrocks.connector.partitiontraits.PaimonPartitionTraits;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
@@ -34,14 +36,14 @@ public class ConnectorPartitionTraitsTest {
         Partition p2 = new Partition("p2", 200);
         fakePartitionInfo.put("p1", p1);
         fakePartitionInfo.put("p2", p2);
-        new MockUp<ConnectorPartitionTraits.DefaultTraits>() {
+        new MockUp<DefaultTraits>() {
             @Mock
             public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
                 return fakePartitionInfo;
             }
         };
 
-        Optional<Long> result = new ConnectorPartitionTraits.PaimonPartitionTraits().maxPartitionRefreshTs();
+        Optional<Long> result = new PaimonPartitionTraits().maxPartitionRefreshTs();
         Assert.assertTrue(result.isPresent());
         Assert.assertEquals(200L, result.get().longValue());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -19,9 +19,11 @@ import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
+import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
@@ -39,6 +41,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
@@ -336,5 +339,32 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
                     .explainContains(mvName);
             starRocksAssert.dropMaterializedView(mvName);
         }
+    }
+
+    @Test
+    public void testRefreshWithCachePartitionTraits() {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_mv1`\n" +
+                        "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;",
+                () -> {
+                    MaterializedView mv = getMv("test", "test_mv1");
+                    PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                    RuntimeProfile runtimeProfile = processor.getRuntimeProfile();
+                    QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
+                    Assert.assertTrue(queryCacheStats != null);
+                    queryCacheStats.getCounter().forEach((key, value) -> {
+                        if (key.contains("cache_partitionNames")) {
+                            Assert.assertEquals(2L, value.longValue());
+                        } else if (key.contains("cache_getPartitionKeyRange")) {
+                            Assert.assertEquals(3L, value.longValue());
+                        } else {
+                            Assert.assertEquals(1L, value.longValue());
+                        }
+                    });
+                    Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);
+                    Assert.assertTrue(partitionsToRefresh1.isEmpty());
+                });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -16,10 +16,15 @@ package com.starrocks.scheduler;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvUpdateInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.After;
@@ -33,6 +38,7 @@ import org.junit.runners.MethodSorters;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
 
@@ -217,5 +223,71 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 9: k1 > 3\n" +
                 "     partitions=1/3");
+    }
+
+    @Test
+    public void testRefreshWithCachePartitionTraits() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE tbl1 \n" +
+                "(\n" +
+                "    k1 date,\n" +
+                "    k2 int,\n" +
+                "    v1 int sum\n" +
+                ")\n" +
+                "PARTITION BY RANGE(k1)\n" +
+                "(\n" +
+                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');");
+        starRocksAssert.withMaterializedView("create materialized view test_mv1 \n" +
+                        "partition by (k1) \n" +
+                        "distributed by random \n" +
+                        "refresh deferred manual\n" +
+                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;",
+                () -> {
+                    executeInsertSql(connectContext, "insert into tbl1 values(\"2022-02-20\", 1, 10)");
+                    OlapTable table = (OlapTable) getTable("test", "tbl1");
+                    MaterializedView mv = getMv("test", "test_mv1");
+                    PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                    QueryMaterializationContext queryMVContext = connectContext.getQueryMVContext();
+                    Assert.assertTrue(queryMVContext == null);
+
+                    {
+                        RuntimeProfile runtimeProfile = processor.getRuntimeProfile();
+                        QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
+                        String key = String.format("cache_getUpdatedPartitionNames_%s", table.getId());
+                        Assert.assertTrue(queryCacheStats != null);
+                        Assert.assertTrue(queryCacheStats.getCounter().containsKey(key));
+                        Assert.assertTrue(queryCacheStats.getCounter().get(key) == 1);
+                    }
+
+                    Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);
+                    Assert.assertTrue(partitionsToRefresh1.isEmpty());
+
+                    executeInsertSql(connectContext, "insert into tbl1 values(\"2022-02-20\", 2, 10)");
+                    Partition p2 = table.getPartition("p2");
+                    while (p2.getVisibleVersion()  != 3) {
+                        System.out.println("waiting for partition p2 to be visible:" + p2.getVisibleVersion());
+                        Thread.sleep(1000);
+                    }
+                    MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv);
+                    System.out.println(mvUpdateInfo);
+                    Assert.assertTrue(mvUpdateInfo.getMvToRefreshType() == MvUpdateInfo.MvToRefreshType.PARTIAL);
+                    Assert.assertTrue(mvUpdateInfo.isValidRewrite());
+                    partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);
+                    Assert.assertFalse(partitionsToRefresh1.isEmpty());
+
+                    {
+                        processor = refreshMV("test", mv);
+                        RuntimeProfile runtimeProfile = processor.getRuntimeProfile();
+                        QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
+                        String key = String.format("cache_getUpdatedPartitionNames_%s", table.getId());
+                        Assert.assertTrue(queryCacheStats != null);
+                        Assert.assertTrue(queryCacheStats.getCounter().containsKey(key));
+                        Assert.assertTrue(queryCacheStats.getCounter().get(key) == 1);
+                    }
+                });
+        starRocksAssert.dropTable("tbl1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -2886,9 +2886,12 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
                             "MVRefreshUpdateMeta",
                             "MVRefreshLockRetryTimes",
                             "MVRefreshRetryTimes",
-                            "MVRefreshSyncPartitionsRetryTimes"
+                            "MVRefreshSyncPartitionsRetryTimes",
+                            "MVQueryContextCacheStats",
+                            "MVQueryCacheStats"
                     );
                     for (Map.Entry<String, String> e : result.entrySet()) {
+                        System.out.println(e.getKey() + ": " + e.getValue());
                         Assert.assertTrue(mvRefreshProfileKeys.stream().anyMatch(k -> e.getKey().contains(k)));
                     }
                 });

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -27,9 +27,9 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
-import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.partitiontraits.DefaultTraits;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -783,7 +783,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 return metaMap;
             }
         };
-        new MockUp<ConnectorPartitionTraits.DefaultTraits>() {
+        new MockUp<DefaultTraits>() {
             @Mock
             public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
                 return ImmutableMap.of("date=2020-01-01", new com.starrocks.connector.iceberg.Partition(
@@ -816,7 +816,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         100));
             }
         };
-        new MockUp<ConnectorPartitionTraits.DefaultTraits>() {
+        new MockUp<DefaultTraits>() {
             @Mock
             public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
                 long needUpdateTime = statsUpdateTime.plusSeconds(120).

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -615,7 +615,6 @@ public class StarRocksAssert {
             withView(sql);
             action.run();
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail("With view " + viewName + " failed:" + e.getMessage());
         } finally {
             dropView(viewName);


### PR DESCRIPTION
## Why I'm doing:
- PartitionTraits may time-cost when mv contains external tables. 

## What I'm doing:
- Refactor ConnectorPartitionTraits into separate classes.
- Add CachedPartitionTraits to cache partition trait results in mv refresh and rewrite

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
