### PR TITLE
[Enhancement] Apply query queue based on slot estimation 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -664,6 +664,15 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_port = 8030;
 
+    @ConfField
+    public static boolean enable_query_queue_v2 = false;
+    @ConfField(mutable = true)
+    public static int query_queue_v2_num_rows_per_slot = 4096;
+
+    // TODO(lzh): add prop min=1
+    @ConfField(mutable = true)
+    public static int query_queue_v2_concurrency_level = 4;
+
     /**
      * Number of worker threads for http server to deal with http requests which may do
      * some I/O operations. If set with a non-positive value, it will use netty's default
@@ -1215,7 +1224,7 @@ public class Config extends ConfigBase {
     public static boolean enable_materialized_view_metrics_collect = true;
 
     @ConfField(mutable = true, comment = "whether to enable text based rewrite by default, if true it will " +
-               "build ast tree in materialized view initialization")
+            "build ast tree in materialized view initialization")
     public static boolean enable_materialized_view_text_based_rewrite = true;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -664,6 +664,11 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_port = 8030;
 
+    /**
+     * Configs for query queue v2.
+     * The configs {@code query_queue_v2_xxx} are effective only when {@code enable_query_queue_v2} is true.
+     * @see com.starrocks.qe.scheduler.slot.QueryQueueOptions
+     */
     @ConfField
     public static boolean enable_query_queue_v2 = false;
     /**
@@ -674,15 +679,15 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int query_queue_v2_concurrency_level = 4;
     /**
-     * Used to estimate the number of slots of a query based on the cardinality of the Source Node.
-     * It is equal to the cardinality of the Source Node divided by the configuration value and is limited to between [1, DOP].
+     * Used to estimate the number of slots of a query based on the cardinality of the Source Node. It is equal to the
+     * cardinality of the Source Node divided by the configuration value and is limited to between [1, DOP*numBEs].
      * It will be set to `1` if it is non-positive.
      */
     @ConfField(mutable = true)
     public static int query_queue_v2_num_rows_per_slot = 4096;
     /**
      * Used to estimate the number of slots of a query based on the plan cpu costs.
-     * It is equal to the plan cpu costs divided by the configuration value.
+     * It is equal to the plan cpu costs divided by the configuration value and is limited to between [1, totalSlots].
      * It will be set to `1` if it is non-positive.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -671,7 +671,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int query_queue_v2_num_rows_per_slot = 4096;
     @ConfField(mutable = true)
-    public static long query_queue_v2_cpu_costs_per_slot = 100_000_000;
+    public static long query_queue_v2_cpu_costs_per_slot = 1_000_000_000;
 
     /**
      * Number of worker threads for http server to deal with http requests which may do

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -667,9 +667,11 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean enable_query_queue_v2 = false;
     @ConfField(mutable = true)
+    public static int query_queue_v2_concurrency_level = 4;
+    @ConfField(mutable = true)
     public static int query_queue_v2_num_rows_per_slot = 4096;
     @ConfField(mutable = true)
-    public static int query_queue_v2_concurrency_level = 4;
+    public static long query_queue_v2_cpu_costs_per_slot = 100_000_000;
 
     /**
      * Number of worker threads for http server to deal with http requests which may do

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -668,8 +668,6 @@ public class Config extends ConfigBase {
     public static boolean enable_query_queue_v2 = false;
     @ConfField(mutable = true)
     public static int query_queue_v2_num_rows_per_slot = 4096;
-
-    // TODO(lzh): add prop min=1
     @ConfField(mutable = true)
     public static int query_queue_v2_concurrency_level = 4;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -666,10 +666,25 @@ public class Config extends ConfigBase {
 
     @ConfField
     public static boolean enable_query_queue_v2 = false;
+    /**
+     * Used to calculate the total number of slots the system has,
+     * which is equal to the configuration value * BE number * BE cores.
+     * It will be set to `4` if it is non-positive.
+     */
     @ConfField(mutable = true)
     public static int query_queue_v2_concurrency_level = 4;
+    /**
+     * Used to estimate the number of slots of a query based on the cardinality of the Source Node.
+     * It is equal to the cardinality of the Source Node divided by the configuration value and is limited to between [1, DOP].
+     * It will be set to `1` if it is non-positive.
+     */
     @ConfField(mutable = true)
     public static int query_queue_v2_num_rows_per_slot = 4096;
+    /**
+     * Used to estimate the number of slots of a query based on the plan cpu costs.
+     * It is equal to the plan cpu costs divided by the configuration value.
+     * It will be set to `1` if it is non-positive.
+     */
     @ConfField(mutable = true)
     public static long query_queue_v2_cpu_costs_per_slot = 1_000_000_000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -111,6 +111,31 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_QUERY_QUEUE_SLOT_PENDING;
     public static LongCounterMetric COUNTER_QUERY_QUEUE_SLOT_RUNNING;
 
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING =
+            new MetricWithLabelGroup<>("category",
+                    () -> new LongCounterMetric("query_queue_v2_category_pending_slots", MetricUnit.REQUESTS,
+                            "the number of current pending slots for each category"));
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_QUERY_QUEUE_CATEGORY_SLOT_RUNNING =
+            new MetricWithLabelGroup<>("category",
+                    () -> new LongCounterMetric("query_queue_v2_category_running_slots", MetricUnit.REQUESTS,
+                            "the number of current running slots for each category"));
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_QUERY_QUEUE_CATEGORY_SLOT_ALLOCATED_TOTAL =
+            new MetricWithLabelGroup<>("category",
+                    () -> new LongCounterMetric("query_queue_v2_category_total_allocated_slots", MetricUnit.REQUESTS,
+                            "the accumulated value of allocated slots for each category"));
+    public static final MetricWithLabelGroup<GaugeMetricImpl<Integer>> GAUGE_QUERY_QUEUE_CATEGORY_WEIGHT =
+            new MetricWithLabelGroup<>("category",
+                    () -> new GaugeMetricImpl<>("query_queue_v2_category_weight", MetricUnit.REQUESTS,
+                            "the weight of each category"));
+    public static final MetricWithLabelGroup<GaugeMetricImpl<Integer>> GAUGE_QUERY_QUEUE_CATEGORY_SLOT_MIN_SLOTS =
+            new MetricWithLabelGroup<>("category",
+                    () -> new GaugeMetricImpl<>("query_queue_v2_category_min_slots", MetricUnit.REQUESTS,
+                            "the min slots of each category"));
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_QUERY_QUEUE_CATEGORY_SLOT_STATE =
+            new MetricWithLabelGroup<>("category",
+                    () -> new LongCounterMetric("query_queue_v2_category_state", MetricUnit.REQUESTS,
+                            "the current state of each category"));
+
     public static LongCounterMetric COUNTER_UNFINISHED_BACKUP_JOB;
     public static LongCounterMetric COUNTER_UNFINISHED_RESTORE_JOB;
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricWithLabelGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricWithLabelGroup.java
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class MetricWithLabelGroup<E extends Metric<?>> {
+    private final String labelKey;
+    private final Supplier<E> metricCreator;
+
+    private final Map<String, E> labelValueToMetric = Maps.newConcurrentMap();
+
+    public MetricWithLabelGroup(String labelKey, Supplier<E> metricCreator) {
+        this.labelKey = labelKey;
+        this.metricCreator = metricCreator;
+    }
+
+    public E getMetric(String labelValue) {
+        return labelValueToMetric.computeIfAbsent(labelValue, k -> {
+            E metric = metricCreator.get();
+            metric.addLabel(new MetricLabel(labelKey, labelValue));
+            MetricRepo.addMetric(metric);
+            return metric;
+        });
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -661,6 +661,10 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         return dataPartition;
     }
 
+    public boolean isGatherFragment() {
+        return getDataPartition() == DataPartition.UNPARTITIONED;
+    }
+
     public void setOutputPartition(DataPartition outputPartition) {
         this.outputPartition = outputPartition;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -121,6 +121,8 @@ public class AuditEvent {
     public double planMemCosts = -1;
     @AuditField(value = "PendingTimeMs")
     public long pendingTimeMs = -1;
+    @AuditField(value = "Slots")
+    public int numSlots = -1;
     @AuditField(value = "BigQueryLogCPUSecondThreshold")
     public long bigQueryLogCPUSecondThreshold = -1;
     @AuditField(value = "BigQueryLogScanBytesThreshold")
@@ -287,6 +289,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setPendingTimeMs(long pendingTimeMs) {
             auditEvent.pendingTimeMs = pendingTimeMs;
+            return this;
+        }
+
+        public AuditEventBuilder setNumSlots(int numSlots) {
+            auditEvent.numSlots = numSlots;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -140,7 +140,9 @@ public class QueryQueueManager {
         QueryQueueOptions opts = QueryQueueOptions.createFromEnvAndQuery(coord);
 
         SlotEstimator estimator = SlotEstimatorFactory.create(opts);
-        int numSlots = estimator.estimateSlots(opts, context, coord);
+        final int numSlots = estimator.estimateSlots(opts, context, coord);
+        // Write numSlots to the audit log if query queue v2 is enabled, since numSlots is always 1 for query queue v1 and
+        // may be different for query queue v2.
         if (opts.isEnableQueryQueueV2()) {
             context.auditEventBuilder.setNumSlots(numSlots);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
-import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.MultiCastPlanFragment;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
@@ -71,8 +70,7 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
             return;
         }
 
-        boolean isGatherFragment = fragment.getDataPartition() == DataPartition.UNPARTITIONED;
-        if (isGatherFragment) {
+        if (fragment.isGatherFragment()) {
             assignGatherFragmentToWorker(execFragment);
             return;
         }
@@ -183,9 +181,8 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
         // is executed that way (could have been downgraded from distributed)
     }
 
-
     private Set<Long> adaptiveChooseNodes(PlanFragment fragment, List<Long> candidates,
-                                           Set<Long> childUsedHosts) {
+                                          Set<Long> childUsedHosts) {
         List<Long> childHosts = Lists.newArrayList(childUsedHosts);
 
         // sometimes we may reverse the fragment order like SHUFFLE_HASH_BUCKET plan, so we need sort

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.common.Config;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.system.BackendResourceStat;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class QueryQueueOptions {
+    private final boolean enableQueryQueueV2;
+    private final V2 v2;
+
+    public static QueryQueueOptions createFromEnvAndQuery(DefaultCoordinator coord) {
+        if (!coord.getJobSpec().isEnableQueue() || !coord.getJobSpec().isNeedQueued()) {
+            return new QueryQueueOptions(false, new V2());
+        }
+
+        return createFromEnv();
+    }
+
+    public static QueryQueueOptions createFromEnv() {
+        if (!Config.enable_query_queue_v2) {
+            return new QueryQueueOptions(false, new V2());
+        }
+
+        V2 v2 = new V2(Config.query_queue_v2_concurrency_level,
+                BackendResourceStat.getInstance().getNumBes(),
+                BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe(),
+                BackendResourceStat.getInstance().getAvgMemLimitBytes(),
+                Config.query_queue_v2_num_rows_per_slot);
+        return new QueryQueueOptions(true, v2);
+    }
+
+    @VisibleForTesting
+    QueryQueueOptions(boolean enableQueryQueueV2, V2 v2) {
+        this.enableQueryQueueV2 = enableQueryQueueV2 && v2 != null;
+        this.v2 = v2;
+    }
+
+    public boolean isEnableQueryQueueV2() {
+        return enableQueryQueueV2;
+    }
+
+    public V2 v2() {
+        return v2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryQueueOptions that = (QueryQueueOptions) o;
+        return enableQueryQueueV2 == that.enableQueryQueueV2 && Objects.equals(v2, that.v2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enableQueryQueueV2, v2);
+    }
+
+    public static class V2 {
+        private final int numWorkers;
+        private final int numRowsPerSlot;
+
+        private final int totalSlots;
+        private final long memBytesPerSlot;
+        private final int totalSmallSlots;
+
+        @VisibleForTesting
+        V2() {
+            this(1, 1, 1, 1, 1);
+        }
+
+        @VisibleForTesting
+        V2(int concurrencyLevel, int numWorkers, int numCoresPerWorker, long memLimitBytesPerWorker, int numRowsPerSlot) {
+            if (concurrencyLevel <= 0) {
+                concurrencyLevel = 4;
+            }
+            int normNumWorkers = Math.max(1, numWorkers);
+            int normNumCoresPerWorker = Math.max(1, numCoresPerWorker);
+            int normNumRowsPerSlot = Math.max(1, numRowsPerSlot);
+
+            this.numWorkers = normNumWorkers;
+            this.numRowsPerSlot = normNumRowsPerSlot;
+
+            this.totalSlots = normNumCoresPerWorker * concurrencyLevel * normNumWorkers;
+            int totalSlotsPerWorker = normNumCoresPerWorker * concurrencyLevel;
+            this.totalSmallSlots = normNumCoresPerWorker;
+            this.memBytesPerSlot = isAnyZero(memLimitBytesPerWorker, numCoresPerWorker) ? Long.MAX_VALUE :
+                    memLimitBytesPerWorker / totalSlotsPerWorker;
+        }
+
+        public int getNumWorkers() {
+            return numWorkers;
+        }
+
+        public int getNumRowsPerSlot() {
+            return numRowsPerSlot;
+        }
+
+        public int getTotalSlots() {
+            return totalSlots;
+        }
+
+        public long getMemBytesPerSlot() {
+            return memBytesPerSlot;
+        }
+
+        public int getTotalSmallSlots() {
+            return totalSmallSlots;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            V2 v2 = (V2) o;
+            return numWorkers == v2.numWorkers && numRowsPerSlot == v2.numRowsPerSlot && totalSlots == v2.totalSlots &&
+                    memBytesPerSlot == v2.memBytesPerSlot && totalSmallSlots == v2.totalSmallSlots;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(numWorkers, numRowsPerSlot, totalSlots, memBytesPerSlot, totalSmallSlots);
+        }
+    }
+
+    private static boolean isAnyZero(long... values) {
+        return Arrays.stream(values).anyMatch(val -> val == 0);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
@@ -28,7 +28,7 @@ public class QueryQueueOptions {
 
     public static QueryQueueOptions createFromEnvAndQuery(DefaultCoordinator coord) {
         if (!coord.getJobSpec().isEnableQueue() || !coord.getJobSpec().isNeedQueued()) {
-            return new QueryQueueOptions(false, new V2());
+            return new QueryQueueOptions(false, V2.DEFAULT);
         }
 
         return createFromEnv();
@@ -36,7 +36,7 @@ public class QueryQueueOptions {
 
     public static QueryQueueOptions createFromEnv() {
         if (!Config.enable_query_queue_v2) {
-            return new QueryQueueOptions(false, new V2());
+            return new QueryQueueOptions(false, V2.DEFAULT);
         }
 
         V2 v2 = new V2(Config.query_queue_v2_concurrency_level,
@@ -80,6 +80,8 @@ public class QueryQueueOptions {
     }
 
     public static class V2 {
+        private static final V2 DEFAULT = new V2();
+
         private final int numWorkers;
         private final int numRowsPerSlot;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
@@ -43,7 +43,8 @@ public class QueryQueueOptions {
                 BackendResourceStat.getInstance().getNumBes(),
                 BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe(),
                 BackendResourceStat.getInstance().getAvgMemLimitBytes(),
-                Config.query_queue_v2_num_rows_per_slot);
+                Config.query_queue_v2_num_rows_per_slot,
+                Config.query_queue_v2_cpu_costs_per_slot);
         return new QueryQueueOptions(true, v2);
     }
 
@@ -84,21 +85,24 @@ public class QueryQueueOptions {
 
         private final int totalSlots;
         private final long memBytesPerSlot;
+        private final long cpuCostsPerSlot;
         private final int totalSmallSlots;
 
         @VisibleForTesting
         V2() {
-            this(1, 1, 1, 1, 1);
+            this(1, 1, 1, 1, 1, 1);
         }
 
         @VisibleForTesting
-        V2(int concurrencyLevel, int numWorkers, int numCoresPerWorker, long memLimitBytesPerWorker, int numRowsPerSlot) {
+        V2(int concurrencyLevel, int numWorkers, int numCoresPerWorker, long memLimitBytesPerWorker, int numRowsPerSlot,
+                long cpuCostsPerSlot) {
             if (concurrencyLevel <= 0) {
                 concurrencyLevel = 4;
             }
             int normNumWorkers = Math.max(1, numWorkers);
             int normNumCoresPerWorker = Math.max(1, numCoresPerWorker);
             int normNumRowsPerSlot = Math.max(1, numRowsPerSlot);
+            long normCpuCostsPerSlot = Math.max(1, cpuCostsPerSlot);
 
             this.numWorkers = normNumWorkers;
             this.numRowsPerSlot = normNumRowsPerSlot;
@@ -108,6 +112,7 @@ public class QueryQueueOptions {
             this.totalSmallSlots = normNumCoresPerWorker;
             this.memBytesPerSlot = isAnyZero(memLimitBytesPerWorker, numCoresPerWorker) ? Long.MAX_VALUE :
                     memLimitBytesPerWorker / totalSlotsPerWorker;
+            this.cpuCostsPerSlot = normCpuCostsPerSlot;
         }
 
         public int getNumWorkers() {
@@ -130,6 +135,10 @@ public class QueryQueueOptions {
             return totalSmallSlots;
         }
 
+        public long getCpuCostsPerSlot() {
+            return cpuCostsPerSlot;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -140,12 +149,13 @@ public class QueryQueueOptions {
             }
             V2 v2 = (V2) o;
             return numWorkers == v2.numWorkers && numRowsPerSlot == v2.numRowsPerSlot && totalSlots == v2.totalSlots &&
-                    memBytesPerSlot == v2.memBytesPerSlot && totalSmallSlots == v2.totalSmallSlots;
+                    memBytesPerSlot == v2.memBytesPerSlot && totalSmallSlots == v2.totalSmallSlots &&
+                    cpuCostsPerSlot == v2.cpuCostsPerSlot;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(numWorkers, numRowsPerSlot, totalSlots, memBytesPerSlot, totalSmallSlots);
+            return Objects.hash(numWorkers, numRowsPerSlot, totalSlots, memBytesPerSlot, totalSmallSlots, cpuCostsPerSlot);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimator.java
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DefaultCoordinator;
+
+public interface SlotEstimator {
+    /**
+     * Estimate the number of slots needed for the given query.
+     */
+    int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
@@ -1,0 +1,177 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanFragmentId;
+import com.starrocks.planner.PlanNode;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.thrift.TScanRangeLocation;
+import com.starrocks.thrift.TScanRangeLocations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.Utils.computeMaxLEPower2;
+
+public class SlotEstimatorFactory {
+    public static SlotEstimator create(QueryQueueOptions opts) {
+        if (!opts.isEnableQueryQueueV2()) {
+            return new DefaultSlotEstimator();
+        }
+        return new MaxSlotsEstimator(new MemoryBasedSlotsEstimator(), new ParallelismBasedSlotsEstimator());
+    }
+
+    public static class DefaultSlotEstimator implements SlotEstimator {
+        @Override
+        public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
+            return 1;
+        }
+    }
+
+    public static class MemoryBasedSlotsEstimator implements SlotEstimator {
+        @Override
+        public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
+            final long planMemCosts = (long) context.getAuditEventBuilder().build().planMemCosts;
+            long numSlotsPerWorker = planMemCosts / opts.v2().getNumWorkers() / opts.v2().getMemBytesPerSlot();
+            numSlotsPerWorker = Math.max(numSlotsPerWorker, 0);
+            numSlotsPerWorker = computeMaxLEPower2((int) numSlotsPerWorker);
+
+            long numSlots = numSlotsPerWorker * opts.v2().getNumWorkers();
+            numSlots = Math.max(numSlots, 1);
+            numSlots = Math.min(numSlots, opts.v2().getTotalSlots());
+
+            return (int) numSlots;
+        }
+    }
+
+    public static class ParallelismBasedSlotsEstimator implements SlotEstimator {
+        @Override
+        public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
+            Map<PlanFragmentId, FragmentContext> fragmentContexts = collectFragmentContexts(coord);
+
+            return fragmentContexts.values().stream()
+                    .mapToInt(fragmentContext -> estimateFragmentSlots(opts, fragmentContext))
+                    .max().orElse(1);
+        }
+
+        private static int estimateFragmentSlots(QueryQueueOptions opts, FragmentContext context) {
+            int numSlots = 1;
+            for (PlanNode sourceNode : context.sourceNodes) {
+                int curNumSlots = estimateNumSlotsBySourceNode(opts, sourceNode);
+
+                curNumSlots /= context.numWorkers;
+                curNumSlots = Math.max(curNumSlots, 1);
+                curNumSlots = Math.min(curNumSlots, context.fragment.getPipelineDop());
+
+                curNumSlots *= context.numWorkers;
+                curNumSlots = Math.min(curNumSlots, opts.v2().getTotalSlots());
+
+                numSlots = Math.max(numSlots, curNumSlots);
+            }
+            return numSlots;
+        }
+
+        private static int estimateNumSlotsBySourceNode(QueryQueueOptions opts, PlanNode sourceNode) {
+            if (sourceNode instanceof OlapScanNode) {
+                OlapScanNode olapScanNode = (OlapScanNode) sourceNode;
+                List<TScanRangeLocations> locations = olapScanNode.getScanRangeLocations(0);
+                if (locations != null) {
+                    return locations.size();
+                }
+            }
+
+            return (int) (sourceNode.getCardinality() / opts.v2().getNumRowsPerSlot());
+        }
+
+        private static Map<PlanFragmentId, FragmentContext> collectFragmentContexts(DefaultCoordinator coord) {
+            PlanFragment rootFragment = coord.getExecutionDAG().getRootFragment().getPlanFragment();
+            PlanNode rootNode = rootFragment.getPlanRoot();
+
+            Map<PlanFragmentId, FragmentContext> contexts = Maps.newHashMap();
+            collectFragmentSourceNodes(rootNode, contexts);
+            calculateFragmentWorkers(rootFragment, contexts);
+
+            return contexts;
+        }
+
+        private static void collectFragmentSourceNodes(PlanNode node, Map<PlanFragmentId, FragmentContext> contexts) {
+            PlanFragmentId fragmentId = node.getFragmentId();
+            if (node.getChildren().isEmpty() || !fragmentId.equals(node.getChildren().get(0).getFragmentId())) {
+                contexts.computeIfAbsent(fragmentId, k -> new FragmentContext(node.getFragment()))
+                        .sourceNodes.add(node);
+            }
+
+            node.getChildren().forEach(child -> collectFragmentSourceNodes(child, contexts));
+        }
+
+        private static void calculateFragmentWorkers(PlanFragment fragment, Map<PlanFragmentId, FragmentContext> contexts) {
+            fragment.getChildren().forEach(child -> calculateFragmentWorkers(child, contexts));
+
+            FragmentContext context = contexts.get(fragment.getFragmentId());
+            if (context == null) {
+                return;
+            }
+
+            PlanNode leftMostNode = fragment.getLeftMostNode();
+            if (leftMostNode instanceof OlapScanNode) {
+                OlapScanNode scanNode = (OlapScanNode) leftMostNode;
+                context.numWorkers = scanNode.getScanRangeLocations(0).stream()
+                        .flatMap(locations -> locations.getLocations().stream())
+                        .map(TScanRangeLocation::getBackend_id)
+                        .collect(Collectors.toSet())
+                        .size();
+            } else if (fragment.isGatherFragment()) {
+                context.numWorkers = 1;
+            } else {
+                context.numWorkers = fragment.getChildren().stream()
+                        .mapToInt(child -> contexts.get(child.getFragmentId()).numWorkers)
+                        .max().orElse(1);
+            }
+        }
+
+        private static class FragmentContext {
+            private final PlanFragment fragment;
+            private final List<PlanNode> sourceNodes = Lists.newArrayList();
+            private int numWorkers = 1;
+
+            public FragmentContext(PlanFragment fragment) {
+                this.fragment = fragment;
+            }
+        }
+    }
+
+    public static class MaxSlotsEstimator implements SlotEstimator {
+        private final SlotEstimator[] estimators;
+
+        public MaxSlotsEstimator(SlotEstimator... estimators) {
+            this.estimators = estimators;
+        }
+
+        @Override
+        public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
+            return Arrays.stream(estimators)
+                    .mapToInt(estimator -> estimator.estimateSlots(opts, context, coord))
+                    .max()
+                    .orElse(1);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
@@ -75,7 +75,7 @@ public class SlotEstimatorFactory {
                     .mapToInt(fragmentContext -> fragmentContext.numWorkers)
                     .max().orElse(1);
             final long planCpuCosts = (long) context.getAuditEventBuilder().build().planCpuCosts;
-            int numSlotsByCpuCosts = (int) (planCpuCosts / opts.v2().getNumWorkers() / 1e8);
+            int numSlotsByCpuCosts = (int) (planCpuCosts / opts.v2().getCpuCostsPerSlot());
             numSlotsByCpuCosts = Math.max(1, numSlotsByCpuCosts / numWorkers) * numWorkers;
 
             return Math.min(Math.max(numSlots / 2, numSlotsByCpuCosts), numSlots);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
@@ -78,6 +78,7 @@ public class SlotEstimatorFactory {
             int numSlotsByCpuCosts = (int) (planCpuCosts / opts.v2().getCpuCostsPerSlot());
             numSlotsByCpuCosts = Math.max(1, numSlotsByCpuCosts / numWorkers) * numWorkers;
 
+            // Restrict numSlotsByCpuCosts to be within [numSlots / 2, numSlots].
             return Math.min(Math.max(numSlots / 2, numSlotsByCpuCosts), numSlots);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
@@ -126,8 +126,12 @@ public class SlotManager {
     public SlotManager(ResourceUsageMonitor resourceUsageMonitor) {
         resourceUsageMonitor.registerResourceAvailableListener(this::notifyResourceUsageAvailable);
 
-        this.slotSelectionStrategy = new DefaultSlotSelectionStrategy(
-                resourceUsageMonitor::isGlobalResourceOverloaded, resourceUsageMonitor::isGroupResourceOverloaded);
+        if (Config.enable_query_queue_v2) {
+            this.slotSelectionStrategy = new SlotSelectionStrategyV2();
+        } else {
+            this.slotSelectionStrategy = new DefaultSlotSelectionStrategy(
+                    resourceUsageMonitor::isGlobalResourceOverloaded, resourceUsageMonitor::isGroupResourceOverloaded);
+        }
 
         this.slotTracker = new SlotTracker(ImmutableList.of(slotSelectionStrategy, new SlotListenerForPipelineDriverAllocator()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -1,0 +1,477 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.starrocks.metric.LongCounterMetric;
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.commons.compress.utils.Lists;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The slot resource is divided into small extra slots and normal slots.
+ *
+ * <p> Small slots are tried to allocate slots from the small extra slots. If it fails, will try to allocate them from the normal
+ * slots. The small slot is defined as the query that requires only one slot.
+ *
+ * <p> Selecting slots to allocate from the normal slots is based on the smooth weighted round-robin algorithm.
+ * The slots are divided into multiple sub-queues according to the number of slots required by the query.
+ * Each sub-queue has a different weight. See {@link WeightedRoundRobinQueue} for details.
+ */
+public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
+    private static final long UPDATE_OPTIONS_INTERVAL_MS = 1000;
+
+    /**
+     * These three members are initialized in the first call of {@link #updateOptionsPeriodically};
+     */
+    private long lastUpdateOptionsTime = 0;
+    private QueryQueueOptions opts = null;
+    private WeightedRoundRobinQueue requiringQueue = null;
+
+    private final Map<TUniqueId, SlotContext> slotContexts = Maps.newHashMap();
+
+    private final LinkedHashMap<TUniqueId, SlotContext> requiringSmallSlots = new LinkedHashMap<>();
+    private int numAllocatedSmallSlots = 0;
+
+    @Override
+    public void onRequireSlot(LogicalSlot slot) {
+        updateOptionsPeriodically();
+
+        SlotContext slotContext = new SlotContext(slot);
+
+        slotContexts.put(slot.getSlotId(), slotContext);
+        if (isSmallSlot(slot)) {
+            requiringSmallSlots.put(slot.getSlotId(), slotContext);
+        }
+        requiringQueue.add(slotContext);
+
+        MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING.getMetric(String.valueOf(slotContext.getSubQueueIndex()))
+                .increase((long) slot.getNumPhysicalSlots());
+    }
+
+    @Override
+    public void onAllocateSlot(LogicalSlot slot) {
+        updateOptionsPeriodically();
+
+        SlotContext slotContext = slotContexts.get(slot.getSlotId());
+        if (isSmallSlot(slot)) {
+            requiringSmallSlots.remove(slot.getSlotId());
+            if (slotContext.isAllocatedAsSmallSlot()) {
+                numAllocatedSmallSlots += slot.getNumPhysicalSlots();
+            }
+        }
+        requiringQueue.remove(slotContext);
+
+        String category = String.valueOf(slotContext.getSubQueueIndex());
+        MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING.getMetric(category).increase((long) -slot.getNumPhysicalSlots());
+        MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_RUNNING.getMetric(category).increase((long) slot.getNumPhysicalSlots());
+        MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_ALLOCATED_TOTAL.getMetric(category)
+                .increase((long) slot.getNumPhysicalSlots());
+    }
+
+    @Override
+    public void onReleaseSlot(LogicalSlot slot) {
+        updateOptionsPeriodically();
+
+        SlotContext slotContext = slotContexts.remove(slot.getSlotId());
+        if (isSmallSlot(slot)) {
+            requiringSmallSlots.remove(slot.getSlotId());
+            if (slotContext.isAllocatedAsSmallSlot()) {
+                numAllocatedSmallSlots -= slot.getNumPhysicalSlots();
+            }
+        }
+        if (requiringQueue.remove(slotContext)) {
+            MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING.getMetric(String.valueOf(slotContext.getSubQueueIndex()))
+                    .increase((long) -slot.getNumPhysicalSlots());
+        } else {
+            MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_RUNNING.getMetric(String.valueOf(slotContext.getSubQueueIndex()))
+                    .increase((long) -slot.getNumPhysicalSlots());
+        }
+    }
+
+    @Override
+    public List<LogicalSlot> peakSlotsToAllocate(SlotTracker slotTracker) {
+        updateOptionsPeriodically();
+
+        List<LogicalSlot> slotsToAllocate = Lists.newArrayList();
+
+        int curNumAllocatedSmallSlots = numAllocatedSmallSlots;
+        for (SlotContext slotContext : requiringSmallSlots.values()) {
+            LogicalSlot slot = slotContext.getSlot();
+            if (curNumAllocatedSmallSlots + slot.getNumPhysicalSlots() > opts.v2().getTotalSmallSlots()) {
+                break;
+            }
+
+            requiringQueue.remove(slotContext);
+
+            slotsToAllocate.add(slot);
+            slotContext.setAllocateAsSmallSlot();
+            curNumAllocatedSmallSlots += slot.getNumPhysicalSlots();
+        }
+
+        int numAllocatedSlots = slotTracker.getNumAllocatedSlots() - numAllocatedSmallSlots;
+        while (!requiringQueue.isEmpty()) {
+            SlotContext slotContext = requiringQueue.peak();
+            if (!isGlobalSlotAvailable(numAllocatedSlots, slotContext.getSlot())) {
+                break;
+            }
+
+            requiringQueue.poll();
+
+            slotsToAllocate.add(slotContext.getSlot());
+            numAllocatedSlots += slotContext.getSlot().getNumPhysicalSlots();
+        }
+
+        return slotsToAllocate;
+    }
+
+    private void updateOptionsPeriodically() {
+        long now = System.currentTimeMillis();
+        if (now - lastUpdateOptionsTime < UPDATE_OPTIONS_INTERVAL_MS) {
+            return;
+        }
+
+        lastUpdateOptionsTime = now;
+        QueryQueueOptions newOpts = QueryQueueOptions.createFromEnv();
+        if (!newOpts.equals(opts)) {
+            opts = newOpts;
+            requiringQueue = new WeightedRoundRobinQueue(opts.v2().getTotalSlots(), opts.v2().getNumWorkers());
+            slotContexts.values().stream()
+                    .filter(slotContext -> slotContext.getSlot().getState() == LogicalSlot.State.REQUIRING)
+                    .forEach(slotContext -> requiringQueue.add(slotContext));
+        }
+    }
+
+    private boolean isGlobalSlotAvailable(int numAllocatedSlots, LogicalSlot slot) {
+        final int numTotalSlots = opts.v2().getTotalSlots();
+        return numAllocatedSlots == 0 || numAllocatedSlots + slot.getNumPhysicalSlots() <= numTotalSlots;
+    }
+
+    private static boolean isSmallSlot(LogicalSlot slot) {
+        return slot.getNumPhysicalSlots() <= 1;
+    }
+
+    /**
+     * The implementation of the smooth weighted round-robin algorithm.
+     *
+     * <p> If the peaking sub-queue is empty, will update {@link SlotSubQueue#state} as usual and record the skip
+     * times of this sub-queue. Repeat this process until the peaking sub-queue is not empty.
+     * When this sub-queue is not empty anymore, will give it some compensations according to the skip times.
+     *
+     * <p> The rules to divide sub-queues are as follows:
+     * <ul>
+     * <li> The minimum slots of {@code subQueues[i]} is {@code 2^(lastSubQueueLog2Bound-(NUM_SUB_QUEUES-1-i) )}, that is, the
+     * minimum slots of 0~7 sub-queues are 2^(b-7), 2^(b-6), 2^(b-5), 2^(b-4), 2^(b-3), 2^(b-2), 2^(b-1), 2^b, respectively.
+     * where {@code b} denotes {@code lastSubQueueLog2Bound}.
+     * <li> The weight of {@code subQueues[i]} is {@code 2.5^(NUM_SUB_QUEUES-1-i)}, that is, the weights of 0~7 sub-queues
+     * are 2.5^7, 2.5^6, 2.5^5, 2.5^4, 2.5^3, 2.5^2, 2.5^1, 2.5^0 respectively.
+     * </ul>
+     */
+    @VisibleForTesting
+    static class WeightedRoundRobinQueue {
+        private static final int NUM_SUB_QUEUES = 8;
+
+        private final int lastSubQueueLog2Bound;
+        private final int numWorkers;
+
+        private final SlotSubQueue[] subQueues;
+        private int size = 0;
+        private final int totalWeight;
+
+        private SlotContext nextSlotToPeak = null;
+
+        public WeightedRoundRobinQueue(int totalSlots, int numWorkers) {
+            this.numWorkers = numWorkers;
+
+            final int numSlotsPerWorker = totalSlots / numWorkers;
+            this.lastSubQueueLog2Bound = Utils.log2(numSlotsPerWorker);
+
+            int curMinSlots = 1 << lastSubQueueLog2Bound;
+            int curWeight = 1;
+            int totalWeight = 0;
+            this.subQueues = new SlotSubQueue[NUM_SUB_QUEUES];
+            for (int i = subQueues.length - 1; i >= 0; i--) {
+                subQueues[i] = new SlotSubQueue(i, curWeight);
+                totalWeight += curWeight;
+
+                String category = String.valueOf(i);
+                LongCounterMetric m = MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING.getMetric(category);
+                m.increase(-m.getValue());  // Reset the pending slots of this category.
+                MetricRepo.GAUGE_QUERY_QUEUE_CATEGORY_WEIGHT.getMetric(category).setValue(curWeight);
+                MetricRepo.GAUGE_QUERY_QUEUE_CATEGORY_SLOT_MIN_SLOTS.getMetric(category).setValue(curMinSlots * numWorkers);
+
+                if (curMinSlots > 1) {
+                    curWeight = (curWeight >>> 1) + (curWeight << 1); // curWeight*=2.5
+                    curMinSlots = curMinSlots >>> 1;
+                }
+            }
+            this.totalWeight = totalWeight;
+        }
+
+        public int size() {
+            return size;
+        }
+
+        public boolean isEmpty() {
+            return size() == 0;
+        }
+
+        public void add(SlotContext slotContext) {
+            int queueIndex = getSubQueueIndex(slotContext);
+            SlotSubQueue subQueue = subQueues[queueIndex];
+            if (subQueue.add(slotContext) != null) {
+                return;
+            }
+
+            slotContext.setSubQueueIndex(queueIndex);
+            size++;
+
+            if (subQueue.size() != 1) {
+                return;
+            }
+
+            // This sub-queue is empty before adding this slot, so give it some compensations.
+            subQueue.comeback();
+
+            if (nextSlotToPeak != null) {
+                // If the previous peaked slot is in a lower priority sub-queue due to this higher priority sub-queue is empty,
+                // peak the slot in this higher priority sub-queue instead.
+                SlotSubQueue prevPeakSubQueue = subQueues[nextSlotToPeak.getSubQueueIndex()];
+                if (prevPeakSubQueue.state + totalWeight < subQueue.state) {
+                    nextSlotToPeak = slotContext;
+                    subQueue.incrState(-totalWeight);
+                    prevPeakSubQueue.incrState(totalWeight);
+                }
+            }
+        }
+
+        public boolean remove(SlotContext slotContext) {
+            int queueIndex = getSubQueueIndex(slotContext);
+            TUniqueId slotId = slotContext.getSlotId();
+            boolean contains = subQueues[queueIndex].remove(slotId) != null;
+            if (contains) {
+                size--;
+                if (nextSlotToPeak != null && slotId.equals(nextSlotToPeak.getSlotId())) {
+                    nextSlotToPeak = null;
+                }
+            }
+            return contains;
+        }
+
+        public SlotContext peak() {
+            if (size == 0) {
+                return null;
+            }
+
+            if (nextSlotToPeak != null) {
+                return nextSlotToPeak;
+            }
+
+            int queueIndex = nextSubQueueIndex();
+            nextSlotToPeak = subQueues[queueIndex].peak();
+            return nextSlotToPeak;
+        }
+
+        public SlotContext poll() {
+            SlotContext slotContext = peak();
+            if (slotContext != null) {
+                remove(slotContext);
+            }
+            return slotContext;
+        }
+
+        @VisibleForTesting
+        SlotSubQueue[] getSubQueues() {
+            return subQueues;
+        }
+
+        private int nextSubQueueIndex() {
+            if (isEmpty()) {
+                return -1;
+            }
+
+            int maxQueueIndex;
+            while (true) {
+                // Find the sub-queue with the maximum state.
+                maxQueueIndex = 0;
+                for (int i = 0; i < subQueues.length; i++) {
+                    SlotSubQueue queue = subQueues[i];
+                    queue.incrState(queue.weight);
+                    if (queue.state > subQueues[maxQueueIndex].state) {
+                        maxQueueIndex = i;
+                    }
+                }
+                SlotSubQueue maxSubQueue = subQueues[maxQueueIndex];
+                maxSubQueue.incrState(-totalWeight);
+
+                if (!maxSubQueue.isEmpty()) {
+                    break;
+                }
+
+                // If the highest state sub-queue is empty, skip it
+                final int selectTimes = calculateContinuousSelectTimesForQueue(maxQueueIndex);
+                maxSubQueue.skip(1 + selectTimes);
+                maxSubQueue.incrState(-(totalWeight - maxSubQueue.weight) * selectTimes);
+                for (int i = 0; i < subQueues.length; i++) {
+                    SlotSubQueue queue = subQueues[i];
+                    if (i != maxQueueIndex) {
+                        queue.incrState(queue.weight * selectTimes);
+                    }
+                }
+            }
+
+            return maxQueueIndex;
+        }
+
+        /**
+         * Calculate the times of selecting the queue with the given index continuously.
+         *
+         * @param queueIndex The index of the queue to calculate.
+         * @return The times of selecting the queue with the given index continuously.
+         */
+        private int calculateContinuousSelectTimesForQueue(int queueIndex) {
+            SlotSubQueue selectQueue = subQueues[queueIndex];
+            int minSelectTimes = Integer.MAX_VALUE;
+            for (int i = 0; i < subQueues.length; i++) {
+                if (i == queueIndex) {
+                    continue;
+                }
+
+                SlotSubQueue queue = subQueues[i];
+
+                // The queue_s is in a higher priority than queue_i, until `state_i + weight_i >= state_s + weight_s`,
+                // that is `deltaState >= deltaWeight`.
+                // When peaking queue_s one time, state_s decreases `totalWeight - weight_s`, and state_i increases `weight_i`.
+                // Therefore, queue_i increases `weight_i + (totalWeight - weight_s)` = `totalWeight - deltaWeight` each time
+                // compared to queue_s.
+                // Thus, the times of peaking queue_s before queue_i is `deltaWeight - deltaState / (totalWeight - deltaWeight)`.
+                int deltaWeight = selectQueue.weight - queue.weight;
+                int deltaState = queue.state - selectQueue.state;
+                int incrStatePerTime = totalWeight - deltaWeight;
+
+                if (deltaState >= deltaWeight) {
+                    return 0;
+                }
+
+                int curSkipTimes = (deltaWeight - deltaState + incrStatePerTime - 1) / incrStatePerTime;
+                minSelectTimes = Math.min(minSelectTimes, curSkipTimes);
+            }
+
+            return minSelectTimes == Integer.MAX_VALUE ? 0 : minSelectTimes;
+        }
+
+        private int getSubQueueIndex(SlotContext slotContext) {
+            int numSlotsPerWorker = slotContext.getSlot().getNumPhysicalSlots() / numWorkers;
+            int index = (NUM_SUB_QUEUES - 1) - (lastSubQueueLog2Bound - Utils.log2(numSlotsPerWorker));
+            return Math.max(0, Math.min(index, NUM_SUB_QUEUES - 1));
+        }
+
+        class SlotSubQueue {
+            private final int queueIndex;
+
+            private final LinkedHashMap<TUniqueId, SlotContext> slots = Maps.newLinkedHashMap();
+            private final int weight;
+            private int state;
+            private long skipTimes;
+
+            public SlotSubQueue(int queueIndex, int weight) {
+                this.queueIndex = queueIndex;
+                this.weight = weight;
+                this.state = 0;
+                this.skipTimes = 0;
+            }
+
+            public void skip(int incr) {
+                skipTimes += incr;
+            }
+
+            public void comeback() {
+                // Give it some compensations according to the skip times.
+                state += (int) Math.min((totalWeight - weight) * skipTimes, totalWeight * 2L);
+                skipTimes = 0;
+            }
+
+            public void incrState(int incr) {
+                this.state += incr;
+                MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_STATE.getMetric(String.valueOf(queueIndex)).increase((long) incr);
+            }
+
+            public boolean isEmpty() {
+                return slots.isEmpty();
+            }
+
+            public int size() {
+                return slots.size();
+            }
+
+            public SlotContext add(SlotContext context) {
+                return slots.put(context.getSlotId(), context);
+            }
+
+            public SlotContext remove(TUniqueId slotId) {
+                return slots.remove(slotId);
+            }
+
+            public SlotContext peak() {
+                return slots.values().iterator().next();
+            }
+
+            public long getSkipTimes() {
+                return skipTimes;
+            }
+        }
+    }
+
+    @VisibleForTesting
+    static class SlotContext {
+        private final LogicalSlot slot;
+        private boolean allocatedAsSmallSlot = false;
+        private int subQueueIndex = 0;
+
+        public SlotContext(LogicalSlot slot) {
+            this.slot = slot;
+        }
+
+        public boolean isAllocatedAsSmallSlot() {
+            return allocatedAsSmallSlot;
+        }
+
+        public void setAllocateAsSmallSlot() {
+            this.allocatedAsSmallSlot = true;
+        }
+
+        public LogicalSlot getSlot() {
+            return slot;
+        }
+
+        public TUniqueId getSlotId() {
+            return slot.getSlotId();
+        }
+
+        public int getSubQueueIndex() {
+            return subQueueIndex;
+        }
+
+        public void setSubQueueIndex(int subQueueIndex) {
+            this.subQueueIndex = subQueueIndex;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -327,9 +327,10 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                     break;
                 }
 
+                // If the highest state sub-queue is empty, skip it
+
                 maxSubQueue.skip(1);
 
-                // If the highest state sub-queue is empty, skip it
                 final int selectTimes = calculateContinuousSelectTimesForQueue(maxQueueIndex);
                 if (selectTimes > 0) {
                     maxSubQueue.skip(selectTimes);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -221,10 +221,8 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                 MetricRepo.GAUGE_QUERY_QUEUE_CATEGORY_WEIGHT.getMetric(category).setValue(curWeight);
                 MetricRepo.GAUGE_QUERY_QUEUE_CATEGORY_SLOT_MIN_SLOTS.getMetric(category).setValue(curMinSlots * numWorkers);
 
-                if (curMinSlots > 1) {
-                    curWeight = (curWeight >>> 1) + (curWeight << 1); // curWeight*=2.5
-                    curMinSlots = curMinSlots >>> 1;
-                }
+                curWeight = (curWeight >>> 1) + (curWeight << 1); // curWeight*=2.5
+                curMinSlots = curMinSlots >>> 1;
             }
             this.totalWeight = totalWeight;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -607,6 +607,10 @@ public class Utils {
         return num < 0 ? 1 : num + 1;
     }
 
+    public static int log2(int n) {
+        return 31 - Integer.numberOfLeadingZeros(n);
+    }
+
     /**
      * Check the input expression is not nullable or not.
      * @param nullOutputColumnOps the nullable column reference operators.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.starrocks.common.Config;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.qe.scheduler.SchedulerTestBase;
+import com.starrocks.system.BackendResourceStat;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryQueueOptionsTest extends SchedulerTestBase {
+    private boolean prevEnableQueryQueueV2 = false;
+    private boolean prevEnableQueryQueueSelect = false;
+
+    @Before
+    public void before() {
+        prevEnableQueryQueueV2 = Config.enable_query_queue_v2;
+        prevEnableQueryQueueSelect = GlobalVariable.isEnableQueryQueueSelect();
+    }
+
+    @After
+    public void after() {
+        Config.enable_query_queue_v2 = prevEnableQueryQueueV2;
+        GlobalVariable.setEnableQueryQueueSelect(prevEnableQueryQueueSelect);
+
+        BackendResourceStat.getInstance().reset();
+    }
+
+    @Test
+    public void testZeroConcurrencyLevel() {
+        Assert.assertThrows("concurrencyLevel should be positive", IllegalStateException.class,
+                () -> new QueryQueueOptions(true, new QueryQueueOptions.V2(0, 0, 0, 0, 0)));
+    }
+
+    @Test
+    public void testZeroOthers() {
+        QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2(2, 0, 0, 0, 0));
+        assertThat(opts.v2().getNumWorkers()).isOne();
+        assertThat(opts.v2().getNumRowsPerSlot()).isOne();
+        assertThat(opts.v2().getTotalSlots()).isEqualTo(2);
+        assertThat(opts.v2().getTotalSmallSlots()).isOne();
+        assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testCreateFromEnv() {
+        {
+            Config.enable_query_queue_v2 = false;
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnv();
+
+            assertThat(opts.isEnableQueryQueueV2()).isFalse();
+        }
+
+        {
+            final int numCores = 16;
+            final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+            final int numBEs = 2;
+            final int concurrencyLevel = Config.query_queue_v2_concurrency_level;
+
+            BackendResourceStat.getInstance().setNumHardwareCoresOfBe(1, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(1, memLimitBytes);
+            BackendResourceStat.getInstance().setNumHardwareCoresOfBe(2, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(2, memLimitBytes);
+            Config.enable_query_queue_v2 = true;
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnv();
+
+            assertThat(opts.isEnableQueryQueueV2()).isTrue();
+            assertThat(opts.v2().getNumWorkers()).isEqualTo(numBEs);
+            assertThat(opts.v2().getNumRowsPerSlot()).isEqualTo(Config.query_queue_v2_num_rows_per_slot);
+            assertThat(opts.v2().getTotalSlots()).isEqualTo(concurrencyLevel * numBEs * numCores);
+            assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(memLimitBytes / concurrencyLevel / numCores);
+            assertThat(opts.v2().getTotalSmallSlots()).isEqualTo(numCores);
+        }
+    }
+
+    @Test
+    public void testCreateFromEnvAndQuery() throws Exception {
+        Config.enable_query_queue_v2 = true;
+
+        {
+            GlobalVariable.setEnableQueryQueueSelect(false);
+            DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(enable_query_queue=true)*/ * FROM lineitem");
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnvAndQuery(coordinator);
+            assertThat(opts.isEnableQueryQueueV2()).isFalse();
+        }
+
+        {
+            GlobalVariable.setEnableQueryQueueSelect(true);
+            DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(enable_query_queue=true)*/ * FROM lineitem");
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnvAndQuery(coordinator);
+            assertThat(opts.isEnableQueryQueueV2()).isTrue();
+        }
+
+        {
+            GlobalVariable.setEnableQueryQueueSelect(true);
+            DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(enable_query_queue=false)*/ * FROM lineitem");
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnvAndQuery(coordinator);
+            assertThat(opts.isEnableQueryQueueV2()).isFalse();
+        }
+
+        {
+            GlobalVariable.setEnableQueryQueueSelect(true);
+            DefaultCoordinator coordinator = getScheduler(
+                    "SELECT /*+SET_VAR(enable_query_queue=true)*/ * FROM information_schema.columns");
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnvAndQuery(coordinator);
+            assertThat(opts.isEnableQueryQueueV2()).isFalse();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
@@ -20,7 +20,6 @@ import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.scheduler.SchedulerTestBase;
 import com.starrocks.system.BackendResourceStat;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
@@ -46,8 +46,8 @@ public class QueryQueueOptionsTest extends SchedulerTestBase {
 
     @Test
     public void testZeroConcurrencyLevel() {
-        Assert.assertThrows("concurrencyLevel should be positive", IllegalStateException.class,
-                () -> new QueryQueueOptions(true, new QueryQueueOptions.V2(0, 0, 0, 0, 0)));
+        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(0, 0, 0, 0, 0);
+        assertThat(opts.getTotalSlots()).isEqualTo(4);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
@@ -45,18 +45,19 @@ public class QueryQueueOptionsTest extends SchedulerTestBase {
 
     @Test
     public void testZeroConcurrencyLevel() {
-        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(0, 0, 0, 0, 0);
+        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(0, 0, 0, 0, 0, 0);
         assertThat(opts.getTotalSlots()).isEqualTo(4);
     }
 
     @Test
     public void testZeroOthers() {
-        QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2(2, 0, 0, 0, 0));
+        QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2(2, 0, 0, 0, 0, 0));
         assertThat(opts.v2().getNumWorkers()).isOne();
         assertThat(opts.v2().getNumRowsPerSlot()).isOne();
         assertThat(opts.v2().getTotalSlots()).isEqualTo(2);
         assertThat(opts.v2().getTotalSmallSlots()).isOne();
         assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(Long.MAX_VALUE);
+        assertThat(opts.v2().getCpuCostsPerSlot()).isOne();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
@@ -1,0 +1,181 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.starrocks.planner.PlanNode;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.SchedulerTestBase;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SlotEstimatorTest extends SchedulerTestBase {
+    @Test
+    public void testDefaultSlotEstimator() {
+        SlotEstimatorFactory.DefaultSlotEstimator estimator = new SlotEstimatorFactory.DefaultSlotEstimator();
+        assertThat(estimator.estimateSlots(null, null, null)).isOne();
+    }
+
+    @Test
+    public void testMemoryBasedSlotsEstimator() throws Exception {
+        final int numWorkers = 3;
+        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
+        QueryQueueOptions opts =
+                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096));
+        SlotEstimatorFactory.MemoryBasedSlotsEstimator estimator = new SlotEstimatorFactory.MemoryBasedSlotsEstimator();
+
+        DefaultCoordinator coordinator = getScheduler("SELECT * FROM lineitem");
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(1);
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers - 10);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots() / 2);
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers + 10);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers * 100);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+    }
+
+    @Test
+    public void testParallelismBasedSlotsEstimator() throws Exception {
+        SlotEstimatorFactory.ParallelismBasedSlotsEstimator estimator = new SlotEstimatorFactory.ParallelismBasedSlotsEstimator();
+        final int numWorkers = 3;
+        final int numCoresPerWorker = 16;
+        final int numRowsPerWorker = 4096;
+        final int dop = numCoresPerWorker / 2;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, numCoresPerWorker, 64L * 1024 * 1024 * 1024, numRowsPerWorker));
+
+        {
+            DefaultCoordinator coordinator = getScheduler("SELECT * FROM lineitem");
+            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(20 / 3 * 3);
+        }
+
+        String sql = "SELECT /*+SET_VAR(pipeline_dop=8)*/ " +
+                "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: L_ORDERKEY = 18: L_ORDERKEY\n" +
+                "  |  \n" +
+                "  |----3:EXCHANGE\n" +
+                "  |    \n" +
+                "  1:EXCHANGE");
+        assertContains(plan, "  RESULT SINK\n" +
+                "\n" +
+                "  8:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(35: count)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  7:EXCHANGE");
+        {
+            DefaultCoordinator coordinator = getScheduler(sql);
+            setNodeCardinality(coordinator, 1, 10);
+            setNodeCardinality(coordinator, 3, 10);
+            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(20 / 3 * 3);
+        }
+        {
+            DefaultCoordinator coordinator = getScheduler(sql);
+            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop);
+            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * numWorkers);
+        }
+        {
+            DefaultCoordinator coordinator = getScheduler(sql);
+            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop * 10);
+            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * numWorkers);
+        }
+        {
+            DefaultCoordinator coordinator = getScheduler(sql);
+            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * 7);
+            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(7 * numWorkers);
+        }
+        {
+            DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=100)*/ " +
+                    "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey");
+            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * 100);
+            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+        }
+
+        {
+            DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=19)*/ " +
+                    "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey");
+            // The exchange source node of the sink node only on one BE.
+            setNodeCardinality(coordinator, 7, numRowsPerWorker * 19);
+            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(19);
+        }
+    }
+
+    @Test
+    public void testMaxSlotsEstimator() {
+        SlotEstimator estimator1 = (opts, context, coord) -> 1;
+        SlotEstimator estimator2 = (opts, context, coord) -> 2;
+        SlotEstimator estimator3 = (opts, context, coord) -> 3;
+
+        {
+            SlotEstimatorFactory.MaxSlotsEstimator estimator = new SlotEstimatorFactory.MaxSlotsEstimator(estimator1, estimator2);
+            assertThat(estimator.estimateSlots(null, null, null)).isEqualTo(2);
+        }
+
+        {
+            SlotEstimatorFactory.MaxSlotsEstimator estimator = new SlotEstimatorFactory.MaxSlotsEstimator(estimator1, estimator3);
+            assertThat(estimator.estimateSlots(null, null, null)).isEqualTo(3);
+        }
+
+        {
+            SlotEstimatorFactory.MaxSlotsEstimator estimator = new SlotEstimatorFactory.MaxSlotsEstimator(estimator2, estimator3);
+            assertThat(estimator.estimateSlots(null, null, null)).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void testCreate() {
+        QueryQueueOptions opts = new QueryQueueOptions(false, new QueryQueueOptions.V2());
+        assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.DefaultSlotEstimator.class);
+
+        opts = new QueryQueueOptions(true, new QueryQueueOptions.V2(1, 1, 1, 1, 1));
+        assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.MaxSlotsEstimator.class);
+    }
+
+    private static void setNodeCardinality(DefaultCoordinator coordinator, int nodeId, long cardinality) {
+        PlanNode node = findPlanNodeById(coordinator.getExecutionDAG().getRootFragment().getPlanFragment().getPlanRoot(), nodeId);
+        assertThat(node).isNotNull();
+
+        Statistics statistics = Statistics.builder().setOutputRowCount(cardinality).build();
+        node.computeStatistics(statistics);
+    }
+
+    private static PlanNode findPlanNodeById(PlanNode root, int nodeId) {
+        if (root.getId().asInt() == nodeId) {
+            return root;
+        }
+
+        for (PlanNode child : root.getChildren()) {
+            PlanNode res = findPlanNodeById(child, nodeId);
+            if (res != null) {
+                return res;
+            }
+        }
+
+        return null;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
@@ -1,0 +1,294 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.system.BackendResourceStat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SlotSelectionStrategyV2Test {
+    private static final int NUM_CORES = 16;
+
+    private boolean prevEnableQueryQueueV2 = false;
+
+    @BeforeClass
+    public static void beforeClass() {
+        MetricRepo.init();
+    }
+
+    @Before
+    public void before() {
+        prevEnableQueryQueueV2 = Config.enable_query_queue_v2;
+        Config.enable_query_queue_v2 = true;
+
+        BackendResourceStat.getInstance().setNumHardwareCoresOfBe(1, NUM_CORES);
+    }
+
+    @After
+    public void after() {
+        Config.enable_query_queue_v2 = prevEnableQueryQueueV2;
+
+        BackendResourceStat.getInstance().reset();
+    }
+
+    @Test
+    public void testSmallSlot() {
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2();
+        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+
+        LogicalSlot largeSlot = generateSlot(opts.v2().getTotalSlots() - 1);
+        List<LogicalSlot> smallSlots = IntStream.range(0, NUM_CORES + 2)
+                .mapToObj(i -> generateSlot(1))
+                .collect(Collectors.toList());
+
+        // 1. Require and allocate the large slot with `totalSlots - 1` slots.
+        slotTracker.requireSlot(largeSlot);
+        List<LogicalSlot> peakSlots = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peakSlots).containsExactly(largeSlot);
+        slotTracker.allocateSlot(largeSlot);
+
+        // 2. Require `NUM_CORES + 2` small slots.
+        for (LogicalSlot smallSlot : smallSlots) {
+            slotTracker.requireSlot(smallSlot);
+        }
+
+        // 3. Could peak and allocate `NUM_CORES + 1` small slots:
+        // - `NUM_CORES` small slot are allocated as small slots.
+        // - 1 small slot is allocated as a non-small slot.
+        List<LogicalSlot> peakSmallSlots = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peakSmallSlots).hasSize(NUM_CORES + 1);
+        for (LogicalSlot peakSmallSlot : peakSmallSlots) {
+            slotTracker.allocateSlot(peakSmallSlot);
+        }
+
+        // 4. Release the large slot and then the rest one small slot could be peaked.
+        peakSlots = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peakSlots).isEmpty();
+
+        slotTracker.releaseSlot(largeSlot.getSlotId());
+        peakSlots = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peakSlots).hasSize(1);
+        slotTracker.allocateSlot(peakSlots.get(0));
+        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(smallSlots.size());
+
+        // 5. Require `10+numAvailableSlots` small slots.
+        final int numAvailableSlots = opts.v2().getTotalSlots() + opts.v2().getTotalSmallSlots() - smallSlots.size();
+        List<LogicalSlot> smallSlots2 =
+                IntStream.range(0, 10 + numAvailableSlots)
+                        .mapToObj(i -> generateSlot(1))
+                        .collect(Collectors.toList());
+        smallSlots2.forEach(slotTracker::requireSlot);
+
+        // 6. Could peak and allocate `numAvailableSlots` small slots.
+        peakSmallSlots = strategy.peakSlotsToAllocate(slotTracker);
+        peakSmallSlots.forEach(slotTracker::allocateSlot);
+        assertThat(peakSmallSlots).hasSize(numAvailableSlots);
+        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(opts.v2().getTotalSlots() + opts.v2().getTotalSmallSlots());
+
+        // 7. Release 10 small slots and then the rest small slots could be peaked and allocated.
+        smallSlots.stream().limit(10).forEach(slot -> slotTracker.releaseSlot(slot.getSlotId()));
+        peakSmallSlots = strategy.peakSlotsToAllocate(slotTracker);
+        peakSmallSlots.forEach(slotTracker::allocateSlot);
+        assertThat(peakSmallSlots).hasSize(10);
+        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(opts.v2().getTotalSlots() + opts.v2().getTotalSmallSlots());
+    }
+
+    @Test
+    public void testHeadLineBlocking1() {
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2();
+        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(opts.v2().getTotalSlots() / 2 + 1);
+        LogicalSlot slot2 = generateSlot(opts.v2().getTotalSlots() / 2);
+        LogicalSlot slot3 = generateSlot(2);
+
+        // 1. Require and allocate slot1.
+        slotTracker.requireSlot(slot1);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot1);
+        slotTracker.allocateSlot(slot1);
+
+        // 2. Require slot2.
+        slotTracker.requireSlot(slot2);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 3. Require enough small slots to make its priority lower.
+        {
+            List<LogicalSlot> smallSlots = IntStream.range(0, 10)
+                    .mapToObj(i -> generateSlot(2))
+                    .collect(Collectors.toList());
+            smallSlots.forEach(slotTracker::requireSlot);
+            for (int numPeakedSmallSlots = 0; numPeakedSmallSlots < 10; ) {
+                List<LogicalSlot> peakSlots = strategy.peakSlotsToAllocate(slotTracker);
+                numPeakedSmallSlots += peakSlots.size();
+                peakSlots.forEach(slotTracker::allocateSlot);
+                peakSlots.forEach(slot -> assertThat(slotTracker.releaseSlot(slot.getSlotId())).isSameAs(slot));
+            }
+        }
+
+        // Try peak the only rest slot2, but it is blocked by slot1.
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 4. slot3 cannot be peaked because it is blocked by slot2.
+        slotTracker.requireSlot(slot3);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 5. slot3 can be peaked after releasing the pending slot2.
+        assertThat(slotTracker.releaseSlot(slot2.getSlotId())).isSameAs(slot2);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot3);
+        slotTracker.allocateSlot(slot3);
+        assertThat(slotTracker.releaseSlot(slot3.getSlotId())).isSameAs(slot3);
+    }
+
+    @Test
+    public void testHeadLineBlocking2() {
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2();
+        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(opts.v2().getTotalSlots() / 2 + 1);
+        LogicalSlot slot2 = generateSlot(opts.v2().getTotalSlots() / 2);
+        LogicalSlot slot3 = generateSlot(2);
+
+        // 1. Require and allocate slot1.
+        slotTracker.requireSlot(slot1);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot1);
+        slotTracker.allocateSlot(slot1);
+
+        // 2. Require slot2.
+        slotTracker.requireSlot(slot2);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 3. Require enough small slots to make its priority lower.
+        {
+            List<LogicalSlot> smallSlots = IntStream.range(0, 10)
+                    .mapToObj(i -> generateSlot(2))
+                    .collect(Collectors.toList());
+            smallSlots.forEach(slotTracker::requireSlot);
+            for (int numPeakedSmallSlots = 0; numPeakedSmallSlots < 10; ) {
+                List<LogicalSlot> peakSlots = strategy.peakSlotsToAllocate(slotTracker);
+                numPeakedSmallSlots += peakSlots.size();
+                peakSlots.forEach(slotTracker::allocateSlot);
+                peakSlots.forEach(slot -> assertThat(slotTracker.releaseSlot(slot.getSlotId())).isSameAs(slot));
+            }
+        }
+
+        // Try peak the only rest slot2, but it is blocked by slot1.
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 4. slot3 cannot be peaked because it is blocked by slot2.
+        for (int i = 0; i < 10; i++) {
+            slotTracker.requireSlot(slot3);
+            assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+            assertThat(slotTracker.releaseSlot(slot3.getSlotId())).isSameAs(slot3);
+        }
+        slotTracker.requireSlot(slot3);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 5. slot2 and slot3 can be peaked after releasing slot1.
+        slotTracker.releaseSlot(slot1.getSlotId());
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot2, slot3);
+    }
+
+    @Test
+    public void testUpdateOptionsPeriodicallyAtAllocating() throws InterruptedException {
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2();
+        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(opts.v2().getTotalSlots() / 2 + 1);
+        LogicalSlot slot2 = generateSlot(opts.v2().getTotalSlots() / 2 - 1);
+        LogicalSlot slot3 = generateSlot(2);
+
+        // 1. Require slot1, slot2, slot3.
+        assertThat(slotTracker.requireSlot(slot1)).isTrue();
+        assertThat(slotTracker.requireSlot(slot2)).isTrue();
+        assertThat(slotTracker.requireSlot(slot3)).isTrue();
+
+        // 2. Peak slot2 and slot3.
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot3, slot2);
+
+        // Make options changed.
+        BackendResourceStat.getInstance().setNumHardwareCoresOfBe(1, NUM_CORES * 2);
+        Thread.sleep(1200);
+        // 3. Allocate slot2 and slot3.
+        slotTracker.allocateSlot(slot2);
+        slotTracker.allocateSlot(slot3);
+        assertThat(slot2.getState()).isEqualTo(LogicalSlot.State.ALLOCATED);
+        assertThat(slot3.getState()).isEqualTo(LogicalSlot.State.ALLOCATED);
+        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(slot2.getNumPhysicalSlots() + slot3.getNumPhysicalSlots());
+
+        // 4. Peak slot1.
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot1);
+        slotTracker.allocateSlot(slot1);
+        assertThat(slot1.getState()).isEqualTo(LogicalSlot.State.ALLOCATED);
+        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(
+                slot2.getNumPhysicalSlots() + slot3.getNumPhysicalSlots() + slot1.getNumPhysicalSlots());
+    }
+
+    @Test
+    public void testUpdateOptionsPeriodicallyAtReleasing() throws InterruptedException {
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2();
+        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(opts.v2().getTotalSlots() / 2 + 1);
+        LogicalSlot slot2 = generateSlot(opts.v2().getTotalSlots() / 2 - 1);
+        LogicalSlot slot3 = generateSlot(2);
+
+        // 1. Require slot1, slot2, slot3.
+        assertThat(slotTracker.requireSlot(slot1)).isTrue();
+        assertThat(slotTracker.requireSlot(slot2)).isTrue();
+        assertThat(slotTracker.requireSlot(slot3)).isTrue();
+
+        // 2. Peak, allocate slot2 and slot3.
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot3, slot2);
+        slotTracker.allocateSlot(slot2);
+        slotTracker.allocateSlot(slot3);
+        assertThat(slot2.getState()).isEqualTo(LogicalSlot.State.ALLOCATED);
+        assertThat(slot3.getState()).isEqualTo(LogicalSlot.State.ALLOCATED);
+        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(slot2.getNumPhysicalSlots() + slot3.getNumPhysicalSlots());
+
+        // Make options changed.
+        BackendResourceStat.getInstance().setNumHardwareCoresOfBe(1, NUM_CORES * 2);
+        Thread.sleep(1200);
+        // 3. Release slot2 and slot3.
+        assertThat(slotTracker.releaseSlot(slot2.getSlotId())).isSameAs(slot2);
+        assertThat(slotTracker.releaseSlot(slot3.getSlotId())).isSameAs(slot3);
+
+        // 4. Peak slot1.
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot1);
+        slotTracker.allocateSlot(slot1);
+        assertThat(slot1.getState()).isEqualTo(LogicalSlot.State.ALLOCATED);
+        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(slot1.getNumPhysicalSlots());
+    }
+
+    private static LogicalSlot generateSlot(int numSlots) {
+        return new LogicalSlot(UUIDUtil.genTUniqueId(), "fe", LogicalSlot.ABSENT_GROUP_ID, numSlots, 0, 0, 0, 0, 0);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2WeightedRoundRobinQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2WeightedRoundRobinQueueTest.java
@@ -1,0 +1,335 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.util.UUIDUtil;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static com.starrocks.qe.scheduler.slot.SlotSelectionStrategyV2.SlotContext;
+import static com.starrocks.qe.scheduler.slot.SlotSelectionStrategyV2.WeightedRoundRobinQueue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SlotSelectionStrategyV2WeightedRoundRobinQueueTest {
+    @Test
+    public void testInit() {
+        class TestCase {
+            final int numSlotsPerWorker;
+            final int expectedQueueIndex;
+
+            public TestCase(int numSlotsPerWorker, int expectedQueueIndex) {
+                this.numSlotsPerWorker = numSlotsPerWorker;
+                this.expectedQueueIndex = expectedQueueIndex;
+            }
+
+            @Override
+            public String toString() {
+                return "TestCase{" +
+                        "numSlotsPerWorker=" + numSlotsPerWorker +
+                        ", expectedQueueIndex=" + expectedQueueIndex +
+                        '}';
+            }
+        }
+
+        final int numWorkers = 3;
+
+        {
+            // 7: [64, inf)
+            // 6: [32, 64)
+            // 5: [16, 8)
+            // 4: [8, 4)
+            // 3: [4, 1)
+            // 2: [2, 1)
+            // 1: [1, 1]
+            // 0: [0, 0]
+            WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(64 * numWorkers, numWorkers);
+            List<TestCase> cases = ImmutableList.of(
+                    new TestCase(65, 7),
+                    new TestCase(64, 7),
+
+                    new TestCase(63, 6),
+                    new TestCase(33, 6),
+                    new TestCase(32, 6),
+
+                    new TestCase(31, 5),
+                    new TestCase(17, 5),
+                    new TestCase(16, 5),
+
+                    new TestCase(15, 4),
+                    new TestCase(9, 4),
+                    new TestCase(8, 4),
+
+                    new TestCase(7, 3),
+                    new TestCase(5, 3),
+                    new TestCase(4, 3),
+
+                    new TestCase(3, 2),
+                    new TestCase(2, 2),
+
+                    new TestCase(1, 1),
+                    new TestCase(0, 0)
+            );
+            for (TestCase tc : cases) {
+                validateQueueIndexOfSlot(queue, tc.numSlotsPerWorker * numWorkers, tc.expectedQueueIndex, tc.toString());
+            }
+        }
+
+        {
+            // 7: [1024, inf)
+            // 6: [512, 1024)
+            // 5: [256, 512)
+            // 4: [128, 256)
+            // 3: [64, 128)
+            // 2: [32, 64)
+            // 1: [16, 32]
+            // 0: [0, 16)
+            WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024 * numWorkers, numWorkers);
+            List<TestCase> cases = ImmutableList.of(
+                    new TestCase(1025, 7),
+                    new TestCase(1024, 7),
+
+                    new TestCase(1023, 6),
+                    new TestCase(513, 6),
+                    new TestCase(512, 6),
+
+                    new TestCase(511, 5),
+                    new TestCase(257, 5),
+                    new TestCase(256, 5),
+
+                    new TestCase(255, 4),
+                    new TestCase(129, 4),
+                    new TestCase(128, 4),
+
+                    new TestCase(127, 3),
+                    new TestCase(65, 3),
+                    new TestCase(64, 3),
+
+                    new TestCase(63, 2),
+                    new TestCase(33, 2),
+                    new TestCase(32, 2),
+
+                    new TestCase(31, 1),
+                    new TestCase(17, 1),
+                    new TestCase(16, 1),
+
+                    new TestCase(15, 0),
+                    new TestCase(8, 0),
+                    new TestCase(1, 0),
+                    new TestCase(0, 0)
+            );
+            for (TestCase tc : cases) {
+                validateQueueIndexOfSlot(queue, tc.numSlotsPerWorker * numWorkers, tc.expectedQueueIndex, tc.toString());
+            }
+        }
+    }
+
+    private static SlotContext generateSlotContext(int numSlots) {
+        LogicalSlot slot = new LogicalSlot(UUIDUtil.genTUniqueId(), "fe", LogicalSlot.ABSENT_GROUP_ID, numSlots, 0, 0, 0, 0, 0);
+        return new SlotContext(slot);
+    }
+
+    private static void validateQueueIndexOfSlot(WeightedRoundRobinQueue queue, int numSlots, int expectedQueueIndex,
+                                                 String failMsg) {
+        SlotContext context = generateSlotContext(numSlots);
+        queue.add(context);
+        assertThat(context.getSubQueueIndex()).describedAs(failMsg).isEqualTo(expectedQueueIndex);
+
+        SlotContext curContext = queue.peak();
+        assertThat(curContext).describedAs(failMsg).isSameAs(context);
+
+        curContext = queue.poll();
+        assertThat(curContext).describedAs(failMsg).isSameAs(context);
+
+        assertThat(queue.isEmpty()).describedAs(failMsg).isTrue();
+    }
+
+    @Test
+    public void testAddAndPeakByPriority() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        int numSlots = 1024;
+        for (int i = 7; i >= 0; i--) {
+            for (int j = 0; j < 16384; j++) {
+                queue.add(generateSlotContext(numSlots));
+            }
+            numSlots = numSlots >>> 1;
+        }
+
+        final int[] expectedPeakTimes = new int[] {0, 0, 0, 0, 0, 0, 0, 0};
+        int curWeight = 1;
+        for (int i = 7; i >= 0; i--) {
+            expectedPeakTimes[i] = curWeight;
+            curWeight = (int) (curWeight * 2.5);
+        }
+
+        final int totalPeakTimes = Arrays.stream(expectedPeakTimes).sum();
+        int[] peakTimes = new int[] {0, 0, 0, 0, 0, 0, 0, 0};
+        for (int i = 0; i < totalPeakTimes; i++) {
+            SlotContext context = queue.peak();
+            peakTimes[context.getSubQueueIndex()]++;
+
+            // Return the same one when peaking multiple times.
+            for (int j = 0; j < 3; j++) {
+                SlotContext curContext = queue.peak();
+                assertThat(curContext).isSameAs(context);
+            }
+
+            SlotContext curContext = queue.poll();
+            assertThat(curContext).isSameAs(context);
+        }
+
+        assertThat(peakTimes).containsExactly(expectedPeakTimes);
+    }
+
+    @Test
+    public void testRemovePeaked() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        SlotContext context1 = generateSlotContext(1024);
+        SlotContext context2 = generateSlotContext(1);
+        queue.add(context1);
+        queue.add(context2);
+        assertThat(queue.size()).isEqualTo(2);
+
+        SlotContext peak = queue.peak();
+        assertThat(peak).isSameAs(context2);
+
+        queue.remove(context2);
+        peak = queue.peak();
+        assertThat(peak).isSameAs(context1);
+        assertThat(queue.isEmpty()).isFalse();
+        assertThat(queue.size()).isOne();
+    }
+
+    @Test
+    public void testRemoveToPeak() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        SlotContext context1 = generateSlotContext(1024);
+        SlotContext context2 = generateSlotContext(1);
+        queue.add(context1);
+        queue.add(context2);
+        assertThat(queue.size()).isEqualTo(2);
+
+        queue.remove(context2);
+        SlotContext peak = queue.peak();
+        assertThat(peak).isSameAs(context1);
+        assertThat(queue.isEmpty()).isFalse();
+        assertThat(queue.size()).isOne();
+    }
+
+    @Test
+    public void testRemoveNonExist() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        SlotContext context1 = generateSlotContext(1024);
+        SlotContext context2 = generateSlotContext(1);
+        queue.add(context1);
+        queue.add(context2);
+        assertThat(queue.size()).isEqualTo(2);
+
+        SlotContext context3 = generateSlotContext(256);
+        queue.remove(context3);
+        assertThat(queue.size()).isEqualTo(2);
+
+        SlotContext peak = queue.peak();
+        assertThat(peak).isSameAs(context2);
+    }
+
+    @Test
+    public void testPoll() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        final int numSlots = 100;
+        Random rand = new Random();
+
+        // Add `numSlots` slots.
+        for (int i = 0; i < numSlots; i++) {
+            queue.add(generateSlotContext(rand.nextInt()));
+        }
+        assertThat(queue.size()).isEqualTo(numSlots);
+
+        // Poll all slots.
+        for (int i = 0; i < numSlots; i++) {
+            SlotContext context = queue.poll();
+            assertThat(context).isNotNull();
+        }
+        assertThat(queue.size()).isZero();
+        assertThat(queue.isEmpty()).isTrue();
+
+        // Poll an empty queue.
+        SlotContext context = queue.poll();
+        assertThat(context).isNull();
+    }
+
+    @Test
+    public void testEmptyQueueComeback() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        SlotContext slot1 = generateSlotContext(1024);
+        SlotContext slot2 = generateSlotContext(512);
+        SlotContext slot3 = generateSlotContext(256);
+        SlotContext slot4 = generateSlotContext(1);
+
+        queue.add(slot1);
+        assertThat(queue.peak()).isSameAs(slot1);
+
+        // The queue of slot2 comebacks and slot2 > slot1 (peak)
+        queue.add(slot2);
+        assertThat(queue.peak()).isSameAs(slot2);
+
+        // The queue of slot4 comebacks and slot4 > slot2 (peak)
+        queue.add(slot4);
+        assertThat(queue.peak()).isSameAs(slot4);
+
+        // The queue of slot3 comebacks but slot3 < slot4 (peak)
+        queue.add(slot3);
+        assertThat(queue.peak()).isSameAs(slot4);
+
+        // Poll all the slots.
+        assertThat(queue.poll()).isSameAs(slot4);
+        assertThat(queue.poll()).isSameAs(slot3);
+        assertThat(queue.poll()).isSameAs(slot2);
+        assertThat(queue.poll()).isSameAs(slot1);
+        assertThat(queue.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testSkipEmptyQueue() {
+        SlotContext slot1 = generateSlotContext(1024);
+        SlotContext slot2 = generateSlotContext(512);
+        SlotContext slot3 = generateSlotContext(256);
+        SlotContext slot4 = generateSlotContext(1);
+
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        queue.add(slot1);
+        assertThat(queue.peak()).isSameAs(slot1);
+
+        assertThat(queue.getSubQueues()[7].getSkipTimes()).isZero();
+        int skipTimes = 1;
+        for (int i = 6; i >= 0; i--) {
+            assertThat(queue.getSubQueues()[i].getSkipTimes())
+                    .describedAs("subQueue#" + i)
+                    .isBetween(skipTimes - 1L, skipTimes + 1L);
+            skipTimes = (int) ((double) skipTimes * 2.5);
+        }
+    }
+
+}


### PR DESCRIPTION
## Why I'm doing:

Apply query queue based on slot estimation

## What I'm doing:

### Implementation

The slot resource is divided into small extra slots and normal slots.

- Small slots are tried to allocate slots from the small extra slots. If it fails, will try to allocate them from the normal slots. The small slot is defined as the query that requires only one slot.

- Selecting slots to allocate from the normal slots is based on the smooth weighted round-robin algorithm. The slots are divided into multiple sub-queues according to the number of slots required by the query. Each sub-queue has a different weight. 
    - The implementation of the smooth weighted round-robin algorithm.
        - Besides, if the peaking sub-queue is empty, will update `state` as usual and record the skip times of this sub-queue. Repeat this process until the peaking sub-queue is not empty. When this sub-queue is not empty anymore, will give it some compensations according to the skip times.
        - The rules to divide sub-queues are as follows:
            - The minimum slots of `subQueues[i]` is $2^{b-(7-i)}$, that is, the minimum slots of 0~7 sub-queues are $2^{b-7}$, $2^{b-6}$, $2^{b-5}$, $2^{b-4}$, $2^{b-3}$, $2^{b-2}$, $2^{b-1}$, $2^b$, respectively. where $b$ denotes `lastSubQueueLog2Bound`.
            - The weight of `subQueues[i]` is $2.5^{7-i}$, that is, the weights of 0~7 sub-queues are $2.5^7$, $2.5^6$, $2.5^5$, $2.5^4$, $2.5^3$, $2.5^2$, $2.5^1$, $2.5^0$ respectively.

### How to use

The query queue strategy uses the previous strategy by default. To switch to the new strategy, add `enable_query_queue_v2=true` to `fe.conf` and **restart all the FEs**.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
