### PR TITLE
[Tool] Connect non-StarRocks engine on demand

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -644,14 +644,17 @@ class StarrocksSQLApiLib(object):
 
     def trino_execute_sql(self, sql):
         """trino execute query"""
+        self.connect_trino()
         return self.conn_execute_sql(self.trino_lib.connector, sql)
 
     def spark_execute_sql(self, sql):
         """spark execute query"""
+        self.connect_spark()
         return self.conn_execute_sql(self.spark_lib.connector, sql)
 
     def hive_execute_sql(self, sql):
         """hive execute query"""
+        self.connect_hive()
         return self.conn_execute_sql(self.hive_lib.connector, sql)
 
     def delete_from(self, args_dict):

--- a/test/test_sql_cases.py
+++ b/test/test_sql_cases.py
@@ -84,9 +84,6 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
         """set up"""
         super().setUp()
         self.connect_starrocks()
-        self.connect_trino()
-        self.connect_spark()
-        self.connect_hive()
 
     def tearDown(self):
         """tear down"""


### PR DESCRIPTION
## Why I'm doing:

For cases where only starrocks connection is required, user only need to provide connection config of SR cluster.

## What I'm doing:

Connect to other engines (e.g. hive) on demand. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
