### PR TITLE
[BugFix]remove check on num_rows and avail levels, batch skip to avoid big memory alloc

### DIFF
--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -251,7 +251,7 @@ void OptionalStoredColumnReader::reset_levels() {
 
 Status OptionalStoredColumnReader::_decode_levels(size_t* num_rows, size_t* num_levels_parsed, level_t** def_levels) {
     size_t avail_levels = _reader->def_level_decoder().get_avail_levels(*num_rows, def_levels);
-    if (UNLIKELY(avail_levels == 0 || *num_rows > avail_levels)) {
+    if (UNLIKELY(avail_levels == 0)) {
         return Status::InternalError(
                 fmt::format("def levels need to parsed: {}, def levels parsed: {}", *num_rows, avail_levels));
     }
@@ -303,7 +303,7 @@ Status StoredColumnReaderImpl::read_range(const Range<uint64_t>& range, const Fi
 Status StoredColumnReaderImpl::_skip(uint64_t rows_to_skip) {
     uint64_t skipped_row = 0;
     while (skipped_row < rows_to_skip) {
-        uint64_t batch_to_skip = std::min(rows_to_skip - skipped_row, (uint64_t)10000);
+        uint64_t batch_to_skip = std::min(rows_to_skip - skipped_row, (uint64_t)BATCH_PROCESS_SIZE);
         size_t batch_skipped = 0;
         while (batch_skipped < batch_to_skip) {
             if (_num_values_left_in_cur_page > 0) {
@@ -400,7 +400,9 @@ Status OptionalStoredColumnReader::_lazy_skip_values(uint64_t begin) {
         level_t* def_levels = nullptr;
         size_t level_parsed = 0;
         size_t cur_to_skip = row_to_skip - row_skipped;
-        RETURN_IF_ERROR(_decode_levels(&cur_to_skip, &level_parsed, &def_levels));
+        // skip batch by batch to avoid big memory alloc
+        size_t batch_to_skip = std::min(cur_to_skip, (size_t)BATCH_PROCESS_SIZE);
+        RETURN_IF_ERROR(_decode_levels(&batch_to_skip, &level_parsed, &def_levels));
         values_to_skip += count_not_null(&def_levels[0], level_parsed, _field->max_def_level());
         row_skipped += level_parsed;
         // reset_levels() to avoiding using too much memory and prepare levels for new reading.

--- a/be/src/formats/parquet/stored_column_reader.h
+++ b/be/src/formats/parquet/stored_column_reader.h
@@ -126,6 +126,7 @@ protected:
     const ColumnReaderOptions& _opts;
     bool _cur_page_loaded = false;
     uint64_t _read_cursor = _opts.first_row_index;
+    static constexpr size_t BATCH_PROCESS_SIZE = 8192;
 
 private:
     Status _next_selected_page(size_t records_to_read, ColumnContentType content_type, size_t* records_to_skip,


### PR DESCRIPTION
## Why I'm doing:
to avoid big memory alloc, level_decoder return 1024*1024 level at most, 
so row_nums > avail_level is not suitable.

And to avoid big memory alloc, we'd better skip batch by batch(8096 in code). 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
