### PR TITLE
[BugFix] fix the userIdentity of mv task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -330,7 +330,8 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 TaskBuilder.updateTaskInfo(task, refreshSchemeDesc, materializedView);
                 taskManager.createTask(task, false);
             } else {
-                Task changedTask = TaskBuilder.rebuildMvTask(materializedView, dbName, currentTask.getProperties());
+                Task changedTask = TaskBuilder.rebuildMvTask(materializedView, dbName, currentTask.getProperties(),
+                        currentTask);
                 TaskBuilder.updateTaskInfo(changedTask, refreshSchemeDesc, materializedView);
                 taskManager.alterTask(currentTask, changedTask, false);
                 task = currentTask;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
@@ -23,6 +23,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.persist.TaskSchedule;
+import com.starrocks.sql.ast.UserIdentity;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -74,7 +75,11 @@ public class Task implements Writable {
 
     // set default to ROOT is for compatibility
     @SerializedName("createUser")
+    @Deprecated
     private String createUser = AuthenticationMgr.ROOT_USER;
+
+    @SerializedName("createUserIdentity")
+    private UserIdentity userIdentity;
 
     public Task() {}
 
@@ -194,6 +199,14 @@ public class Task implements Writable {
 
     public void setCreateUser(String createUser) {
         this.createUser = createUser;
+    }
+
+    public UserIdentity getUserIdentity() {
+        return userIdentity;
+    }
+
+    public void setUserIdentity(UserIdentity userIdentity) {
+        this.userIdentity = userIdentity;
     }
 
     public String getPostRun() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -211,7 +211,11 @@ public class TaskRun implements Comparable<TaskRun> {
         runCtx.setCurrentCatalog(task.getCatalogName());
         runCtx.setDatabase(task.getDbName());
         runCtx.setQualifiedUser(status.getUser());
-        runCtx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp(status.getUser(), "%"));
+        if (status.getUserIdentity() != null) {
+            runCtx.setCurrentUserIdentity(status.getUserIdentity());
+        } else {
+            runCtx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp(status.getUser(), "%"));
+        }
         runCtx.setCurrentRoleIds(runCtx.getCurrentUserIdentity());
         runCtx.getState().reset();
         runCtx.setQueryId(UUID.fromString(status.getQueryId()));
@@ -318,6 +322,7 @@ public class TaskRun implements Comparable<TaskRun> {
         status.setSource(task.getSource());
         status.setCreateTime(created);
         status.setUser(task.getCreateUser());
+        status.setUserIdentity(task.getUserIdentity());
         status.setCatalogName(task.getCatalogName());
         status.setDbName(task.getDbName());
         status.setPostRun(task.getPostRun());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -23,6 +23,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.Constants;
+import com.starrocks.sql.ast.UserIdentity;
 import org.apache.commons.collections.MapUtils;
 
 import java.io.DataInput;
@@ -64,7 +65,11 @@ public class TaskRunStatus implements Writable {
     private String postRun;
 
     @SerializedName("user")
+    @Deprecated
     private String user;
+
+    @SerializedName("userIdentity")
+    private UserIdentity userIdentity;
 
     @SerializedName("expireTime")
     private long expireTime;
@@ -203,6 +208,14 @@ public class TaskRunStatus implements Writable {
 
     public void setUser(String user) {
         this.user = user;
+    }
+
+    public UserIdentity getUserIdentity() {
+        return userIdentity;
+    }
+
+    public void setUserIdentity(UserIdentity userIdentity) {
+        this.userIdentity = userIdentity;
     }
 
     public String getPostRun() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
@@ -36,6 +36,8 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.thrift.TException;
 import org.junit.Assert;
@@ -142,11 +144,16 @@ public class LeaderOpExecutorTest {
 
     @Test
     public void testCreateTMasterOpRequest(@Mocked GlobalStateMgr globalStateMgr, @Mocked WarehouseManager warehouseManager) {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isReady() {
+                return true;
+            }
+
+        };
         new Expectations() {
             {
                 globalStateMgr.getServingState();
-                minTimes = 0;
-                globalStateMgr.isReady();
                 minTimes = 0;
 
                 globalStateMgr.getWarehouseMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -909,7 +909,7 @@ public class StarRocksAssert {
             taskRunProperties.put(TaskRun.PARTITION_END, range == null ? null : range.getPartitionEnd());
             taskRunProperties.put(TaskRun.FORCE, "true");
 
-            Task task = TaskBuilder.rebuildMvTask(mv, mvName.getDb(), taskRunProperties);
+            Task task = TaskBuilder.rebuildMvTask(mv, mvName.getDb(), taskRunProperties, null);
             TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(taskRunProperties).build();
             taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
             taskRun.executeTaskRun();

--- a/test/sql/test_materialized_view/R/test_create_mv_with_user
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_user
@@ -1,0 +1,66 @@
+-- name: test_create_mv_with_user
+drop database if exists test_create_mv_with_user;
+-- result:
+-- !result
+create database test_create_mv_with_user;
+-- result:
+-- !result
+use test_create_mv_with_user;
+-- result:
+-- !result
+shell: ip=hostname -I | awk '{print $1}';
+-- result:
+0
+172.26.92.227
+-- !result
+DROP USER IF EXISTS mv_creator@'${ip[1]}';
+-- result:
+-- !result
+CREATE USER mv_creator@'${ip[1]}';
+-- result:
+-- !result
+GRANT DELETE, DROP, INSERT, SELECT, ALTER, UPDATE ON ALL TABLES IN DATABASE test_create_mv_with_user
+    TO USER mv_creator@'${ip[1]}';
+-- result:
+-- !result
+GRANT CREATE TABLE, CREATE MATERIALIZED VIEW ON DATABASE test_create_mv_with_user
+    TO USER mv_creator@'${ip[1]}';
+-- result:
+-- !result
+GRANT SELECT, DROP, ALTER, REFRESH ON ALL MATERIALIZED VIEWS IN DATABASE test_create_mv_with_user
+    TO USER mv_creator@'${ip[1]}';
+-- result:
+-- !result
+    
+GRANT IMPERSONATE ON USER root TO mv_creator@'${ip[1]}';
+-- result:
+-- !result
+EXECUTE AS mv_creator@'${ip[1]}' with no revert;
+-- result:
+-- !result
+create table t1(c1 int, c2 int);
+-- result:
+-- !result
+insert into t1 values(1,1);
+-- result:
+-- !result
+create materialized view mv1 refresh async as select * from t1;
+-- result:
+-- !result
+refresh materialized view mv1;
+alter materialized view mv1 refresh manual;
+-- result:
+-- !result
+refresh materialized view mv1;
+select * from mv1;
+-- result:
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+drop user mv_creator@'${ip[1]}';
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/R/test_create_mv_with_user
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_user
@@ -8,7 +8,7 @@ create database test_create_mv_with_user;
 use test_create_mv_with_user;
 -- result:
 -- !result
-shell: ip=hostname -I | awk '{print $1}';
+[UC]shell: ip=hostname -I | awk '{print $1}';
 -- result:
 0
 172.26.92.227

--- a/test/sql/test_materialized_view/T/test_create_mv_with_user
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_user
@@ -1,0 +1,33 @@
+-- name: test_create_mv_with_user
+
+drop database if exists test_create_mv_with_user;
+create database test_create_mv_with_user;
+use test_create_mv_with_user;
+
+shell: ip=hostname -I | awk '{print $1}';
+DROP USER IF EXISTS mv_creator@'${ip[1]}';
+CREATE USER mv_creator@'${ip[1]}';
+
+GRANT DELETE, DROP, INSERT, SELECT, ALTER, UPDATE ON ALL TABLES IN DATABASE test_create_mv_with_user
+    TO USER mv_creator@'${ip[1]}';
+GRANT CREATE TABLE, CREATE MATERIALIZED VIEW ON DATABASE test_create_mv_with_user
+    TO USER mv_creator@'${ip[1]}';
+GRANT SELECT, DROP, ALTER, REFRESH ON ALL MATERIALIZED VIEWS IN DATABASE test_create_mv_with_user
+    TO USER mv_creator@'${ip[1]}';
+    
+-- switch user mv_creator
+GRANT IMPERSONATE ON USER root TO mv_creator@'${ip[1]}';
+EXECUTE AS mv_creator@'${ip[1]}' with no revert;
+
+-- create & use materialized view
+create table t1(c1 int, c2 int);
+insert into t1 values(1,1);
+create materialized view mv1 refresh async as select * from t1;
+refresh materialized view mv1;
+alter materialized view mv1 refresh manual;
+refresh materialized view mv1;
+select * from mv1;
+drop materialized view mv1;
+
+execute as root with no revert;
+drop user mv_creator@'${ip[1]}';

--- a/test/sql/test_materialized_view/T/test_create_mv_with_user
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_user
@@ -4,7 +4,7 @@ drop database if exists test_create_mv_with_user;
 create database test_create_mv_with_user;
 use test_create_mv_with_user;
 
-shell: ip=hostname -I | awk '{print $1}';
+[UC]shell: ip=hostname -I | awk '{print $1}';
 DROP USER IF EXISTS mv_creator@'${ip[1]}';
 CREATE USER mv_creator@'${ip[1]}';
 


### PR DESCRIPTION
## Why I'm doing:
- Previously the mv task uses `user@%` as user identity, which is incorrect if the create user has a domain like `user@10.11.%`
- As a result , a domain user can create a materialized view, but would get a privilege error when refreshing the mv, like `Access denied; you need (at least one of) the SELECT privilege(s) on TABLE t1 for this operation.`

## What I'm doing:
- Add `userIdentity` into task, and pass it to the task execution
- Compatibility
  - Once the MV/task is created, the persisted information would not be changed, so existing MV/Task still suffer from this issue
  - But the new created one would use the `userIdentity` instead of `user@%`, so new created one doesn't suffer from it
  - Upgrade: new created mv would use `userIdentity`
  - Downgrade: still suffer from the same issue, the old code would use `user@%` to authorize 

Fixes #47562

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
