### PR TITLE
[BugFix] fix get_tablets_basic_infos always return empty tablet_infos

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1576,7 +1576,7 @@ void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_
                 auto& tablet = itr.second;
                 auto table_id_in_meta = tablet->tablet_meta()->table_id();
                 if ((table_id == -1 || table_id_in_meta == table_id) &&
-                    (authorized_table_ids != nullptr &&
+                    (authorized_table_ids == nullptr ||
                      authorized_table_ids->find(table_id_in_meta) != authorized_table_ids->end())) {
                     auto& info = tablet_infos.emplace_back();
                     tablet->get_basic_info(info);


### PR DESCRIPTION
## Why I'm doing:

when I execute script on BE,  no tablet_infos will return
## What I'm doing:
not need to check authorized_table_ids when authorized_table_ids is null 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
