### PR TITLE
[BugFix] Fix miss update job state when replaying restore log may cause restored table lost after FE restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -734,7 +734,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     /**
      * will remove finished/cancelled job periodically
      */
-    public boolean isJobExpired(AbstractJob job, long currentTimeMs) {
+    private boolean isJobExpired(AbstractJob job, long currentTimeMs) {
         return (job.isDone() || job.isCancelled())
                 && (currentTimeMs - job.getFinishedTime()) / 1000 > Config.history_job_keep_max_second;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.backup;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
@@ -1767,6 +1768,11 @@ public class RestoreJob extends AbstractJob {
         sb.append(", backup ts: ").append(backupTimestamp);
         sb.append(", state: ").append(state.name());
         return sb.toString();
+    }
+
+    @VisibleForTesting
+    public void setState(RestoreJobState state) {
+        this.state = state;
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
@@ -119,6 +119,9 @@ public class MvRestoreContext {
             }
 
             BackupMeta backupMeta = restoreJob.getBackupMeta();
+            if (backupMeta == null) {
+                continue;
+            }
             Table remoteTable = backupMeta.getTable(e.getKey());
             if (remoteTable == null || !remoteTable.isMaterializedView()) {
                 continue;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -555,5 +555,28 @@ public class RestoreJobTest {
         System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
     }
 
+    @Test
+    public void testReplayAddExpiredJob() {
+        RestoreJob job1 = new RestoreJob(label, "2018-01-01 01:01:01", db.getId() + 999, db.getFullName() + "xxx",
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        RestoreJob job2 = new RestoreJob(label, "2018-01-01 01:01:01", db.getId() + 999, db.getFullName() + "xxx",
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        RestoreJob job3 = new RestoreJob(label, "2018-01-01 01:01:01", db.getId() + 999, db.getFullName() + "xxx",
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job1.setState(RestoreJob.RestoreJobState.PENDING);
+        backupHandler.replayAddJob(job1);
+        job2.setState(RestoreJob.RestoreJobState.COMMIT);
+        backupHandler.replayAddJob(job2);
+        new MockUp<MockBackupHandler>() {
+            @Mock
+            private boolean isJobExpired(AbstractJob job, long currentTimeMs) {
+                return true;
+            }
+        };
+        job3.setState(RestoreJob.RestoreJobState.FINISHED);
+        backupHandler.replayAddJob(job3);
+    }
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -54,6 +54,7 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -570,13 +571,9 @@ public class RestoreJobTest {
         backupHandler.replayAddJob(job1);
         job2.setState(RestoreJob.RestoreJobState.COMMIT);
         backupHandler.replayAddJob(job2);
-        new MockUp<MockBackupHandler>() {
-            @Mock
-            private boolean isJobExpired(AbstractJob job, long currentTimeMs) {
-                return true;
-            }
-        };
+        int oldVal = Config.history_job_keep_max_second;
         job3.setState(RestoreJob.RestoreJobState.FINISHED);
         backupHandler.replayAddJob(job3);
+        Config.history_job_keep_max_second = oldVal;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -564,9 +564,16 @@ public class RestoreJobTest {
         RestoreJob job2 = new RestoreJob(label, "2018-01-01 01:01:01", db.getId() + 999, db.getFullName() + "xxx",
                 new BackupJobInfo(), false, 3, 100000,
                 globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+
+        BackupJobInfo jobInfo = new BackupJobInfo();
+        BackupTableInfo tblInfo = new BackupTableInfo();
+        tblInfo.id = CatalogMocker.TEST_TBL2_ID;
+        tblInfo.name = CatalogMocker.TEST_TBL2_NAME;
+        jobInfo.tables.put(tblInfo.name, tblInfo);
         RestoreJob job3 = new RestoreJob(label, "2018-01-01 01:01:01", db.getId() + 999, db.getFullName() + "xxx",
-                new BackupJobInfo(), false, 3, 100000,
+                jobInfo, false, 3, 100000,
                 globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+
         job1.setState(RestoreJob.RestoreJobState.PENDING);
         backupHandler.replayAddJob(job1);
         job2.setState(RestoreJob.RestoreJobState.COMMIT);


### PR DESCRIPTION
## Why I'm doing:
If we set `history_job_keep_max_second` < `checkpoint time interval` (no matter by background daemon or manlly create image). When we replay the log for the restore job, the final FINISHED state log will be skipped to update the job state in BackupHandler because this job is considered as a expired job controlled by `history_job_keep_max_second`.

But the point here is that, Only FINISHED state is skipped to be updated but not other state log, the BackupHandler will persistent the unfinished state for this job even the job is actually finished now.

When we restart FE in this case, we will get a unfinished restore job in FE and want to rewrite the original table which is restored before FE restart and cause this problem.

## What I'm doing:
When we meet a expired job with FINISHED state, we can skip to update the finished state if and only if there is no other state of this job in backuphandler

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7904
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
