### PR TITLE
[Enhancement] lazy initialization external catalg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorContext.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import java.util.Map;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorFactory.java
@@ -34,11 +34,30 @@ public class ConnectorFactory {
      * @param context - encapsulate all information needed to create a connector
      * @return a connector instance
      */
-    public static CatalogConnector createConnector(ConnectorContext context) throws StarRocksConnectorException {
+    public static CatalogConnector createConnector(ConnectorContext context, boolean isReplay)
+            throws StarRocksConnectorException {
         if (null == context || !ConnectorType.isSupport(context.getType())) {
             return null;
         }
 
+        try {
+            LazyConnector lazyConnector = new LazyConnector(context);
+            if (!isReplay) {
+                lazyConnector.initIfNeeded();
+            }
+
+            InformationSchemaConnector informationSchemaConnector =
+                    new InformationSchemaConnector(context.getCatalogName());
+            TableMetaConnector tableMetaConnector = new TableMetaConnector(context.getCatalogName());
+            return new CatalogConnector(lazyConnector, informationSchemaConnector, tableMetaConnector);
+        } catch (Exception e) {
+            LOG.error(String.format("create [%s] connector failed", context.getType()), e);
+            throw new StarRocksConnectorException(e.getMessage(), e);
+        }
+    }
+
+    public static Connector createRealConnector(ConnectorContext context)
+            throws StarRocksConnectorException {
         ConnectorType connectorType = ConnectorType.from(context.getType());
         Class<Connector> connectorClass = connectorType.getConnectorClass();
         Class<ConnectorConfig> ctConfigClass = connectorType.getConfigClass();
@@ -53,10 +72,7 @@ public class ConnectorFactory {
                 connector.bindConfig(connectorConfig);
             }
 
-            InformationSchemaConnector informationSchemaConnector =
-                    new InformationSchemaConnector(context.getCatalogName());
-            TableMetaConnector tableMetaConnector = new TableMetaConnector(context.getCatalogName());
-            return new CatalogConnector(connector, informationSchemaConnector, tableMetaConnector);
+            return connector;
         } catch (InvocationTargetException e) {
             LOG.error(String.format("create [%s] connector failed", context.getType()), e);
             Throwable rootCause = ExceptionUtils.getCause(e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
@@ -32,14 +32,14 @@ public class ConnectorMgr {
     private final ConcurrentHashMap<String, CatalogConnector> connectors = new ConcurrentHashMap<>();
     private final ReadWriteLock connectorLock = new ReentrantReadWriteLock();
 
-    public CatalogConnector createConnector(ConnectorContext context) throws StarRocksConnectorException {
+    public CatalogConnector createConnector(ConnectorContext context, boolean isReplay) throws StarRocksConnectorException {
         String catalogName = context.getCatalogName();
         CatalogConnector connector = null;
         readLock();
         try {
             Preconditions.checkState(!connectors.containsKey(catalogName),
                     "Connector of catalog '%s' already exists", catalogName);
-            connector = ConnectorFactory.createConnector(context);
+            connector = ConnectorFactory.createConnector(context, isReplay);
             if (connector == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class LazyConnector implements Connector {
+    private static final Logger LOG = LogManager.getLogger(LazyConnector.class);
+    private Connector delegate;
+    private final ConnectorContext context;
+
+    public LazyConnector(ConnectorContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata() {
+        initIfNeeded();
+        return delegate.getMetadata();
+    }
+
+    public void initIfNeeded() {
+        synchronized (this) {
+            if (delegate == null) {
+                try {
+                    delegate = ConnectorFactory.createRealConnector(context);
+                } catch (Exception e) {
+                    LOG.error("Failed to init connector [type: {}, name: {}]",
+                            context.getType(), context.getCatalogName(), e);
+                    throw new StarRocksConnectorException("Failed to init connector [type: %s, name: %s]. msg: %s",
+                            context.getType(), context.getCatalogName(), e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        synchronized (this) {
+            if (delegate != null) {
+                delegate.shutdown();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -128,7 +128,7 @@ public class CatalogMgr {
             }
 
             // TODO：please keep connector and catalog create together, they need keep in consistent asap.
-            CatalogConnector connector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, properties));
+            CatalogConnector connector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, properties), false);
             if (null == connector) {
                 LOG.error("{} connector [{}] create failed", type, catalogName);
                 throw new DdlException("connector create failed");
@@ -277,7 +277,8 @@ public class CatalogMgr {
 
         // TODO：please keep connector and catalog create together, they need keep in consistent asap.
         try {
-            CatalogConnector catalogConnector = connectorMgr.createConnector(new ConnectorContext(catalogName, type, config));
+            CatalogConnector catalogConnector = connectorMgr.createConnector(
+                    new ConnectorContext(catalogName, type, config), true);
             if (catalogConnector == null) {
                 LOG.error("{} connector [{}] create failed.", type, catalogName);
                 throw new DdlException("connector create failed");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeConnectorTest.java
@@ -15,18 +15,14 @@
 package com.starrocks.connector.delta;
 
 import com.google.common.collect.ImmutableMap;
-import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorFactory;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Constructor;
 import java.util.Map;
 
 public class DeltaLakeConnectorTest {
@@ -50,11 +46,12 @@ public class DeltaLakeConnectorTest {
                 "aws.glue.secret_key", "xxxx",
                 "aws.glue.region", "us-west-2");
         try {
-            ConnectorFactory.createConnector(new ConnectorContext("delta0", "deltalake", properties));
+            ConnectorFactory.createConnector(new ConnectorContext("delta0", "deltalake", properties), false);
             Assert.fail("Should throw exception");
         } catch (Exception e) {
             Assert.assertTrue(e instanceof StarRocksConnectorException);
-            Assert.assertEquals("hive.metastore.uris must be set in properties when creating catalog of hive-metastore",
+            Assert.assertEquals("Failed to init connector [type: deltalake, name: delta0]. msg: " +
+                            "hive.metastore.uris must be set in properties when creating catalog of hive-metastore",
                     e.getMessage());
         }
     }
@@ -66,31 +63,13 @@ public class DeltaLakeConnectorTest {
                 "aws.glue.secret_key", "xxxx",
                 "aws.glue.region", "us-west-2");
         try {
-            ConnectorFactory.createConnector(new ConnectorContext("delta0", "deltalake", properties));
+            ConnectorFactory.createConnector(new ConnectorContext("delta0", "deltalake", properties), false);
             Assert.fail("Should throw exception");
         } catch (Exception e) {
             Assert.assertTrue(e instanceof StarRocksConnectorException);
-            Assert.assertEquals("Getting analyzing error. Detail message: hive metastore type [error_metastore] " +
+            Assert.assertEquals("Failed to init connector [type: deltalake, name: delta0]. " +
+                    "msg: Getting analyzing error. Detail message: hive metastore type [error_metastore] " +
                             "is not supported.", e.getMessage());
-        }
-    }
-
-    @Test
-    public void testCreateDeltaLakeConnectorWithException3() {
-        Map<String, String> properties = ImmutableMap.of("type", "deltalake",
-                "hive.metastore.type", "glue",  "aws.glue.access_key", "xxxxx",
-                "aws.glue.secret_key", "xxxx", "aws.glue.region", "us-west-2");
-        new MockUp<Class<Connector>>() {
-            @Mock
-            public Constructor<Connector> getDeclaredConstructor(Class<?>... parameterTypes) {
-                throw new RuntimeException("mock exception");
-            }
-        };
-        try {
-            ConnectorFactory.createConnector(new ConnectorContext("delta0", "deltalake", properties));
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof StarRocksConnectorException);
-            Assert.assertEquals("mock exception", e.getMessage());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedConnectorTest.java
@@ -39,7 +39,7 @@ public class UnifiedConnectorTest {
         properties.put("kudu.schema-emulation.enabled", "true");
         properties.put("kudu.schema-emulation.prefix", "impala::");
         ConnectorContext context = new ConnectorContext("unified_catalog", "unified", properties);
-        CatalogConnector catalogConnector = ConnectorFactory.createConnector(context);
+        CatalogConnector catalogConnector = ConnectorFactory.createConnector(context, false);
         ConnectorMetadata metadata = catalogConnector.getMetadata();
         assertTrue(metadata instanceof CatalogConnectorMetadata);
         catalogConnector.shutdown();

--- a/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
@@ -88,9 +88,7 @@ public class CatalogMgrTest {
 
         config.put("type", "paimon");
         final ExternalCatalog catalog1 = new ExternalCatalog(10000, "catalog_3", "", config);
-        Assert.assertThrows(DdlException.class, () -> {
-            catalogMgr.replayCreateCatalog(catalog1);
-        });
+        catalogMgr.replayCreateCatalog(catalog1);
     }
 
     @Test
@@ -100,9 +98,7 @@ public class CatalogMgrTest {
 
         config.put("type", "paimon");
         final ExternalCatalog catalog = new ExternalCatalog(10000, "catalog_0", "", config);
-        Assert.assertThrows(DdlException.class, () -> {
-            catalogMgr.replayCreateCatalog(catalog);
-        });
+        catalogMgr.replayCreateCatalog(catalog);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
During the current fe startup process, we will catch the exception when failed to replay catalog due to some causes like error core-site.xml format, which will cause the user to lose the catalog after startup. If the exception is not caught, the fe startup will fail.

## What I'm doing:
ony lazy init conector when replaying


Fixes #issue
demo:
![image](https://github.com/StarRocks/starrocks/assets/91597003/20841801-5360-4c6f-b6ce-cbffc7541f29)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
