### PR TITLE
[BugFix] Uninstalling StarRocks Cluster is stuck in k8s

### DIFF
--- a/docker/dockerfiles/be/cn_entrypoint.sh
+++ b/docker/dockerfiles/be/cn_entrypoint.sh
@@ -113,7 +113,8 @@ drop_my_self()
     local start=`date +%s`
     local memlist=
 
-    while true
+    # If we infinitely retry to drop myself, it may cause the pod to be stuck in the Terminating state.
+    for ((i=0;i<3;++i))
     do
         log_stderr "try to drop myself($MY_SELF) from FE ..."
         memlist=`show_compute_nodes $svc`
@@ -122,11 +123,12 @@ drop_my_self()
             # return code 0: no error
             selfinfo=`echo "$memlist" | grep -w "\<$MY_SELF\>" | awk '{printf("%s:%s\n", $2, $3);}'`
             if [[ "x$selfinfo" == "x" ]] ; then
-                log_stderr "myself $selfinfo is not in fe cluster"
+                log_stderr "myself is not in fe cluster"
                 return 0
             else
                 log_stderr "drop my self $selfinfo ..."
                 timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u root --skip-column-names --batch -e "ALTER SYSTEM DROP COMPUTE NODE \"$selfinfo\";"
+                break;
             fi
         else
             log_stderr "Got error $ret, sleep and retry ..."


### PR DESCRIPTION
## Why I'm doing:

When user uninstall from k8s, and if there are CN nodes. they will be stuck in terminating state.
The root cause is that because FE service is deleted, `DROP compute node` operation will always fail

Fixes #issue

see https://github.com/StarRocks/starrocks-kubernetes-operator/issues/558 for more information

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
