### PR TITLE
[BugFix] Fix deadlock in tablet schema map

### DIFF
--- a/be/src/storage/tablet_schema_map.cpp
+++ b/be/src/storage/tablet_schema_map.cpp
@@ -74,6 +74,7 @@ std::pair<TabletSchemaMap::TabletSchemaPtr, bool> TabletSchemaMap::emplace(const
     // in map until the shard lock is release. If not, we may be deconstruct the original schema which will cause
     // a dead lock(#issue 5646)
     TabletSchemaPtr result = nullptr;
+    TabletSchemaPtr ptr = nullptr; // Do not move this definition inside the lock scope, otherwise it will deadlock
     bool insert = false;
     {
         std::unique_lock l(shard->mtx);
@@ -84,7 +85,7 @@ std::pair<TabletSchemaMap::TabletSchemaPtr, bool> TabletSchemaMap::emplace(const
             _insert(*shard, id, result);
             insert = true;
         } else {
-            TabletSchemaPtr ptr = it->second.tablet_schema.lock();
+            ptr = it->second.tablet_schema.lock();
             if (UNLIKELY(!ptr)) {
                 result = TabletSchema::create(schema_pb, this);
 
@@ -133,6 +134,7 @@ std::pair<TabletSchemaMap::TabletSchemaPtr, bool> TabletSchemaMap::emplace(const
     MapShard* shard = get_shard(id);
     bool insert = false;
     TabletSchemaPtr result = nullptr;
+    TabletSchemaPtr ptr = nullptr; // Do not move this definition inside the lock scope, otherwise it will deadlock
     {
         std::unique_lock l(shard->mtx);
         auto it = shard->map.find(id);
@@ -142,7 +144,7 @@ std::pair<TabletSchemaMap::TabletSchemaPtr, bool> TabletSchemaMap::emplace(const
             _insert(*shard, id, result);
             insert = true;
         } else {
-            TabletSchemaPtr ptr = it->second.tablet_schema.lock();
+            ptr = it->second.tablet_schema.lock();
             if (UNLIKELY(!ptr)) {
                 result = tablet_schema;
 


### PR DESCRIPTION
## Why I'm doing:
There is deadlock in tablet schema map.
In `TabletSchemaMap::emplace`, there is a local variable `TabletSchemPtr ptr` inside the lock scope.
The TabletSchema object pointed by `ptr` may be destructed inside the lock scope, and its destructor will call `TabletSchemaMap::erase` which also try to lock, causing a deadlock.

## What I'm doing:
Define the local variable `TabletSchemPtr ptr` outside the lock scope, making the destruction outside the lock scope.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
