### PR TITLE
[Enhancement] Improve routine load error rows message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -311,7 +311,11 @@ public enum ErrorCode {
             "Inserted target column count: %d doesn't match select/value column count: %d"),
     ERR_ILLEGAL_BYTES_LENGTH(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid bytes length for '%s' is [%d, %d]"),
     ERR_TOO_MANY_ERROR_ROWS(5606, new byte[] {'2', '2', '0', '0', '0'},
-            "Current error rows: %d is more than max error num: %d. Check the 'TrackingSQL' field for detailed information"),
+            "%s. Check the 'TrackingSQL' field for detailed information. If you are sure that the data has many errors, " +
+                    "you can set '%s' property to a greater value through ALTER ROUTINE LOAD and RESUME the job."),
+    ERR_ROUTINE_LOAD_OFFSET_INVALID(5607, new byte[] {'0', '2', '0', '0', '0'},
+            "Consume offset: %d is greater than the latest offset: %d in kafka partition: %d. " +
+            "You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job."),
 
     /**
      * 5700 - 5799: Partition

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -39,7 +39,6 @@ import com.google.gson.Gson;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.KafkaUtil;
@@ -60,6 +59,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static com.starrocks.common.ErrorCode.ERR_ROUTINE_LOAD_OFFSET_INVALID;
 
 public class KafkaTaskInfo extends RoutineLoadTaskInfo {
     private static final Logger LOG = LogManager.getLogger(KafkaTaskInfo.class);
@@ -135,9 +136,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                     return true;
                 } else if (latestOffset < consumeOffset) {
                     throw new RoutineLoadPauseException(
-                            "there is no data in partition: " + partitionId + " at offset: " + consumeOffset + ". " +
-                                    "you can modify kafka_offsets by alter routine load, then resume the job. " +
-                                    "refer to " + FeConstants.DOCUMENT_ALTER_ROUTINE_LOAD);
+                            ERR_ROUTINE_LOAD_OFFSET_INVALID.formatErrorMsg(consumeOffset, latestOffset, partitionId));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -789,9 +789,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                 // if this is a replay thread, the update state should already be replayed by OP_CHANGE_ROUTINE_LOAD_JOB
                 if (!isReplay) {
                     // remove all of task in jobs and change job state to paused
+                    String errMsg =
+                            String.format("Current error rows: %d is more than max error num: %d", currentErrorRows, maxErrorNum);
                     updateState(JobState.PAUSED,
                             new ErrorReason(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR,
-                                    ERR_TOO_MANY_ERROR_ROWS.formatErrorMsg(currentErrorRows, maxErrorNum)),
+                                    ERR_TOO_MANY_ERROR_ROWS.formatErrorMsg(errMsg, "max_error_number")),
                             isReplay);
                 }
             }
@@ -817,9 +819,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                     .build());
             if (!isReplay) {
                 // remove all of task in jobs and change job state to paused
+                String errMsg =
+                        String.format("Current error rows: %d is more than max error num: %d", currentErrorRows, maxErrorNum);
                 updateState(JobState.PAUSED,
                         new ErrorReason(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR,
-                                ERR_TOO_MANY_ERROR_ROWS.formatErrorMsg(currentErrorRows, maxErrorNum)),
+                                ERR_TOO_MANY_ERROR_ROWS.formatErrorMsg(errMsg, "max_error_number")),
                         isReplay);
             }
             // reset currentTotalNum and currentErrorNum
@@ -1219,7 +1223,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         if (TransactionState.TxnStatusChangeReason.fromString(txnStatusChangeReasonStr) ==
                 TransactionState.TxnStatusChangeReason.FILTERED_ROWS) {
             updateState(JobState.PAUSED,
-                    new ErrorReason(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR, txnStatusChangeReasonStr),
+                    new ErrorReason(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR,
+                            ERR_TOO_MANY_ERROR_ROWS.formatErrorMsg(txnStatusChangeReasonStr, "max_filter_ratio")),
                     false /* not replay */);
             LOG.warn(
                     "routine load task [job name {}, task id {}] aborted because of {}, change state to PAUSED",

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -198,7 +198,7 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
             routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
 
         } catch (RoutineLoadPauseException e) {
-            String msg = "fe abort task with reason: check task ready to execute failed, " + e.getMessage();
+            String msg = "FE aborts the task with reason: failed to check task ready to execute, err: " + e.getMessage();
             routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateState(
                     JobState.PAUSED, new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg), false);
             LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_TASK, routineLoadTaskInfo.getId())
@@ -206,8 +206,8 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
                     .build());
             return;
         } catch (Exception e) {
-            LOG.warn("check task ready to execute failed", e);
-            delayPutToQueue(routineLoadTaskInfo, "check task ready to execute failed, err: " + e.getMessage());
+            LOG.warn("failed to check task ready to execute", e);
+            delayPutToQueue(routineLoadTaskInfo, "failed to check task ready to execute, err: " + e.getMessage());
             return;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.KafkaUtil;
@@ -67,7 +68,7 @@ public class KafkaTaskInfoTest {
         Assert.assertTrue(kafkaTaskInfo1.readyToExecute());
 
         Map<Integer, Long> offset2 = Maps.newHashMap();
-        offset1.put(0, 100L);
+        offset2.put(0, 100L);
         KafkaTaskInfo kafkaTaskInfo2 = new KafkaTaskInfo(UUID.randomUUID(),
                 kafkaRoutineLoadJob,
                 System.currentTimeMillis(),
@@ -75,6 +76,20 @@ public class KafkaTaskInfoTest {
                 offset2,
                 Config.routine_load_task_timeout_second * 1000);
         Assert.assertFalse(kafkaTaskInfo2.readyToExecute());
+
+        // consume offset > latest offset
+        Map<Integer, Long> offset3 = Maps.newHashMap();
+        offset3.put(0, 101L);
+        KafkaTaskInfo kafkaTaskInfo3 = new KafkaTaskInfo(UUID.randomUUID(),
+                kafkaRoutineLoadJob,
+                System.currentTimeMillis(),
+                System.currentTimeMillis(),
+                offset3,
+                Config.routine_load_task_timeout_second * 1000);
+        ExceptionChecker.expectThrowsWithMsg(RoutineLoadPauseException.class,
+                "Consume offset: 101 is greater than the latest offset: 100 in kafka partition: 0. " +
+                        "You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job.",
+                () -> kafkaTaskInfo3.readyToExecute());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -360,8 +360,8 @@ public class RoutineLoadJobTest {
         Assert.assertEquals(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR, reason.getCode());
         Assert.assertEquals(
                 "Current error rows: 1 is more than max error num: 0. Check the 'TrackingSQL' field for detailed information. " +
-                        "If you are sure that the data has many errors, you can set the '%s' property to a greater value " +
-                        "through ALTER ROUTINE LOAD and RESUME the job.",
+                        "If you are sure that the data has many errors, you can set 'max_error_number' property " +
+                        "to a greater value through ALTER ROUTINE LOAD and RESUME the job.",
                 reason.getMsg());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -359,7 +359,9 @@ public class RoutineLoadJobTest {
         ErrorReason reason = routineLoadJob.pauseReason;
         Assert.assertEquals(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR, reason.getCode());
         Assert.assertEquals(
-                "Current error rows: 1 is more than max error num: 0. Check the 'TrackingSQL' field for detailed information",
+                "Current error rows: 1 is more than max error num: 0. Check the 'TrackingSQL' field for detailed information. " +
+                        "If you are sure that the data has many errors, you can set the '%s' property to a greater value " +
+                        "through ALTER ROUTINE LOAD and RESUME the job.",
                 reason.getMsg());
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. error rows > max_error_number
```
ReasonOfStateChanged: ErrorReason{errCode = 102, msg='Current error rows: 87137 is more than max error num: 0. Check the 'TrackingSQL' field for detailed information. If you are sure that the data has many errors, you can set 'max_error_number' property to a greater value through ALTER ROUTINE LOAD and RESUME the job.'}
        ErrorLogUrls: http://172.26.92.212:8049/api/_load_error_log?file=error_log_75af0f9627ea4866_89a8b76edc646023
         TrackingSQL: select tracking_log from information_schema.load_tracking_logs where job_id=375251
```

2. max_filter_ratio, routine load task failed because of too many filtered rows
```
ReasonOfStateChanged: ErrorReason{errCode = 102, msg='too many filtered rows. Check the 'TrackingSQL' field for detailed information. If you are sure that the data has many errors, you can set 'max_filter_ratio' property to a greater value through ALTER ROUTINE LOAD and RESUME the job.'}
        ErrorLogUrls: http://172.26.92.212:8049/api/_load_error_log?file=error_log_8be89cfb5a3946b5_9646fb10152e7216
         TrackingSQL: select tracking_log from information_schema.load_tracking_logs where job_id=377254
```

3. consume offset > latest offset
```
ReasonOfStateChanged: ErrorReason{errCode = 104, msg='FE aborts the task with reason: failed to check task ready to execute, err: Consume offset: 2434968 is greater than the latest offset: 2434958 in kafka partition: 0. You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job.'}
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
