### PR TITLE
[BugFix] Fix the issue of inaccurate disk usage statistics causing datacache to not take immediate effect. (backport #47251)

### DIFF
--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -86,8 +86,7 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
         }
         cache_options.mem_space_size = parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit);
         if (config::datacache_disk_path.value().empty()) {
-            // If the disk cache does not be configured for datacache, set default path according storage path,
-            // and turn on the automatic adjust switch.
+            // If the disk cache does not be configured for datacache, set default path according storage path.
             std::vector<std::string> datacache_paths;
             std::for_each(storage_paths.begin(), storage_paths.end(), [&](const StorePath& root_path) {
                 std::filesystem::path sp(root_path.path);
@@ -95,10 +94,18 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
                 datacache_paths.push_back(dp.string());
             });
             config::datacache_disk_path = JoinStrings(datacache_paths, ";");
-            config::datacache_auto_adjust_enable = true;
         }
         RETURN_IF_ERROR(parse_conf_datacache_disk_spaces(config::datacache_disk_path, config::datacache_disk_size,
                                                          config::ignore_broken_disk, &cache_options.disk_spaces));
+
+        size_t total_quota_byts = 0;
+        for (auto& space : cache_options.disk_spaces) {
+            total_quota_byts += space.size;
+        }
+        if (total_quota_byts == 0) {
+            // If disk cache quota is zero, turn on the automatic adjust switch.
+            config::datacache_auto_adjust_enable = true;
+        }
 
         // Adjust the default engine based on build switches.
         if (config::datacache_engine == "") {

--- a/be/test/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/block_cache/disk_space_monitor_test.cpp
@@ -138,17 +138,14 @@ TEST_F(DiskSpaceMonitorTest, adjust_for_dirty_cache_dir) {
     mock_fs->set_space(2, "disk2", space_info);
     mock_fs->set_global_directory_capacity(200 * GB);
 
-    std::vector<DirSpace> dir_spaces = {{.path = "disk1/dir1", .size = 500 * GB},
-                                        {.path = "disk1/dir2", .size = 500 * GB},
-                                        {.path = "disk2/dir2", .size = 500 * GB}};
+    std::vector<DirSpace> dir_spaces = {
+            {.path = "disk1/dir1", .size = 0}, {.path = "disk1/dir2", .size = 0}, {.path = "disk2/dir2", .size = 0}};
 
-    // disk2 usage: (1000G - 180G) / 1000G = 82%
-    // disk2 safe usage: 70%
-    // delta bytes: (70% - 82%) * 1000G = -120G
-    // quota for each cache dir: 200G - 120G = 80G
-    ASSERT_TRUE(space_monitor->adjust_spaces(&dir_spaces));
+    // disk1 usage: (1000G - 180G - 200G) / 1000G = 62%
+    // This will not triger adjustment because it between low level and high level.
+    ASSERT_FALSE(space_monitor->adjust_spaces(&dir_spaces));
     for (auto& dir : dir_spaces) {
-        ASSERT_EQ(dir.size, 80 * GB);
+        ASSERT_EQ(dir.size, 0);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
When restarting the BE process, some old block files may remain in the datacache path and can be reused to cache data. When calculating the disk usage before initialize the datacache, the old block files also be calculated as other data in the disk. This may cause the available space too small to enable the datacache immediately, and further leading to a decrease in query performance after process restart.

## What I'm doing:
1. Check and ignore the residual block files to make the disk usage more accurate.
2. Turn on the auto adjustment switch by cache quota instead of cache path.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

