### PR TITLE
[BugFix] Fix mv refresh timer profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
@@ -242,5 +242,4 @@ class TracerImpl extends Tracer {
         buildVars(parent);
         buildReasons(parent);
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -79,13 +79,29 @@ public class Tracers {
         return THREAD_LOCAL.get();
     }
 
+    /**
+     * Init tracer with context and mode.
+     * @param context connect context
+     * @param mode tracer mode
+     * @param moduleStr tracer module
+     */
     public static void init(ConnectContext context, Mode mode, String moduleStr) {
-        Tracers tracers = THREAD_LOCAL.get();
         boolean enableProfile =
                 context.getSessionVariable().isEnableProfile() || context.getSessionVariable().isEnableBigQueryProfile();
         boolean checkMV = context.getSessionVariable().isEnableMaterializedViewRewriteOrError();
-
         Module module = getTraceModule(moduleStr);
+        init(mode, module, enableProfile, checkMV);
+    }
+
+    /**
+     * Init tracer with params.
+     * @param mode tracer mode
+     * @param module tracer module
+     * @param enableProfile enable profile or not
+     * @param checkMV check mv or not
+     */
+    public static void init(Mode mode, Module module, boolean enableProfile, boolean checkMV) {
+        Tracers tracers = THREAD_LOCAL.get();
         if (Module.NONE == module || null == module) {
             tracers.moduleMask = 0;
         }
@@ -184,6 +200,10 @@ public class Tracers {
     public static void reasoning(Module module, String reason, Object... args) {
         Tracers tracers = THREAD_LOCAL.get();
         tracers.tracer(module, Mode.REASON).reason(reason, args);
+    }
+
+    public static void record(String name, String value) {
+        record(Module.BASE, name, value);
     }
 
     public static void record(Module module, String name, String value) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -46,14 +46,17 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.DeepCopy;
+import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.RangeUtils;
+import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
@@ -164,6 +167,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private long oldTransactionVisibleWaitTimeout;
 
+    @VisibleForTesting
+    private RuntimeProfile runtimeProfile;
+
     // represents the refresh job final job status
     public enum RefreshJobStatus {
         SUCCESS,
@@ -174,6 +180,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     // for testing
     private TaskRun nextTaskRun = null;
 
+    public PartitionBasedMvRefreshProcessor() {
+    }
+
     @VisibleForTesting
     public MvTaskRunContext getMvContext() {
         return mvContext;
@@ -182,6 +191,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @VisibleForTesting
     public void setMvContext(MvTaskRunContext mvContext) {
         this.mvContext = mvContext;
+    }
+
+    @VisibleForTesting
+    public RuntimeProfile getRuntimeProfile() {
+        return runtimeProfile;
     }
 
     public TaskRun getNextTaskRun() {
@@ -195,26 +209,42 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     // 4. construct the refresh sql and execute it
     // 5. update the source table version map if refresh task completes successfully
     @Override
-    public void processTaskRun(TaskRunContext context) throws Exception {
-        Tracers.register();
+    public void processTaskRun(TaskRunContext context) {
+        // register tracers
+        Tracers.register(context.getCtx());
+        // init to collect the base timer for refresh profile
+        Tracers.init(Tracers.Mode.TIMER, Tracers.Module.BASE, true, false);
 
-        prepare(context);
-
-        Preconditions.checkState(materializedView != null);
-        IMaterializedViewMetricsEntity mvEntity =
-                MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(materializedView.getMvId());
-
+        IMaterializedViewMetricsEntity mvEntity = null;
         ConnectContext connectContext = context.getCtx();
         try {
-            RefreshJobStatus status = doMvRefresh(context, mvEntity);
-            mvEntity.increaseRefreshJobStatus(status);
-            connectContext.getState().setOk();
+            // prepare
+            try (Timer ignored = Tracers.watchScope("MVRefreshPrepare")) {
+                prepare(context);
+            }
+
+            // do refresh
+            try (Timer ignored = Tracers.watchScope("MVRefreshDoWholeRefresh")) {
+                // refresh mv
+                Preconditions.checkState(materializedView != null);
+                mvEntity = MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(materializedView.getMvId());
+                RefreshJobStatus status = doMvRefresh(context, mvEntity);
+                // update metrics
+                mvEntity.increaseRefreshJobStatus(status);
+                connectContext.getState().setOk();
+            }
         } catch (Exception e) {
-            mvEntity.increaseRefreshJobStatus(RefreshJobStatus.FAILED);
+            if (mvEntity != null) {
+                mvEntity.increaseRefreshJobStatus(RefreshJobStatus.FAILED);
+            }
             connectContext.getState().setError(e.getMessage());
             throw e;
         } finally {
             postProcess();
+            if (FeConstants.runningUnitTest) {
+                runtimeProfile = new RuntimeProfile();
+                Tracers.toRuntimeProfile(runtimeProfile);
+            }
             Tracers.close();
         }
     }
@@ -230,22 +260,32 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Stopwatch stopwatch = Stopwatch.createStarted();
         while (!checked && retryNum++ < Config.max_mv_check_base_table_change_retry_times) {
             mvEntity.increaseRefreshRetryMetaCount(1L);
-            // refresh external table meta cache before sync partitions
-            refreshExternalTable(context);
-            // sync partitions between materialized view and base tables out of lock
-            // do it outside lock because it is a time-cost operation
-            syncPartitions(context);
-            // check whether there are partition changes for base tables, eg: partition rename
-            // retry to sync partitions if any base table changed the partition infos
-            if (checkBaseTablePartitionChange(materializedView)) {
-                LOG.info("materialized view:{} base partition has changed. retry to sync partitions, retryNum:{}",
-                        materializedView.getName(), retryNum);
-                // sleep 100ms
-                Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-                continue;
+            try (Timer ignored = Tracers.watchScope("MVRefreshExternalTable")) {
+                // refresh external table meta cache before sync partitions
+                refreshExternalTable(context);
+            }
+
+            try (Timer ignored = Tracers.watchScope("MVRefreshSyncPartitions")) {
+                // sync partitions between materialized view and base tables out of lock
+                // do it outside lock because it is a time-cost operation
+                syncPartitions(context);
+            }
+
+            try (Timer ignored = Tracers.watchScope("MVRefreshCheckBaseTableChange")) {
+                // check whether there are partition changes for base tables, eg: partition rename
+                // retry to sync partitions if any base table changed the partition infos
+                if (checkBaseTablePartitionChange(materializedView)) {
+                    LOG.info("materialized view:{} base partition has changed. retry to sync partitions, retryNum:{}",
+                            materializedView.getName(), retryNum);
+                    // sleep 100ms
+                    Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+                    continue;
+                }
             }
             checked = true;
         }
+        Tracers.record("MVRefreshSyncPartitionsRetryTimes", String.valueOf(retryNum));
+
         LOG.info("materialized view {} after checking partitions change {} times: {}, costs: {} ms",
                 materializedView.getName(), retryNum, checked, stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return checked;
@@ -323,6 +363,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         while (refreshFailedTimes < maxRefreshMaterializedViewRetryNum &&
                 lockFailedTimes < Config.max_mv_refresh_try_lock_failure_retry_times) {
             try {
+                Tracers.record("MVRefreshRetryTimes", String.valueOf(refreshFailedTimes));
+                Tracers.record("MVRefreshLockRetryTimes", String.valueOf(lockFailedTimes));
                 return doRefreshMaterializedView(taskRunContext, mvEntity);
             } catch (LockTimeoutException e) {
                 // if lock timeout, retry to refresh
@@ -372,20 +414,25 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                                        IMaterializedViewMetricsEntity mvEntity) throws Exception {
 
         ///// 1. check to refresh partition names of base tables and materialized view
-        if (!syncAndCheckPartitions(context, mvEntity)) {
-            throw new DmlException(String.format("materialized view %s refresh task failed: sync partition failed",
-                    materializedView.getName()));
+        try (Timer ignored = Tracers.watchScope("MVRefreshSyncAndCheckPartitions")) {
+            if (!syncAndCheckPartitions(context, mvEntity)) {
+                throw new DmlException(String.format("materialized view %s refresh task failed: sync partition failed",
+                        materializedView.getName()));
+            }
         }
 
-        Set<String> mvToRefreshedPartitions = checkMvToRefreshedPartitions(context);
-        if (Objects.isNull(mvToRefreshedPartitions) || mvToRefreshedPartitions.isEmpty()) {
-            return RefreshJobStatus.EMPTY;
+        Set<String> mvToRefreshedPartitions = null;
+        try (Timer ignored = Tracers.watchScope("MVRefreshSyncAndCheckPartitions")) {
+            mvToRefreshedPartitions = checkMvToRefreshedPartitions(context);
+            if (Objects.isNull(mvToRefreshedPartitions) || mvToRefreshedPartitions.isEmpty()) {
+                return RefreshJobStatus.EMPTY;
+            }
         }
         // ref table of materialized view : refreshed partition names
         Map<TableSnapshotInfo, Set<String>> refTableRefreshPartitions = getRefTableRefreshPartitions(mvToRefreshedPartitions);
         // ref table of materialized view : refreshed partition names
         Map<String, Set<String>> refTablePartitionNames = refTableRefreshPartitions.entrySet().stream()
-                .collect(Collectors.toMap(x -> x.getKey().getBaseTable().getName(), Map.Entry::getValue));
+                .collect(Collectors.toMap(x -> x.getKey().getName(), Map.Entry::getValue));
         LOG.info("materialized view:{} source partitions :{}",
                 materializedView.getName(), refTableRefreshPartitions);
         // add a message into information_schema
@@ -393,11 +440,18 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         updateBaseTablePartitionSnapshotInfos(refTableRefreshPartitions);
 
         ///// 2. execute the ExecPlan of insert stmt
-        InsertStmt insertStmt = prepareRefreshPlan(mvToRefreshedPartitions, refTablePartitionNames);
-        refreshMaterializedView(mvContext, mvContext.getExecPlan(), insertStmt);
+        InsertStmt insertStmt = null;
+        try (Timer ignored = Tracers.watchScope("MVRefreshPrepareRefreshPlan")) {
+            insertStmt = prepareRefreshPlan(mvToRefreshedPartitions, refTablePartitionNames);
+        }
+        try (Timer ignored = Tracers.watchScope("MVRefreshMaterializedView")) {
+            refreshMaterializedView(mvContext, mvContext.getExecPlan(), insertStmt);
+        }
 
         ///// 3. insert execute successfully, update the meta of materialized view according to ExecPlan
-        updateMeta(mvToRefreshedPartitions, mvContext.getExecPlan(), refTableRefreshPartitions);
+        try (Timer ignored = Tracers.watchScope("MVRefreshUpdateMeta")) {
+            updateMeta(mvToRefreshedPartitions, mvContext.getExecPlan(), refTableRefreshPartitions);
+        }
 
         return RefreshJobStatus.SUCCESS;
     }
@@ -421,7 +475,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         changeDefaultConnectContextIfNeeded(ctx);
 
         // 3. AST
-        InsertStmt insertStmt = generateInsertAst(mvToRefreshedPartitions, materializedView, ctx);
+        InsertStmt insertStmt = null;
+        try (Timer ignored = Tracers.watchScope("MVRefreshParser")) {
+            insertStmt = generateInsertAst(mvToRefreshedPartitions, materializedView, ctx);
+        }
 
         PlannerMetaLocker locker = new PlannerMetaLocker(ctx, insertStmt);
         ExecPlan execPlan = null;
@@ -433,12 +490,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         try {
             // 4. Analyze and prepare partition & Rebuild insert statement by
             // considering to-refresh partitions of ref tables/ mv
-            insertStmt = planBuilder.analyzeAndBuildInsertPlan(insertStmt, refTablePartitionNames, ctx);
-            // Must set execution id before StatementPlanner.plan
-            ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+            try (Timer ignored = Tracers.watchScope("MVRefreshAnalyzer")) {
+                insertStmt = planBuilder.analyzeAndBuildInsertPlan(insertStmt, refTablePartitionNames, ctx);
+                // Must set execution id before StatementPlanner.plan
+                ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+            }
 
             // 5. generate insert stmt's exec plan, make thread local ctx existed
-            try (var guard = ctx.bindScope()) {
+            try (ConnectContext.ScopeGuard guard = ctx.bindScope(); Timer ignored = Tracers.watchScope("MVRefreshPlanner")) {
                 execPlan = StatementPlanner.planInsertStmt(locker, insertStmt, ctx);
             }
         } finally {
@@ -579,8 +638,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     private void setNextPartitionStartAndEnd(Set<String> partitionsToRefresh,
-                   Map<String, Range<PartitionKey>> mappedPartitionsToRefresh,
-                   Iterator<String> partitionNameIter) {
+                                             Map<String, Range<PartitionKey>> mappedPartitionsToRefresh,
+                                             Iterator<String> partitionNameIter) {
         String nextPartitionStart = null;
         String endPartitionName = null;
         if (partitionNameIter.hasNext()) {
@@ -834,62 +893,64 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                             ExecPlan execPlan,
                             Map<TableSnapshotInfo, Set<String>> refTableAndPartitionNames) {
         LOG.info("start to update meta for mv:{}", materializedView.getName());
+
+        // check
+        Table mv = db.getTable(materializedView.getId());
+        if (mv == null) {
+            throw new DmlException(
+                    "update meta failed. materialized view:" + materializedView.getName() + " not exist");
+        }
+        // check
+        if (mvRefreshedPartitions == null || refTableAndPartitionNames == null) {
+            return;
+        }
+
+        // NOTE: update all base tables meta to be used in mv rewrite.
+        Map<Boolean, List<TableSnapshotInfo>> snapshotInfoSplits = snapshotBaseTables.values()
+                .stream()
+                .collect(Collectors.partitioningBy(s -> s.getBaseTable().isNativeTableOrMaterializedView()));
+        Set<Long> refBaseTableIds = refTableAndPartitionNames.keySet().stream()
+                .map(t -> t.getId())
+                .collect(Collectors.toSet());
+
         Locker locker = new Locker();
         // update the meta if succeed
         if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
             throw new DmlException("update meta failed. database:" + db.getFullName() + " not exist");
         }
+
         try {
-            // check
-            Table mv = db.getTable(materializedView.getId());
-            if (mv == null) {
-                throw new DmlException(
-                        "update meta failed. materialized view:" + materializedView.getName() + " not exist");
-            }
-
-            // check
-            if (mvRefreshedPartitions == null || refTableAndPartitionNames == null) {
-                return;
-            }
-
             MaterializedView.MvRefreshScheme mvRefreshScheme = materializedView.getRefreshScheme();
             MaterializedView.AsyncRefreshContext refreshContext = mvRefreshScheme.getAsyncRefreshContext();
 
             // update materialized view partition to ref base table partition names meta
             updateAssociatedPartitionMeta(refreshContext, mvRefreshedPartitions, refTableAndPartitionNames);
 
-            // NOTE: update all base tables meta to be used in mv rewrite.
-            Map<Boolean, List<TableSnapshotInfo>> snapshotInfoSplits = snapshotBaseTables.values()
-                    .stream()
-                    .collect(Collectors.partitioningBy(s -> s.getBaseTable().isNativeTableOrMaterializedView()));
-            Set<Long> refBaseTableIds = refTableAndPartitionNames.keySet().stream()
-                    .map(t -> t.getBaseTable().getId())
-                    .collect(Collectors.toSet());
             if (snapshotInfoSplits.get(true) != null) {
                 updateMetaForOlapTable(refreshContext, snapshotInfoSplits.get(true), refBaseTableIds);
             }
             if (snapshotInfoSplits.get(false) != null) {
                 updateMetaForExternalTable(refreshContext, snapshotInfoSplits.get(false), refBaseTableIds);
             }
-
-            // update mv status message
-            updateTaskRunStatus(status -> {
-                try {
-                    MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
-                    Map<String, Set<String>> baseTableRefreshedPartitionsByExecPlan =
-                            getBaseTableRefreshedPartitionsByExecPlan(execPlan);
-                    extraMessage.setBasePartitionsToRefreshMap(baseTableRefreshedPartitionsByExecPlan);
-                } catch (Exception e) {
-                    // just log warn and no throw exceptions for an updating task runs message.
-                    LOG.warn("update task run messages failed:", e);
-                }
-            });
         } catch (Exception e) {
             LOG.warn("update final meta failed after mv refreshed:", e);
             throw e;
         } finally {
             locker.unLockDatabase(db, LockType.WRITE);
         }
+
+        // update mv status message
+        updateTaskRunStatus(status -> {
+            try {
+                MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
+                Map<String, Set<String>> baseTableRefreshedPartitionsByExecPlan =
+                        getBaseTableRefreshedPartitionsByExecPlan(execPlan);
+                extraMessage.setBasePartitionsToRefreshMap(baseTableRefreshedPartitionsByExecPlan);
+            } catch (Exception e) {
+                // just log warn and no throw exceptions for an updating task runs message.
+                LOG.warn("update task run messages failed:", e);
+            }
+        });
     }
 
     /**
@@ -1026,9 +1087,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             // FIXME: If base table's partition has been dropped, should drop the according version partition too?
             // remove partition info of not-exist partition for snapshot table from version map
-            Table table = MvUtils.getTableChecked(baseTableInfo);
-            Set<String> partitionNames =
-                    Sets.newHashSet(PartitionUtil.getPartitionNames(table));
+            Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(snapshotTable));
             currentTablePartitionInfo.keySet().removeIf(partitionName -> !partitionNames.contains(partitionName));
         }
         if (!changedTablePartitionInfos.isEmpty()) {
@@ -1104,7 +1163,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         PartitionInfo partitionInfo = materializedView.getPartitionInfo();
         if (!(partitionInfo instanceof SinglePartitionInfo)) {
             Pair<Table, Column> partitionTableAndColumn = getRefBaseTableAndPartitionColumn(snapshotBaseTables);
-            mvContext.setRefBaseTable(partitionTableAndColumn.first);
+            Table refBaseTable = partitionTableAndColumn.first;
+            if (!snapshotBaseTables.containsKey(refBaseTable.getId())) {
+                throw new DmlException("The ref base table {} of materialized view {} is not existed in snapshot.",
+                        refBaseTable.getName(), materializedView.getName());
+            }
+            mvContext.setRefBaseTable(snapshotBaseTables.get(refBaseTable.getId()).getBaseTable());
             mvContext.setRefBaseTablePartitionColumn(partitionTableAndColumn.second);
         }
         int partitionTTLNumber = materializedView.getTableProperty().getPartitionTTLNumber();
@@ -1235,7 +1299,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         mvContext.setRefBaseTableListPartitionMap(baseListPartitionMap);
     }
 
-    private static boolean supportPartitionRefresh(Table table) {
+    private boolean supportPartitionRefresh(Table table) {
         return ConnectorPartitionTraits.build(table).supportPartitionRefresh();
     }
 
@@ -1261,11 +1325,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      * Whether partitioned materialized view needs to be refreshed or not base on the non-ref base tables, it needs refresh when:
      * - its non-ref base table except un-supported base table has updated.
      */
-    private boolean isPartitionedMVNeedToRefreshBaseOnNonRefTables(Table partitionTable) {
+    private boolean isPartitionedMVNeedToRefreshBaseOnNonRefTables(Table baseTable) {
         Map<Table, Column> tableColumnMap = materializedView.getRelatedPartitionTableAndColumn();
         for (TableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
             Table snapshotTable = snapshotInfo.getBaseTable();
-            if (snapshotTable.getId() == partitionTable.getId()) {
+            if (snapshotTable.getId() == baseTable.getId()) {
                 continue;
             }
             if (!supportPartitionRefresh(snapshotTable)) {
@@ -1348,7 +1412,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             }
         } else if (mvPartitionInfo instanceof ExpressionRangePartitionInfo) {
             // range partitioned materialized views
-            Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
             Table refBaseTable = mvContext.getRefBaseTable();
 
             boolean isAutoRefresh = mvContext.getTaskType().isAutoRefresh();
@@ -1462,7 +1525,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
 
         // step1: check updated partition names in the ref base table and add it to the refresh candidate
-        MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(materializedView, refBaseTable, false, false);
+        MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(materializedView,
+                refBaseTable, false, false);
         if (mvBaseTableUpdateInfo == null) {
             LOG.warn("Cannot find the updated partition info of ref base table {} of mv: {}",
                     refBaseTable.getName(), materializedView.getName());
@@ -1705,9 +1769,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      *
      * @param materializedView: the materialized view to check
      * @return: the deduplicated databases of the materialized view's base tables,
-     * throw exception if the database do not exist.
+     * throw exception if the database does not exist.
      */
-    List<Database> collectDatabases(MaterializedView materializedView) {
+    private List<Database> collectDatabases(MaterializedView materializedView) {
         Map<Long, Database> databaseMap = Maps.newHashMap();
         for (BaseTableInfo baseTableInfo : materializedView.getBaseTableInfos()) {
             Optional<Database> dbOpt = GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(baseTableInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * `TableSnapshotInfo` represents a snapshot of the base table of materialized view.
@@ -33,12 +34,22 @@ public class TableSnapshotInfo {
     Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos = Maps.newHashMap();
 
     public TableSnapshotInfo(BaseTableInfo baseTableInfo, Table baseTable) {
+        Objects.requireNonNull(baseTableInfo);
+        Objects.requireNonNull(baseTable);
         this.baseTableInfo = baseTableInfo;
         this.baseTable = baseTable;
     }
 
     public BaseTableInfo getBaseTableInfo() {
         return baseTableInfo;
+    }
+
+    public long getId() {
+        return baseTableInfo.getTableId();
+    }
+
+    public String getName() {
+        return baseTable.getName();
     }
 
     public Table getBaseTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -232,7 +232,7 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        try (Timer ignored = Tracers.watchScope("preprocessMvs")) {
+        try (Timer ignored = Tracers.watchScope("MVPreprocess")) {
             Set<Table> queryTables = MvUtils.getAllTables(queryOptExpression).stream().collect(Collectors.toSet());
             logMVParams(connectContext, queryTables);
 
@@ -243,23 +243,23 @@ public class MvRewritePreprocessor {
 
                 // 2. choose best related mvs by user's config or related mv limit
                 Set<MaterializedView> selectedRelatedMVs;
-                try (Timer t1 = Tracers.watchScope("chooseCandidates")) {
+                try (Timer t1 = Tracers.watchScope("MVChooseCandidates")) {
                     selectedRelatedMVs = chooseBestRelatedMVs(queryTables, relatedMVs, queryOptExpression);
                 }
 
                 // 3. convert to mv with planContext, skip if mv has no valid plan(not SPJG)
                 Set<MvWithPlanContext> mvWithPlanContexts;
-                try (Timer t2 = Tracers.watchScope("generateMvPlan")) {
+                try (Timer t2 = Tracers.watchScope("MVGenerateMvPlan")) {
                     mvWithPlanContexts = getMvWithPlanContext(selectedRelatedMVs);
                 }
 
                 // 4. process related mvs to candidates
-                try (Timer t3 = Tracers.watchScope("validateMv")) {
+                try (Timer t3 = Tracers.watchScope("MVValidateMv")) {
                     prepareRelatedMVs(queryTables, mvWithPlanContexts);
                 }
 
                 // 5. process relate mvs with views
-                try (Timer t4 = Tracers.watchScope("mvWithView")) {
+                try (Timer t4 = Tracers.watchScope("MVProcessWithView")) {
                     processPlanWithView(queryMaterializationContext, connectContext, queryOptExpression,
                             queryColumnRefFactory, requiredColumns);
                 }


### PR DESCRIPTION
## Why I'm doing:
MV Refersh misses the Planner time profile.

## What I'm doing:
- Add more mv refresh timer profile  for performace analysis

Fixes https://github.com/StarRocks/starrocks/issues/46953


Result:
```
  Planner:
     - -- MVRefreshPrepare[1] 3ms
     - -- MVRefreshSyncAndCheckPartitions[2] 26ms
     -     -- MVRefreshExternalTable[1] 0
     -     -- MVRefreshSyncPartitions[1] 15ms
     -     -- MVRefreshCheckBaseTableChange[1] 8ms
     - -- MVRefreshPrepareRefreshPlan[1] 103ms
     -     -- MVRefreshParser[1] 4ms
     -     -- MVRefreshAnalyzer[1] 6ms
     -         -- AnalyzeDatabase[4] 0
     -         -- AnalyzeTemporaryTable[4] 0
     -         -- AnalyzeTable[4] 0
     -     -- MVRefreshPlanner[1] 89ms
     -         -- Transform[2] 8ms
     -         -- InsertPlanner[2] 89ms
     -             -- Optimizer[2] 47ms
     -                 -- RuleBaseOptimize[2] 38ms
     -                 -- CostBaseOptimize[2] 5ms
     -                 -- PhysicalRewrite[2] 2ms
     -                 -- PlanValidate[2] 0
     -                     -- InputDependenciesChecker[2] 0
     -                     -- TypeChecker[2] 0
     -                     -- CTEUniqueChecker[2] 0
     -                     -- ColumnReuseChecker[2] 0
     -             -- PlanBuilder[2] 16ms
     - -- MVRefreshMaterializedView[1] 1s509ms
     -     -- Analyzer[1] 1ms
     -     -- Pending[1] 0
     -     -- Prepare[1] 11ms
     -     -- Deploy[1] 43ms
     -         -- DeployLockInternalTime[1] 43ms
     -             -- DeploySerializeConcurrencyTime[2] 12ms
     -             -- DeployStageByStageTime[6] 2ms
     -             -- DeployWaitTime[6] 17ms
     -                 -- DeployAsyncSendTime[3] 2ms
     - MVRefreshRetryTimes: 0
     - MVRefreshLockRetryTimes: 0
     - MVSyncBaseTablePartitionsRetryTimes: 1
     - DeployDataSize: 22016
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
