### PR TITLE
[BugFix] Fill null if struct field is not found in json

### DIFF
--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -448,7 +448,7 @@ Status add_adaptive_nullable_column_by_json_object(Column* column, const TypeDes
 Status add_adaptive_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                                     simdjson::ondemand::value* value, bool invalid_as_null) {
     try {
-        if (value->is_null()) {
+        if (value == nullptr || value->is_null()) {
             column->append_nulls(1);
             return Status::OK();
         }
@@ -470,7 +470,7 @@ Status add_adaptive_nullable_column(Column* column, const TypeDescriptor& type_d
 Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                            simdjson::ondemand::value* value, bool invalid_as_null) {
     try {
-        if (value->is_null()) {
+        if (value == nullptr || value->is_null()) {
             column->append_nulls(1);
             return Status::OK();
         }

--- a/be/src/formats/json/struct_column.cpp
+++ b/be/src/formats/json/struct_column.cpp
@@ -37,8 +37,19 @@ Status add_struct_column(Column* column, const TypeDescriptor& type_desc, const 
             const auto& field_type_desc = type_desc.children[i];
 
             auto field_column = struct_column->field_column(field_name);
-            simdjson::ondemand::value field_value = obj.find_field_unordered(field_name);
-            RETURN_IF_ERROR(add_nullable_column(field_column.get(), field_type_desc, name, &field_value, true));
+            simdjson::ondemand::value field_value;
+            auto err = obj.find_field_unordered(field_name).get(field_value);
+            simdjson::ondemand::value* field_value_ptr = nullptr;
+            if (err == simdjson::SUCCESS) {
+                field_value_ptr = &field_value;
+            } else if (err == simdjson::NO_SUCH_FIELD) {
+                // nullptr
+            } else {
+                auto err_msg = strings::Substitute("Failed to parse value, field=$0.$1, error=$2", name, field_name,
+                                                   simdjson::error_message(err));
+                return Status::DataQualityError(err_msg);
+            }
+            RETURN_IF_ERROR(add_nullable_column(field_column.get(), field_type_desc, name, field_value_ptr, true));
         }
         return Status::OK();
     } catch (simdjson::simdjson_error& e) {

--- a/be/test/formats/json/struct_column_test.cpp
+++ b/be/test/formats/json/struct_column_test.cpp
@@ -53,4 +53,19 @@ TEST_F(AddStructColumnTest, test_bad_json) {
     EXPECT_STATUS(Status::DataQualityError(""), add_struct_column(column.get(), type_desc, "root_key", &val));
 }
 
+TEST_F(AddStructColumnTest, test_field_not_found) {
+    TypeDescriptor type_desc = TypeDescriptor::create_struct_type(
+            {"key1", "key2"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(10)});
+    auto column = ColumnHelper::create_column(type_desc, false);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "key1": "foo", "key3": "baz" }  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.get_value();
+
+    EXPECT_OK(add_struct_column(column.get(), type_desc, "root_key", &val));
+
+    EXPECT_EQ("{key1:'foo',key2:NULL}", column->debug_string());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
if any struct field is not found in json, the struct column will be null.

## What I'm doing:

only the struct field that is not found in json will be filled with null.

Fixes #issue

#45406 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
