### PR TITLE
[Enhancement] Improve auto spill strategy

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -602,9 +602,21 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
         }
         request_reserved += state->spill_mem_table_num() * state->spill_mem_table_size();
 
+        bool need_spill = false;
         if (!tls_thread_status.try_mem_reserve(request_reserved)) {
+            need_spill = true;
             mem_resource_mgr.to_low_memory_mode();
         }
+
+        auto query_mem_tracker = _query_ctx->mem_tracker();
+        auto query_consumption = query_mem_tracker->consumption();
+        auto limited = query_mem_tracker->limit();
+        auto reserved_limit = query_mem_tracker->reserve_limit();
+
+        TRACE_SPILL_LOG << "TRACE spill:" << op->get_name() << " request: " << request_reserved
+                        << " revocable: " << op->revocable_mem_bytes() << " set finishing: " << (chunk == nullptr)
+                        << " need_spill:" << need_spill << " query_consumption:" << query_consumption
+                        << " limit:" << limited << "query reserved limit:" << reserved_limit;
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -613,7 +613,7 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
         auto limited = query_mem_tracker->limit();
         auto reserved_limit = query_mem_tracker->reserve_limit();
 
-        TRACE_SPILL_LOG << "TRACE spill:" << op->get_name() << " request: " << request_reserved
+        TRACE_SPILL_LOG << "adjust memory spill:" << op->get_name() << " request: " << request_reserved
                         << " revocable: " << op->revocable_mem_bytes() << " set finishing: " << (chunk == nullptr)
                         << " need_spill:" << need_spill << " query_consumption:" << query_consumption
                         << " limit:" << limited << "query reserved limit:" << reserved_limit;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 #include "exec/pipeline/fragment_context.h"
@@ -154,7 +155,7 @@ public:
     /// Positive `big_query_mem_limit` and non-null `wg` indicate
     /// that there is a big query memory limit of this resource group.
     void init_mem_tracker(int64_t query_mem_limit, MemTracker* parent, int64_t big_query_mem_limit = -1,
-                          int64_t spill_mem_limit = -1, workgroup::WorkGroup* wg = nullptr,
+                          std::optional<double> spill_mem_limit = std::nullopt, workgroup::WorkGroup* wg = nullptr,
                           RuntimeState* state = nullptr);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
     MemTracker* connector_scan_mem_tracker() { return _connector_scan_mem_tracker.get(); }

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -132,6 +132,8 @@ private:
                 _reserved_bytes = 0;
             }
         }
+        // release memory to reserved
+        void release_to_reserved(size_t release_bytes) { _reserved_bytes += release_bytes; }
 
         void release(int64_t size) {
             _cache_size -= size;
@@ -272,16 +274,24 @@ public:
 
     bool try_mem_reserve(int64_t size) {
         if (_mem_cache_manager.try_mem_reserve(size)) {
+            _reserve_mod = true;
             return true;
         }
         return false;
     }
 
-    void release_reserved() { _mem_cache_manager.release_reserved(); }
+    void release_reserved() {
+        _reserve_mod = false;
+        _mem_cache_manager.release_reserved();
+    }
 
     void mem_release(int64_t size) {
-        _mem_cache_manager.release(size);
-        _operator_mem_cache_manager.release(size);
+        if (_reserve_mod) {
+            _mem_cache_manager.release_to_reserved(size);
+        } else {
+            _mem_cache_manager.release(size);
+            _operator_mem_cache_manager.release(size);
+        }
     }
 
     static void mem_consume_without_cache(int64_t size) {
@@ -331,6 +341,7 @@ private:
     int32_t _driver_id = 0;
     bool _is_catched = false;
     bool _check = true;
+    bool _reserve_mod = false;
 };
 
 inline thread_local CurrentThread tls_thread_status;
@@ -465,10 +476,12 @@ private:
         return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)               \
-    do {                                        \
-        TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
-        TRY_CATCH_ALLOC_SCOPE_END()             \
+#define TRY_CATCH_BAD_ALLOC(stmt)       \
+    do {                                \
+        TRY_CATCH_ALLOC_SCOPE_START() { \
+            stmt;                       \
+        }                               \
+        TRY_CATCH_ALLOC_SCOPE_END()     \
     } while (0)
 
 // TRY_CATCH_ALL will not set catched=true, only used for catch unexpected crash,

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -476,12 +476,10 @@ private:
         return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)       \
-    do {                                \
-        TRY_CATCH_ALLOC_SCOPE_START() { \
-            stmt;                       \
-        }                               \
-        TRY_CATCH_ALLOC_SCOPE_END()     \
+#define TRY_CATCH_BAD_ALLOC(stmt)               \
+    do {                                        \
+        TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
+        TRY_CATCH_ALLOC_SCOPE_END()             \
     } while (0)
 
 // TRY_CATCH_ALL will not set catched=true, only used for catch unexpected crash,

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -228,13 +228,14 @@ public:
         // Walk the tracker tree top-down.
         for (i = _all_trackers.size() - 1; i >= 0; --i) {
             MemTracker* tracker = _all_trackers[i];
-            if (tracker->limit() < 0) {
+            int64_t limit = tracker->reserve_limit();
+            if (limit < 0) {
+                limit = tracker->limit();
+            }
+            if (limit < 0) {
+                DCHECK_EQ(limit, -1);
                 tracker->_consumption->add(bytes); // No limit at this tracker.
             } else {
-                int64_t limit = tracker->reserve_limit();
-                if (limit == -1) {
-                    limit = tracker->limit();
-                }
                 if (LIKELY(tracker->_consumption->try_add(bytes, limit))) {
                     continue;
                 } else {


### PR DESCRIPTION




## Why I'm doing:
In the current spill policy, thread A tries to reserve a certain amount of memory. thread B's operator enters spill mode when it fails to reserve. There is a problem with this.
1. if there is no memory limit configured. thread B always reserves.
2. If there is a memory freeing operation in thread A and a large amount of memory is requested, then thread B will still reserve successfully.

## What I'm doing:
For these two problems, this PR has the following optimizations.
1. find the smallest memory limit in parent memory according to the memory tracker, and set the reserve limit accordingly
2. the memory freed by the reserve thread will be temporarily put back into reserve. This prevents other threads from claiming it.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
