### PR TITLE
[Enhancement]eliminate warning when compiling

### DIFF
--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -48,7 +48,7 @@ Status RollingAsyncParquetWriter::init() {
     ASSIGN_OR_RETURN(auto compression_codec,
                      parquet::ParquetBuildHelper::convert_compression_type(_table_info.compress_type));
     builder.compression(compression_codec);
-    builder.version(::parquet::ParquetVersion::PARQUET_2_0);
+    builder.version(::parquet::ParquetVersion::PARQUET_2_6);
     _properties = builder.build();
 
     return Status::OK();

--- a/be/test/exec/arrow_converter_test.cpp
+++ b/be/test/exec/arrow_converter_test.cpp
@@ -1257,18 +1257,18 @@ static std::shared_ptr<arrow::Array> create_map_array(int64_t num_elements, cons
     arrow::TypeTraits<arrow::MapType>::BuilderType builder(arrow::default_memory_pool(), key_builder, item_builder);
 
     for (int i = 0; i < num_elements; i++) {
-        builder.Append();
+        std::ignore = builder.Append();
         for (auto& [key, value] : value) {
-            key_builder->Append(key);
-            item_builder->Append(value);
+            std::ignore = key_builder->Append(key);
+            std::ignore = item_builder->Append(value);
             if (null_dup) {
-                key_builder->Append(key);
-                item_builder->Append(value);
+                std::ignore = key_builder->Append(key);
+                std::ignore = item_builder->Append(value);
             }
         }
         counter += 1;
         if (null_dup) {
-            builder.AppendNull();
+            std::ignore = builder.AppendNull();
             counter++;
         }
     }
@@ -1292,12 +1292,12 @@ static std::shared_ptr<arrow::Array> create_struct_array(int elemnts_num, bool i
 
     for (int i = 0; i < elemnts_num; i++) {
         if (is_null && i % 2 == 0) {
-            builder.AppendNull();
+            std::ignore = builder.AppendNull();
         } else {
-            builder.Append();
-            int1_builder->Append(i);
-            str_builder->Append(fmt::format("char-{}", i));
-            int2_builder->Append(i * 10);
+            std::ignore = builder.Append();
+            std::ignore = int1_builder->Append(i);
+            std::ignore = str_builder->Append(fmt::format("char-{}", i));
+            std::ignore = int2_builder->Append(i * 10);
         }
     }
     return builder.Finish().ValueOrDie();
@@ -1358,13 +1358,13 @@ static std::shared_ptr<arrow::Array> create_list_array(int64_t num_elements, ssi
     arrow::TypeTraits<arrow::FixedSizeListType>::BuilderType builder(arrow::default_memory_pool(), value_builder,
                                                                      fix_size);
     for (auto num = 0; num < num_elements; num = num + fix_size) {
-        builder.Append();
+        std::ignore = builder.Append();
         for (int i = 0; i < fix_size; i++) {
-            value_builder->Append(counter);
+            std::ignore = value_builder->Append(counter);
             counter += 1;
         }
         if (add_null) {
-            builder.AppendNull();
+            std::ignore = builder.AppendNull();
         }
     }
     return builder.Finish().ValueOrDie();
@@ -1427,11 +1427,11 @@ static std::shared_ptr<arrow::Array> create_nest_list_array(int64_t num_parents,
                                                                       num_children);
 
     for (auto num1 = 0; num1 < num_parents; ++num1) {
-        builder1.Append();
+        std::ignore = builder1.Append();
         for (auto num = 0; num < num_children; ++num) {
-            builder->Append();
+            std::ignore = builder->Append();
             for (int i = 0; i < num_child_values; ++i) {
-                value_builder->Append(counter);
+                std::ignore = value_builder->Append(counter);
                 counter += 1;
             }
         }

--- a/be/test/runtime/result_queue_mgr_test.cpp
+++ b/be/test/runtime/result_queue_mgr_test.cpp
@@ -93,9 +93,9 @@ TEST_F(ResultQueueMgrTest, fetch_result_normal) {
 
     std::shared_ptr<arrow::Array> k1_col;
     arrow::NumericBuilder<arrow::Int32Type> builder;
-    builder.Reserve(1);
-    builder.Append(20);
-    builder.Finish(&k1_col);
+    std::ignore = builder.Reserve(1);
+    std::ignore = builder.Append(20);
+    std::ignore = builder.Finish(&k1_col);
 
     std::vector<std::shared_ptr<arrow::Array>> arrays;
     arrays.push_back(k1_col);


### PR DESCRIPTION
## Why I'm doing:
the warning is because of the new version arrow.
arrow add [nodiscard] for some function, we use this in be/test and can be ignored.
arrow deprecated PARQUET_2_0, and use PARQUET_2_4/PARQUET_2_6.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
