### PR TITLE
[BugFix] Optimize mv refresh locks by intensive locks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockParams.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common.util.concurrent.lock;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
+
+import java.util.Map;
+import java.util.Set;
+
+public class LockParams {
+    // Map database id -> database
+    private final Map<Long, Database> dbs = Maps.newTreeMap(Long::compareTo);
+    /**
+     * Map database id -> table id set, Use db id as sort key to avoid deadlock,
+     * lockTablesWithIntensiveDbLock can internally guarantee the order of locking,
+     * so the table ids do not need to be ordered here.
+     */
+    private final Map<Long, Set<Long>> tables = Maps.newTreeMap(Long::compareTo);
+
+    public LockParams() {
+    }
+
+    public void add(Database db, long tableId) {
+        dbs.put(db.getId(), db);
+        tables.computeIfAbsent(db.getId(), k -> Sets.newHashSet()).add(tableId);
+    }
+
+    public Map<Long, Database> getDbs() {
+        return dbs;
+    }
+
+    public Map<Long, Set<Long>> getTables() {
+        return tables;
+    }
+
+    @Override
+    public String toString() {
+        return "LockParams{" +
+                "tables=" + tables +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
@@ -17,7 +17,9 @@ package com.starrocks.common.util.concurrent.lock;
 import com.google.api.client.util.Lists;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
@@ -31,6 +33,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class Locker {
@@ -125,23 +129,16 @@ public class Locker {
     public boolean lockDatabaseAndCheckExist(Database database, LockType lockType) {
         if (Config.lock_manager_enabled) {
             lockDatabase(database, lockType);
-            if (database.getExist()) {
-                return true;
-            } else {
-                unLockDatabase(database, lockType);
-                return false;
-            }
         } else {
             if (lockType.isWriteLock()) {
                 LockUtils.dbWriteLock(database.getRwLock(), database.getId(),
                         database.getFullName(), database.getSlowLockLogStats());
-                return checkExistenceInLock(database, false);
             } else {
                 LockUtils.dbReadLock(database.getRwLock(), database.getId(),
                         database.getFullName(), database.getSlowLockLogStats());
-                return checkExistenceInLock(database, true);
             }
         }
+        return checkExistenceInLock(database, lockType);
     }
 
     /**
@@ -267,15 +264,11 @@ public class Locker {
         }
     }
 
-    private boolean checkExistenceInLock(Database database, boolean isInReadLock) {
+    private boolean checkExistenceInLock(Database database, LockType lockType) {
         if (database.isExist()) {
             return true;
         } else {
-            if (isInReadLock) {
-                unLockDatabase(database, LockType.READ);
-            } else {
-                unLockDatabase(database, LockType.WRITE);
-            }
+            unLockDatabase(database, lockType);
             return false;
         }
     }
@@ -370,6 +363,144 @@ public class Locker {
         } else {
             //Fallback to db lock
             unLockDatabase(database, lockType);
+        }
+    }
+
+    /**
+     * Lock database and table with intensive db lock.
+     * @param database database for intensive db lock
+     * @param table table to be locked
+     * @param lockType lock type
+     * @return true if database exits, false otherwise
+     */
+    public boolean lockDatabaseAndCheckExist(Database database, Table table, LockType lockType) {
+        return lockDatabaseAndCheckExist(database, table.getId(), lockType);
+    }
+
+    /**
+     * Lock database and table with intensive db lock.
+     */
+    public boolean lockDatabaseAndCheckExist(Database database, long tableId, LockType lockType) {
+        if (Config.lock_manager_enabled) {
+            lockTableWithIntensiveDbLock(database, tableId, lockType);
+            return checkExistenceInLock(database, tableId, lockType);
+        } else {
+            if (lockType.isWriteLock()) {
+                LockUtils.dbWriteLock(database.getRwLock(), database.getId(),
+                        database.getFullName(), database.getSlowLockLogStats());
+            } else {
+                LockUtils.dbReadLock(database.getRwLock(), database.getId(),
+                        database.getFullName(), database.getSlowLockLogStats());
+            }
+            return checkExistenceInLock(database, lockType);
+        }
+    }
+
+    private boolean checkExistenceInLock(Database database, long tableId, LockType lockType) {
+        if (database.isExist()) {
+            return true;
+        } else {
+            unLockTablesWithIntensiveDbLock(database, ImmutableList.of(tableId), lockType);
+            return false;
+        }
+    }
+
+    public void unLockTableWithIntensiveDbLock(Database database, Table table, LockType lockType) {
+        unLockTablesWithIntensiveDbLock(database, ImmutableList.of(table.getId()), lockType);
+    }
+
+    /**
+     * Lock table with intensive db lock.
+     * @param database db for intensive db lock
+     * @param tableId table to be locked
+     * @param lockType lock type
+     */
+    public void lockTableWithIntensiveDbLock(Database database, Long tableId, LockType lockType) {
+        Preconditions.checkState(lockType.equals(LockType.READ) || lockType.equals(LockType.WRITE));
+        if (Config.lock_manager_enabled && Config.lock_manager_enable_using_fine_granularity_lock) {
+            try {
+                if (lockType == LockType.WRITE) {
+                    this.lock(database.getId(), LockType.INTENTION_EXCLUSIVE, 0);
+                } else {
+                    this.lock(database.getId(), LockType.INTENTION_SHARED, 0);
+                }
+                this.lock(tableId, lockType, 0);
+            } catch (IllegalLockStateException e) {
+                ErrorReportException.report(ErrorCode.ERR_LOCK_ERROR, e.getMessage());
+            }
+        } else {
+            //Fallback to db lock
+            lockDatabase(database, lockType);
+        }
+    }
+
+    /**
+     * Try lock database and table with intensive db lock.
+     * @return try if try lock success, false otherwise.
+     */
+    public boolean tryLockTableWithIntensiveDbLock(Database db, Table table, LockType lockType, long timeout, TimeUnit unit) {
+        return tryLockTableWithIntensiveDbLock(db, table.getId(), lockType, timeout, unit);
+    }
+
+    /**
+     * Try lock database and table id with intensive db lock.
+     * @return try if try lock success, false otherwise.
+     */
+    public boolean tryLockTableWithIntensiveDbLock(Database db, Long tableId, LockType lockType, long timeout, TimeUnit unit) {
+        boolean isLockSuccess = false;
+        try {
+            if (!tryLockTablesWithIntensiveDbLock(db, ImmutableList.of(tableId), lockType, timeout, unit)) {
+                return false;
+            }
+            isLockSuccess = true;
+        } finally {
+            if (!isLockSuccess) {
+                unLockTablesWithIntensiveDbLock(db, ImmutableList.of(tableId), lockType);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Try lock database and tables with intensive db lock.
+     * @return try if try lock success, false otherwise.
+     */
+    public boolean tryLockTableWithIntensiveDbLock(LockParams lockParams, LockType lockType, long timeout, TimeUnit unit) {
+        boolean isLockSuccess = false;
+        List<Database> lockedDbs = Lists.newArrayList();
+        Map<Long, Database> dbs = lockParams.getDbs();
+        Map<Long, Set<Long>> tables = lockParams.getTables();
+        try {
+            for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
+                Database database = dbs.get(entry.getKey());
+                if (!tryLockTablesWithIntensiveDbLock(database, new ArrayList<>(entry.getValue()),
+                        lockType, timeout, unit)) {
+                    return false;
+                }
+                lockedDbs.add(database);
+            }
+            isLockSuccess = true;
+        } finally {
+            if (!isLockSuccess) {
+                for (Database database : lockedDbs) {
+                    unLockTablesWithIntensiveDbLock(database, new ArrayList<>(tables.get(database.getId())), lockType);
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Unlock db and tables with intensive db lock.
+     */
+    public void unLockTableWithIntensiveDbLock(LockParams params, LockType lockType) {
+        Map<Long, Database> dbs = params.getDbs();
+        Map<Long, Set<Long>> tables = params.getTables();
+        Locker locker = new Locker();
+        for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
+            Database database = dbs.get(entry.getKey());
+            List<Long> tableIds = new ArrayList<>(entry.getValue());
+            locker.unLockTablesWithIntensiveDbLock(database, tableIds, lockType);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
@@ -13,6 +13,9 @@
 // limitations under the License.
 package com.starrocks.common.util.concurrent.lock;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -20,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 public class MultiUserLock extends Lock {
+    private static final Logger LOG = LogManager.getLogger(MultiUserLock.class);
     /*
      * The owner of the current Lock. For efficiency reasons, the first owner is stored separately.
      * If Locker successfully obtains the lock, it will be added to the owner.
@@ -82,6 +86,11 @@ public class MultiUserLock extends Lock {
              * whether there are other Lockers with the same LockType.
              */
             if (lockHolderRequest.getLocker().equals(lockOwner.getLocker())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Locker {} already holds lock on {} with type {}/{}, detail:{}", lockOwner.getLocker(),
+                            lockOwner.getLocker(), lockOwner.getLockType(), lockHolderRequest.getLockType(), this);
+                }
+
                 if (lockHolderRequest.getLockType().equals(lockOwner.getLockType())) {
                     lockOwner.increaseRefCount();
                     return LockGrantType.EXISTING;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -53,14 +53,14 @@ import java.util.stream.Collectors;
  */
 public class PlannerMetaLocker {
     // Map database id -> database
-    Map<Long, Database> dbs = Maps.newTreeMap(Long::compareTo);
+    private Map<Long, Database> dbs = Maps.newTreeMap(Long::compareTo);
 
     /**
      * Map database id -> table id set, Use db id as sort key to avoid deadlock,
      * lockTablesWithIntensiveDbLock can internally guarantee the order of locking,
      * so the table ids do not need to be ordered here.
      */
-    Map<Long, Set<Long>> tables = Maps.newTreeMap(Long::compareTo);
+    private Map<Long, Set<Long>> tables = Maps.newTreeMap(Long::compareTo);
 
     public PlannerMetaLocker(ConnectContext session, StatementBase statementBase) {
         new TableCollector(session, dbs, tables).visit(statementBase);

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.google.api.client.util.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.schema.MSchema;
+import com.starrocks.schema.MTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * This is a test in which:
+ * x dbs which contains one table
+ * y mvs which contains x/2 tables and uses `union all` to concatenate them
+ *
+ * refresh mvs with concurrency to test lock and preformance
+ */
+public class MvRefreshConcurrencyTest extends MvRewriteTestBase {
+
+    @Rule
+    public TestRule benchRun = new BenchmarkRule();
+
+    private static String buildDbName(int idx) {
+        return "mock_db_" + idx;
+    }
+
+    private static String buildTableName(int idx) {
+        return "mock_t_" + idx;
+    }
+
+    private static String buildMVName(int idx) {
+        return "mock_mv_" + idx;
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+
+        // Env
+        Config.mv_plan_cache_max_size = 1024;
+        CachingMvPlanContextBuilder.getInstance().rebuildCache();
+        starRocksAssert.getCtx().setDumpInfo(null);
+    }
+
+    @Before
+    public void before() {
+    }
+
+    private static String buildMV(Random rnd, List<MTable> tables, int mvIdx) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE MATERIALIZED VIEW test." + buildMVName(mvIdx) + " REFRESH ASYNC" +
+                " AS ");
+
+        List<String> sqls = Lists.newArrayList();
+        int tableNum = tables.size();
+        for (int i = 0; i < tableNum / 2; i++) {
+            int idx = rnd.nextInt(tableNum);
+            MTable table = tables.get(idx);
+            String sql = String.format("select k1, v1, v2 from %s.%s  ", table.getDbName(), buildTableName(idx));
+            sqls.add(sql);
+        }
+        sb.append(String.join(" union all ", sqls));
+        return sb.toString();
+    }
+
+    private int refreshFinishedMVCount(List<MaterializedView> mvs) {
+        int count = 0;
+        for (MaterializedView mv : mvs) {
+            if (starRocksAssert.waitRefreshFinished(mv.getId())) {
+                count += 1;
+            }
+        }
+        return count;
+    }
+
+    private void testRefreshWithConcurrency(int tableNum, int mvNum) {
+        Random rnd = new Random();
+
+        // Base tables
+        MTable mTable = MSchema.getTable("t1");
+        List<MTable> tables = Lists.newArrayList();
+        for (int i = 0; i < tableNum; i++) {
+            MTable copied = mTable.copyWithName(buildTableName(i));
+            copied.withDbName(buildDbName(i));
+            tables.add(copied);
+        }
+
+        starRocksAssert.withMTables(cluster, tables, () -> {
+            // create mvs
+            List<MaterializedView> mvs = Lists.newArrayList();
+            try {
+                for (int i = 0; i < mvNum; i++) {
+                    System.out.println("create mv " + i);
+                    String sql = buildMV(rnd, tables, i);
+                    System.out.println(sql);
+                    starRocksAssert.withMaterializedView(sql);
+
+                    Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                    String mvName = buildMVName(i);
+                    Table table = db.getTable(mvName);
+                    Assert.assertTrue(table != null);
+                    mvs.add((MaterializedView) table);
+                    starRocksAssert.useDatabase("test");
+                    starRocksAssert.refreshMV(connectContext, mvName);
+                }
+                LOG.info("prepared {} materialized views", mvNum);
+
+                // refresh mv with concurrency
+                int finishedCount = 0;
+                while (finishedCount != mvNum) {
+                    finishedCount = refreshFinishedMVCount(mvs);
+                }
+                Assert.assertTrue(finishedCount == mvNum);
+            } finally {
+                starRocksAssert.useDatabase("test");
+                for (MaterializedView mv : mvs) {
+                    starRocksAssert.dropMaterializedView(mv.getName());
+                }
+            }
+        });
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    public void testWithTables2() {
+        testRefreshWithConcurrency(4, 2);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    public void testWithTables10() {
+        testRefreshWithConcurrency(10, 4);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    public void testWithTables20() {
+        testRefreshWithConcurrency(20, 10);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    public void testWithTables100_c50() {
+        Config.task_runs_concurrency = 50;
+        testRefreshWithConcurrency(100, 100);
+        Config.task_runs_concurrency = 4;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
@@ -149,25 +149,33 @@ public class MvRefreshConcurrencyTest extends MvRewriteTestBase {
     }
 
     @Test
-    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
-    public void testWithTables2() {
+    @BenchmarkOptions(warmupRounds = 0, benchmarkRounds = 1)
+    public void testWithTables2_c4() {
         testRefreshWithConcurrency(4, 2);
     }
 
     @Test
-    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
-    public void testWithTables10() {
+    @BenchmarkOptions(warmupRounds = 0, benchmarkRounds = 1)
+    public void testWithTables10_c4() {
         testRefreshWithConcurrency(10, 4);
     }
 
     @Test
-    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
-    public void testWithTables20() {
+    @BenchmarkOptions(warmupRounds = 0, benchmarkRounds = 1)
+    public void testWithTables20_c4() {
         testRefreshWithConcurrency(20, 10);
     }
 
     @Test
-    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    @BenchmarkOptions(warmupRounds = 0, benchmarkRounds = 1)
+    public void testWithTables100_c16() {
+        Config.task_runs_concurrency = 16;
+        testRefreshWithConcurrency(100, 100);
+        Config.task_runs_concurrency = 4;
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 0, benchmarkRounds = 1)
     public void testWithTables100_c50() {
         Config.task_runs_concurrency = 50;
         testRefreshWithConcurrency(100, 100);

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockInterface.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockInterface.java
@@ -13,12 +13,14 @@
 // limitations under the License.
 package com.starrocks.common.lock;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock;
 import com.starrocks.common.util.concurrent.lock.IllegalLockStateException;
 import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.common.util.concurrent.lock.LockParams;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.server.GlobalStateMgr;
@@ -49,12 +51,22 @@ public class TestLockInterface {
     }
 
     @Test
-    public void testLockAndCheckExist() {
+    public void testLockAndCheckExist1() {
         long rid = 1L;
         Database database = new Database(rid, "db");
         database.setExist(false);
         Locker locker = new Locker();
         Assert.assertFalse(locker.lockDatabaseAndCheckExist(database, LockType.READ));
+    }
+
+    @Test
+    public void testLockAndCheckExist2() {
+        long rid = 1L;
+        long rid2 = 2L;
+        Database database = new Database(rid, "db");
+        database.setExist(false);
+        Locker locker = new Locker();
+        Assert.assertFalse(locker.lockDatabaseAndCheckExist(database, rid2, LockType.READ));
     }
 
     @Test
@@ -223,5 +235,59 @@ public class TestLockInterface {
         }
 
         Config.lock_manager_enabled = true;
+    }
+
+    @Test
+    public void testTryLockTablesWithIntensiveDbLock2() throws IllegalLockStateException {
+        long rid = 1L;
+        Database database = new Database(rid, "db");
+        long rid2 = 2L;
+        Locker locker = new Locker();
+        Assert.assertTrue(locker.tryLockTableWithIntensiveDbLock(database, rid2, LockType.READ, 10, TimeUnit.MILLISECONDS));
+        LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
+        Assert.assertTrue(lockManager.isOwner(rid, locker, LockType.INTENTION_SHARED));
+        Assert.assertTrue(lockManager.isOwner(rid2, locker, LockType.READ));
+
+        locker.unLockTablesWithIntensiveDbLock(database, ImmutableList.of(rid2), LockType.READ);
+        Assert.assertFalse(lockManager.isOwner(rid, locker, LockType.INTENTION_SHARED));
+        Assert.assertFalse(lockManager.isOwner(rid2, locker, LockType.READ));
+
+        locker.lock(rid2, LockType.READ);
+        Assert.assertTrue(locker.tryLockTableWithIntensiveDbLock(database, rid2, LockType.WRITE, 10, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(lockManager.isOwner(rid2, locker, LockType.READ));
+        Assert.assertTrue(lockManager.isOwner(rid, locker, LockType.INTENTION_EXCLUSIVE));
+        Assert.assertTrue(lockManager.isOwner(rid2, locker, LockType.WRITE));
+    }
+
+    @Test
+    public void testTryLockTablesWithIntensiveDbLock3() throws IllegalLockStateException {
+        long rid = 1L;
+        long rid2 = 2L;
+        long rid3 = 3L;
+        Database database = new Database(rid, "db");
+
+        LockParams params = new LockParams();
+        params.add(database, rid2);
+        params.add(database, rid3);
+
+        Locker locker = new Locker();
+        Assert.assertTrue(locker.tryLockTableWithIntensiveDbLock(params, LockType.READ, 10, TimeUnit.MILLISECONDS));
+
+        LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
+        Assert.assertTrue(lockManager.isOwner(rid, locker, LockType.INTENTION_SHARED));
+        Assert.assertTrue(lockManager.isOwner(rid2, locker, LockType.READ));
+        Assert.assertTrue(lockManager.isOwner(rid3, locker, LockType.READ));
+
+        locker.unLockTableWithIntensiveDbLock(params, LockType.READ);
+        Assert.assertFalse(lockManager.isOwner(rid, locker, LockType.INTENTION_SHARED));
+        Assert.assertFalse(lockManager.isOwner(rid2, locker, LockType.READ));
+        Assert.assertFalse(lockManager.isOwner(rid3, locker, LockType.READ));
+
+        locker.lock(rid2, LockType.READ);
+        Assert.assertTrue(locker.tryLockTableWithIntensiveDbLock(params, LockType.WRITE, 10, TimeUnit.MILLISECONDS));
+        Assert.assertTrue(lockManager.isOwner(rid2, locker, LockType.READ));
+        Assert.assertTrue(lockManager.isOwner(rid, locker, LockType.INTENTION_EXCLUSIVE));
+        Assert.assertTrue(lockManager.isOwner(rid2, locker, LockType.WRITE));
+        Assert.assertTrue(lockManager.isOwner(rid3, locker, LockType.WRITE));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockInterface.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockInterface.java
@@ -98,7 +98,7 @@ public class TestLockInterface {
     }
 
     @Test
-    public void testTryLockTablesWithIntensiveDbLock() throws IllegalLockStateException {
+    public void testTryLockTablesWithIntensiveDbLock1() throws IllegalLockStateException {
         long rid = 1L;
         Database database = new Database(rid, "db");
 

--- a/fe/fe-core/src/test/java/com/starrocks/schema/MTable.java
+++ b/fe/fe-core/src/test/java/com/starrocks/schema/MTable.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
  * MTable means Mocked-Table and is used to mock SR's table so can be used for FE's unit tests.
  */
 public class MTable {
+    private String dbName;
     private String tableName;
     private List<String> columns;
     private String distCol;
@@ -108,6 +109,10 @@ public class MTable {
         this.replicateNum = replicateNum;
     }
 
+    public String getDbName() {
+        return this.dbName;
+    }
+
     public MTable withValues(String value) {
         String[] arr = value.split(",");
         return withValues(List.of(arr));
@@ -124,6 +129,11 @@ public class MTable {
 
     public MTable withProperties(List<String> values) {
         this.properties = values;
+        return this;
+    }
+
+    public MTable withDbName(String dbName) {
+        this.dbName = dbName;
         return this;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -1274,7 +1274,7 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createMVSQL);
 
         String query = "select k1, sum(case when(k2=0) then k3 else 0 end) from t1 group by k1";
-        String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "MV");
+        String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
         // TODO: support this for amv
         PlanTestBase.assertNotContains(plan, "test_mv1)\n");
         starRocksAssert.dropTable("t1");
@@ -1287,7 +1287,7 @@ public class MVRewriteTest {
                 "bitmap_union(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id, time;";
         starRocksAssert.withMaterializedView(createUserTagMVSql);
         String query = "select bitmap_union_count(to_bitmap(tag_id)) from " + USER_TAG_TABLE_NAME + " group by user_id;";
-        String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "MV");
+        String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
         PlanTestBase.assertContains(plan, USER_TAG_MV_NAME);
         PlanTestBase.assertContains(plan, "  |  <slot 2> : 2: user_id\n" +
                 "  |  <slot 6> : 5: mv_bitmap_union_tag_id");
@@ -1711,7 +1711,7 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createMVSQL);
 
         String query = "select k1, sum(k3) from t1 where k1 = '2024-06-12' group by k1";
-        String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "Optimizer");
+        String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
         PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 1: k1 = '2024-06-12'\n" +
@@ -1741,7 +1741,7 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createMVSQL);
 
         String query = "select k1, sum(k3) from t1 where k1 = '2024-06-12' group by k1";
-        String plan = UtFrameUtils.getFragmentPlan(connectContext, query, "Optimizer");
+        String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
         System.out.println(plan);
         PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
                 "     PREAGGREGATION: ON\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -873,6 +873,11 @@ public class StarRocksAssert {
         return this;
     }
 
+    /**
+     * Wait the input mv refresh task finished.
+     * @param mvId: mv id
+     * @return true if the mv refresh task finished, otherwise false.
+     */
     public boolean waitRefreshFinished(long mvId) {
         TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
         Task task = tm.getTask(TaskBuilder.getMvTaskName(mvId));
@@ -883,13 +888,18 @@ public class StarRocksAssert {
         int maxTimes = 120;
         int count = 0;
         while (taskRun != null && count < maxTimes) {
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(300L);
             taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
             count += 1;
         }
         return taskRun == null;
     }
 
+    /**
+     * Refresh materialized view asynchronously.
+     * @param ctx connnect context
+     * @param mvName mv's name
+     */
     public StarRocksAssert refreshMV(ConnectContext ctx, String mvName) throws Exception {
         String sql = "REFRESH MATERIALIZED VIEW " + mvName;
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
@@ -899,7 +909,6 @@ public class StarRocksAssert {
         Table table = db.getTable(tableName.getTbl());
         Assert.assertNotNull(table);
         Assert.assertTrue(table instanceof MaterializedView);
-        MaterializedView mv = (MaterializedView) table;
         ctx.executeSql(sql);
         return this;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -51,12 +51,14 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.routineload.RoutineLoadMgr;
@@ -178,6 +180,18 @@ public class StarRocksAssert {
         CreateDbStmt createDbStmt =
                 (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database `" + dbName + "`;", ctx);
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+        return this;
+    }
+
+    public StarRocksAssert createDatabaseIfNotExists(String dbName) throws Exception {
+        try {
+            CreateDbStmt createDbStmt =
+                    (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database if not exists `"
+                            + dbName + "`;", ctx);
+            GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+        } catch (AlreadyExistsException e) {
+            // ignore
+        }
         return this;
     }
 
@@ -369,7 +383,7 @@ public class StarRocksAssert {
     public StarRocksAssert withTable(PseudoCluster cluster,
                                      MTable mTable,
                                      ExceptionRunnable action) {
-        return withTableValues(cluster, List.of(mTable), action);
+        return withMTables(cluster, List.of(mTable), action);
     }
 
     public StarRocksAssert withTable(MTable mTable,
@@ -379,23 +393,29 @@ public class StarRocksAssert {
 
     public StarRocksAssert withTables(List<MTable> mTables,
                                       ExceptionRunnable action) {
-        return withTableValues(null, mTables, action);
+        return withMTables(null, mTables, action);
     }
-    private StarRocksAssert withTableValues(PseudoCluster cluster,
-                                            List<MTable> mTables,
-                                            ExceptionRunnable action) {
-        List<String> names = Lists.newArrayList();
+
+    public StarRocksAssert withMTables(PseudoCluster cluster,
+                                       List<MTable> mTables,
+                                       ExceptionRunnable action) {
+        List<Pair<String, String>> names = Lists.newArrayList();
         try {
             for (MTable mTable : mTables) {
+                String dbName = mTable.getDbName();
+                if (!Strings.isNullOrEmpty(dbName)) {
+                    this.createDatabaseIfNotExists(dbName);
+                    this.useDatabase(dbName);
+                }
                 String sql = mTable.getCreateTableSql();
                 System.out.println(sql);
                 CreateTableStmt createTableStmt =
                         (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
                 utCreateTableWithRetry(createTableStmt, ctx);
-                names.add(mTable.getTableName());
+                names.add(Pair.create(dbName, mTable.getTableName()));
 
                 if (cluster != null) {
-                    String dbName = createTableStmt.getDbName();
+                    dbName = createTableStmt.getDbName();
                     String insertSQL = mTable.getGenerateDataSQL();
                     if (!Strings.isNullOrEmpty(insertSQL)) {
                         cluster.runSql(dbName, insertSQL);
@@ -409,9 +429,12 @@ public class StarRocksAssert {
             e.printStackTrace();
             Assert.fail("create table failed");
         } finally {
-            for (String t : names) {
+            for (Pair<String, String> t : names) {
                 try {
-                    dropTable(t);
+                    if (!Strings.isNullOrEmpty(t.first)) {
+                        useDatabase(t.first);
+                    }
+                    dropTable(t.second);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -850,6 +873,37 @@ public class StarRocksAssert {
         return this;
     }
 
+    public boolean waitRefreshFinished(long mvId) {
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        Task task = tm.getTask(TaskBuilder.getMvTaskName(mvId));
+        Assert.assertTrue(task != null);
+        TaskRunManager taskRunManager = tm.getTaskRunManager();
+        TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
+        TaskRun taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
+        int maxTimes = 120;
+        int count = 0;
+        while (taskRun != null && count < maxTimes) {
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
+            taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
+            count += 1;
+        }
+        return taskRun == null;
+    }
+
+    public StarRocksAssert refreshMV(ConnectContext ctx, String mvName) throws Exception {
+        String sql = "REFRESH MATERIALIZED VIEW " + mvName;
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        RefreshMaterializedViewStatement refreshMaterializedViewStatement = (RefreshMaterializedViewStatement) stmt;
+        TableName tableName = refreshMaterializedViewStatement.getMvName();
+        Database db = GlobalStateMgr.getCurrentState().getDb(tableName.getDb());
+        Table table = db.getTable(tableName.getTbl());
+        Assert.assertNotNull(table);
+        Assert.assertTrue(table instanceof MaterializedView);
+        MaterializedView mv = (MaterializedView) table;
+        ctx.executeSql(sql);
+        return this;
+    }
+
     public StarRocksAssert refreshMV(String sql) throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         RefreshMaterializedViewStatement refreshMaterializedViewStatement = (RefreshMaterializedViewStatement) stmt;
@@ -862,14 +916,7 @@ public class StarRocksAssert {
         getCtx().executeSql(sql);
         TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
 
-        Task task = tm.getTask(TaskBuilder.getMvTaskName(mv.getId()));
-        TaskRunManager taskRunManager = tm.getTaskRunManager();
-        TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
-        TaskRun taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
-        while (taskRun != null) {
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
-            taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
-        }
+        waitRefreshFinished(mv.getId());
         return this;
     }
 


### PR DESCRIPTION
## Why I'm doing:

Since SR v3.3 has supported db intensive lock and table lock, mv refresh should use them.

## What I'm doing:

- Change mv refresh db locks to db intensive lock + table lock .

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
