### PR TITLE
[BugFix] executor may be null when analysis exception thrown

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -309,7 +309,7 @@ public class ConnectProcessor {
         // add execution statistics into queryDetail
         queryDetail.setReturnRows(ctx.getReturnRows());
         queryDetail.setDigest(ctx.getAuditEventBuilder().build().digest);
-        PQueryStatistics statistics = executor.getQueryStatisticsForAuditLog();
+        PQueryStatistics statistics = (executor != null) ? executor.getQueryStatisticsForAuditLog() : null;
         if (statistics != null) {
             queryDetail.setScanBytes(statistics.scanBytes);
             queryDetail.setScanRows(statistics.scanRows);


### PR DESCRIPTION
## Why I'm doing:
connection will be lost when analysis exception thrown
```
MySQL [(none)]> select * from test lll 1;
ERROR 2013 (HY000): Lost connection to MySQL server during query
```


## What I'm doing:
check if executor is null or not

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
