### PR TITLE
[BugFix] cloud native index support rebuilding via del files

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -444,7 +444,6 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
             op_write->mutable_rowset()->add_segment_size(f.size.value());
         } else if (is_del(f.path)) {
             op_write->add_dels(std::move(f.path));
-            op_write->add_del_file_sizes(f.size.value());
         } else {
             return Status::InternalError(fmt::format("unknown file {}", f.path));
         }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -444,6 +444,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
             op_write->mutable_rowset()->add_segment_size(f.size.value());
         } else if (is_del(f.path)) {
             op_write->add_dels(std::move(f.path));
+            op_write->add_del_file_sizes(f.size.value());
         } else {
             return Status::InternalError(fmt::format("unknown file {}", f.path));
         }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -476,7 +476,8 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
     return Status::OK();
 }
 
-// rebuild index from del files.
+// Rebuild index's memtable via del files, it will read from del file and write to index.
+// If it fail, SR will retry publish txn, and this index's memtable will be release and rebuild again.
 Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version) {
     TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
     // Build pk column struct from schema

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -97,6 +97,15 @@ public:
         return Status::NotSupported("LakePersistentIndex::erase not supported");
     }
 
+    // batch insert delete operations, used when rebuild index.
+    // |n|: size of key/value array
+    // |keys|: key array as raw buffer
+    // |filter| : used for filter keys that need to skip. `True` means need skip.
+    // |version|: version of values
+    // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
+    Status replay_erase(size_t n, const Slice* keys, const std::vector<bool>& filter, int64_t version,
+                        uint32_t rowset_id);
+
     // batch replace
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
@@ -120,15 +129,6 @@ public:
     // |values|: value array
     // |version|: version of values
     Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version);
-
-    // batch insert delete operations, used when rebuild index.
-    // |n|: size of key/value array
-    // |keys|: key array as raw buffer
-    // |filter| : used for filter keys that need to skip. `True` means need skip.
-    // |version|: version of values
-    // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
-    Status replay_erase(size_t n, const Slice* keys, const std::vector<bool>& filter, int64_t version,
-                        uint32_t rowset_id);
 
     Status minor_compact();
 

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -127,7 +127,7 @@ public:
     // |filter| : used for filter keys that need to skip. `True` means need skip.
     // |version|: version of values
     // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
-    Status insert_erase(size_t n, const Slice* keys, const std::vector<bool>& filter, int64_t version,
+    Status replay_erase(size_t n, const Slice* keys, const std::vector<bool>& filter, int64_t version,
                         uint32_t rowset_id);
 
     Status minor_compact();
@@ -147,7 +147,7 @@ public:
                                         std::vector<PersistentIndexSstablePB>* sstables, bool* merge_base_level);
 
     // Check if this rowset need to rebuild, return `True` means need to rebuild this rowset.
-    static bool rowset_rebuild_checker(const RowsetMetadataPB& rowset, uint32_t rebuild_rss_id);
+    static bool needs_rowset_rebuild(const RowsetMetadataPB& rowset, uint32_t rebuild_rss_id);
 
 private:
     Status flush_memtable();

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -258,4 +258,41 @@ void LakePrimaryIndex::set_local_pk_index_write_amp_score(double score) {
     }
 }
 
+Status LakePrimaryIndex::erase(const TabletMetadataPtr& metadata, const Column& pks, DeletesMap* deletes,
+                               uint32_t rowset_id) {
+    // No need to setup rebuild point for in-memory index and local persistent index,
+    // so keep using previous erase interface.
+    if (!_enable_persistent_index) {
+        return PrimaryIndex::erase(pks, deletes);
+    }
+
+    switch (metadata->persistent_index_type()) {
+    case PersistentIndexTypePB::LOCAL: {
+        return PrimaryIndex::erase(pks, deletes);
+    }
+    case PersistentIndexTypePB::CLOUD_NATIVE: {
+        auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
+        if (lake_persistent_index != nullptr) {
+            std::vector<Slice> keys;
+            std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
+            const Slice* vkeys = _build_persistent_keys(pks, 0, pks.size(), &keys);
+            // Cloud native index need to setup rowset id as rebuild point when erase.
+            RETURN_IF_ERROR(lake_persistent_index->erase(pks.size(), vkeys,
+                                                         reinterpret_cast<IndexValue*>(old_values.data()), rowset_id));
+            for (unsigned long old : old_values) {
+                if (old != NullIndexValue) {
+                    (*deletes)[(uint32_t)(old >> 32)].push_back((uint32_t)(old & ROWID_MASK));
+                }
+            }
+            return Status::OK();
+        } else {
+            return Status::InternalError("Persistent index is not a LakePersistentIndex.");
+        }
+    }
+    default:
+        return Status::InternalError("Unsupported lake_persistent_index_type " +
+                                     PersistentIndexTypePB_Name(metadata->persistent_index_type()));
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -72,6 +72,12 @@ public:
 
     void set_local_pk_index_write_amp_score(double score);
 
+    // |key_col| contains the *encoded* primary keys to be deleted from this index.
+    // The position of deleted keys will be appended into |new_deletes|.
+    //
+    // |rowset_id| The rowset that keys belong to. Used for setup rebuild point (cloud native index only).
+    Status erase(const TabletMetadataPtr& metadata, const Column& pks, DeletesMap* deletes, uint32_t rowset_id);
+
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -72,6 +72,12 @@ public:
 
     void set_local_pk_index_write_amp_score(double score);
 
+    // This function is used for handling delete operation in cloud native PK table.
+    // It is different from another pk index implementation (such as in-memory index or local persistent index),
+    // because it need `rowset_id` to setup the rebuild point.
+    //
+    // |metadata| Used to decide the index type.
+    //
     // |key_col| contains the *encoded* primary keys to be deleted from this index.
     // The position of deleted keys will be appended into |new_deletes|.
     //

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -116,6 +116,10 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
 
     rowset->set_id(_tablet_meta->next_rowset_id());
     rowset->set_version(_tablet_meta->version());
+    // collect del files
+    for (const auto& del_file : op_write.dels()) {
+        rowset->add_del_files(del_file);
+    }
     // if rowset don't contain segment files, still inc next_rowset_id
     _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + std::max(1, rowset->segments_size()));
     // collect trash files
@@ -123,11 +127,6 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         DCHECK(is_segment(orphan_file));
         FileMetaPB file_meta;
         file_meta.set_name(orphan_file);
-        _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
-    }
-    for (const auto& del_file : op_write.dels()) {
-        FileMetaPB file_meta;
-        file_meta.set_name(del_file);
         _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
     }
 }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -121,9 +121,9 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
     DCHECK(op_write.del_file_sizes_size() == 0 || op_write.del_file_sizes_size() == op_write.dels_size());
     for (int i = 0; i < op_write.dels_size(); i++) {
         DelfileWithRowsetId del_file_with_rid;
-        del_file_with_rid.set_del_file(op_write.dels(i));
+        del_file_with_rid.set_name(op_write.dels(i));
         if (op_write.del_file_sizes_size() > 0) {
-            del_file_with_rid.set_del_file_size(op_write.del_file_sizes(i));
+            del_file_with_rid.set_size(op_write.del_file_sizes(i));
         }
         del_file_with_rid.set_origin_rowset_id(rowset->id());
         rowset->add_del_files()->CopyFrom(del_file_with_rid);
@@ -190,7 +190,7 @@ void MetaFileBuilder::_collect_del_files_above_rebuild_point(RowsetMetadataPB* r
     // Rebuild persistent index from `rebuild_rss_rowid_point`
     const uint64_t rebuild_rss_rowid_point = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid();
     const uint32_t rebuild_rss_id = rebuild_rss_rowid_point >> 32;
-    if (rowset->del_files_size() > 0 && LakePersistentIndex::rowset_rebuild_checker(*rowset, rebuild_rss_id)) {
+    if (rowset->del_files_size() > 0 && LakePersistentIndex::needs_rowset_rebuild(*rowset, rebuild_rss_id)) {
         // Above rebuild point
         for (const auto& each : rowset->del_files()) {
             collect_del_files->push_back(each);

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -18,6 +18,7 @@
 
 #include "fs/fs_util.h"
 #include "storage/del_vector.h"
+#include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/update_manager.h"
@@ -117,8 +118,15 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
     rowset->set_id(_tablet_meta->next_rowset_id());
     rowset->set_version(_tablet_meta->version());
     // collect del files
-    for (const auto& del_file : op_write.dels()) {
-        rowset->add_del_files(del_file);
+    DCHECK(op_write.del_file_sizes_size() == 0 || op_write.del_file_sizes_size() == op_write.dels_size());
+    for (int i = 0; i < op_write.dels_size(); i++) {
+        DelfileWithRowsetId del_file_with_rid;
+        del_file_with_rid.set_del_file(op_write.dels(i));
+        if (op_write.del_file_sizes_size() > 0) {
+            del_file_with_rid.set_del_file_size(op_write.del_file_sizes(i));
+        }
+        del_file_with_rid.set_origin_rowset_id(rowset->id());
+        rowset->add_del_files()->CopyFrom(del_file_with_rid);
     }
     // if rowset don't contain segment files, still inc next_rowset_id
     _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + std::max(1, rowset->segments_size()));
@@ -168,6 +176,30 @@ static int delete_from_protobuf_map(T* protobuf_map, const std::vector<std::pair
     return erase_cnt;
 }
 
+// When using cloud native persistent index, the del files which are above rebuild point,
+// need to be transfer to compaction's output rowset.
+// Use this function to collect all del files that need to be transfer.
+void MetaFileBuilder::_collect_del_files_above_rebuild_point(RowsetMetadataPB* rowset,
+                                                             std::vector<DelfileWithRowsetId>* collect_del_files) {
+    if (!_tablet_meta->enable_persistent_index() ||
+        _tablet_meta->persistent_index_type() != PersistentIndexTypePB::CLOUD_NATIVE) {
+        // do nothing, unpersisted del files is collect only for cloud native persistent index.
+        return;
+    }
+    const auto& sstables = _tablet_meta->sstable_meta().sstables();
+    // Rebuild persistent index from `rebuild_rss_rowid_point`
+    const uint64_t rebuild_rss_rowid_point = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid();
+    const uint32_t rebuild_rss_id = rebuild_rss_rowid_point >> 32;
+    if (rowset->del_files_size() > 0 && LakePersistentIndex::rowset_rebuild_checker(*rowset, rebuild_rss_id)) {
+        // Above rebuild point
+        for (const auto& each : rowset->del_files()) {
+            collect_del_files->push_back(each);
+        }
+        // These del files will be collect and transfer to compaction's output rowset.
+        rowset->clear_del_files();
+    }
+}
+
 void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction,
                                          uint32_t max_compact_input_rowset_id) {
     // delete input rowsets
@@ -177,6 +209,8 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
         uint32_t id;
         bool operator()(const uint32_t rowid) const { return rowid == id; }
     };
+    // Only used for cloud native persistent index.
+    std::vector<DelfileWithRowsetId> collect_del_files;
     auto it = _tablet_meta->mutable_rowsets()->begin();
     while (it != _tablet_meta->mutable_rowsets()->end()) {
         auto search_it = std::find_if(op_compaction.input_rowsets().begin(), op_compaction.input_rowsets().end(),
@@ -184,6 +218,8 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
         if (search_it != op_compaction.input_rowsets().end()) {
             // find it
             delete_delvec_sid_range.emplace_back(it->id(), it->id() + it->segments_size() - 1);
+            // Collect del files.
+            _collect_del_files_above_rebuild_point(&(*it), &collect_del_files);
             _tablet_meta->mutable_compaction_inputs()->Add(std::move(*it));
             it = _tablet_meta->mutable_rowsets()->erase(it);
             del_range_ss << "[" << delete_delvec_sid_range.back().first << "," << delete_delvec_sid_range.back().second
@@ -226,6 +262,9 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
         rowset->set_id(_tablet_meta->next_rowset_id());
         rowset->set_max_compact_input_rowset_id(max_compact_input_rowset_id);
         rowset->set_version(_tablet_meta->version());
+        for (const auto& each : collect_del_files) {
+            rowset->add_del_files()->CopyFrom(each);
+        }
         _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + rowset->segments_size());
     }
 

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -69,6 +69,9 @@ private:
     Status _finalize_delvec(int64_t version, int64_t txn_id);
     // fill delvec cache, for better reading latency
     void _fill_delvec_cache();
+    // collect del files which are above cloud native index's rebuild point
+    void _collect_del_files_above_rebuild_point(RowsetMetadataPB* rowset,
+                                                std::vector<DelfileWithRowsetId>* collect_del_files);
 
 private:
     Tablet _tablet;

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -67,8 +67,12 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
                 // shouldn't happen
                 std::string msg = strings::Substitute("PersistentIndexMemtable<$0> insert found duplicate key $1", size,
                                                       hexdump((const char*)key.data(), size));
-                LOG(WARNING) << msg;
-                return Status::AlreadyExist(msg);
+                LOG(ERROR) << msg;
+                if (!config::experimental_lake_ignore_pk_consistency_check) {
+                    return Status::AlreadyExist(msg);
+                } else {
+                    update_index_value(&old_index_value_vers, version, value);
+                }
             } else {
                 // cover delete operation.
                 update_index_value(&old_index_value_vers, version, value);

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -71,7 +71,7 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
 }
 
 Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexSet* not_founds,
-                                      size_t* num_found, int64_t version) {
+                                      size_t* num_found, int64_t version, uint32_t rowset_id) {
     size_t nfound = 0;
     for (size_t i = 0; i < n; ++i) {
         auto key = keys[i].to_string();
@@ -89,6 +89,7 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
             update_index_value(&old_index_value_vers, version, IndexValue(NullIndexValue));
         }
     }
+    _max_rss_rowid = std::max(_max_rss_rowid, ((uint64_t)rowset_id) << 32);
     *num_found = nfound;
     return Status::OK();
 }

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -25,6 +25,7 @@ using IndexValueWithVer = std::pair<int64_t, IndexValue>;
 
 class PersistentIndexMemtable {
 public:
+    PersistentIndexMemtable(uint64_t max_rss_rowid) : _max_rss_rowid(max_rss_rowid) {}
     // |version|: version of index values
     Status upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
                   KeyIndexSet* not_founds, size_t* num_found, int64_t version);
@@ -33,8 +34,9 @@ public:
     Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version);
 
     // |version|: version of index values
+    // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
     Status erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexSet* not_founds, size_t* num_found,
-                 int64_t version);
+                 int64_t version, uint32_t rowset_id);
 
     // |version|: version of index values
     Status replace(const Slice* keys, const IndexValue* values, const std::vector<size_t>& replace_idxes,
@@ -58,7 +60,7 @@ public:
 
     void clear();
 
-    const int64_t max_rss_rowid() const { return _max_rss_rowid; }
+    const uint64_t max_rss_rowid() const { return _max_rss_rowid; }
 
 private:
     static void update_index_value(std::list<IndexValueWithVer>* index_value_info, int64_t version,

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -38,6 +38,15 @@ public:
     Status erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexSet* not_founds, size_t* num_found,
                  int64_t version, uint32_t rowset_id);
 
+    // Erase from index, used when rebuild index.
+    // |n| : key count
+    // |keys| : key array as raw buffer
+    // |filter| : used for filter keys that need to skip. `True` means need skip.
+    // |version|: version of index values
+    // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
+    Status erase_with_filter(size_t n, const Slice* keys, const std::vector<bool>& filter, int64_t version,
+                             uint32_t rowset_id);
+
     // |version|: version of index values
     Status replace(const Slice* keys, const IndexValue* values, const std::vector<size_t>& replace_idxes,
                    int64_t version);
@@ -53,15 +62,6 @@ public:
     // |version|: version of values
     Status get(const Slice* keys, IndexValue* values, const KeyIndexSet& key_indexes, KeyIndexSet* found_key_indexes,
                int64_t version) const;
-
-    // Erase from index, used when rebuild index.
-    // |n| : key count
-    // |keys| : key array as raw buffer
-    // |filter| : used for filter keys that need to skip. `True` means need skip.
-    // |version|: version of index values
-    // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
-    Status erase_with_filter(size_t n, const Slice* keys, const std::vector<bool>& filter, int64_t version,
-                             uint32_t rowset_id);
 
     size_t memory_usage() const;
 

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -25,7 +25,7 @@ using IndexValueWithVer = std::pair<int64_t, IndexValue>;
 
 class PersistentIndexMemtable {
 public:
-    PersistentIndexMemtable(uint64_t max_rss_rowid) : _max_rss_rowid(max_rss_rowid) {}
+    PersistentIndexMemtable(uint64_t max_rss_rowid = 0) : _max_rss_rowid(max_rss_rowid) {}
     // |version|: version of index values
     Status upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
                   KeyIndexSet* not_founds, size_t* num_found, int64_t version);
@@ -53,6 +53,15 @@ public:
     // |version|: version of values
     Status get(const Slice* keys, IndexValue* values, const KeyIndexSet& key_indexes, KeyIndexSet* found_key_indexes,
                int64_t version) const;
+
+    // Erase from index, used when rebuild index.
+    // |n| : key count
+    // |keys| : key array as raw buffer
+    // |filter| : used for filter keys that need to skip. `True` means need skip.
+    // |version|: version of index values
+    // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
+    Status erase_with_filter(size_t n, const Slice* keys, const std::vector<bool>& filter, int64_t version,
+                             uint32_t rowset_id);
 
     size_t memory_usage() const;
 

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -741,18 +741,10 @@ Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStatePa
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_path));
     const std::string& path = params.op_write.dels(del_id);
     ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(params.tablet->del_location(path)));
-    int64_t file_size = 0;
-    if (params.op_write.del_file_sizes_size() > 0) {
-        DCHECK(params.op_write.dels_size() == params.op_write.del_file_sizes_size());
-        file_size = params.op_write.del_file_sizes(del_id);
-    } else {
-        // TxnLog is generated in old version SR.
-        ASSIGN_OR_RETURN(file_size, read_file->get_size());
-    }
-    std::vector<uint8_t> read_buffer(file_size);
-    RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
+    ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
     auto col = pk_column->clone();
-    if (serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()) == nullptr) {
+    if (serde::ColumnArraySerde::deserialize(reinterpret_cast<const uint8_t*>(read_buffer.data()), col.get()) ==
+        nullptr) {
         return Status::InternalError("column deserialization failed");
     }
     col->raw_data();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -232,7 +232,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
         }
         // 2.3 handle auto increment deletes
         if (state.auto_increment_deletes(segment_id) != nullptr) {
-            RETURN_IF_ERROR(index.erase(*state.auto_increment_deletes(segment_id), &new_deletes));
+            RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(segment_id), &new_deletes, rowset_id));
         }
         _index_cache.update_object_size(index_entry, index.memory_usage());
         state.release_segment(segment_id);
@@ -243,7 +243,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     for (uint32_t del_id = 0; del_id < op_write.dels_size(); del_id++) {
         RETURN_IF_ERROR(state.load_delete(del_id, params));
         DCHECK(state.deletes(del_id) != nullptr);
-        RETURN_IF_ERROR(index.erase(*state.deletes(del_id), &new_deletes));
+        RETURN_IF_ERROR(index.erase(metadata, *state.deletes(del_id), &new_deletes, rowset_id));
         _index_cache.update_object_size(index_entry, index.memory_usage());
         state.release_delete(del_id);
     }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -259,7 +259,7 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
             RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, segment)));
         }
         for (const auto& del_file : rowset.del_files()) {
-            RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, del_file.del_file())));
+            RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, del_file.name())));
         }
         *garbage_data_size += rowset.data_size();
     }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -258,6 +258,9 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
         for (const auto& segment : rowset.segments()) {
             RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, segment)));
         }
+        for (const auto& del_file : rowset.del_files()) {
+            RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, del_file)));
+        }
         *garbage_data_size += rowset.data_size();
     }
     for (const auto& file : metadata.orphan_files()) {

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -259,7 +259,7 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
             RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, segment)));
         }
         for (const auto& del_file : rowset.del_files()) {
-            RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, del_file)));
+            RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, del_file.del_file())));
         }
         *garbage_data_size += rowset.data_size();
     }

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -161,6 +161,7 @@ public:
 
 protected:
     void _set_schema(const Schema& pk_schema);
+    // Return the pointer of specific position of slice array.
     const Slice* _build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                                         std::vector<Slice>* key_slices) const;
 

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -161,6 +161,8 @@ public:
 
 protected:
     void _set_schema(const Schema& pk_schema);
+    const Slice* _build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
+                                        std::vector<Slice>* key_slices) const;
 
 private:
     Status _do_load(Tablet* tablet);
@@ -170,9 +172,6 @@ private:
 
     Status _build_persistent_values(uint32_t rssid, const vector<uint32_t>& rowids, uint32_t idx_begin,
                                     uint32_t idx_end, std::vector<uint64_t>* values) const;
-
-    const Slice* _build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
-                                        std::vector<Slice>* key_slices) const;
 
     Status _insert_into_persistent_index(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks);
 

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -337,7 +337,7 @@ TEST_F(LakePersistentIndexTest, test_insert_delete) {
             filter[i] = true;
         }
     }
-    ASSERT_OK(index->insert_erase(N, key_slices.data(), filter, 0, 0));
+    ASSERT_OK(index->replay_erase(N, key_slices.data(), filter, 0, 0));
     // 4. check result
     std::vector<IndexValue> new_get_values(keys.size());
     ASSERT_TRUE(index->get(N, key_slices.data(), new_get_values.data()).ok());

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -28,6 +28,8 @@ public:
         _tablet_metadata = std::make_unique<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
+        _tablet_metadata->set_enable_persistent_index(true);
+        _tablet_metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
         //
         //  | column | type | KEY | NULL |
         //  +--------+------+-----+------+
@@ -36,7 +38,7 @@ public:
         auto schema = _tablet_metadata->mutable_schema();
         schema->set_id(next_id());
         schema->set_num_short_key_columns(1);
-        schema->set_keys_type(DUP_KEYS);
+        schema->set_keys_type(PRIMARY_KEYS);
         schema->set_num_rows_per_row_block(65535);
         auto c0 = schema->add_column();
         {
@@ -127,7 +129,7 @@ TEST_F(LakePersistentIndexTest, test_basic_api) {
         num++;
     }
     vector<IndexValue> erase_old_values(erase_keys.size());
-    ASSERT_TRUE(index->erase(num, erase_key_slices.data(), erase_old_values.data()).ok());
+    ASSERT_TRUE(index->erase(num, erase_key_slices.data(), erase_old_values.data(), 1).ok());
 
     // test upsert
     vector<Key> upsert_keys(N, 0);
@@ -298,6 +300,56 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy) {
     // 5. <1000000, 10000, 10000, 10000, ...(11 items)>
     test_fn(10000, 11, true);
     config::lake_pk_index_sst_max_compaction_versions = old;
+}
+
+TEST_F(LakePersistentIndexTest, test_insert_delete) {
+    auto tablet_id = _tablet_metadata->id();
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+
+    auto l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+    using Key = uint64_t;
+    vector<Key> keys;
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    const int N = 10000;
+    keys.reserve(N);
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
+        values.emplace_back(i * 2);
+    }
+
+    // 1. insert
+    ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
+    for (int i = 0; i < N; i++) {
+        values[i] = i * 3;
+    }
+    // 2. upsert
+    vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
+    ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), old_values.data()));
+
+    // 3. insert delete
+    vector<bool> filter(N, false);
+    for (int i = 0; i < N; i++) {
+        if (i % 2 == 0) {
+            filter[i] = true;
+        }
+    }
+    ASSERT_OK(index->insert_erase(N, key_slices.data(), filter, 0, 0));
+    // 4. check result
+    std::vector<IndexValue> new_get_values(keys.size());
+    ASSERT_TRUE(index->get(N, key_slices.data(), new_get_values.data()).ok());
+    ASSERT_EQ(N, new_get_values.size());
+    for (int i = 0; i < new_get_values.size(); i++) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(IndexValue(i * 3), new_get_values[i]);
+        } else {
+            ASSERT_EQ(IndexValue(NullIndexValue), new_get_values[i]);
+        }
+    }
+    config::l0_max_mem_usage = l0_max_mem_usage;
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -407,4 +407,121 @@ TEST_F(MetaFileTest, test_dcg) {
     }
 }
 
+TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
+    // 1. generate metadata
+    const int64_t tablet_id = 10001;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_enable_persistent_index(true);
+    metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(110);
+    {
+        MetaFileBuilder builder(*tablet, metadata);
+        Status st = builder.finalize(next_id());
+        EXPECT_TRUE(st.ok());
+    }
+
+    // 2. write first rowset (110)
+    {
+        metadata->set_version(11);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rowset_metadata;
+        rowset_metadata.add_segments("aaa.dat");
+        TxnLogPB_OpWrite op_write;
+        std::map<int, FileInfo> replace_segments;
+        std::vector<std::string> orphan_files;
+        op_write.mutable_rowset()->CopyFrom(rowset_metadata);
+        builder.apply_opwrite(op_write, replace_segments, orphan_files);
+        Status st = builder.finalize(next_id());
+        EXPECT_TRUE(st.ok());
+    }
+    // 3. write second rowset with del files (111)
+    {
+        metadata->set_version(12);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rowset_metadata;
+        rowset_metadata.add_segments("bbb.dat");
+        DelfileWithRowsetId delfile;
+        delfile.set_del_file("bbb1.del");
+        delfile.set_origin_rowset_id(metadata->next_rowset_id());
+        rowset_metadata.add_del_files()->CopyFrom(delfile);
+        delfile.set_del_file("bbb2.del");
+        rowset_metadata.add_del_files()->CopyFrom(delfile);
+        TxnLogPB_OpWrite op_write;
+        std::map<int, FileInfo> replace_segments;
+        std::vector<std::string> orphan_files;
+        op_write.mutable_rowset()->CopyFrom(rowset_metadata);
+        builder.apply_opwrite(op_write, replace_segments, orphan_files);
+        PersistentIndexSstablePB sstable;
+        sstable.set_max_rss_rowid((uint64_t)111 << 32);
+        metadata->mutable_sstable_meta()->add_sstables()->CopyFrom(sstable);
+        Status st = builder.finalize(next_id());
+        EXPECT_TRUE(st.ok());
+    }
+    // 4. compact (112)
+    {
+        metadata->set_version(13);
+        MetaFileBuilder builder(*tablet, metadata);
+        TxnLogPB_OpCompaction op_compaction;
+        op_compaction.add_input_rowsets(110);
+        op_compaction.add_input_rowsets(111);
+        RowsetMetadataPB rowset_metadata;
+        rowset_metadata.add_segments("ccc.dat");
+        op_compaction.mutable_output_rowset()->CopyFrom(rowset_metadata);
+        op_compaction.set_compact_version(13);
+        builder.apply_opcompaction(op_compaction, 111);
+        Status st = builder.finalize(next_id());
+        EXPECT_TRUE(st.ok());
+        // check unpersistent del files
+        EXPECT_TRUE(metadata->rowsets_size() == 1);
+        EXPECT_TRUE(metadata->rowsets(0).del_files_size() == 2);
+        EXPECT_TRUE(metadata->rowsets(0).del_files(0).del_file() == "bbb1.del");
+        EXPECT_TRUE(metadata->rowsets(0).del_files(0).origin_rowset_id() == 111);
+        EXPECT_TRUE(metadata->rowsets(0).del_files(1).del_file() == "bbb2.del");
+        EXPECT_TRUE(metadata->rowsets(0).del_files(1).origin_rowset_id() == 111);
+        EXPECT_TRUE(metadata->compaction_inputs_size() == 2);
+        EXPECT_TRUE(metadata->compaction_inputs(0).del_files_size() == 0);
+        EXPECT_TRUE(metadata->compaction_inputs(1).del_files_size() == 0);
+    }
+    // 5. keep write (113)
+    {
+        metadata->set_version(14);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rowset_metadata;
+        rowset_metadata.add_segments("ddd.dat");
+        TxnLogPB_OpWrite op_write;
+        std::map<int, FileInfo> replace_segments;
+        std::vector<std::string> orphan_files;
+        op_write.mutable_rowset()->CopyFrom(rowset_metadata);
+        builder.apply_opwrite(op_write, replace_segments, orphan_files);
+        PersistentIndexSstablePB sstable;
+        sstable.set_max_rss_rowid((uint64_t)113 << 32);
+        metadata->mutable_sstable_meta()->add_sstables()->CopyFrom(sstable);
+        Status st = builder.finalize(next_id());
+        EXPECT_TRUE(st.ok());
+    }
+    // 6. compact (114)
+    {
+        metadata->set_version(15);
+        MetaFileBuilder builder(*tablet, metadata);
+        TxnLogPB_OpCompaction op_compaction;
+        op_compaction.add_input_rowsets(112);
+        op_compaction.add_input_rowsets(113);
+        RowsetMetadataPB rowset_metadata;
+        rowset_metadata.add_segments("eee.dat");
+        op_compaction.mutable_output_rowset()->CopyFrom(rowset_metadata);
+        op_compaction.set_compact_version(15);
+        builder.apply_opcompaction(op_compaction, 113);
+        Status st = builder.finalize(next_id());
+        EXPECT_TRUE(st.ok());
+        // check unpersistent del files
+        EXPECT_TRUE(metadata->rowsets_size() == 1);
+        EXPECT_TRUE(metadata->rowsets(0).del_files_size() == 0);
+        EXPECT_TRUE(metadata->compaction_inputs(0).del_files_size() == 0);
+        EXPECT_TRUE(metadata->compaction_inputs(1).del_files_size() == 0);
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -444,10 +444,10 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         RowsetMetadataPB rowset_metadata;
         rowset_metadata.add_segments("bbb.dat");
         DelfileWithRowsetId delfile;
-        delfile.set_del_file("bbb1.del");
+        delfile.set_name("bbb1.del");
         delfile.set_origin_rowset_id(metadata->next_rowset_id());
         rowset_metadata.add_del_files()->CopyFrom(delfile);
-        delfile.set_del_file("bbb2.del");
+        delfile.set_name("bbb2.del");
         rowset_metadata.add_del_files()->CopyFrom(delfile);
         TxnLogPB_OpWrite op_write;
         std::map<int, FileInfo> replace_segments;
@@ -477,9 +477,9 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         // check unpersistent del files
         EXPECT_TRUE(metadata->rowsets_size() == 1);
         EXPECT_TRUE(metadata->rowsets(0).del_files_size() == 2);
-        EXPECT_TRUE(metadata->rowsets(0).del_files(0).del_file() == "bbb1.del");
+        EXPECT_TRUE(metadata->rowsets(0).del_files(0).name() == "bbb1.del");
         EXPECT_TRUE(metadata->rowsets(0).del_files(0).origin_rowset_id() == 111);
-        EXPECT_TRUE(metadata->rowsets(0).del_files(1).del_file() == "bbb2.del");
+        EXPECT_TRUE(metadata->rowsets(0).del_files(1).name() == "bbb2.del");
         EXPECT_TRUE(metadata->rowsets(0).del_files(1).origin_rowset_id() == 111);
         EXPECT_TRUE(metadata->compaction_inputs_size() == 2);
         EXPECT_TRUE(metadata->compaction_inputs(0).del_files_size() == 0);

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -34,7 +34,7 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
         values.emplace_back(i * 2);
         key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
-    auto memtable = std::make_unique<PersistentIndexMemtable>();
+    auto memtable = std::make_unique<PersistentIndexMemtable>(0);
     ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
     // insert duplicate should return error
     ASSERT_FALSE(memtable->insert(N, key_slices.data(), values.data(), -1).ok());
@@ -130,7 +130,7 @@ TEST(PersistentIndexMemtableTest, test_replace) {
         replace_idxes.emplace_back(i);
     }
 
-    auto memtable = std::make_unique<PersistentIndexMemtable>();
+    auto memtable = std::make_unique<PersistentIndexMemtable>(0);
     ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
 
     //replace

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -34,7 +34,7 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
         values.emplace_back(i * 2);
         key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
-    auto memtable = std::make_unique<PersistentIndexMemtable>(0);
+    auto memtable = std::make_unique<PersistentIndexMemtable>();
     ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
     // insert duplicate should return error
     ASSERT_FALSE(memtable->insert(N, key_slices.data(), values.data(), -1).ok());
@@ -76,7 +76,7 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
     KeyIndexSet erase_not_found;
     size_t erase_num_found = 0;
     ASSERT_TRUE(memtable->erase(num, erase_key_slices.data(), erase_old_values.data(), &erase_not_found,
-                                &erase_num_found, -1)
+                                &erase_num_found, -1, 1)
                         .ok());
     ASSERT_EQ(erase_num_found, (N + 2) / 3);
     // N+2 not found
@@ -130,7 +130,7 @@ TEST(PersistentIndexMemtableTest, test_replace) {
         replace_idxes.emplace_back(i);
     }
 
-    auto memtable = std::make_unique<PersistentIndexMemtable>(0);
+    auto memtable = std::make_unique<PersistentIndexMemtable>();
     ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
 
     //replace

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -822,7 +822,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_batch_publish) {
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, new_version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 2);
-    EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 0);
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), 12);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), 0);
     EXPECT_EQ(0, read_rows(tablet_id, new_version));
@@ -833,7 +833,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_batch_publish) {
     ASSERT_OK(batch_publish(tablet_id, base_version, new_version, txn_ids).status());
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, new_version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 2);
-    EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 0);
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), 12);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), 0);
     EXPECT_EQ(0, read_rows(tablet_id, new_version));
@@ -1066,6 +1066,193 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_with_cloud_native_index_rebuild) {
     // 3. second time
     do_load_func();
     ASSERT_EQ(kChunkSize * 3 * 4, read_rows(tablet_id, version));
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels) {
+    std::vector<std::pair<ChunkPtr, std::vector<uint32_t>>> chunks;
+    // upsert + delete
+    chunks.push_back(gen_data_and_index(kChunkSize, 0, true, true));
+    chunks.push_back(gen_data_and_index(kChunkSize, 0, false, false));
+    chunks.push_back(gen_data_and_index(kChunkSize, 1, true, true));
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    auto old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 2;
+    // publish upsert and delete on different txn
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[2].first), chunks[2].second.data(), chunks[2].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    config::l0_max_mem_usage = old_val;
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[1].first), chunks[1].second.data(), chunks[1].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).segments_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_rows(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).del_files_size(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).segments_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_rows(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).del_files_size(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).segments_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_rows(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).del_files_size(), 1);
+    EXPECT_EQ(kChunkSize, read_rows(tablet_id, version));
+    // clear index, and then rebuild
+    EXPECT_TRUE(_update_mgr->try_remove_primary_index_cache(tablet_id));
+    {
+        // re write chunk0
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
+    EXPECT_EQ(new_tablet_metadata->rowsets(3).segments_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(3).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(3).num_rows(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(3).del_files_size(), 0);
+    EXPECT_EQ(2 * kChunkSize, read_rows(tablet_id, version));
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels2) {
+    std::vector<std::pair<ChunkPtr, std::vector<uint32_t>>> chunks;
+    // upsert + delete
+    chunks.push_back(gen_data_and_index(kChunkSize, 0, true, true));
+    chunks.push_back(gen_data_and_index(kChunkSize, 0, false, false));
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    const int64_t old_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    auto old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 1;
+    // publish upsert and delete on one txn
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->write(*(chunks[1].first), chunks[1].second.data(), chunks[1].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    config::write_buffer_size = old_size;
+    config::l0_max_mem_usage = old_val;
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).segments_size(), 2);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_rows(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).del_files_size(), 1);
+    EXPECT_EQ(0, read_rows(tablet_id, version));
+    // clear index, and then rebuild
+    EXPECT_TRUE(_update_mgr->try_remove_primary_index_cache(tablet_id));
+    {
+        // re write chunk0
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 2);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).segments_size(), 2);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_rows(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).del_files_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).segments_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_rows(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).del_files_size(), 0);
+    EXPECT_EQ(kChunkSize, read_rows(tablet_id, version));
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -24,6 +24,7 @@
 #include "common/logging.h"
 #include "fs/fs_util.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/compaction_task.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
@@ -1165,7 +1166,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels) {
                                                    .set_slot_descriptors(&_slot_pointers)
                                                    .build());
         ASSERT_OK(delta_writer->open());
-        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size() / 2));
         ASSERT_OK(delta_writer->finish_with_txnlog());
         delta_writer->close();
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
@@ -1175,9 +1176,49 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
     EXPECT_EQ(new_tablet_metadata->rowsets(3).segments_size(), 1);
     EXPECT_EQ(new_tablet_metadata->rowsets(3).num_dels(), 0);
-    EXPECT_EQ(new_tablet_metadata->rowsets(3).num_rows(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(3).num_rows(), kChunkSize / 2);
     EXPECT_EQ(new_tablet_metadata->rowsets(3).del_files_size(), 0);
-    EXPECT_EQ(2 * kChunkSize, read_rows(tablet_id, version));
+    EXPECT_EQ(kChunkSize + kChunkSize / 2, read_rows(tablet_id, version));
+    // Compaction
+    {
+        auto old_val = config::lake_pk_compaction_min_input_segments;
+        config::lake_pk_compaction_min_input_segments = 1;
+        int64_t txn_id = next_id();
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+        ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+        EXPECT_EQ(100, task_context->progress.value());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        config::lake_pk_compaction_min_input_segments = old_val;
+    }
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    EXPECT_EQ(kChunkSize + kChunkSize / 2, read_rows(tablet_id, version));
+    // clear index, and then rebuild
+    EXPECT_TRUE(_update_mgr->try_remove_primary_index_cache(tablet_id));
+    {
+        // re write chunk0
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 2);
+    EXPECT_EQ(kChunkSize * 2, read_rows(tablet_id, version));
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels2) {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -68,9 +68,8 @@ message DeltaColumnGroupMetadataPB {
 
 message DelfileWithRowsetId {
     optional string name = 1;
-    optional uint64 size = 2;
     // origin rowset that generate this del file.
-    optional uint32 origin_rowset_id = 3;
+    optional uint32 origin_rowset_id = 2;
 }
 
 message RowsetMetadataPB {
@@ -143,8 +142,6 @@ message TxnLogPB {
         repeated string dels = 3;
         // for partial update, record dest rewrite segment names to avoid gc
         repeated string rewrite_segments = 4;
-        // record the file size of `dels`, used for reduce `get_file_size` call.
-        repeated uint64 del_file_sizes = 5;
     }
 
     message OpCompaction {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -81,6 +81,8 @@ message RowsetMetadataPB {
     optional uint32 max_compact_input_rowset_id = 9;
     // The generated version of rowset.
     optional int64 version = 10;
+    // del_files are generated when pk table handle delete operation.
+    repeated string del_files = 11;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -66,6 +66,13 @@ message DeltaColumnGroupMetadataPB {
     map<uint32, DeltaColumnGroupVerPB> dcgs = 1;
 }
 
+message DelfileWithRowsetId {
+    optional string del_file = 1;
+    optional uint64 del_file_size = 2;
+    // origin rowset that generate this del file.
+    optional uint32 origin_rowset_id = 3;
+}
+
 message RowsetMetadataPB {
     optional uint32 id = 1;
     optional bool overlapped = 2;
@@ -82,7 +89,7 @@ message RowsetMetadataPB {
     // The generated version of rowset.
     optional int64 version = 10;
     // del_files are generated when pk table handle delete operation.
-    repeated string del_files = 11;
+    repeated DelfileWithRowsetId del_files = 11;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,
@@ -136,6 +143,7 @@ message TxnLogPB {
         repeated string dels = 3;
         // for partial update, record dest rewrite segment names to avoid gc
         repeated string rewrite_segments = 4;
+        repeated uint64 del_file_sizes = 5;
     }
 
     message OpCompaction {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -67,8 +67,8 @@ message DeltaColumnGroupMetadataPB {
 }
 
 message DelfileWithRowsetId {
-    optional string del_file = 1;
-    optional uint64 del_file_size = 2;
+    optional string name = 1;
+    optional uint64 size = 2;
     // origin rowset that generate this del file.
     optional uint32 origin_rowset_id = 3;
 }
@@ -143,6 +143,7 @@ message TxnLogPB {
         repeated string dels = 3;
         // for partial update, record dest rewrite segment names to avoid gc
         repeated string rewrite_segments = 4;
+        // record the file size of `dels`, used for reduce `get_file_size` call.
         repeated uint64 del_file_sizes = 5;
     }
 


### PR DESCRIPTION
## Why I'm doing:
When PK table handle delete operation, it will generate `.del` files in Rowset and also delete from PK index. And when rebuild cloud native PK index, we miss the part about load `.del` files and it will cause delete lost in PK index, which is a BUG.

## What I'm doing:
1. Add del files to Rowset, they will be used when index rebuild.
2. Support load and rebuild del files in cloud native PK index, so we can fix  delete lost bug.
3. When compaction merge Rowsets with del files, and the pk associated with these del files is not yet dump into sst files, we need to transfer these del files into output Rowset.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
