### PR TITLE
[Enhancement] Support date_trunc with week granularity for asychronized materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -142,7 +142,15 @@ import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
 
 public class AnalyzerUtils {
 
-    public static final Set<String> SUPPORTED_PARTITION_FORMAT = ImmutableSet.of("hour", "day", "week", "month", "year");
+    // The partition format supported by date_trunc
+    public static final Set<String> DATE_TRUNC_SUPPORTED_PARTITION_FORMAT =
+            ImmutableSet.of("hour", "day", "month", "year");
+    // The partition format supported by time_slice
+    public static final Set<String> TIME_SLICE_SUPPORTED_PARTITION_FORMAT =
+            ImmutableSet.of("hour", "day", "month", "year");
+    // The partition format supported by mv date_trunc
+    public static final Set<String> MV_DATE_TRUNC_SUPPORTED_PARTITION_FORMAT =
+            ImmutableSet.of("hour", "day", "week", "month", "year");
 
     public static String getOrDefaultDatabase(String dbName, ConnectContext context) {
         if (Strings.isNullOrEmpty(dbName)) {
@@ -1550,8 +1558,20 @@ public class AnalyzerUtils {
         }
     }
 
-    // check the partition expr is legal and extract partition columns
     public static List<String> checkAndExtractPartitionCol(FunctionCallExpr expr, List<ColumnDef> columnDefs) {
+        return checkAndExtractPartitionCol(expr, columnDefs, AnalyzerUtils.DATE_TRUNC_SUPPORTED_PARTITION_FORMAT);
+    }
+
+    /**
+     * Check the partition expr is legal and extract partition columns
+     * TODO: support date_trunc('week', dt) for normal olap table.
+     * @param expr partition expr
+     * @param columnDefs partition column defs
+     * @param supportedDateTruncFormats date trunc supported formats which are a bit different bewtween mv and olap table
+     * @return partition column names
+     */
+    public static List<String> checkAndExtractPartitionCol(FunctionCallExpr expr, List<ColumnDef> columnDefs,
+                                                           Set<String> supportedDateTruncFormats) {
         String functionName = expr.getFnName().getFunction();
         NodePosition pos = expr.getPos();
         List<String> columnList = Lists.newArrayList();
@@ -1573,7 +1593,7 @@ public class AnalyzerUtils {
             if (firstExpr instanceof StringLiteral) {
                 StringLiteral stringLiteral = (StringLiteral) firstExpr;
                 String fmt = stringLiteral.getValue();
-                if (!AnalyzerUtils.SUPPORTED_PARTITION_FORMAT.contains(fmt.toLowerCase())) {
+                if (!supportedDateTruncFormats.contains(fmt.toLowerCase())) {
                     throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"),
                             pos);
                 }
@@ -1599,7 +1619,7 @@ public class AnalyzerUtils {
             if (secondExpr instanceof IntLiteral && thirdExpr instanceof StringLiteral) {
                 StringLiteral stringLiteral = (StringLiteral) thirdExpr;
                 String fmt = stringLiteral.getValue();
-                if (!AnalyzerUtils.SUPPORTED_PARTITION_FORMAT.contains(fmt.toLowerCase())) {
+                if (!AnalyzerUtils.TIME_SLICE_SUPPORTED_PARTITION_FORMAT.contains(fmt.toLowerCase())) {
                     throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"),
                             pos);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -142,7 +142,7 @@ import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
 
 public class AnalyzerUtils {
 
-    public static final Set<String> SUPPORTED_PARTITION_FORMAT = ImmutableSet.of("hour", "day", "month", "year");
+    public static final Set<String> SUPPORTED_PARTITION_FORMAT = ImmutableSet.of("hour", "day", "week", "month", "year");
 
     public static String getOrDefaultDatabase(String dbName, ConnectContext context) {
         if (Strings.isNullOrEmpty(dbName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionFunctionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionFunctionChecker.java
@@ -59,11 +59,6 @@ public class PartitionFunctionChecker {
             return false;
         }
         String fmt = ((StringLiteral) fnExpr.getChild(0)).getValue();
-        if (fmt.equalsIgnoreCase("week")) {
-            throw new SemanticException("The function date_trunc used by the materialized view for partition" +
-                    " does not support week formatting", expr.getPos());
-        }
-
         Expr child1 = fnExpr.getChild(1);
         if (child1 instanceof SlotRef) {
             SlotRef slotRef = (SlotRef) child1;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -54,8 +54,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +67,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.starrocks.catalog.FunctionSet.WEEK;
 import static com.starrocks.sql.common.PRangeCellPlus.toPRangeCellPlus;
 import static com.starrocks.sql.common.TimeUnitUtils.DAY;
 import static com.starrocks.sql.common.TimeUnitUtils.HOUR;
@@ -393,6 +396,9 @@ public class SyncPartitionUtils {
             case DAY:
                 return DEFAULT_PREFIX + lowerDateTime.format(DateUtils.DATEKEY_FORMATTER) +
                         "_" + upperDateTime.format(DateUtils.DATEKEY_FORMATTER);
+            case WEEK:
+                return DEFAULT_PREFIX + lowerDateTime.format(DateUtils.DATEKEY_FORMATTER) +
+                        "_" + upperDateTime.format(DateUtils.DATEKEY_FORMATTER);
             case MONTH:
                 return DEFAULT_PREFIX + lowerDateTime.format(DateUtils.MONTH_FORMATTER) +
                         "_" + upperDateTime.format(DateUtils.MONTH_FORMATTER);
@@ -431,6 +437,13 @@ public class SyncPartitionUtils {
                     truncUpperDateTime = upperDateTime;
                 } else {
                     truncUpperDateTime = upperDateTime.plusDays(1).with(LocalTime.MIN);
+                }
+                break;
+            case WEEK:
+                if (upperDateTime.with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS).equals(upperDateTime)) {
+                    truncUpperDateTime = upperDateTime;
+                } else {
+                    truncUpperDateTime = upperDateTime.plusWeeks(1).with(LocalTime.MIN);
                 }
                 break;
             case MONTH:
@@ -480,6 +493,9 @@ public class SyncPartitionUtils {
             case DAY:
                 truncUpperDateTime = upperDateTime.plusDays(1).with(LocalTime.MIN);
                 break;
+            case WEEK:
+                truncUpperDateTime = upperDateTime.plusWeeks(1).with(LocalTime.MIN);
+                break;
             case MONTH:
                 truncUpperDateTime = upperDateTime.plusMonths(1).with(TemporalAdjusters.firstDayOfMonth());
                 break;
@@ -512,6 +528,9 @@ public class SyncPartitionUtils {
                 break;
             case DAY:
                 truncLowerDateTime = lowerDateTime.with(LocalTime.MIN);
+                break;
+            case WEEK:
+                truncLowerDateTime = lowerDateTime.with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
                 break;
             case MONTH:
                 truncLowerDateTime = lowerDateTime.with(TemporalAdjusters.firstDayOfMonth());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1725,7 +1725,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 if (expr instanceof SlotRef) {
                     expressionPartitionDesc = new ExpressionPartitionDesc(expr);
                 } else if (expr instanceof FunctionCallExpr) {
-                    AnalyzerUtils.checkAndExtractPartitionCol((FunctionCallExpr) expr, null);
+                    AnalyzerUtils.checkAndExtractPartitionCol((FunctionCallExpr) expr, null,
+                            AnalyzerUtils.MV_DATE_TRUNC_SUPPORTED_PARTITION_FORMAT);
                     expressionPartitionDesc = new ExpressionPartitionDesc(expr);
                 } else {
                     throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"),

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1295,7 +1295,7 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testPartitionByAllowedFunctionUseWeek() {
+    public void testPartitionByAllowedFunctionUseWeek1() {
         String sql = "create materialized view mv1 " +
                 "partition by ss " +
                 "distributed by hash(k2) buckets 10 " +
@@ -1307,6 +1307,26 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
+            Assert.assertEquals("Getting analyzing error from line 3, column 11 to line 3, column 31. " +
+                    "Detail message: Materialized view partition function date_trunc check failed: " +
+                    "date_trunc('week', `k2`).", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testPartitionByAllowedFunctionUseWeek2() {
+        String sql = "create materialized view mv1 " +
+                "partition by ss " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as select date_trunc('week',k1) ss, k2 from tbl1;";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            e.printStackTrace();
             Assert.fail();
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1332,6 +1332,24 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
+    public void testPartitionByAllowedFunctionUseWeek3() {
+        String sql = "create materialized view mv1 " +
+                "partition by date_trunc('week', k1) " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as select k1, k2 from tbl1;";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
     public void testPartitionByNoAllowedFunction() {
         String sql = "create materialized view mv1 " +
                 "partition by ss " +

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -61,7 +61,6 @@ import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.parser.SqlParser;
@@ -1308,9 +1307,7 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
-            Assert.assertEquals("Getting analyzing error from line 3, column 11 to line 3, column 31. " +
-                    "Detail message: The function date_trunc used by the materialized view for partition " +
-                    "does not support week formatting.", e.getMessage());
+            Assert.fail();
         }
     }
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_date_trunc_week
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_date_trunc_week
@@ -1,0 +1,824 @@
+-- name: test_mv_refresh_with_multi_union1
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-01"), ("2024-04-02")),
+  PARTITION p7 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2023-01-01"), ("2024-01-01")),
+  PARTITION p2 VALUES [("2024-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-01-01"), ("2024-02-01")),
+  PARTITION p2 VALUES [("2024-02-01"), ("2024-03-01")),
+  PARTITION p3 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p4 VALUES [("2024-04-01"), ("2024-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE (dt) (
+  START ("2024-01-01") END ("2024-05-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13');
+-- result:
+-- !result
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14');
+-- result:
+-- !result
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+-- result:
+-- !result
+	 
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u1 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u2 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u3 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u4 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u5 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u6 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv11`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS 
+    select dt from u1
+    union all
+    select dt from u2;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv12`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS 
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv13`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+    union all
+    select dt from test_mv6;
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+refresh materialized view test_mv11 with sync mode;
+refresh materialized view test_mv12 with sync mode;
+refresh materialized view test_mv13 with sync mode;
+select count(1) from test_mv1;
+-- result:
+10
+-- !result
+select count(1) from test_mv2;
+-- result:
+4
+-- !result
+select count(1) from test_mv3;
+-- result:
+6
+-- !result
+select count(1) from test_mv4;
+-- result:
+3
+-- !result
+select count(1) from test_mv5;
+-- result:
+3
+-- !result
+select count(1) from test_mv6;
+-- result:
+3
+-- !result
+select count(1) from test_mv11;
+-- result:
+14
+-- !result
+select count(1) from test_mv12;
+-- result:
+29
+-- !result
+select count(1) from test_mv13;
+-- result:
+29
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+-- result:
+None
+-- !result
+select dt, s1 from test_mv1 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv2 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, s1 from test_mv3 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv4 order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, s1 from test_mv5 order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv6 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, count(1) from test_mv11 group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from test_mv12 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from test_mv13 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+select dt, sum(id) from u1 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u2 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, sum(id) from u3 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, sum(id) from u4 group by dt order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, sum(id) from u5 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u6 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+INSERT INTO u1 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+-- result:
+-- !result
+INSERT INTO u2 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11');
+-- result:
+-- !result
+INSERT INTO u3 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+-- result:
+-- !result
+INSERT INTO u4 (id,dt) VALUES (13,'2024-03-16'), (14,'2024-03-17');
+-- result:
+-- !result
+INSERT INTO u5 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+-- result:
+-- !result
+INSERT INTO u6 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+-- result:
+-- !result
+select count(1) from test_mv1;
+-- result:
+10
+-- !result
+select count(1) from test_mv2;
+-- result:
+4
+-- !result
+select count(1) from test_mv3;
+-- result:
+6
+-- !result
+select count(1) from test_mv4;
+-- result:
+3
+-- !result
+select count(1) from test_mv5;
+-- result:
+3
+-- !result
+select count(1) from test_mv6;
+-- result:
+3
+-- !result
+select count(1) from test_mv11;
+-- result:
+14
+-- !result
+select count(1) from test_mv12;
+-- result:
+29
+-- !result
+select count(1) from test_mv13;
+-- result:
+29
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+-- result:
+None
+-- !result
+select dt, s1 from test_mv1 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv2 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, s1 from test_mv3 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv4 order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, s1 from test_mv5 order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv6 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, count(1) from test_mv11 group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from test_mv12 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from test_mv13 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+select dt, sum(id) from u1 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u2 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, sum(id) from u3 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, sum(id) from u4 group by dt order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, sum(id) from u5 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u6 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv3;
+-- result:
+-- !result
+drop materialized view test_mv4;
+-- result:
+-- !result
+drop materialized view test_mv5;
+-- result:
+-- !result
+drop materialized view test_mv6;
+-- result:
+-- !result
+drop materialized view test_mv11;
+-- result:
+-- !result
+drop materialized view test_mv12;
+-- result:
+-- !result
+drop materialized view test_mv13;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_date_trunc_week
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_date_trunc_week
@@ -1,0 +1,384 @@
+-- name: test_mv_refresh_with_multi_union1
+
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-01"), ("2024-04-02")),
+  PARTITION p7 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2023-01-01"), ("2024-01-01")),
+  PARTITION p2 VALUES [("2024-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-01-01"), ("2024-02-01")),
+  PARTITION p2 VALUES [("2024-02-01"), ("2024-03-01")),
+  PARTITION p3 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p4 VALUES [("2024-04-01"), ("2024-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE (dt) (
+  START ("2024-01-01") END ("2024-05-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13');
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14');
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+	 
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u1 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u2 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u3 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u4 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u5 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS select dt, sum(id) as s1 from u6 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv11`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS 
+    select dt from u1
+    union all
+    select dt from u2;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv12`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS 
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv13`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL 
+AS 
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+    union all
+    select dt from test_mv6;
+
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+
+refresh materialized view test_mv11 with sync mode;
+refresh materialized view test_mv12 with sync mode;
+refresh materialized view test_mv13 with sync mode;
+
+select count(1) from test_mv1;
+select count(1) from test_mv2;
+select count(1) from test_mv3;
+select count(1) from test_mv4;
+select count(1) from test_mv5;
+select count(1) from test_mv6;
+
+select count(1) from test_mv11;
+select count(1) from test_mv12;
+select count(1) from test_mv13;
+
+function: check_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+function: check_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+function: check_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+function: check_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+function: check_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+
+select dt, s1 from test_mv1 order by 1;
+select dt, s1 from test_mv2 order by 1;
+select dt, s1 from test_mv3 order by 1;
+select dt, s1 from test_mv4 order by 1;
+select dt, s1 from test_mv5 order by 1;
+select dt, s1 from test_mv6 order by 1;
+
+select dt, count(1) from test_mv11 group by dt order by 1;
+select dt, count(1) from test_mv12 group by dt order by 1;
+select dt, count(1) from test_mv13 group by dt order by 1;
+
+set enable_materialized_view_rewrite = false;
+select dt, sum(id) from u1 group by dt order by 1;
+select dt, sum(id) from u2 group by dt order by 1;
+select dt, sum(id) from u3 group by dt order by 1;
+select dt, sum(id) from u4 group by dt order by 1;
+select dt, sum(id) from u5 group by dt order by 1;
+select dt, sum(id) from u6 group by dt order by 1;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+set enable_materialized_view_rewrite = true;
+
+INSERT INTO u1 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+INSERT INTO u2 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11');
+INSERT INTO u3 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+INSERT INTO u4 (id,dt) VALUES (13,'2024-03-16'), (14,'2024-03-17');
+INSERT INTO u5 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+INSERT INTO u6 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+
+select count(1) from test_mv1;
+select count(1) from test_mv2;
+select count(1) from test_mv3;
+select count(1) from test_mv4;
+select count(1) from test_mv5;
+select count(1) from test_mv6;
+
+select count(1) from test_mv11;
+select count(1) from test_mv12;
+select count(1) from test_mv13;
+
+function: check_no_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+function: check_no_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+function: check_no_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+function: check_no_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+function: check_no_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+
+select dt, s1 from test_mv1 order by 1;
+select dt, s1 from test_mv2 order by 1;
+select dt, s1 from test_mv3 order by 1;
+select dt, s1 from test_mv4 order by 1;
+select dt, s1 from test_mv5 order by 1;
+select dt, s1 from test_mv6 order by 1;
+
+select dt, count(1) from test_mv11 group by dt order by 1;
+select dt, count(1) from test_mv12 group by dt order by 1;
+select dt, count(1) from test_mv13 group by dt order by 1;
+
+set enable_materialized_view_rewrite = false;
+select dt, sum(id) from u1 group by dt order by 1;
+select dt, sum(id) from u2 group by dt order by 1;
+select dt, sum(id) from u3 group by dt order by 1;
+select dt, sum(id) from u4 group by dt order by 1;
+select dt, sum(id) from u5 group by dt order by 1;
+select dt, sum(id) from u6 group by dt order by 1;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+set enable_materialized_view_rewrite = true;
+
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop materialized view test_mv3;
+drop materialized view test_mv4;
+drop materialized view test_mv5;
+drop materialized view test_mv6;
+drop materialized view test_mv11;
+drop materialized view test_mv12;
+drop materialized view test_mv13;


### PR DESCRIPTION
## Why I'm doing:
- date_trunc('week', dt) is not supported for creating mv for now.

## What I'm doing:
- Support date_trunc with week granularity for asychronized materialized view

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/7946)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
