### PR TITLE
[BugFix] Disallow auto conversion for the cols of Non-OLAP table that's being created from double/float to decimal type in CTAS

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -20,11 +20,8 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TypeDef;
-import com.starrocks.catalog.HiveTable;
-import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.RunMode;
@@ -39,6 +36,7 @@ import com.starrocks.sql.ast.MultiRangePartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RangePartitionDesc;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.parser.ParsingException;
 
 import java.util.HashMap;
@@ -89,21 +87,13 @@ public class CTASAnalyzer {
             }
         }
 
+        TableName tableNameObject = createTableStmt.getDbTbl();
+        MetaUtils.normalizationTableName(session, tableNameObject);
+        CreateTableAnalyzer.analyzeEngineName(createTableStmt, tableNameObject.getCatalog());
+
         for (int i = 0; i < allFields.size(); i++) {
-            boolean isConnectorTable = false;
-            try {
-                Table connectorTable = tableRefToTable.get(allFields.get(i).getRelationAlias().getTbl());
-                if (connectorTable != null) {
-                    isConnectorTable = connectorTable instanceof HiveTable
-                            || connectorTable instanceof TableFunctionTable
-                            || connectorTable instanceof IcebergTable;
-                }
-            } catch (NullPointerException ignored) {
-                // skip if nullPointer called
-            }
-            Type type = isConnectorTable
-                    ? AnalyzerUtils.transformTableColumnType(allFields.get(i).getType(), false)
-                    : AnalyzerUtils.transformTableColumnType(allFields.get(i).getType());
+            Type type = AnalyzerUtils.transformTableColumnType(allFields.get(i).getType(),
+                    createTableStmt.isOlapEngine());
             Expr originExpression = allFields.get(i).getOriginExpression();
             ColumnDef columnDef = new ColumnDef(finalColumnNames.get(i), new TypeDef(type), false,
                     null, originExpression.isNullable(), ColumnDef.DefaultValueDef.NOT_SET, "");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -129,7 +129,7 @@ public class CreateTableAnalyzer {
         }
     }
 
-    private static void analyzeEngineName(CreateTableStmt stmt, String catalogName) {
+    protected static void analyzeEngineName(CreateTableStmt stmt, String catalogName) {
         String engineName = stmt.getEngineName();
 
         if (CatalogMgr.isInternalCatalog(catalogName)) {


### PR DESCRIPTION
## Why I'm doing:

The previous fix does not cover the case that cols cannot be inferred at this stage. 
E.g.
create table temp.tbl1 as select col1, avg(col1) from temp.tbl2.

Furthermore, ensuring that Hive tables do not apply double type conversion optimization could prevent decimal value overflow.

<img width="1879" alt="image" src="https://github.com/StarRocks/starrocks/assets/42195839/344ba426-dd57-4018-872d-79fc67a60405">


## What I'm doing:

Disallow auto type conversion for NON-OLAP tables' double/ float cols during analyzing stage. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
