### PR TITLE
[Enhancement] Skip empty mv partitions in loose mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -151,6 +151,7 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
             String mvPartitionName = addEntry.getKey();
             mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName);
         }
+        addEmptyPartitionsToRefresh(mvUpdateInfo);
         return mvUpdateInfo;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -177,6 +177,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
             String mvPartitionName = addEntry.getKey();
             mvUpdateInfo.addMvToRefreshPartitionNames(mvPartitionName);
         }
+        addEmptyPartitionsToRefresh(mvUpdateInfo);
         return mvUpdateInfo;
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When "query_rewrite_consistency" = "LOOSE" is set in mv properties, empty partitions are also selected which cause incorrect result
## What I'm doing:
Skip empty mv partitions in loose mode

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
