### PR TITLE
[Enhancement] Support convert escaped characters in stream load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Delimiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Delimiter.java
@@ -49,7 +49,15 @@ public class Delimiter {
             }
             return writer.toString();
         } else {
-            return originStr;
+            return convertEscapedCharacters(originStr);
         }
+    }
+
+    public static String convertEscapedCharacters(String input) {
+        // replace \\t with \t
+        input = input.replaceAll("\\\\t", "\t");
+        // replace \\n with \n
+        input = input.replaceAll("\\\\n", "\n");
+        return input;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnSeparatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnSeparatorTest.java
@@ -49,6 +49,30 @@ public class ColumnSeparatorTest {
         Assert.assertEquals("\t", separator.getColumnSeparator());
         Assert.assertEquals("\t", separator.getOriSeparator());
 
+        // \\t
+        separator = new ColumnSeparator("\\t");
+        Assert.assertEquals("'\\t'", separator.toSql());
+        Assert.assertEquals("\t", separator.getColumnSeparator());
+        Assert.assertEquals("\\t", separator.getOriSeparator());
+
+        // \\t\\t
+        separator = new ColumnSeparator("\\t\\t");
+        Assert.assertEquals("'\\t\\t'", separator.toSql());
+        Assert.assertEquals("\t\t", separator.getColumnSeparator());
+        Assert.assertEquals("\\t\\t", separator.getOriSeparator());
+
+        // a\\ta\\t
+        separator = new ColumnSeparator("a\\ta\\t");
+        Assert.assertEquals("'a\\ta\\t'", separator.toSql());
+        Assert.assertEquals("a\ta\t", separator.getColumnSeparator());
+        Assert.assertEquals("a\\ta\\t", separator.getOriSeparator());
+
+        // \\t\\n
+        separator = new ColumnSeparator("\\t\\n");
+        Assert.assertEquals("'\\t\\n'", separator.toSql());
+        Assert.assertEquals("\t\n", separator.getColumnSeparator());
+        Assert.assertEquals("\\t\\n", separator.getOriSeparator());
+
         // \x01
         separator = new ColumnSeparator("\\x01");
         Assert.assertEquals("'\\x01'", separator.toSql());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RowDelimiterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RowDelimiterTest.java
@@ -49,6 +49,24 @@ public class RowDelimiterTest {
         Assert.assertEquals("\n", delimiter.getRowDelimiter());
         Assert.assertEquals("\n", delimiter.getOriDelimiter());
 
+        // \\n
+        delimiter = new RowDelimiter("\\n");
+        Assert.assertEquals("'\\n'", delimiter.toSql());
+        Assert.assertEquals("\n", delimiter.getRowDelimiter());
+        Assert.assertEquals("\\n", delimiter.getOriDelimiter());
+
+        // \\n\\n
+        delimiter = new RowDelimiter("\\n\\n");
+        Assert.assertEquals("'\\n\\n'", delimiter.toSql());
+        Assert.assertEquals("\n\n", delimiter.getRowDelimiter());
+        Assert.assertEquals("\\n\\n", delimiter.getOriDelimiter());
+
+        // a\\na\\n
+        delimiter = new RowDelimiter("a\\na\\n");
+        Assert.assertEquals("'a\\na\\n'", delimiter.toSql());
+        Assert.assertEquals("a\na\n", delimiter.getRowDelimiter());
+        Assert.assertEquals("a\\na\\n", delimiter.getOriDelimiter());
+
         // \x01
         delimiter = new RowDelimiter("\\x01");
         Assert.assertEquals("'\\x01'", delimiter.toSql());


### PR DESCRIPTION
## Why I'm doing:
stream load does not support `-H "column_separator:\t" -H "row_delimiter:\n"`. 
currently, users must use `column_separator:0x09` or `column_separator:\\x09`.

## What I'm doing:
support this

Fixes #47430

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
