### PR TITLE
[Enhancement]use lz4_hadoop as default of sink to be compatible with other system

### DIFF
--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -312,7 +312,7 @@ StatusOr<::parquet::Compression::type> ParquetFileWriter::_convert_compression_t
         break;
     }
     case TCompressionType::LZ4: {
-        converted_type = ::parquet::Compression::LZ4;
+        converted_type = ::parquet::Compression::LZ4_HADOOP;
         break;
     }
     default: {


### PR DESCRIPTION
## Why I'm doing:
LZ4_RAW is future, but LZ4_HADOOP is more compatible.
LZ4_HADOOP has been deprecated in parquet, and use LZ4_RAW as default, 
but parquet-mr support LZ4_RAW from 2022/12, so many old version system
use parquet-mr can't read lz4_raw, and trino  still not support LZ4_RAW.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
