### PR TITLE
[BugFix] Fix testCreateTMasterOpRequest UT

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
@@ -166,6 +166,7 @@ public class LeaderOpExecutorTest {
         connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
         connectContext.setCurrentRoleIds(UserIdentity.ROOT);
         connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setThreadLocalInfo();
 
         LeaderOpExecutor executor = new LeaderOpExecutor(new OriginStatement(""),
                 connectContext, RedirectStatus.FORWARD_NO_SYNC);


### PR DESCRIPTION
## Why I'm doing:

Sometimes, UT will report the following error:
```
Error:  Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 28.485 s <<< FAILURE! - in com.starrocks.qe.LeaderOpExecutorTest
Error:  testCreateTMasterOpRequest  Time elapsed: 1.812 s  <<< ERROR!
java.lang.NullPointerException
	at com.starrocks.sql.ast.UserIdentity.toThrift(UserIdentity.java:208)
	at com.starrocks.qe.LeaderOpExecutor.createTMasterOpRequest(LeaderOpExecutor.java:230)
	at com.starrocks.qe.LeaderOpExecutorTest.testCreateTMasterOpRequest(LeaderOpExecutorTest.java:172)
```

## What I'm doing:

set context to thread local in UT

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
