### PR TITLE
[BugFix] Fix report task timeout cancel long running alter job (backport #46959)

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -270,35 +270,22 @@ void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& a
     std::string alter_msg_head = strings::Substitute("[Alter Job:$0, tablet:$1]: ", agent_task_req->task_req.job_id,
                                                      agent_task_req->task_req.base_tablet_id);
     LOG(INFO) << alter_msg_head << "get alter table task, signature: " << agent_task_req->signature;
-    bool is_task_timeout = false;
-    std::string error_msg = "";
+    bool is_task_req_expired = false;
     if (agent_task_req->isset.recv_time) {
         int64_t time_elapsed = time(nullptr) - agent_task_req->recv_time;
         if (time_elapsed > config::report_task_interval_seconds * 20) {
-            error_msg = "task elapsed " + std::to_string(time_elapsed) +
-                        " seconds since it is inserted to queue, it is timeout";
-            LOG(WARNING) << error_msg;
-            is_task_timeout = true;
+            // task have been in queue for a long time, this task may already be cancelled by FE
+            // so just ignore this task, cause if it's not cancelled, FE will resend a new one
+            LOG(INFO) << alter_msg_head << " ignore expired task request " << time_elapsed << "s since enqueue";
+            is_task_req_expired = true;
         }
     }
-    if (!is_task_timeout) {
+    if (!is_task_req_expired) {
         TFinishTaskRequest finish_task_request;
         TTaskType::type task_type = agent_task_req->task_type;
         if (task_type == TTaskType::ALTER) {
             alter_tablet(agent_task_req->task_req, signatrue, &finish_task_request);
         }
-        finish_task(finish_task_request);
-    } else {
-        // Response should be reported to FE even if timeout.
-        TFinishTaskRequest finish_task_request;
-        finish_task_request.__set_backend(BackendOptions::get_localBackend());
-        finish_task_request.__set_task_type(agent_task_req->task_type);
-        finish_task_request.__set_signature(agent_task_req->signature);
-        TStatus task_status;
-        task_status.__set_status_code(TStatusCode::TIMEOUT);
-        task_status.__set_error_msgs(std::vector<std::string>{error_msg});
-        finish_task_request.__set_task_status(task_status);
-
         finish_task(finish_task_request);
     }
     remove_task_info(agent_task_req->task_type, agent_task_req->signature);


### PR DESCRIPTION
Why I'm doing:
#44611 introduces a bug, it treats expired task as timeout error, which will cause long running alter job to fail.

What I'm doing:
revert this behavior and add more comment to explain this expire mechanism

Fixes #46958

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

