### PR TITLE
[Enhancement] Unified Catalog support Paimon

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -25,7 +25,9 @@ import org.apache.paimon.table.DataTable;
 import org.apache.paimon.types.DataField;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -33,12 +35,17 @@ import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
 
 
 public class PaimonTable extends Table {
-    private final String catalogName;
-    private final String databaseName;
-    private final String tableName;
-    private final org.apache.paimon.table.Table paimonNativeTable;
-    private final List<String> partColumnNames;
-    private final List<String> paimonFieldNames;
+    private String catalogName;
+    private String databaseName;
+    private String tableName;
+    private org.apache.paimon.table.Table paimonNativeTable;
+    private List<String> partColumnNames;
+    private List<String> paimonFieldNames;
+    private Map<String, String> properties;
+
+    public PaimonTable() {
+        super(TableType.PAIMON);
+    }
 
     public PaimonTable(String catalogName, String dbName, String tblName, List<Column> schema,
                        org.apache.paimon.table.Table paimonNativeTable, long createTime) {
@@ -83,6 +90,14 @@ public class PaimonTable extends Table {
         } else {
             return paimonNativeTable.name().toString();
         }
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        if (properties == null) {
+            this.properties = new HashMap<>();
+        }
+        return properties;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -41,8 +41,8 @@ import static org.apache.paimon.options.CatalogOptions.URI;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 
 public class PaimonConnector implements Connector {
-    private static final String PAIMON_CATALOG_TYPE = "paimon.catalog.type";
-    private static final String PAIMON_CATALOG_WAREHOUSE = "paimon.catalog.warehouse";
+    public static final String PAIMON_CATALOG_TYPE = "paimon.catalog.type";
+    public static final String PAIMON_CATALOG_WAREHOUSE = "paimon.catalog.warehouse";
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     private static final String DLF_CATGALOG_ID = "dlf.catalog.id";
     private final HdfsEnvironment hdfsEnvironment;
@@ -82,7 +82,9 @@ public class PaimonConnector implements Connector {
                 && !catalogType.equalsIgnoreCase("dlf")) {
             throw new StarRocksConnectorException("The property %s must be set.", PAIMON_CATALOG_WAREHOUSE);
         }
-        paimonOptions.setString(WAREHOUSE.key(), warehousePath);
+        if (!Strings.isNullOrEmpty(warehousePath)) {
+            paimonOptions.setString(WAREHOUSE.key(), warehousePath);
+        }
         initFsOption(cloudConfiguration);
         String keyPrefix = "paimon.option.";
         Set<String> optionKeys = properties.keySet().stream().filter(k -> k.startsWith(keyPrefix)).collect(Collectors.toSet());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedConnector.java
@@ -66,7 +66,6 @@ public class UnifiedConnector implements Connector {
         ConnectorContext derivedContext = new ConnectorContext(context.getCatalogName(), context.getType(),
                 derivedProperties.build());
 
-        boolean shouldCreatePaimonConnector = null != context.getProperties().get(PAIMON_CATALOG_WAREHOUSE);
         ImmutableMap.Builder<Table.TableType, Connector> builder = ImmutableMap.builder();
 
         builder.put(HIVE, new HiveConnector(derivedContext))
@@ -74,7 +73,8 @@ public class UnifiedConnector implements Connector {
                 .put(HUDI, new HudiConnector(derivedContext))
                 .put(DELTALAKE, new DeltaLakeConnector(derivedContext))
                 .put(KUDU, new KuduConnector(derivedContext));
-        if (shouldCreatePaimonConnector) {
+        boolean containsPaimon = null != context.getProperties().get(PAIMON_CATALOG_WAREHOUSE);
+        if (containsPaimon) {
             builder.put(PAIMON, new PaimonConnector(derivedContext));
         }
         connectorMap = builder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedConnector.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.hive.HiveConnector;
 import com.starrocks.connector.hudi.HudiConnector;
 import com.starrocks.connector.iceberg.IcebergConnector;
 import com.starrocks.connector.kudu.KuduConnector;
+import com.starrocks.connector.paimon.PaimonConnector;
 import com.starrocks.sql.analyzer.SemanticException;
 
 import java.util.HashMap;
@@ -37,14 +38,17 @@ import static com.starrocks.catalog.Table.TableType.HIVE;
 import static com.starrocks.catalog.Table.TableType.HUDI;
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
 import static com.starrocks.catalog.Table.TableType.KUDU;
+import static com.starrocks.catalog.Table.TableType.PAIMON;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
 import static com.starrocks.connector.kudu.KuduConnector.KUDU_CATALOG_TYPE;
+import static com.starrocks.connector.paimon.PaimonConnector.PAIMON_CATALOG_TYPE;
+import static com.starrocks.connector.paimon.PaimonConnector.PAIMON_CATALOG_WAREHOUSE;
 
 public class UnifiedConnector implements Connector {
     public static final String UNIFIED_METASTORE_TYPE = "unified.metastore.type";
     public static final List<String> SUPPORTED_METASTORE_TYPE = ImmutableList.of("hive", "glue");
-    private final Map<Table.TableType, Connector> connectorMap;
+    private Map<Table.TableType, Connector> connectorMap;
 
     public UnifiedConnector(ConnectorContext context) {
         String metastoreType = context.getProperties().get(UNIFIED_METASTORE_TYPE);
@@ -56,18 +60,24 @@ public class UnifiedConnector implements Connector {
         derivedProperties.putAll(context.getProperties());
         derivedProperties.put(HIVE_METASTORE_TYPE, metastoreType);
         derivedProperties.put(ICEBERG_CATALOG_TYPE, metastoreType);
+        derivedProperties.put(PAIMON_CATALOG_TYPE, metastoreType);
         derivedProperties.put(KUDU_CATALOG_TYPE, metastoreType);
 
         ConnectorContext derivedContext = new ConnectorContext(context.getCatalogName(), context.getType(),
                 derivedProperties.build());
 
-        connectorMap = ImmutableMap.of(
-                HIVE, new HiveConnector(derivedContext),
-                ICEBERG, new IcebergConnector(derivedContext),
-                HUDI, new HudiConnector(derivedContext),
-                DELTALAKE, new DeltaLakeConnector(derivedContext),
-                KUDU, new KuduConnector(derivedContext)
-        );
+        boolean shouldCreatePaimonConnector = null != context.getProperties().get(PAIMON_CATALOG_WAREHOUSE);
+        ImmutableMap.Builder<Table.TableType, Connector> builder = ImmutableMap.builder();
+
+        builder.put(HIVE, new HiveConnector(derivedContext))
+                .put(ICEBERG, new IcebergConnector(derivedContext))
+                .put(HUDI, new HudiConnector(derivedContext))
+                .put(DELTALAKE, new DeltaLakeConnector(derivedContext))
+                .put(KUDU, new KuduConnector(derivedContext));
+        if (shouldCreatePaimonConnector) {
+            builder.put(PAIMON, new PaimonConnector(derivedContext));
+        }
+        connectorMap = builder.build();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -52,6 +52,7 @@ import static com.starrocks.catalog.Table.TableType.HIVE;
 import static com.starrocks.catalog.Table.TableType.HUDI;
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
 import static com.starrocks.catalog.Table.TableType.KUDU;
+import static com.starrocks.catalog.Table.TableType.PAIMON;
 import static java.util.Objects.requireNonNull;
 
 public class UnifiedMetadata implements ConnectorMetadata {
@@ -97,6 +98,9 @@ public class UnifiedMetadata implements ConnectorMetadata {
         }
         if (isDeltaLakeTable(table.getProperties())) {
             return DELTALAKE;
+        }
+        if (isPaimonTable(table.getProperties())) {
+            return PAIMON;
         }
         if (table.isKuduTable()) {
             return KUDU;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class PaimonTableTest {
 
@@ -63,6 +64,8 @@ public class PaimonTableTest {
         };
         PaimonTable paimonTable = new PaimonTable("testCatalog", "testDB", "testTable", fullSchema,
                 paimonNativeTable, 100L);
+        Map<String, String> properties = paimonTable.getProperties();
+        Assert.assertEquals(0, properties.size());
         List<Column> partitionColumns = paimonTable.getPartitionColumns();
         Assertions.assertThat(partitionColumns).hasSameElementsAs(partitionSchema);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedConnectorTest.java
@@ -20,6 +20,10 @@ import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorFactory;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.paimon.PaimonConnector;
+import com.starrocks.connector.paimon.PaimonMetadata;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -28,13 +32,22 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnifiedConnectorTest {
+    @Mocked private PaimonConnector paimonConnector;
+    @Mocked private PaimonMetadata paimonMetadata;
 
     @Test
     public void testCreateUnifiedConnectorFromConnectorFactory() throws StarRocksConnectorException {
+        new Expectations() {
+            {
+                paimonConnector.getMetadata();
+                result = paimonMetadata;
+            }
+        };
         Map<String, String> properties = new HashMap<>();
         properties.put("type", "unified");
         properties.put("unified.metastore.type", "hive");
         properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
+        properties.put("paimon.catalog.warehouse", "file:///tmp/");
         properties.put("kudu.master", "localhost:7051");
         properties.put("kudu.schema-emulation.enabled", "true");
         properties.put("kudu.schema-emulation.prefix", "impala::");
@@ -47,10 +60,17 @@ public class UnifiedConnectorTest {
 
     @Test
     public void testCreateUnifiedConnector() {
+        new Expectations() {
+            {
+                paimonConnector.getMetadata();
+                result = paimonMetadata;
+            }
+        };
         Map<String, String> properties = new HashMap<>();
         properties.put("type", "unified");
         properties.put("unified.metastore.type", "hive");
         properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
+        properties.put("paimon.catalog.warehouse", "file:///tmp/");
         properties.put("kudu.master", "localhost:7051");
         properties.put("kudu.schema-emulation.enabled", "true");
         properties.put("kudu.schema-emulation.prefix", "impala::");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -37,6 +37,7 @@ import com.starrocks.connector.hudi.HudiMetadata;
 import com.starrocks.connector.iceberg.IcebergMetaSpec;
 import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.connector.kudu.KuduMetadata;
+import com.starrocks.connector.paimon.PaimonMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -53,6 +54,7 @@ import static com.starrocks.catalog.Table.TableType.HIVE;
 import static com.starrocks.catalog.Table.TableType.HUDI;
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
 import static com.starrocks.catalog.Table.TableType.KUDU;
+import static com.starrocks.catalog.Table.TableType.PAIMON;
 import static com.starrocks.connector.unified.UnifiedMetadata.DELTA_LAKE_PROVIDER;
 import static com.starrocks.connector.unified.UnifiedMetadata.ICEBERG_TABLE_TYPE_NAME;
 import static com.starrocks.connector.unified.UnifiedMetadata.ICEBERG_TABLE_TYPE_VALUE;
@@ -70,6 +72,8 @@ public class UnifiedMetadataTest {
     @Mocked
     private DeltaLakeMetadata deltaLakeMetadata;
     @Mocked
+    private PaimonMetadata paimonMetadata;
+    @Mocked
     private KuduMetadata kuduMetadata;
     private final CreateTableStmt createTableStmt = new CreateTableStmt(false, true,
             new TableName("test_db", "test_tbl"), ImmutableList.of(), "hive",
@@ -82,11 +86,12 @@ public class UnifiedMetadataTest {
     @BeforeEach
     public void setUp() {
         this.unifiedMetadata = new UnifiedMetadata(ImmutableMap.of(
-                HIVE, hiveMetadata,
-                ICEBERG, icebergMetadata,
-                HUDI, hudiMetadata,
-                DELTALAKE, deltaLakeMetadata,
-                KUDU, kuduMetadata
+            HIVE, hiveMetadata,
+            ICEBERG, icebergMetadata,
+            HUDI, hudiMetadata,
+            DELTALAKE, deltaLakeMetadata,
+            PAIMON, paimonMetadata,
+            KUDU, kuduMetadata
         )
         );
         this.getRemoteFilesParams = GetRemoteFilesParams.newBuilder().setPartitionKeys(ImmutableList.of())


### PR DESCRIPTION
## Why I'm doing:
Make unified catalog support paimon data sources.

example:
```sql
CREATE EXTERNAL CATALOG unified
PROPERTIES
(
    "type" = "unified",
    "unified.metastore.type" = "hive",
    "hive.metastore.uris" = "thrift://localhost:9083",
    "paimon.catalog.warehouse" = "hdfs://127.0.0.1:9000/paimon"
);
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
