### PR TITLE
[BugFix](hdfsScanner) Fix that column nums might continuously expand if the the chunk filtered is empty every time

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -468,6 +468,9 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
         ck->append_or_update_column(std::move(col), slot_desc->id());
     } else {
         for (auto* slot_desc : not_existed_slots) {
+            if (ck->is_slot_exist(slot_desc->id())) {
+                continue;
+            }
             auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
             if (row_count > 0) {
                 col->append_default(row_count);
@@ -528,6 +531,9 @@ void HdfsScannerContext::append_or_update_partition_column_to_chunk(ChunkPtr* ch
     ChunkPtr& ck = (*chunk);
     for (size_t i = 0; i < partition_columns.size(); i++) {
         SlotDescriptor* slot_desc = partition_columns[i].slot_desc;
+        if (ck->is_slot_exist(slot_desc->id())) {
+            continue;
+        }
         DCHECK(partition_values[i]->is_constant());
         auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(partition_values[i]);
         ColumnPtr data_column = const_column->data_column();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [x] 2.5
