### PR TITLE
[BugFix] add finished query into QueryDetailQueue for SqlTaskRunProcessor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -59,7 +59,9 @@ public class DataCacheSelectExecutor {
         if (connectContext.getExecutor() != null) {
             connectContext.getExecutor().registerSubStmtExecutor(stmtExecutor);
         }
+        stmtExecutor.addRunningQueryDetail(insertStmt);
         stmtExecutor.execute();
+        stmtExecutor.addFinishedQueryDetail();
 
         if (connectContext.getState().isError()) {
             // throw exception if StmtExecutor execute failed

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -60,8 +60,11 @@ public class DataCacheSelectExecutor {
             connectContext.getExecutor().registerSubStmtExecutor(stmtExecutor);
         }
         stmtExecutor.addRunningQueryDetail(insertStmt);
-        stmtExecutor.execute();
-        stmtExecutor.addFinishedQueryDetail();
+        try {
+            stmtExecutor.execute();
+        } finally {
+            stmtExecutor.addFinishedQueryDetail();
+        }
 
         if (connectContext.getState().isError()) {
             // throw exception if StmtExecutor execute failed

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
@@ -86,6 +86,7 @@ public class HttpConnectProcessor extends ConnectProcessor {
         }
 
         try {
+            executor.addRunningQueryDetail(parsedStmt);
             executor.execute();
         } catch (IOException e) {
             // Client failed.
@@ -118,12 +119,11 @@ public class HttpConnectProcessor extends ConnectProcessor {
         // We may need to find some way to resolve this.
         if (executor != null) {
             auditAfterExec(sql, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+            executor.addFinishedQueryDetail();
         } else {
             // executor can be null if we encounter analysis error.
             auditAfterExec(sql, null, null);
         }
-
-        addFinishedQueryDetail();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -47,7 +47,6 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.AuditStatisticsUtil;
-import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -281,47 +280,6 @@ public class ConnectProcessor {
         }
     }
 
-    private boolean containsComment(String sql) {
-        return (sql.contains("--")) || sql.contains("#");
-    }
-
-    protected void addFinishedQueryDetail() {
-        if (!Config.enable_collect_query_detail_info) {
-            return;
-        }
-        QueryDetail queryDetail = ctx.getQueryDetail();
-        if (queryDetail == null || !queryDetail.getQueryId().equals(DebugUtil.printId(ctx.getQueryId()))) {
-            return;
-        }
-
-        long endTime = System.currentTimeMillis();
-        long elapseMs = endTime - ctx.getStartTime();
-
-        if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
-            queryDetail.setState(QueryDetail.QueryMemState.FAILED);
-            queryDetail.setErrorMessage(ctx.getState().getErrorMessage());
-        } else {
-            queryDetail.setState(QueryDetail.QueryMemState.FINISHED);
-        }
-        queryDetail.setEndTime(endTime);
-        queryDetail.setLatency(elapseMs);
-        queryDetail.setResourceGroupName(ctx.getResourceGroup() != null ? ctx.getResourceGroup().getName() : "");
-        // add execution statistics into queryDetail
-        queryDetail.setReturnRows(ctx.getReturnRows());
-        queryDetail.setDigest(ctx.getAuditEventBuilder().build().digest);
-        PQueryStatistics statistics = executor.getQueryStatisticsForAuditLog();
-        if (statistics != null) {
-            queryDetail.setScanBytes(statistics.scanBytes);
-            queryDetail.setScanRows(statistics.scanRows);
-            queryDetail.setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
-            queryDetail.setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
-            queryDetail.setSpillBytes(statistics.spillBytes == null ? -1 : statistics.spillBytes);
-        }
-        queryDetail.setCatalog(ctx.getCurrentCatalog());
-
-        QueryDetailQueue.addQueryDetail(queryDetail);
-    }
-
     // process COM_QUERY statement,
     protected void handleQuery() {
         MetricRepo.COUNTER_REQUEST_ALL.increase(1L);
@@ -390,6 +348,12 @@ public class ConnectProcessor {
                         return null;
                     }
                 }.visit(parsedStmt);
+
+                // Only add the last running stmt for multi statement,
+                // because the audit log will only show the last stmt.
+                if (ctx.getIsLastStmt()) {
+                    executor.addRunningQueryDetail(parsedStmt);
+                }
                 executor.execute();
 
                 // do not execute following stmt when current stmt failed, this is consistent with mysql server
@@ -426,12 +390,11 @@ public class ConnectProcessor {
         // We may need to find some way to resolve this.
         if (executor != null) {
             auditAfterExec(originStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+            executor.addFinishedQueryDetail();
         } else {
             // executor can be null if we encounter analysis error.
             auditAfterExec(originStmt, null, null);
         }
-
-        addFinishedQueryDetail();
     }
 
     // Get the column definitions of a table

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -458,11 +458,6 @@ public class StmtExecutor {
         context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
         SessionVariable sessionVariableBackup = context.getSessionVariable();
 
-        // Only add the last running stmt for multi statement,
-        // because the audit log will only show the last stmt.
-        if (context.getIsLastStmt()) {
-            addRunningQueryDetail(parsedStmt);
-        }
 
         // if use http protocal, use httpResultSender to send result to netty channel
         if (context instanceof HttpConnectContext) {
@@ -2500,7 +2495,10 @@ public class StmtExecutor {
         }
     }
 
-    protected void addRunningQueryDetail(StatementBase parsedStmt) {
+    /**
+     * Record this sql into the query details, which would be collected by external query history system
+     */
+    public void addRunningQueryDetail(StatementBase parsedStmt) {
         if (!Config.enable_collect_query_detail_info) {
             return;
         }
@@ -2529,4 +2527,46 @@ public class StmtExecutor {
         // copy queryDetail, cause some properties can be changed in future
         QueryDetailQueue.addQueryDetail(queryDetail.copy());
     }
+
+    /*
+     * Record this finished sql into the query details, which would be collected by external query history system
+     */
+    public void addFinishedQueryDetail() {
+        if (!Config.enable_collect_query_detail_info) {
+            return;
+        }
+        ConnectContext ctx = context;
+        QueryDetail queryDetail = ctx.getQueryDetail();
+        if (queryDetail == null || !queryDetail.getQueryId().equals(DebugUtil.printId(ctx.getQueryId()))) {
+            return;
+        }
+
+        long endTime = System.currentTimeMillis();
+        long elapseMs = endTime - ctx.getStartTime();
+
+        if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+            queryDetail.setState(QueryDetail.QueryMemState.FAILED);
+            queryDetail.setErrorMessage(ctx.getState().getErrorMessage());
+        } else {
+            queryDetail.setState(QueryDetail.QueryMemState.FINISHED);
+        }
+        queryDetail.setEndTime(endTime);
+        queryDetail.setLatency(elapseMs);
+        queryDetail.setResourceGroupName(ctx.getResourceGroup() != null ? ctx.getResourceGroup().getName() : "");
+        // add execution statistics into queryDetail
+        queryDetail.setReturnRows(ctx.getReturnRows());
+        queryDetail.setDigest(ctx.getAuditEventBuilder().build().digest);
+        PQueryStatistics statistics = getQueryStatisticsForAuditLog();
+        if (statistics != null) {
+            queryDetail.setScanBytes(statistics.scanBytes);
+            queryDetail.setScanRows(statistics.scanRows);
+            queryDetail.setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
+            queryDetail.setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
+            queryDetail.setSpillBytes(statistics.spillBytes == null ? -1 : statistics.spillBytes);
+        }
+        queryDetail.setCatalog(ctx.getCurrentCatalog());
+
+        QueryDetailQueue.addQueryDetail(queryDetail);
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -58,11 +58,13 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
             executor = new StmtExecutor(ctx, sqlStmt);
             ctx.setExecutor(executor);
             ctx.setThreadLocalInfo();
+            executor.addRunningQueryDetail(sqlStmt);
             executor.execute();
         } finally {
             Tracers.close();
             if (executor != null) {
                 auditAfterExec(context, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+                executor.addFinishedQueryDetail();
             } else {
                 // executor can be null if we encounter analysis error.
                 auditAfterExec(context, null, null);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -35,12 +35,16 @@
 package com.starrocks.qe;
 
 import com.google.gson.Gson;
+import com.starrocks.common.Config;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
 
-public class QueryDetailQueueTest {
+public class QueryDetailQueueTest extends PlanTestBase {
     @Test
     public void testQueryDetailQueue() {
         QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
@@ -90,4 +94,35 @@ public class QueryDetailQueueTest {
         queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime() - 1);
         Assert.assertEquals(2, queryDetails.size());
     }
+
+    @Test
+    public void testExecutor() throws Exception {
+        boolean old = Config.enable_collect_query_detail_info;
+        Config.enable_collect_query_detail_info = true;
+        starRocksAssert.withDatabase("db1")
+                .useDatabase("db1")
+                .withTable("create table test_running_detail (c1 int, c2 int) " +
+                        "properties('replication_num'='1') ");
+
+        String sql = "select * from test_running_detail";
+        QueryStatement parsedStmt = (QueryStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        StmtExecutor executor = new StmtExecutor(connectContext, parsedStmt);
+        long startTime = System.currentTimeMillis();
+        executor.addRunningQueryDetail(parsedStmt);
+        executor.execute();
+        executor.addFinishedQueryDetail();
+
+        List<QueryDetail> queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startTime);
+
+        QueryDetail runningDetail = queryDetails.get(0);
+        Assert.assertEquals(QueryDetail.QueryMemState.RUNNING, runningDetail.getState());
+        Assert.assertEquals(sql, runningDetail.getSql());
+
+        QueryDetail finishedDetail = queryDetails.get(1);
+        Assert.assertEquals(QueryDetail.QueryMemState.FINISHED, finishedDetail.getState());
+        Assert.assertEquals(sql, finishedDetail.getSql());
+
+        Config.enable_collect_query_detail_info = old;
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:
- The #47159 only fix partial problem
- The sql submitted by `SUBMIT TASK` only `addRunningQueryDetail`, but not `addFinishedQueryDetail`
- Which result in it's always in `RUNNING` state and never `FINISHED`

## What I'm doing:

After this fix:
- Only several queries would be accounted into `QueryDetails`
  - mysql-protocol submitted
  - http-protocol submitted
  - `SUBMIT TASK`
- other queries executed internally would not be taken into account

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
