### PR TITLE
[Refactor] add a config to ignore rpc overcrowded problem

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -627,6 +627,12 @@ CONF_Int64(brpc_max_body_size, "2147483648");
 CONF_Int64(brpc_socket_max_unwritten_bytes, "1073741824");
 // brpc connection types, "single", "pooled", "short".
 CONF_String_enum(brpc_connection_type, "single", "single,pooled,short");
+// If the amount of data to be sent by a single channel of brpc exceeds brpc_socket_max_unwritten_bytes
+// it will cause rpc to report an error. We add configuration to ignore rpc overload.
+// This may cause process memory usage to rise.
+// In the future we need to count the memory on each channel of the rpc. To do application layer rpc flow limiting.
+CONF_mBool(brpc_query_ignore_overcrowded, "false");
+CONF_mBool(brpc_load_ignore_overcrowded, "true");
 
 // Max number of txns for every txn_partition_map in txn manager.
 // this is a self-protection to avoid too many txns saving in manager.

--- a/be/src/exec/dictionary_cache_writer.cpp
+++ b/be/src/exec/dictionary_cache_writer.cpp
@@ -176,7 +176,7 @@ Status DictionaryCacheWriter::_send_request(ChunkPB* pchunk, POlapTableSchemaPar
         auto& closure = closures[i];
         closure->ref();
         closure->cntl.set_timeout_ms(config::dictionary_cache_refresh_timeout_ms);
-        closure->cntl.ignore_eovercrowded();
+        SET_IGNORE_OVERCROWDED(closure->cntl, load);
 
         auto res = HttpBrpcStubCache::getInstance()->get_http_stub(nodes[i]);
         if (!res.ok()) {

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -423,6 +423,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);
+        SET_IGNORE_OVERCROWDED(closure->cntl, query);
 
         Status st;
         if (bthread_self()) {

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -221,7 +221,7 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
     // This ref is for RPC's reference
     open_closure->ref();
     open_closure->cntl.set_timeout_ms(_rpc_timeout_ms);
-    open_closure->cntl.ignore_eovercrowded();
+    SET_IGNORE_OVERCROWDED(open_closure->cntl, load);
 
     if (request.ByteSizeLong() > _parent->_rpc_http_min_size) {
         TNetworkAddress brpc_addr;
@@ -624,7 +624,8 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
     _add_batch_closures[_current_request_index]->ref();
     _add_batch_closures[_current_request_index]->reset();
     _add_batch_closures[_current_request_index]->cntl.set_timeout_ms(_rpc_timeout_ms);
-    _add_batch_closures[_current_request_index]->cntl.ignore_eovercrowded();
+    SET_IGNORE_OVERCROWDED(_add_batch_closures[_current_request_index]->cntl, load);
+
     _add_batch_closures[_current_request_index]->request_size = request.ByteSizeLong();
 
     _mem_tracker->consume(_add_batch_closures[_current_request_index]->request_size);
@@ -977,7 +978,7 @@ void NodeChannel::_cancel(int64_t index_id, const Status& err_st) {
 
     closure->ref();
     closure->cntl.set_timeout_ms(_rpc_timeout_ms);
-    closure->cntl.ignore_eovercrowded();
+    SET_IGNORE_OVERCROWDED(closure->cntl, load);
     _stub->tablet_writer_cancel(&closure->cntl, &request, &closure->result, closure);
     request.release_id();
 }

--- a/be/src/service/brpc.h
+++ b/be/src/service/brpc.h
@@ -72,3 +72,10 @@
 #include <butil/strings/string_piece.h>
 
 #include "common/compiler_util.h"
+#include "common/config.h"
+
+// ignore brpc overcrowded error
+#define SET_IGNORE_OVERCROWDED(ctnl, module)          \
+    if (config::brpc_##module##_ignore_overcrowded) { \
+        ctnl.ignore_eovercrowded();                   \
+    }

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -154,7 +154,7 @@ void ReplicateChannel::_send_request(SegmentPB* segment, butil::IOBuf& data, boo
     _closure->ref();
     _closure->reset();
     _closure->cntl.set_timeout_ms(_opt->timeout_ms);
-    _closure->cntl.ignore_eovercrowded();
+    SET_IGNORE_OVERCROWDED(_closure->cntl, load);
 
     if (segment != nullptr) {
         request.set_allocated_segment(segment);


### PR DESCRIPTION
## Why I'm doing:
If the amount of data to be sent by a single channel of brpc exceeds brpc_socket_max_unwritten_bytes
it will cause rpc to report an error. We add configuration to ignore rpc overload.
This may cause process memory usage to rise.
In the future we need to count the memory on each channel of the rpc. To do application layer rpc flow limiting.

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
