### PR TITLE
[Enhancement] log stack trace in FE thrift service

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -80,7 +80,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"SysWF\" fileName=\"${sys_log_dir}/fe.warn.log\" filePattern=\"${sys_log_dir}/fe.warn.log.${sys_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n %ex</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +


### PR DESCRIPTION
## Why I'm doing:
https://logging.staged.apache.org/log4j/2.x/manual/pattern-layout.html

```
    @Override
    public TReportFragmentFinishResponse reportFragmentFinish(TReportFragmentFinishParams params) {
        final TReportFragmentFinishResponse result = new TReportFragmentFinishResponse();
        final QueryInfo info = coordinatorMap.get(params.query_id);
        final TUniqueId fragment_instance_id = params.fragment_instance_id;
        try {
            info.getCoord().scheduleNextTurn(fragment_instance_id);
        } catch (Exception e) {
            // TODO cancel by error
            LOG.error("schedule error", e);
        }
        result.setStatus(new TStatus(TStatusCode.OK));
        return result;
    }
```


prev:
```
java.lang.NullPointerException: null
2024-06-25 16:57:46.313+08:00 WARN (thrift-server-pool-789|1206) [QeProcessorImpl.reportFragmentFinish():301] schedule error
java.lang.NullPointerException: null
2024-06-25 16:58:23.110+08:00 WARN (thrift-server-pool-1223|1748) [QeProcessorImpl.reportFragmentFinish():301] schedule error
java.lang.NullPointerException: nul
```
now
```
2024-06-25 19:28:02.640+08:00 ERROR (thrift-server-pool-3|172) [QeProcessorImpl.reportFragmentFinish():308] schedule error
 java.lang.NullPointerException
        at com.starrocks.qe.QeProcessorImpl.reportFragmentFinish(QeProcessorImpl.java:305)
        at com.starrocks.service.FrontendServiceImpl.reportFragmentFinish(FrontendServiceImpl.java:2930)
        at com.starrocks.thrift.FrontendService$Processor$reportFragmentFinish.getResult(FrontendService.java:5957)
        at com.starrocks.thrift.FrontendService$Processor$reportFragmentFinish.getResult(FrontendService.java:5934)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40)
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
