### PR TITLE
[Enhancement] DeltaLake support collect min/max/nullcount statistics from metadata file

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeComparators.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeComparators.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.connector.delta;
+
+import com.google.common.collect.ImmutableMap;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.ByteType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.DateType;
+import io.delta.kernel.types.DoubleType;
+import io.delta.kernel.types.FloatType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.ShortType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.TimestampNTZType;
+import io.delta.kernel.types.TimestampType;
+
+import java.util.Comparator;
+
+public class DeltaLakeComparators {
+    private DeltaLakeComparators() {
+    }
+
+    private static final ImmutableMap<DataType, Comparator<?>> COMPARATORS =
+            ImmutableMap.<DataType, Comparator<?>>builder()
+                    .put(BooleanType.BOOLEAN, Comparator.naturalOrder())
+                    .put(ShortType.SHORT, Comparator.naturalOrder())
+                    .put(IntegerType.INTEGER, Comparator.naturalOrder())
+                    .put(LongType.LONG, Comparator.naturalOrder())
+                    .put(FloatType.FLOAT, Comparator.naturalOrder())
+                    .put(DoubleType.DOUBLE, Comparator.naturalOrder())
+                    .put(TimestampType.TIMESTAMP, Comparator.naturalOrder())
+                    .put(TimestampNTZType.TIMESTAMP_NTZ, Comparator.naturalOrder())
+                    .put(DateType.DATE, Comparator.naturalOrder())
+                    .put(StringType.STRING, Comparator.naturalOrder())
+                    .put(BinaryType.BINARY, Comparator.naturalOrder())
+                    .put(ByteType.BYTE, Comparator.naturalOrder())
+                    .buildOrThrow();
+
+    @SuppressWarnings("unchecked")
+    public static <T> Comparator<T> forType(DataType type) {
+        Comparator<?> cmp = COMPARATORS.get(type);
+        if (cmp != null) {
+            return (Comparator<T>) cmp;
+        } else {
+            throw new UnsupportedOperationException("Cannot determine comparator for type: " + type);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -186,14 +186,29 @@ public class DeltaLakeFileStats {
         this.size += numberOfBytes;
     }
 
-    public void updateStats(Map<String, Object> curStat,
+    public void updateMinStats(Map<String, Object> newStat, Map<String, Object> nullCounts,
+                               long recordCount, Predicate<Integer> predicate) {
+        if (!hasValidColumnMetrics) {
+            return;
+        }
+
+        updateStats(this.minValues, newStat, nullCounts, recordCount, predicate);
+    }
+
+    public void updateMaxStats(Map<String, Object> newStat, Map<String, Object> nullCounts,
+                               long recordCount, Predicate<Integer> predicate) {
+        if (!hasValidColumnMetrics) {
+            return;
+        }
+
+        updateStats(this.maxValues, newStat, nullCounts, recordCount, predicate);
+    }
+
+    private void updateStats(Map<String, Object> curStat,
                             Map<String, Object> newStat,
                             Map<String, Object> nullCounts,
                             long recordCount,
                             Predicate<Integer> predicate) {
-        if (!hasValidColumnMetrics) {
-            return;
-        }
         if (newStat == null || nullCounts == null) {
             hasValidColumnMetrics = false;
             return;
@@ -256,11 +271,11 @@ public class DeltaLakeFileStats {
     }
 
     private static double parseDate(String str) {
-        LocalDateTime time = LocalDateTime.parse(str, DateUtils.DATE_FORMATTER_UNIX);
+        LocalDateTime time = DateUtils.parseStrictDateTime(str);
         return time.atZone(ZoneOffset.UTC).toEpochSecond();
     }
 
-    public static Optional<Double> convertObjectToOptionalDouble(DataType type, Object value) {
+    private static Optional<Double> convertObjectToOptionalDouble(DataType type, Object value) {
         // TODO: Decimal
         double result;
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -1,0 +1,258 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import io.delta.kernel.types.BasePrimitiveType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.DoubleType;
+import io.delta.kernel.types.FloatType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.ShortType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class DeltaLakeFileStats {
+    private final StructType schema;
+    private final List<String> nonPartitionPrimitiveColumns;
+    private long recordCount;
+    private long size;
+    private final Map<String, Object> minValues;
+    private final Map<String, Object> maxValues;
+    private final Map<String, Object> nullCounts;
+    private final Set<String> corruptedStats;
+    private boolean hasValidColumnMetrics;
+
+    public DeltaLakeFileStats(StructType schema,
+                              List<String> nonPartitionPrimitiveColumns,
+                              long recordCount,
+                              long size,
+                              Map<String, Object> minValues,
+                              Map<String, Object> maxValues,
+                              Map<String, Object> nullCounts) {
+        this.schema = schema;
+        this.nonPartitionPrimitiveColumns = nonPartitionPrimitiveColumns;
+        this.recordCount = recordCount;
+        this.size = size;
+        if (minValues == null || maxValues == null || nullCounts == null) {
+            this.minValues = null;
+            this.maxValues = null;
+            this.nullCounts = null;
+            this.corruptedStats = null;
+            this.hasValidColumnMetrics = false;
+        } else {
+            this.minValues = new HashMap<>(minValues);
+            this.maxValues = new HashMap<>(maxValues);
+            this.nullCounts = nonPartitionPrimitiveColumns.stream()
+                    .filter(col -> !nullCounts.containsKey(col))
+                    .collect(Collectors.toMap(col -> col, nullCounts::get));
+            this.corruptedStats = nonPartitionPrimitiveColumns.stream()
+                    .filter(col -> !minValues.containsKey(col) &&
+                            (!nullCounts.containsKey(col) || ((Double) nullCounts.get(col)).longValue() != recordCount))
+                    .collect(Collectors.toSet());
+            this.hasValidColumnMetrics = true;
+        }
+    }
+
+    public DeltaLakeFileStats(long recordCount) {
+        this.schema = null;
+        this.nonPartitionPrimitiveColumns = null;
+        this.recordCount = recordCount;
+        this.size = 0;
+        this.minValues = null;
+        this.maxValues = null;
+        this.nullCounts = null;
+        this.corruptedStats = null;
+        this.hasValidColumnMetrics = false;
+    }
+
+    public List<String> getNonPartitionPrimitiveColumns() {
+        return nonPartitionPrimitiveColumns;
+    }
+
+    public long getRecordCount() {
+        return recordCount;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public StructType getSchema() {
+        return schema;
+    }
+
+    public Map<String, Object> getMinValues() {
+        return minValues;
+    }
+
+    public Optional<Double> getMinValue(String colName) {
+        return getBoundStatistic(colName, minValues);
+    }
+
+    public boolean canUseStats(String colName, Map<String, Object> values) {
+        if (schema == null || values == null) {
+            return false;
+        }
+
+        return schema.get(colName) != null && values.get(colName) != null;
+    }
+
+    private Optional<Double> getBoundStatistic(String colName, Map<String, Object> boundValues) {
+        if (boundValues == null) {
+            return Optional.empty();
+        }
+        StructField field = schema.get(colName);
+        if (field == null) {
+            return Optional.empty();
+        }
+        Object value = boundValues.get(colName);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return convertObjectToOptionalDouble(field.getDataType(), value);
+    }
+
+    public Optional<Double> getMaxValue(String colName) {
+        return getBoundStatistic(colName, maxValues);
+    }
+
+    public Map<String, Object> getMaxValues() {
+        return maxValues;
+    }
+
+    public Map<String, Object> getNullCounts() {
+        return nullCounts;
+    }
+
+    public Long getNullCount(String col) {
+        if (nullCounts == null) {
+            return null;
+        }
+        Object v = nullCounts.get(col);
+        if (v == null) {
+            return null;
+        }
+        return ((Double) v).longValue();
+    }
+
+    public Set<String> getCorruptedStats() {
+        return corruptedStats;
+    }
+
+    public boolean isHasValidColumnMetrics() {
+        return hasValidColumnMetrics;
+    }
+
+    public void incrementRecordCount(long count) {
+        this.recordCount += count;
+    }
+
+    public void incrementSize(long numberOfBytes) {
+        this.size += numberOfBytes;
+    }
+
+    public void updateStats(Map<String, Object> curStat,
+                            Map<String, Object> newStat,
+                            Map<String, Object> nullCounts,
+                            long recordCount,
+                            Predicate<Integer> predicate) {
+        if (!hasValidColumnMetrics) {
+            return;
+        }
+        if (newStat == null || nullCounts == null) {
+            hasValidColumnMetrics = false;
+            return;
+        }
+        for (String col : nonPartitionPrimitiveColumns) {
+            if (corruptedStats.contains(col)) {
+                continue;
+            }
+
+            Object newValue = newStat.get(col);
+            if (newValue == null) {
+                Double nullCount = (Double) nullCounts.get(col);
+                if ((nullCount == null) || (nullCount.longValue() != recordCount)) {
+                    curStat.remove(col);
+                    corruptedStats.add(col);
+                }
+                continue;
+            }
+
+            DataType type = schema.get(col).getDataType();
+            Object oldValue = curStat.putIfAbsent(col, newValue);
+            if (oldValue != null) {
+                Comparator<Object> comparator = DeltaLakeComparators.forType(type);
+                if (predicate.test(comparator.compare(oldValue, newValue))) {
+                    curStat.put(col, newValue);
+                }
+            }
+        }
+    }
+
+    public void updateNullCount(Map<String, Object> nullCounts, List<String> nonPartitionPrimitiveColumns) {
+        if (!hasValidColumnMetrics) {
+            return;
+        }
+        if (nullCounts == null) {
+            hasValidColumnMetrics = false;
+            return;
+        }
+
+        for (String col : nonPartitionPrimitiveColumns) {
+            DataType type = schema.get(col).getDataType();
+            if (BasePrimitiveType.isPrimitiveType(type.toString())) {
+                this.nullCounts.merge(col, nullCounts.get(col), DeltaLakeFileStats::sumNullCount);
+            }
+        }
+    }
+
+    public static Object sumNullCount(Object left, Object value) {
+        return (Double) left + (Double) value;
+    }
+
+    public static Optional<Double> convertObjectToOptionalDouble(DataType type, Object value) {
+        // TODO: Timestamp, TimestampNTZ, Date, Decimal
+        double result;
+
+        if (type instanceof BooleanType) {
+            result = (boolean) value ? 1 : 0;
+        } else if (type instanceof ShortType) {
+            result = (double) value;
+        } else if (type instanceof IntegerType) {
+            result = (double) value;
+        } else if (type instanceof LongType) {
+            result = (double) value;
+        } else if (type instanceof FloatType) {
+            result = (double) value;
+        } else if (type instanceof DoubleType) {
+            result = (double) value;
+        } else {
+            return Optional.empty();
+        }
+
+        return Optional.of(result);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -19,6 +19,7 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import io.delta.kernel.types.BasePrimitiveType;
 import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.ByteType;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.DateType;
 import io.delta.kernel.types.DoubleType;
@@ -109,7 +110,8 @@ public class DeltaLakeFileStats {
             return;
         }
 
-        builder.setAverageRowSize(size * 1.0 / Math.max(recordCount, 1));
+        // TODO: Currently not set avg size, will be optimized laster.
+        // builder.setAverageRowSize(xxx);
         builder.setType(ColumnStatistic.StatisticType.UNKNOWN);
 
         String colName = col.getName();
@@ -265,6 +267,8 @@ public class DeltaLakeFileStats {
 
         if (type instanceof BooleanType) {
             result = (boolean) value ? 1 : 0;
+        } else if (type instanceof ByteType) {
+            result = (double) value;
         } else if (type instanceof ShortType) {
             result = (double) value;
         } else if (type instanceof IntegerType) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -44,8 +44,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class DeltaLakeFileStats {
-    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
-    private static final DateTimeFormatter TIME_ZONE_FORMAT =
+    private static final DateTimeFormatter TIMESTAMP_NTZ_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    private static final DateTimeFormatter TIMESTAMP_ZONE_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
     private final StructType schema;
@@ -109,7 +110,7 @@ public class DeltaLakeFileStats {
         }
 
         builder.setAverageRowSize(size * 1.0 / Math.max(recordCount, 1));
-        builder.setDistinctValuesCount(1);
+        builder.setType(ColumnStatistic.StatisticType.UNKNOWN);
 
         String colName = col.getName();
         if (!nonPartitionPrimitiveColumns.contains(colName)) {
@@ -243,13 +244,13 @@ public class DeltaLakeFileStats {
         }
     }
 
-    private static double parseTimestampWithTimeZone(String str) {
-        OffsetDateTime time = OffsetDateTime.parse(str, TIME_ZONE_FORMAT);
+    private static double parseTimestampWithAtZone(String str) {
+        OffsetDateTime time = OffsetDateTime.parse(str, TIMESTAMP_ZONE_FORMAT);
         return time.toEpochSecond();
     }
 
     private static double parseTimestampNTZ(String str) {
-        LocalDateTime time = LocalDateTime.parse(str, TIME_FORMAT);
+        LocalDateTime time = LocalDateTime.parse(str, TIMESTAMP_NTZ_FORMAT);
         return time.atZone(ZoneOffset.UTC).toEpochSecond();
     }
 
@@ -277,7 +278,7 @@ public class DeltaLakeFileStats {
         } else if (type instanceof TimestampNTZType) {
             result = parseTimestampNTZ((String) value);
         } else if (type instanceof TimestampType) {
-            result = parseTimestampWithTimeZone((String) value);
+            result = parseTimestampWithAtZone((String) value);
         } else if (type instanceof DateType) {
             result = parseDate((String) value);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStruct.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStruct.java
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+public class DeltaLakeFileStruct {
+    @SerializedName(value = "numRecords")
+    public long numRecords;
+
+    @SerializedName(value = "minValues")
+    public Map<String, Object> minValues;
+
+    @SerializedName(value = "maxValues")
+    public Map<String, Object> maxValues;
+
+    @SerializedName(value = "nullCount")
+    public Map<String, Object> nullCount;
+
+    public DeltaLakeFileStruct(long numRecords) {
+        this.numRecords = numRecords;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.delta;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.PartitionKey;
@@ -31,19 +32,24 @@ import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import io.delta.kernel.Scan;
-import io.delta.kernel.ScanBuilder;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.ScanBuilderImpl;
+import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.types.BasePrimitiveType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import org.apache.logging.log4j.LogManager;
@@ -57,6 +63,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 
 public class DeltaLakeMetadata implements ConnectorMetadata {
@@ -67,6 +74,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     private final Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor;
     private final Map<PredicateSearchKey, List<Row>> splitTasks = new ConcurrentHashMap<>();
     private final Set<PredicateSearchKey> scannedTables = new HashSet<>();
+    private final DeltaStatisticProvider statisticProvider = new DeltaStatisticProvider();
 
     public DeltaLakeMetadata(HdfsEnvironment hdfsEnvironment, String catalogName, DeltaMetastoreOperations deltaOps,
                              Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor) {
@@ -129,15 +137,45 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         return Lists.newArrayList(remoteFileInfo);
     }
 
-    private void triggerDeltaLakePlanFilesIfNeeded(PredicateSearchKey key, Table table, ScalarOperator operator) {
-        if (!scannedTables.contains(key)) {
-            try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "DELTA_LAKE.processSplit." + key)) {
-                collectDeltaLakePlanFiles(key, table, operator);
+    @Override
+    public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
+                                         List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit) {
+        DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
+        SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
+        String dbName = deltaLakeTable.getDbName();
+        String tableName = deltaLakeTable.getTableName();
+        Engine engine = deltaLakeTable.getDeltaEngine();
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, snapshot.getVersion(engine), predicate);
+
+        DeltaUtils.checkTableFeatureSupported(snapshot.getProtocol(), snapshot.getMetadata());
+
+        triggerDeltaLakePlanFilesIfNeeded(key, deltaLakeTable, predicate);
+
+        List<Row> deltaLakeScanTasks = splitTasks.get(key);
+        if (deltaLakeScanTasks == null) {
+            throw new StarRocksConnectorException("Missing delta split task for table:[{}.{}]. predicate:[{}]",
+                    dbName, table, predicate);
+        }
+
+        if (session.getSessionVariable().enableDeltaLakeColumnStatistics()) {
+            return statisticProvider.getTableStatistics(deltaLakeTable, columns, predicate);
+        } else {
+            try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.calculateCardinality" + key)) {
+                return statisticProvider.getCardinalityStats(columns, deltaLakeScanTasks);
             }
         }
     }
 
-    private void collectDeltaLakePlanFiles(PredicateSearchKey key, Table table, ScalarOperator operator) {
+    private void triggerDeltaLakePlanFilesIfNeeded(PredicateSearchKey key, Table table, ScalarOperator operator) {
+        if (!scannedTables.contains(key)) {
+            try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "DELTA_LAKE.processSplit." + key)) {
+                collectDeltaLakePlanFiles(key, table, operator, ConnectContext.get());
+            }
+        }
+    }
+
+    private void collectDeltaLakePlanFiles(PredicateSearchKey key, Table table, ScalarOperator operator,
+                                           ConnectContext connectContext) {
         DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
         Metadata metadata = deltaLakeTable.getDeltaMetadata();
         Engine engine = deltaLakeTable.getDeltaEngine();
@@ -151,12 +189,17 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                 new ScalarOperationToDeltaLakeExpr.DeltaLakeContext(schema, partitionColumns);
         Predicate deltaLakePredicate = new ScalarOperationToDeltaLakeExpr().convert(scalarOperators, deltaLakeContext);
 
-        ScanBuilder scanBuilder = snapshot.getScanBuilder(engine);
-        Scan scan = scanBuilder.withFilter(engine, deltaLakePredicate).build();
+        ScanBuilderImpl scanBuilder = (ScanBuilderImpl) snapshot.getScanBuilder(engine);
+        ScanImpl scan = (ScanImpl) scanBuilder.withFilter(engine, deltaLakePredicate).build();
+
+        List<String> nonPartitionPrimitiveColumns = schema.fieldNames().stream()
+                .filter(column -> BasePrimitiveType.isPrimitiveType(
+                        schema.get(column).getDataType().toString())
+                        && !partitionColumns.contains(column)).collect(toImmutableList());
 
         List<Row> files = Lists.newArrayList();
 
-        try (CloseableIterator<FilteredColumnarBatch> scanFilesAsBatches = scan.getScanFiles(engine)) {
+        try (CloseableIterator<FilteredColumnarBatch> scanFilesAsBatches = scan.getScanFiles(engine, true)) {
             while (scanFilesAsBatches.hasNext()) {
                 FilteredColumnarBatch scanFileBatch = scanFilesAsBatches.next();
                 try (CloseableIterator<Row> scanFileRows = scanFileBatch.getRows()) {
@@ -168,6 +211,13 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                                     "Delta table feature [deletion vectors] is not supported");
                         }
                         files.add(scanFileRow);
+
+                        if (enableCollectColumnStatistics(connectContext)) {
+                            try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.updateDeltaLakeFileStats")) {
+                                statisticProvider.updateFileStats(deltaLakeTable, key, scanFileRow,
+                                        nonPartitionPrimitiveColumns);
+                            }
+                        }
                     }
                 }
             }
@@ -178,6 +228,18 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
         splitTasks.put(key, files);
         scannedTables.add(key);
+    }
+
+    public boolean enableCollectColumnStatistics(ConnectContext context) {
+        if (context == null) {
+            return false;
+        }
+
+        if (context.getSessionVariable() == null) {
+            return false;
+        }
+
+        return context.getSessionVariable().enableDeltaLakeColumnStatistics();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeStatsStruct.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeStatsStruct.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Map;
 
-public class DeltaLakeFileStruct {
+public class DeltaLakeStatsStruct {
     @SerializedName(value = "numRecords")
     public long numRecords;
 
@@ -31,7 +31,7 @@ public class DeltaLakeFileStruct {
     @SerializedName(value = "nullCount")
     public Map<String, Object> nullCount;
 
-    public DeltaLakeFileStruct(long numRecords) {
+    public DeltaLakeStatsStruct(long numRecords) {
         this.numRecords = numRecords;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -104,7 +104,7 @@ public class DeltaStatisticProvider {
                                   Map<String, Object> upperBounds,
                                   Map<String, Object> nulCounts,
                                   long recordCount) {
-        deltaLakeFileStats.updateMaxStats(upperBounds, nulCounts, recordCount, i -> (i > 0));
+        deltaLakeFileStats.updateMaxStats(upperBounds, nulCounts, recordCount, i -> (i < 0));
     }
 
     public Statistics getTableStatistics(DeltaLakeTable deltaLakeTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -241,7 +241,8 @@ public class DeltaStatisticProvider {
         } else {
             builder.setNullsFraction(nullCount * 1.0 / Math.max(fileStats.getRecordCount(), 1));
         }
-        builder.setAverageRowSize(1);
+        builder.setAverageRowSize(fileStats.getSize() * 1.0 / Math.max(fileStats.getRecordCount(), 1));
+        builder.setDistinctValuesCount(1);
 
         return builder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -76,7 +76,7 @@ public class DeltaStatisticProvider {
         FileStatus status = InternalScanFileUtils.getAddFileStatus(file);
 
         Row addFileEntry = getAddFileEntry(file);
-        DeltaLakeFileStruct fileStat = ScanFileUtils.getColumnStatistics(addFileEntry);
+        DeltaLakeStatsStruct fileStat = ScanFileUtils.getColumnStatistics(addFileEntry);
 
         DeltaLakeFileStats fileStats;
         if (deltaLakeFileStatsMap.containsKey(key)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -1,0 +1,248 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.connector.PredicateSearchKey;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.FileStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_ORDINAL;
+
+public class DeltaStatisticProvider {
+    private static final Logger LOG = LogManager.getLogger(DeltaStatisticProvider.class);
+    private final Map<PredicateSearchKey, DeltaLakeFileStats> deltaLakeFileStatsMap = new HashMap<>();
+
+    public DeltaStatisticProvider() {}
+
+    public Statistics getCardinalityStats(Map<ColumnRefOperator, Column> columnRefOperatorColumnMap,
+                                          List<Row> fileScanTasks) {
+        Statistics.Builder builder = Statistics.builder();
+        long cardinality = 0;
+        Set<String> currentFiles = new HashSet<>();
+
+        for (Row file : fileScanTasks) {
+            FileStatus status = InternalScanFileUtils.getAddFileStatus(file);
+            String path = status.getPath();
+
+            if (currentFiles.contains(path)) {
+                continue;
+            }
+            currentFiles.add(path);
+
+            Row addFileEntry = getAddFileEntry(file);
+            long rows = ScanFileUtils.getFileRows(addFileEntry);
+            cardinality += rows;
+        }
+
+        return builder.setOutputRowCount(cardinality)
+                .addColumnStatistics(buildUnknownColumnStatistics(columnRefOperatorColumnMap.keySet()))
+                .build();
+    }
+
+    public void updateFileStats(DeltaLakeTable table, PredicateSearchKey key, Row file,
+                                List<String> nonPartitionPrimitiveColumn) {
+        StructType schema = table.getDeltaMetadata().getSchema();
+
+        FileStatus status = InternalScanFileUtils.getAddFileStatus(file);
+
+        Row addFileEntry = getAddFileEntry(file);
+        DeltaLakeFileStruct fileStat = ScanFileUtils.getColumnStatistics(addFileEntry);
+
+        DeltaLakeFileStats fileStats;
+        if (deltaLakeFileStatsMap.containsKey(key)) {
+            fileStats = deltaLakeFileStatsMap.get(key);
+            fileStats.incrementRecordCount(fileStat.numRecords);
+            fileStats.incrementSize(status.getSize());
+            updateSummaryMin(fileStats, nonPartitionPrimitiveColumn, fileStat.minValues,
+                    fileStat.nullCount, fileStat.numRecords);
+            updateSummaryMax(fileStats, nonPartitionPrimitiveColumn, fileStat.maxValues,
+                    fileStat.nullCount, fileStat.numRecords);
+            fileStats.updateNullCount(fileStat.nullCount, nonPartitionPrimitiveColumn);
+        } else {
+            fileStats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumn, fileStat.numRecords,
+                    status.getSize(), fileStat.minValues, fileStat.maxValues, fileStat.nullCount);
+            deltaLakeFileStatsMap.put(key, fileStats);
+        }
+    }
+
+    private void updateSummaryMin(DeltaLakeFileStats deltaLakeFileStats,
+                                  List<String> partitionCols,
+                                  Map<String, Object> lowerBounds,
+                                  Map<String, Object> nullCounts,
+                                  long recordCount) {
+        deltaLakeFileStats.updateStats(deltaLakeFileStats.getMinValues(), lowerBounds, nullCounts,
+                recordCount, i -> (i > 0));
+        updatePartitionedStats(deltaLakeFileStats, partitionCols, deltaLakeFileStats.getMinValues(),
+                lowerBounds, i -> (i > 0));
+    }
+
+    private void updateSummaryMax(DeltaLakeFileStats deltaLakeFileStats,
+                                  List<String> partitionCols,
+                                  Map<String, Object> upperBounds,
+                                  Map<String, Object> nulCounts,
+                                  long recordCount) {
+        deltaLakeFileStats.updateStats(deltaLakeFileStats.getMaxValues(), upperBounds, nulCounts,
+                recordCount, i -> (i > 0));
+        updatePartitionedStats(deltaLakeFileStats, partitionCols, deltaLakeFileStats.getMaxValues(),
+                upperBounds, i -> (i > 0));
+    }
+
+    private void updatePartitionedStats(DeltaLakeFileStats deltaLakeFileStats,
+                                        List<String> partitionCols,
+                                        Map<String, Object> curStats,
+                                        Map<String, Object> newStats,
+                                        Predicate<Integer> predicate) {
+        if (!deltaLakeFileStats.isHasValidColumnMetrics()) {
+            return;
+        }
+
+        for (String col : partitionCols) {
+            if (deltaLakeFileStats.getCorruptedStats().contains(col)) {
+                continue;
+            }
+
+            Object newValue = newStats.get(col);
+            if (newValue == null) {
+                curStats.remove(col);
+                deltaLakeFileStats.getCorruptedStats().add(col);
+                continue;
+            }
+
+            DataType type = deltaLakeFileStats.getSchema().get(col).getDataType();
+            Object oldValue = curStats.putIfAbsent(col, newValue);
+            if (oldValue != null) {
+                Comparator<Object> comparator = DeltaLakeComparators.forType(type);
+                if (predicate.test(comparator.compare(oldValue, newValue))) {
+                    curStats.put(col, newValue);
+                }
+            }
+        }
+    }
+
+    public Statistics getTableStatistics(DeltaLakeTable deltaLakeTable,
+                                         Map<ColumnRefOperator, Column> columnRefOperatorColumnMap,
+                                         ScalarOperator predicate) {
+        String dbName = deltaLakeTable.getDbName();
+        String tableName = deltaLakeTable.getTableName();
+        Engine engine = deltaLakeTable.getDeltaEngine();
+        long snapshotId = deltaLakeTable.getDeltaSnapshot().getVersion(engine);
+        StructType schema = deltaLakeTable.getDeltaMetadata().getSchema();
+
+        Statistics.Builder builder = Statistics.builder();
+
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, snapshotId, predicate);
+        DeltaLakeFileStats deltaLakeFileStats;
+        if (deltaLakeFileStatsMap.containsKey(key)) {
+            deltaLakeFileStats = deltaLakeFileStatsMap.get(key);
+        } else {
+            deltaLakeFileStats = new DeltaLakeFileStats(0);
+        }
+
+        builder.setOutputRowCount(deltaLakeFileStats.getRecordCount());
+        builder.addColumnStatistics(buildColumnStatistics(deltaLakeTable, schema,
+                columnRefOperatorColumnMap, deltaLakeFileStats));
+
+        return builder.build();
+    }
+
+    private static Row getAddFileEntry(Row file) {
+        if (file.isNullAt(ADD_FILE_ORDINAL)) {
+            throw new IllegalArgumentException("There is no `add` entry in the scan file row");
+        } else {
+            return file.getStruct(ADD_FILE_ORDINAL);
+        }
+    }
+
+    public Map<ColumnRefOperator, ColumnStatistic> buildUnknownColumnStatistics(Set<ColumnRefOperator> columns) {
+        return columns.stream().collect(Collectors.toMap(column -> column, column -> ColumnStatistic.unknown()));
+    }
+
+    private Map<ColumnRefOperator, ColumnStatistic> buildColumnStatistics(
+            DeltaLakeTable table, StructType schema, Map<ColumnRefOperator, Column> columnRefOperatorColumns,
+            DeltaLakeFileStats fileStats) {
+        Map<ColumnRefOperator, ColumnStatistic> columnStatistics = new HashMap<>();
+
+        for (Map.Entry<ColumnRefOperator, Column> entry : columnRefOperatorColumns.entrySet())  {
+            if (columnStatistics.containsKey(entry.getKey())) {
+                continue;
+            }
+
+            if (schema.get(entry.getValue().getName()) == null) {
+                columnStatistics.put(entry.getKey(), ColumnStatistic.unknown());
+            }
+
+            columnStatistics.put(entry.getKey(), buildColumnStatistic(entry.getValue(), fileStats));
+        }
+
+        return columnStatistics;
+    }
+
+    private ColumnStatistic buildColumnStatistic(Column column, DeltaLakeFileStats fileStats) {
+        ColumnStatistic.Builder builder = ColumnStatistic.builder();
+        String colName = column.getName();
+
+        if (fileStats.canUseStats(colName, fileStats.getMinValues())) {
+            if (column.getType().isStringType()) {
+                String minString = fileStats.getMinValues().get(colName).toString();
+                builder.setMinString(minString);
+            } else {
+                Optional<Double> res = fileStats.getMinValue(colName);
+                res.ifPresent(builder::setMinValue);
+            }
+        }
+
+        if (fileStats.canUseStats(colName, fileStats.getMaxValues())) {
+            if (column.getType().isStringType()) {
+                String maxString = fileStats.getMaxValues().get(colName).toString();
+                builder.setMaxString(maxString);
+            } else {
+                Optional<Double> res = fileStats.getMaxValue(colName);
+                res.ifPresent(builder::setMaxValue);
+            }
+        }
+
+        Long nullCount = fileStats.getNullCount(colName);
+        if (nullCount == null) {
+            builder.setNullsFraction(0);
+        } else {
+            builder.setNullsFraction(nullCount * 1.0 / Math.max(fileStats.getRecordCount(), 1));
+        }
+        builder.setAverageRowSize(1);
+
+        return builder.build();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -17,8 +17,6 @@ package com.starrocks.connector.delta;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.persist.gson.GsonUtils;
 import io.delta.kernel.data.Row;
-import io.delta.kernel.internal.InternalScanFileUtils;
-import io.delta.kernel.utils.FileStatus;
 
 import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_STATS_ORDINAL;
 
@@ -28,13 +26,8 @@ public class ScanFileUtils {
         public long numRecords;
     }
 
-    public static String getPath(Row addFileRow) {
-        FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(addFileRow);
-        return fileStatus.getPath();
-    }
-
-    public static long getFileRows(Row addFileRow) {
-        String stats = addFileRow.getString(ADD_FILE_STATS_ORDINAL);
+    public static long getFileRows(Row file) {
+        String stats = file.getString(ADD_FILE_STATS_ORDINAL);
         if (stats == null) {
             throw new IllegalArgumentException("There is no `stats` entry in the add file row");
         }
@@ -47,8 +40,8 @@ public class ScanFileUtils {
         return records.numRecords;
     }
 
-    public static DeltaLakeFileStruct getColumnStatistics(Row addFileRow) {
-        String stats = addFileRow.getString(ADD_FILE_STATS_ORDINAL);
+    public static DeltaLakeFileStruct getColumnStatistics(Row file) {
+        String stats = file.getString(ADD_FILE_STATS_ORDINAL);
         if (stats == null) {
             throw new IllegalArgumentException("There is no `stats` entry in the add file row");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonUtils;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.utils.FileStatus;
+
+import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_STATS_ORDINAL;
+
+public class ScanFileUtils {
+    public static class Records {
+        @SerializedName(value = "numRecords")
+        public long numRecords;
+    }
+
+    public static String getPath(Row addFileRow) {
+        FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(addFileRow);
+        return fileStatus.getPath();
+    }
+
+    public static long getFileRows(Row addFileRow) {
+        String stats = addFileRow.getString(ADD_FILE_STATS_ORDINAL);
+        if (stats == null) {
+            throw new IllegalArgumentException("There is no `stats` entry in the add file row");
+        }
+
+        Records records = GsonUtils.GSON.fromJson(stats, Records.class);
+        if (records == null) {
+            throw new IllegalArgumentException("There is no `records` entry in the stats row");
+        }
+
+        return records.numRecords;
+    }
+
+    public static DeltaLakeFileStruct getColumnStatistics(Row addFileRow) {
+        String stats = addFileRow.getString(ADD_FILE_STATS_ORDINAL);
+        if (stats == null) {
+            throw new IllegalArgumentException("There is no `stats` entry in the add file row");
+        }
+
+        DeltaLakeFileStruct statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeFileStruct.class);
+        if (statistics == null) {
+            throw new IllegalArgumentException("There is no entry in the stats row");
+        }
+
+        return statistics;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -40,13 +40,13 @@ public class ScanFileUtils {
         return records.numRecords;
     }
 
-    public static DeltaLakeFileStruct getColumnStatistics(Row file) {
+    public static DeltaLakeStatsStruct getColumnStatistics(Row file) {
         String stats = file.getString(ADD_FILE_STATS_ORDINAL);
         if (stats == null) {
             throw new IllegalArgumentException("There is no `stats` entry in the add file row");
         }
 
-        DeltaLakeFileStruct statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeFileStruct.class);
+        DeltaLakeStatsStruct statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeStatsStruct.class);
         if (statistics == null) {
             throw new IllegalArgumentException("There is no entry in the stats row");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
@@ -117,11 +117,7 @@ public class IcebergFileStats {
             return false;
         }
 
-        if (idToTypeMapping.get(fieldId) == null || values.get(fieldId) == null) {
-            return false;
-        }
-
-        return true;
+        return idToTypeMapping.get(fieldId) != null && values.get(fieldId) != null;
     }
 
     private Optional<Double> getBoundStatistic(Integer fieldId, Map<Integer, Object> boundValues) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -412,6 +412,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = "enable_read_iceberg_puffin_ndv";
 
     public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = "enable_iceberg_column_statistics";
+    public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = "enable_delta_lake_column_statistics";
     public static final String PLAN_MODE = "plan_mode";
 
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
@@ -2026,6 +2027,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS)
     private boolean enableIcebergColumnStatistics = false;
 
+    @VarAttr(name = ENABLE_DELTA_LAKE_COLUMN_STATISTICS)
+    private boolean enableDeltaLakeColumnStatistics = false;
+
     @VarAttr(name = PLAN_MODE)
     private String planMode = PlanMode.AUTO.modeName();
 
@@ -2112,8 +2116,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableReadIcebergPuffinNdv = enableReadIcebergPuffinNdv;
     }
 
+    public boolean enableDeltaLakeColumnStatistics() {
+        return enableDeltaLakeColumnStatistics;
+    }
+
     public boolean enableIcebergColumnStatistics() {
         return enableIcebergColumnStatistics;
+    }
+
+    public void setEnableDeltaLakeColumnStatistics(boolean enableDeltaLakeColumnStatistics) {
+        this.enableDeltaLakeColumnStatistics = enableDeltaLakeColumnStatistics;
     }
 
     public void setEnableIcebergColumnStatistics(boolean enableIcebergColumnStatistics) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHudiScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
@@ -420,6 +421,8 @@ public class Utils {
                 return true;
             } else if (operator instanceof LogicalIcebergScanOperator) {
                 return ((LogicalIcebergScanOperator) operator).hasUnknownColumn();
+            } else if (operator instanceof LogicalDeltaLakeScanOperator)  {
+                return ((LogicalDeltaLakeScanOperator) operator).hasUnknownColumn();
             } else {
                 // For other scan operators, we do not know the column statistics.
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalDeltaLakeScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalDeltaLakeScanOperator.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class LogicalDeltaLakeScanOperator extends LogicalScanOperator {
     private ScanOperatorPredicates predicates = new ScanOperatorPredicates();
 
+    private boolean hasUnknownColumn = true;
     public LogicalDeltaLakeScanOperator(Table table,
                                         Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
                                         Map<Column, ColumnRefOperator> columnMetaToColRefMap,
@@ -47,6 +48,13 @@ public class LogicalDeltaLakeScanOperator extends LogicalScanOperator {
         return visitor.visitLogicalDeltaLakeScan(this, context);
     }
 
+    public boolean hasUnknownColumn() {
+        return hasUnknownColumn;
+    }
+
+    public void setHasUnknownColumn(boolean hasUnknownColumn) {
+        this.hasUnknownColumn = hasUnknownColumn;
+    }
     @Override
     public ScanOperatorPredicates getScanOperatorPredicates() {
         return this.predicates;

--- a/test/sql/test_deltalake/R/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/R/test_deltalake_collect_stats
@@ -1,0 +1,166 @@
+-- name: testDeltaLakeCollectStats
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+set time_zone="Asia/Shanghai";
+-- result:
+-- !result
+set enable_delta_lake_column_statistics=false;
+-- result:
+-- !result
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'cardinality=8')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_tinyint-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_smallint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_smallint-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_int from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_int-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_long from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_long-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_float from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_float-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_double from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_double-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_date from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_date-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_timestamp from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_timestamp-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_string from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_string-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_decimal from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_decimal-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_boolean from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_boolean-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_byte from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_byte-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_array from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_array-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_binary from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_binary-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_map from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_map-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_struct-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntz', 'col_timestamp_ntz-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+set enable_delta_lake_column_statistics=true;
+-- result:
+-- !result
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'cardinality=8')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_tinyint-->[1.0, 6.0, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_smallint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_smallint-->[100.0, 600.0, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_int from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_int-->[1000.0, 6000.0, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_long from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_long-->[10000.0, 60000.0, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_float from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_float-->[3.14, 18.84, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_double from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_double-->[3.14159, 18.84956, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_date from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_date-->[1.7139168E9, 1.7143488E9, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_timestamp from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_timestamp-->[1.7139312E9, 1.7143632E9, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_string from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_string-->[-Infinity, Infinity, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_decimal from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_decimal-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_boolean from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_boolean-->[-Infinity, Infinity, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_byte from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_byte-->[1.0, 6.0, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_array from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_array-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_binary from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_binary-->[-Infinity, Infinity, 0.0, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_map from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_map-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_struct-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntz', 'col_timestamp_ntz-->[1.704157323E9, 1.704427506E9, 0.2, NaN, NaN] UNKNOWN')
+-- result:
+None
+-- !result
+drop catalog delta_test_${uuid0}
+-- result:
+-- !result

--- a/test/sql/test_deltalake/T/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/T/test_deltalake_collect_stats
@@ -30,7 +30,7 @@ function: assert_explain_costs_contains('select col_array from delta_test_${uuid
 function: assert_explain_costs_contains('select col_binary from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_binary-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
 function: assert_explain_costs_contains('select col_map from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_map-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
 function: assert_explain_costs_contains('select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_struct-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
-function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntx', 'col_timestamp_ntz-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntz', 'col_timestamp_ntz-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
 
 set enable_delta_lake_column_statistics=true;
 
@@ -52,6 +52,6 @@ function: assert_explain_costs_contains('select col_array from delta_test_${uuid
 function: assert_explain_costs_contains('select col_binary from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_binary-->[-Infinity, Infinity, 0.0, NaN, NaN] UNKNOWN')
 function: assert_explain_costs_contains('select col_map from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_map-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
 function: assert_explain_costs_contains('select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_struct-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
-function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntx', 'col_timestamp_ntz-->[1.704157323E9, 1.704427506E9, 0.2, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntz', 'col_timestamp_ntz-->[1.704157323E9, 1.704427506E9, 0.2, NaN, NaN] UNKNOWN')
 
 drop catalog delta_test_${uuid0}

--- a/test/sql/test_deltalake/T/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/T/test_deltalake_collect_stats
@@ -1,0 +1,57 @@
+-- name: testDeltaLakeCollectStats
+
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+set time_zone="Asia/Shanghai";
+
+set enable_delta_lake_column_statistics=false;
+
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'cardinality=8')
+
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_tinyint-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_smallint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_smallint-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_int from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_int-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_long from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_long-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_float from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_float-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_double from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_double-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_date from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_date-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_timestamp from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_timestamp-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_string from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_string-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_decimal from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_decimal-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_boolean from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_boolean-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_byte from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_byte-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_array from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_array-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_binary from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_binary-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_map from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_map-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_struct-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntx', 'col_timestamp_ntz-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
+
+set enable_delta_lake_column_statistics=true;
+
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'cardinality=8')
+
+function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_tinyint-->[1.0, 6.0, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_smallint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_smallint-->[100.0, 600.0, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_int from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_int-->[1000.0, 6000.0, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_long from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_long-->[10000.0, 60000.0, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_float from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_float-->[3.14, 18.84, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_double from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_double-->[3.14159, 18.84956, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_date from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_date-->[1.7139168E9, 1.7143488E9, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_timestamp from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_timestamp-->[1.7139312E9, 1.7143632E9, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_string from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_string-->[-Infinity, Infinity, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_decimal from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_decimal-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_boolean from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_boolean-->[-Infinity, Infinity, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_byte from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_byte-->[1.0, 6.0, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_array from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_array-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_binary from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_binary-->[-Infinity, Infinity, 0.0, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_map from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_map-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'col_struct-->[-Infinity, Infinity, NaN, NaN, NaN] UNKNOWN')
+function: assert_explain_costs_contains('select col_timestamp_ntz from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntx', 'col_timestamp_ntz-->[1.704157323E9, 1.704427506E9, 0.2, NaN, NaN] UNKNOWN')
+
+drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:

Metadata file format:

```
{
    "add": {
        "path": "part-00000-0e70e2c2-65b9-49d1-b740-0d4f449c831e-c000.snappy.parquet", 
        "partitionValues": { }, 
        "size": 5477, 
        "modificationTime": 1717576197000, 
        "dataChange": true, 
        "stats": {
            "numRecords": 1, 
            "minValues": {
                "col_tinyint": 4, 
                "col_smallint": 400, 
                "col_int": 4000, 
                "col_long": 40000, 
                "col_float": 12.56, 
                "col_double": 12.56637, 
                "col_date": "2024-04-27", 
                "col_timestamp": "2024-04-27T12:00:00.000+08:00", 
                "col_string": "fourth_string", 
                "col_decimal": 987.65, 
                "col_byte": 4, 
                "col_struct": {
                    "name": "Diana", 
                    "sex": "female", 
                    "age": 28
                }
            }, 
            "maxValues": {
                "col_tinyint": 4, 
                "col_smallint": 400, 
                "col_int": 4000, 
                "col_long": 40000, 
                "col_float": 12.56, 
                "col_double": 12.56637, 
                "col_date": "2024-04-27", 
                "col_timestamp": "2024-04-27T12:00:00.000+08:00", 
                "col_string": "fourth_string", 
                "col_decimal": 987.65, 
                "col_byte": 4, 
                "col_struct": {
                    "name": "Diana", 
                    "sex": "female", 
                    "age": 28
                }
            }, 
            "nullCount": {
                "col_tinyint": 0, 
                "col_smallint": 0, 
                "col_int": 0, 
                "col_long": 0, 
                "col_float": 0, 
                "col_double": 0, 
                "col_date": 0, 
                "col_timestamp": 0, 
                "col_string": 0, 
                "col_decimal": 0, 
                "col_boolean": 0, 
                "col_byte": 0, 
                "col_array": 0, 
                "col_binary": 0, 
                "col_map": 0, 
                "col_struct": {
                    "name": 0, 
                    "sex": 0, 
                    "age": 0
                }
            }
        }
    }
}
```

## What I'm doing:

* DeltaLake support collect min/max/nullcount statistics from metadata file.
* Statistics of paritition key is not supported now, will fix in next pr.
* Statistics of nest type is not supported now.
* Statistics of decimal is not supported now.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
