### PR TITLE
[BugFix] Fix routine load kafka_partitions and kafka_offsets analyze bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -312,10 +312,12 @@ public enum ErrorCode {
     ERR_ILLEGAL_BYTES_LENGTH(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid bytes length for '%s' is [%d, %d]"),
     ERR_TOO_MANY_ERROR_ROWS(5606, new byte[] {'2', '2', '0', '0', '0'},
             "%s. Check the 'TrackingSQL' field for detailed information. If you are sure that the data has many errors, " +
-                    "you can set '%s' property to a greater value through ALTER ROUTINE LOAD and RESUME the job."),
+                    "you can set '%s' property to a greater value through ALTER ROUTINE LOAD and RESUME the job"),
     ERR_ROUTINE_LOAD_OFFSET_INVALID(5607, new byte[] {'0', '2', '0', '0', '0'},
             "Consume offset: %d is greater than the latest offset: %d in kafka partition: %d. " +
-            "You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job."),
+            "You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job"),
+    ERR_ROUTINE_LOAD_PROPERTY_PARTITION_OFFSET_INVALID(5608, new byte[] {'4', '2', '0', '0', '0'},
+            "%s '%s' is invalid. It must be %s"),
 
     /**
      * 5700 - 5799: Partition

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -734,7 +734,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                                                      Map<String, String> customKafkaProperties,
                                                      List<Pair<Integer, Long>> kafkaPartitionOffsets)
             throws AnalysisException {
-        kafkaPartitionsString = kafkaPartitionsString.replaceAll(" ", "");
+        kafkaPartitionsString = kafkaPartitionsString.trim();
         if (kafkaPartitionsString.isEmpty()) {
             throw new AnalysisException(KAFKA_PARTITIONS_PROPERTY + " could not be a empty string");
         }
@@ -747,6 +747,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
         String[] kafkaPartitionsStringList = kafkaPartitionsString.split(",");
         for (String s : kafkaPartitionsStringList) {
+            s = s.trim();
             try {
                 kafkaPartitionOffsets.add(
                         Pair.create(getIntegerValueFromString(s, KAFKA_PARTITIONS_PROPERTY),
@@ -761,7 +762,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static void analyzeKafkaOffsetProperty(String kafkaOffsetsString,
                                                   List<Pair<Integer, Long>> kafkaPartitionOffsets)
             throws AnalysisException {
-        kafkaOffsetsString = kafkaOffsetsString.replaceAll(" ", "");
+        kafkaOffsetsString = kafkaOffsetsString.trim();
         if (kafkaOffsetsString.isEmpty()) {
             throw new AnalysisException(KAFKA_OFFSETS_PROPERTY + " could not be a empty string");
         }
@@ -780,6 +781,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     // OFFSET_BEGINNING: -2
     // OFFSET_END: -1
     public static long getKafkaOffset(String offsetStr) throws AnalysisException {
+        offsetStr = offsetStr.trim();
         long offset = -1;
         try {
             offset = getLongValueFromString(offsetStr, "kafka offset");
@@ -972,7 +974,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         try {
             value = Long.valueOf(valueString);
         } catch (NumberFormatException e) {
-            throw new AnalysisException(propertyName + " must be a integer: " + valueString);
+            String errMsg = String.format("%s '%s' is invalid. It must be an integer, %s, or %s", propertyName, valueString,
+                    KafkaProgress.OFFSET_BEGINNING, KafkaProgress.OFFSET_END);
+            throw new AnalysisException(errMsg);
         }
         return value;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -734,8 +734,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                                                      Map<String, String> customKafkaProperties,
                                                      List<Pair<Integer, Long>> kafkaPartitionOffsets)
             throws AnalysisException {
-        kafkaPartitionsString = kafkaPartitionsString.trim();
-        if (kafkaPartitionsString.isEmpty()) {
+        String trimedKafkaPartitionsStr = kafkaPartitionsString.trim();
+        if (trimedKafkaPartitionsStr.isEmpty()) {
             throw new AnalysisException(KAFKA_PARTITIONS_PROPERTY + " could not be a empty string");
         }
 
@@ -745,7 +745,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             kafkaDefaultOffset = getKafkaOffset(customKafkaProperties.get(KAFKA_DEFAULT_OFFSETS));
         }
 
-        String[] kafkaPartitionsStringList = kafkaPartitionsString.split(",");
+        String[] kafkaPartitionsStringList = trimedKafkaPartitionsStr.split(",");
         for (String s : kafkaPartitionsStringList) {
             s = s.trim();
             try {
@@ -753,8 +753,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                         Pair.create(getIntegerValueFromString(s, KAFKA_PARTITIONS_PROPERTY),
                                 kafkaDefaultOffset == null ? KafkaProgress.OFFSET_END_VAL : kafkaDefaultOffset));
             } catch (AnalysisException e) {
-                throw new AnalysisException(KAFKA_PARTITIONS_PROPERTY
-                        + " must be a number string with comma-separated");
+                throw new AnalysisException(String.format("%s '%s' must be a number string with comma-separated",
+                        KAFKA_PARTITIONS_PROPERTY, kafkaPartitionsString));
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -611,7 +611,7 @@ public class CreateRoutineLoadStmtTest {
                         LoadDataSourceType.KAFKA.name(), customProperties);
         CreateRoutineLoadStmt finalCreateRoutineLoadStmt = createRoutineLoadStmt;
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
-                "kafka_partitions ' 1 2 3 ' must be a number string with comma-separated",
+                "kafka partition '1 2 3' is invalid. It must be an integer",
                 () -> CreateRoutineLoadAnalyzer.analyze(finalCreateRoutineLoadStmt, connectContext));
 
         // 6. invalid offset a

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -37,6 +37,7 @@ package com.starrocks.analysis;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
@@ -45,6 +46,7 @@ import com.starrocks.load.routineload.LoadDataSourceType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.CreateRoutineLoadAnalyzer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ColumnSeparator;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ImportWhereStmt;
@@ -541,8 +543,8 @@ public class CreateRoutineLoadStmtTest {
         // 1. kafka_offsets
         // 1 -> OFFSET_BEGINNING, 2 -> OFFSET_END
         Map<String, String> customProperties = getCustomProperties();
-        customProperties.put(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY, "1,2");
-        customProperties.put(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY, "OFFSET_BEGINNING,OFFSET_END");
+        customProperties.put(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY, " 1, 2 ");
+        customProperties.put(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY, " OFFSET_BEGINNING , OFFSET_END ");
         LabelName labelName = new LabelName(dbName, jobName);
         CreateRoutineLoadStmt createRoutineLoadStmt = new CreateRoutineLoadStmt(
                 labelName, tableNameString, loadPropertyList, Maps.newHashMap(),
@@ -598,6 +600,34 @@ public class CreateRoutineLoadStmtTest {
         Assert.assertEquals(KafkaProgress.OFFSET_BEGINNING_VAL, (long) partitionOffsets.get(0).second);
         Assert.assertEquals(KafkaProgress.OFFSET_END_VAL, (long) partitionOffsets.get(1).second);
         Assert.assertEquals(11, (long) partitionOffsets.get(2).second);
+
+        // 5. invalid partitions " 1 2 3 "
+        customProperties = getCustomProperties();
+        customProperties.put(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY, " 1 2 3 ");
+        customProperties.put(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY, "OFFSET_BEGINNING,OFFSET_END,11");
+        customProperties.put(kafkaDefaultOffsetsKey, "10");
+        labelName = new LabelName(dbName, jobName);
+        createRoutineLoadStmt =
+                new CreateRoutineLoadStmt(labelName, tableNameString, loadPropertyList, Maps.newHashMap(),
+                        LoadDataSourceType.KAFKA.name(), customProperties);
+        CreateRoutineLoadStmt finalCreateRoutineLoadStmt = createRoutineLoadStmt;
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "kafka_partitions must be a number string with comma-separated",
+                () -> CreateRoutineLoadAnalyzer.analyze(finalCreateRoutineLoadStmt, connectContext));
+
+        // 6. invalid offset a
+        customProperties = getCustomProperties();
+        customProperties.put(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY, "1,2,3");
+        customProperties.put(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY, "OFFSET_BEGINNING,OFFSET_END,a");
+        customProperties.put(kafkaDefaultOffsetsKey, "10");
+        labelName = new LabelName(dbName, jobName);
+        createRoutineLoadStmt =
+                new CreateRoutineLoadStmt(labelName, tableNameString, loadPropertyList, Maps.newHashMap(),
+                        LoadDataSourceType.KAFKA.name(), customProperties);
+        CreateRoutineLoadStmt finalCreateRoutineLoadStmt2 = createRoutineLoadStmt;
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "kafka offset 'a' is invalid. It must be an integer, OFFSET_BEGINNING, or OFFSET_END",
+                () -> CreateRoutineLoadAnalyzer.analyze(finalCreateRoutineLoadStmt2, connectContext));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -525,7 +525,6 @@ public class CreateRoutineLoadStmtTest {
 
     @Test
     public void testKafkaOffset() {
-
         String jobName = "job1";
         String dbName = "db1";
         String tableNameString = "table1";
@@ -543,7 +542,7 @@ public class CreateRoutineLoadStmtTest {
         // 1. kafka_offsets
         // 1 -> OFFSET_BEGINNING, 2 -> OFFSET_END
         Map<String, String> customProperties = getCustomProperties();
-        customProperties.put(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY, " 1, 2 ");
+        customProperties.put(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY, " 1 , 2 ");
         customProperties.put(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY, " OFFSET_BEGINNING , OFFSET_END ");
         LabelName labelName = new LabelName(dbName, jobName);
         CreateRoutineLoadStmt createRoutineLoadStmt = new CreateRoutineLoadStmt(
@@ -612,7 +611,7 @@ public class CreateRoutineLoadStmtTest {
                         LoadDataSourceType.KAFKA.name(), customProperties);
         CreateRoutineLoadStmt finalCreateRoutineLoadStmt = createRoutineLoadStmt;
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
-                "kafka_partitions must be a number string with comma-separated",
+                "kafka_partitions ' 1 2 3 ' must be a number string with comma-separated",
                 () -> CreateRoutineLoadAnalyzer.analyze(finalCreateRoutineLoadStmt, connectContext));
 
         // 6. invalid offset a

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -88,7 +88,7 @@ public class KafkaTaskInfoTest {
                 Config.routine_load_task_timeout_second * 1000);
         ExceptionChecker.expectThrowsWithMsg(RoutineLoadPauseException.class,
                 "Consume offset: 101 is greater than the latest offset: 100 in kafka partition: 0. " +
-                        "You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job.",
+                        "You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job",
                 () -> kafkaTaskInfo3.readyToExecute());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -361,7 +361,7 @@ public class RoutineLoadJobTest {
         Assert.assertEquals(
                 "Current error rows: 1 is more than max error num: 0. Check the 'TrackingSQL' field for detailed information. " +
                         "If you are sure that the data has many errors, you can set 'max_error_number' property " +
-                        "to a greater value through ALTER ROUTINE LOAD and RESUME the job.",
+                        "to a greater value through ALTER ROUTINE LOAD and RESUME the job",
                 reason.getMsg());
     }
 


### PR DESCRIPTION
## Why I'm doing:
1. 'kafka_partitions' = '1 2 3 4'
error message: 
`there is an invalid custom partition: 1234 for topic: topic_test`

2.  'kafka_offsets' = 'OFFSET_BEGIN'
error message:
`Error 1064 (HY000): Getting analyzing error. Detail message: kafka offset must be a integer: OFFSET_BEGIN.`

## What I'm doing:
1. `ERROR 1064 (HY000): Getting analyzing error. Detail message: kafka partition '1 2 3 4' is invalid. It must be an integer.`
2. `ERROR 1064 (HY000): Getting analyzing error. Detail message: kafka offset 'a' is invalid. It must be an integer, OFFSET_BEGINNING, or OFFSET_END.`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
