### PR TITLE
[UT] shorten DecommissionTest running time

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
@@ -38,8 +38,8 @@ public class DecommissionTest {
         PseudoBackend.reportIntervalMs = 1000;
         PseudoCluster.getOrCreateWithRandomPort(true, 4);
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(500);
-        ColocateTableBalancer.getInstance().setInterval(1000);
-        GlobalStateMgr.getCurrentState().getTabletScheduler().setInterval(1000);
+        ColocateTableBalancer.getInstance().setInterval(500);
+        GlobalStateMgr.getCurrentState().getTabletScheduler().setInterval(500);
         PseudoCluster.getInstance().runSql(null, "create database test");
     }
 
@@ -60,7 +60,7 @@ public class DecommissionTest {
         for (int i = 0; i < numTable; i++) {
             tableNames[i] = "test_" + i;
             PseudoCluster.CreateTableSqlBuilder sqlBuilder = PseudoCluster.newCreateTableSqlBuilder().setTableName(tableNames[i])
-                    .setBuckets(2);
+                    .setBuckets(1);
             if (i % 2 == 0) {
                 sqlBuilder.setColocateGroup("g1");
             }
@@ -80,7 +80,7 @@ public class DecommissionTest {
                 break;
             }
             cluster.runSql("test", insertSqls[rand.nextInt(numTable)]);
-            Thread.sleep(1000);
+            Thread.sleep(3000);
         }
         System.out.println("decommission finished");
     }


### PR DESCRIPTION
## Why I'm doing:

DecommissionTest timeout

## What I'm doing:

shorten DecommissionTest running time

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
