### PR TITLE
[Enhancement] add backgroud gc for crm files

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1319,6 +1319,9 @@ CONF_mInt64(arrow_read_batch_size, "4096");
 CONF_mBool(brpc_socket_keepalive, "false");
 CONF_mBool(apply_del_vec_after_all_index_filter, "true");
 
+// .crm file can be removed after 1day.
+CONF_mInt32(unused_crm_file_threshold_second, "86400" /** 1day **/);
+
 // python envs config
 // create time worker timeout
 CONF_mInt32(create_child_worker_timeout_ms, "1000");

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -641,6 +641,66 @@ void DataDir::perform_path_gc_by_rowsetid() {
     LOG(INFO) << "finished one time path gc by rowsetid.";
 }
 
+void DataDir::perform_crm_gc(int32_t unused_crm_file_threshold_sec) {
+    // init the set of valid path
+    // validate the path in data dir
+    std::unique_lock<std::mutex> lck(_check_path_mutex);
+    if (_stop_bg_worker || _all_check_crm_files.empty()) {
+        return;
+    }
+    LOG(INFO) << "start to crm file gc.";
+    int counter = 0;
+    for (auto& path : _all_check_crm_files) {
+        ++counter;
+        if (config::path_gc_check_step > 0 && counter % config::path_gc_check_step == 0) {
+            SleepFor(MonoDelta::FromMilliseconds(config::path_gc_check_step_interval_ms));
+        }
+        auto now = time(nullptr);
+        auto mtime_or = FileSystem::Default()->get_file_modified_time(path);
+        if (!mtime_or.ok() || (*mtime_or) <= 0) {
+            continue;
+        }
+        if (now >= unused_crm_file_threshold_sec + (*mtime_or)) {
+            _process_garbage_path(path);
+        }
+    }
+    _all_check_crm_files.clear();
+    LOG(INFO) << "finished one time crm file gc.";
+}
+
+void DataDir::perform_tmp_path_scan() {
+    std::unique_lock<std::mutex> lck(_check_path_mutex);
+    if (!_all_check_crm_files.empty()) {
+        LOG(INFO) << "_all_check_crm_files is not empty when tmp path scan.";
+        return;
+    }
+    LOG(INFO) << "start to scan tmp dir path.";
+    std::string tmp_path_str = _path + TMP_PREFIX;
+    std::filesystem::path tmp_path(tmp_path_str.c_str());
+    try {
+        for (const auto& entry : std::filesystem::directory_iterator(tmp_path)) {
+            if (entry.is_regular_file()) {
+                const auto& filename = entry.path().string();
+                if (filename.ends_with(".crm")) {
+                    _all_check_crm_files.insert(filename);
+                }
+            }
+        }
+    } catch (const std::filesystem::filesystem_error& ex) {
+        std::string err_msg = "Iterate dir " + tmp_path_str + " Filesystem error: " + ex.what();
+        LOG(ERROR) << err_msg;
+        // do nothing
+    } catch (const std::exception& ex) {
+        std::string err_msg = "Iterate dir " + tmp_path_str + " Standard error: " + ex.what();
+        LOG(ERROR) << err_msg;
+        // do nothing
+    } catch (...) {
+        std::string err_msg = "Iterate dir " + tmp_path_str + " Unknown exception occurred.";
+        LOG(ERROR) << err_msg;
+        // do nothing
+    }
+}
+
 // path producer
 void DataDir::perform_path_scan() {
     {

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -687,16 +687,13 @@ void DataDir::perform_tmp_path_scan() {
             }
         }
     } catch (const std::filesystem::filesystem_error& ex) {
-        std::string err_msg = "Iterate dir " + tmp_path_str + " Filesystem error: " + ex.what();
-        LOG(ERROR) << err_msg;
+        LOG(ERROR) << "Iterate dir " << tmp_path_str << " Filesystem error: " << ex.what();
         // do nothing
     } catch (const std::exception& ex) {
-        std::string err_msg = "Iterate dir " + tmp_path_str + " Standard error: " + ex.what();
-        LOG(ERROR) << err_msg;
+        LOG(ERROR) << "Iterate dir " << tmp_path_str << " Standard error: " << ex.what();
         // do nothing
     } catch (...) {
-        std::string err_msg = "Iterate dir " + tmp_path_str + " Unknown exception occurred.";
-        LOG(ERROR) << err_msg;
+        LOG(ERROR) << "Iterate dir " << tmp_path_str << " Unknown exception occurred.";
         // do nothing
     }
 }

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -134,11 +134,16 @@ public:
     // this is a producer function. After scan, it will notify the perform_path_gc function to gc
     void perform_path_scan();
 
+    // this function scans the tmp path to collect files that need to gc.
+    void perform_tmp_path_scan();
+
     void perform_path_gc_by_rowsetid();
 
     void perform_path_gc_by_tablet();
 
     void perform_delta_column_files_gc();
+
+    void perform_crm_gc(int32_t unused_crm_file_threshold_sec);
 
     // check if the capacity reach the limit after adding the incoming data
     // return true if limit reached, otherwise, return false.
@@ -159,6 +164,8 @@ public:
 
     // for test
     size_t get_all_check_dcg_files_cnt() const { return _all_check_dcg_files.size(); }
+
+    size_t get_all_crm_files_cnt() const { return _all_check_crm_files.size(); };
 
 private:
     Status _init_data_dir();
@@ -202,6 +209,7 @@ private:
     std::set<std::string> _all_check_paths;
     std::set<std::string> _all_tablet_schemahash_paths;
     std::set<std::string> _all_check_dcg_files;
+    std::set<std::string> _all_check_crm_files;
 };
 
 } // namespace starrocks

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -830,6 +830,8 @@ void* StorageEngine::_path_gc_thread_callback(void* arg) {
         LOG(INFO) << "try to perform path gc by dcg files!";
         // perform dcg files gc
         ((DataDir*)arg)->perform_delta_column_files_gc();
+        // perform crm files gc
+        ((DataDir*)arg)->perform_crm_gc(config::unused_crm_file_threshold_second);
 
         int32_t interval = config::path_gc_check_interval_second;
         if (interval <= 0) {
@@ -856,6 +858,7 @@ void* StorageEngine::_path_scan_thread_callback(void* arg) {
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         LOG(INFO) << "try to perform path scan!";
         ((DataDir*)arg)->perform_path_scan();
+        ((DataDir*)arg)->perform_tmp_path_scan();
 
         int32_t interval = config::path_scan_interval_second;
         if (interval <= 0) {

--- a/be/test/storage/rows_mapper_test.cpp
+++ b/be/test/storage/rows_mapper_test.cpp
@@ -16,6 +16,8 @@
 
 #include "fs/fs.h"
 #include "fs/fs_util.h"
+#include "storage/data_dir.h"
+#include "storage/storage_engine.h"
 #include "testutil/assert.h"
 
 namespace starrocks {
@@ -30,6 +32,11 @@ protected:
     void SetUp() override { ASSERT_OK(fs::create_directories(kTestDirectory)); }
 
     void TearDown() override { (void)fs::remove_all(kTestDirectory); }
+
+    DataDir* get_stores() {
+        TCreateTabletReq request;
+        return StorageEngine::instance()->get_stores_for_create_tablet(request.storage_medium)[0];
+    }
 
     // generate id between [start, end)
     void generate_rssid_rowids(std::vector<uint64_t>* rssid_rowids, uint64_t start, size_t end, uint64_t rssid) {
@@ -104,6 +111,28 @@ TEST_F(RowsMapperTest, test_write_read_multi_segment) {
     // should eof
     std::vector<uint64_t> rows_mapper;
     ASSERT_TRUE(iterator.next_values(1, &rows_mapper).is_end_of_file());
+}
+
+TEST_F(RowsMapperTest, test_crm_file_gc) {
+    DataDir* dir = get_stores();
+    // generate several crm files.
+    ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/aaa.crm"));
+    ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/bbb.crm"));
+    ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/ccc.crm"));
+    // collect files
+    dir->perform_tmp_path_scan();
+    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 3);
+    // try to gc
+    dir->perform_crm_gc(config::unused_crm_file_threshold_second);
+    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
+    // try to gc again
+    dir->perform_tmp_path_scan();
+    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 3);
+    dir->perform_crm_gc(0);
+    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
+    dir->perform_tmp_path_scan();
+    // make sure file have been clean.
+    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
 }
 
 } // namespace starrocks

--- a/be/test/storage/rows_mapper_test.cpp
+++ b/be/test/storage/rows_mapper_test.cpp
@@ -115,24 +115,41 @@ TEST_F(RowsMapperTest, test_write_read_multi_segment) {
 
 TEST_F(RowsMapperTest, test_crm_file_gc) {
     DataDir* dir = get_stores();
-    // generate several crm files.
-    ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/aaa.crm"));
-    ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/bbb.crm"));
-    ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/ccc.crm"));
-    // collect files
-    dir->perform_tmp_path_scan();
-    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 3);
-    // try to gc
-    dir->perform_crm_gc(config::unused_crm_file_threshold_second);
-    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
-    // try to gc again
-    dir->perform_tmp_path_scan();
-    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 3);
-    dir->perform_crm_gc(0);
-    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
-    dir->perform_tmp_path_scan();
-    // make sure file have been clean.
-    ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
+    {
+        // generate several crm files.
+        ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/aaa.crm"));
+        ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/bbb.crm"));
+        ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/ccc.crm"));
+        // collect files
+        dir->perform_tmp_path_scan();
+        dir->perform_tmp_path_scan();
+        ASSERT_TRUE(dir->get_all_crm_files_cnt() == 3);
+        // try to gc
+        dir->perform_crm_gc(config::unused_crm_file_threshold_second);
+        ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
+        // try to gc again
+        dir->perform_tmp_path_scan();
+        ASSERT_TRUE(dir->get_all_crm_files_cnt() == 3);
+        dir->perform_crm_gc(0);
+        ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
+        dir->perform_tmp_path_scan();
+        // make sure file have been clean.
+        ASSERT_TRUE(dir->get_all_crm_files_cnt() == 0);
+    }
+    {
+        ASSERT_OK(fs::new_writable_file(dir->get_tmp_path() + "/aaa.crm"));
+        // collect files
+        dir->perform_tmp_path_scan();
+        // delete this file
+        ASSERT_OK(fs::remove(dir->get_tmp_path() + "/aaa.crm"));
+        // try to gc
+        dir->perform_crm_gc(config::unused_crm_file_threshold_second);
+    }
+    {
+        ASSERT_OK(fs::remove(dir->get_tmp_path()));
+        // collect files
+        dir->perform_tmp_path_scan();
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
In this PR #43934, we introduced `.crm` file to contain the compaction's input segments' rowids, and we will delete `.crm` after compaction transaction publish finish.
But if compaction job fail, `.crm` file will be left behind and lead to disk cost. We need to have a way to clean these `.crm` files.

## What I'm doing:
Introduce backgroud `.crm` file gc, it will clean `.crm` files which are created one day ago (configurable, by `config::unused_crm_file_threshold_second`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
