### PR TITLE
[BugFix] Fix delete index file failed when destory VerticalRowsetWriter after compaction

### DIFF
--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -1084,7 +1084,7 @@ VerticalRowsetWriter::~VerticalRowsetWriter() {
                         if (index.index_type() == GIN) {
                             std::string index_path = IndexDescriptor::inverted_index_file_path(
                                     _context.rowset_path_prefix, _context.rowset_id.to_string(), i, index.index_id());
-                            auto index_st = _fs->delete_file(index_path);
+                            auto index_st = _fs->delete_dir_recursive(index_path);
                             LOG_IF(WARNING, !(index_st.ok() || index_st.is_not_found()))
                                     << "Fail to delete file=" << index_path << ", " << index_st.to_string();
                         }

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -162,6 +162,7 @@ public:
         create_tablet_schema(DUP_KEYS, true);
 
         RowsetWriterContext rowset_writer_context;
+        rowset_writer_context.writer_type = kVertical;
         create_rowset_writer_context(&rowset_writer_context);
         std::unique_ptr<RowsetWriter> _rowset_writer;
         ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &_rowset_writer).ok());

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -17,6 +17,8 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "column/schema.h"
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
@@ -24,6 +26,7 @@
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/compaction.h"
+#include "storage/inverted/index_descriptor.hpp"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
@@ -57,7 +60,7 @@ public:
         rowset_writer_context->version.second = 1;
     }
 
-    void create_tablet_schema(KeysType keys_type) {
+    void create_tablet_schema(KeysType keys_type, bool test_gin = false) {
         TabletSchemaPB tablet_schema_pb;
         tablet_schema_pb.set_keys_type(keys_type);
         tablet_schema_pb.set_num_short_key_columns(2);
@@ -104,6 +107,16 @@ public:
         column_4->set_is_bf_column(false);
         column_4->set_aggregation("REPLACE");
 
+        if (test_gin) {
+            TabletIndexPB tablet_index_pb;
+            tablet_index_pb.set_index_id(100);
+            tablet_index_pb.set_index_name("test_gin_index");
+            tablet_index_pb.set_index_type(GIN);
+            tablet_index_pb.add_col_unique_id(2);
+            auto* tablet_index = tablet_schema_pb.add_table_indices();
+            *tablet_index = tablet_index_pb;
+        }
+
         _tablet_schema = std::make_unique<TabletSchema>(tablet_schema_pb);
     }
 
@@ -143,6 +156,26 @@ public:
             cols[3]->append_datum(Datum(&json));
         }
         CHECK_OK(writer->add_chunk(*chunk));
+    }
+
+    void do_compaction_failed_with_gin() {
+        create_tablet_schema(DUP_KEYS, true);
+
+        RowsetWriterContext rowset_writer_context;
+        create_rowset_writer_context(&rowset_writer_context);
+        std::unique_ptr<RowsetWriter> _rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &_rowset_writer).ok());
+
+        // create fake directory/file for index files and segment file
+        auto seg_path =
+                Rowset::segment_file_path(rowset_writer_context.rowset_path_prefix, rowset_writer_context.rowset_id, 0);
+        std::string index_path = IndexDescriptor::inverted_index_file_path(
+                rowset_writer_context.rowset_path_prefix, rowset_writer_context.rowset_id.to_string(), 0, 100);
+        FileSystem::Default()->new_random_access_file(seg_path);
+        fs::create_directories(index_path).ok();
+        int* _num_segment = (int*)((char*)_rowset_writer.get() + offsetof(VerticalRowsetWriter, _num_segment));
+        (*_num_segment) = 1;
+        // test for the abnormal destory for rowset writer
     }
 
     void do_compaction() {
@@ -345,6 +378,11 @@ TEST_F(BaseCompactionTest, test_horizontal_compact_succeed) {
 TEST_F(BaseCompactionTest, test_vertical_compact_succeed) {
     config::vertical_compaction_max_columns_per_group = 1;
     do_compaction();
+}
+
+TEST_F(BaseCompactionTest, test_vertical_compact_failed_with_gin) {
+    config::vertical_compaction_max_columns_per_group = 1;
+    do_compaction_failed_with_gin();
 }
 
 } // namespace starrocks

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1638,3 +1638,54 @@ DROP VIEW test_view;
 DROP TABLE duplicate_table_demo_datatype_not_replicated_all_varchar;
 -- result:
 -- !result
+-- name: test_vertical_compaction
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE `t_vertical_compaction` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  `col1` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col2` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col3` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col4` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col5` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col6` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col7` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col8` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col9` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col10` varchar(255) DEFAULT "ABC" COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (1, "abc");
+-- result:
+-- !result
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (2, "ABC");
+-- result:
+-- !result
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (3, "bcd");
+-- result:
+-- !result
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (4, "BCD");
+-- result:
+-- !result
+ALTER TABLE t_vertical_compaction BASE COMPACT;
+-- result:
+-- !result
+SELECT sleep(10);
+-- result:
+1
+-- !result
+DROP TABLE t_vertical_compaction;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -894,3 +894,39 @@ select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 
 DROP VIEW test_view;
 DROP TABLE duplicate_table_demo_datatype_not_replicated_all_varchar;
+
+-- name: test_vertical_compaction
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+CREATE TABLE `t_vertical_compaction` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  `col1` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col2` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col3` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col4` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col5` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col6` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col7` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col8` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col9` varchar(255) DEFAULT "ABC" COMMENT "",
+  `col10` varchar(255) DEFAULT "ABC" COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (1, "abc");
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (2, "ABC");
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (3, "bcd");
+INSERT INTO t_vertical_compaction (id1, text_column) VALUES (4, "BCD");
+
+ALTER TABLE t_vertical_compaction BASE COMPACT;
+SELECT sleep(10);
+
+DROP TABLE t_vertical_compaction;


### PR DESCRIPTION
Use delete_dir_recursive for the index, because the index path is directory but not file.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
