### PR TITLE
[BugFix] Fix BE graceful exit use-after-free

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -55,8 +55,12 @@ void PipelineDriver::check_operator_close_states(const std::string& func_name) {
     for (auto& op : _operators) {
         auto& op_state = _operator_stages[op->get_id()];
         if (op_state > OperatorStage::PREPARED && op_state != OperatorStage::CLOSED) {
-            auto msg = fmt::format("{} close operator {} failed, may leak resources when {}, please reflect to SR",
-                                   to_readable_string(), op->get_name(), func_name);
+            std::stringstream ss;
+            ss << "query_id=" << (this->_query_ctx == nullptr ? "None" : print_id(this->query_ctx()->query_id()))
+               << " fragment_id="
+               << (this->_fragment_ctx == nullptr ? "None" : print_id(this->fragment_ctx()->fragment_instance_id()));
+            auto msg = fmt::format("{} close operator {}-{} failed, may leak resources when {}, please reflect to SR",
+                                   ss.str(), op->get_raw_name(), op->get_plan_node_id(), func_name);
             LOG(ERROR) << msg;
             DCHECK(false) << msg;
         }


### PR DESCRIPTION
## Why I'm doing:

Since check_operator_close_states calls Operator::get_name related operations, this calls Operator::is_finished and other related functions. At this point the operator may be in an 'illegal' state (not initialized properly). This will cause a BE crash. This PR will not prevent the BE from exiting. But it will prevent the BE from generating a SIGSEV when it exits, which could affect the troubleshooting of the problem.

## What I'm doing:
be.out
```
*** Aborted at 1719284514 (unix time) try "date -d @1719284514" if you are using GNU date *
**
PC: @                0x0 (unknown)
*** SIGSEGV (@0x0) received by PID 1718083 (TID 0x7ff56d9e9600) from PID 0; stack trace: **
*
    @          0xbefaaba google::(anonymous namespace)::FailureSignalHandler()
    @     0x7ff56c6a1520 (unknown)
    @                0x0 (unknown)
```

```
(gdb) p _morsel_queue[0]
$4 = (starrocks::pipeline::MorselQueue) {
  _vptr.MorselQueue = 0xe3e3208 <vtable for starrocks::pipeline::MorselQueue+16>, 
  _morsels = std::vector of length 1, capacity 1 = {std::unique_ptr<starrocks::pipeline::ScanMorsel> = {get() = 0x0}}, 
  _num_morsels = 1, _unget_morsel = std::unique_ptr<starrocks::pipeline::ScanMorsel> = {get() = 0x0}, 
  _tablets = std::vector of length 1, capacity 1 = {
    std::shared_ptr<starrocks::BaseTablet> (use count 65794, weak count 1) = {get() = 0x7fffb94a1b10}}, 
  _tablet_rowsets = std::vector of length 1, capacity 1 = {std::vector of length 1, capacity 1 = {
      std::shared_ptr<starrocks::BaseRowset> (use count 65794, weak count 1) = {get() = 0x7fffb99b9cf0}}}}
(gdb) 
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
