### PR TITLE
[BugFix] fix npe when forwarding query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -458,7 +458,7 @@ public class StmtExecutor {
 
         // Only add the last running stmt for multi statement,
         // because the audit log will only show the last stmt.
-        if (context.getIsLastStmt()) {
+        if (context.getIsLastStmt() && parsedStmt != null) {
             addRunningQueryDetail(parsedStmt);
         }
 


### PR DESCRIPTION
## Why I'm doing:
- When forwarding a query to leader node
  - Need to execute the session variables statements first, if some of them got modified
  - After that it would execute the real query
- For the first statement, it doesn't set the StmtExecutor.parsedStmt, which would cause NPE


## What I'm doing:
if the StmtExecutor.parsedStmt is null, don't add it the runningDetails

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

