### PR TITLE
[BugFix] Add isSupportPCTRefresh in ConnectorPartitionTraits and fix related bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2841,6 +2841,9 @@ public class Config extends ConfigBase {
                     "which would refresh the materialized view after creating")
     public static boolean default_mv_refresh_immediate = true;
 
+    @ConfField(mutable = true, comment = "Whether enable to cache mv query context or not")
+    public static boolean enable_mv_query_context_cache = false;
+
     /**
      * Whether analyze the mv after refresh in async mode.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2841,6 +2841,9 @@ public class Config extends ConfigBase {
                     "which would refresh the materialized view after creating")
     public static boolean default_mv_refresh_immediate = true;
 
+    @ConfField(mutable = true, comment = "Whether enable to cache mv query context or not")
+    public static boolean enable_mv_query_context_cache = true;
+
     /**
      * Whether analyze the mv after refresh in async mode.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2841,9 +2841,6 @@ public class Config extends ConfigBase {
                     "which would refresh the materialized view after creating")
     public static boolean default_mv_refresh_immediate = true;
 
-    @ConfField(mutable = true, comment = "Whether enable to cache mv query context or not")
-    public static boolean enable_mv_query_context_cache = false;
-
     /**
      * Whether analyze the mv after refresh in async mode.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.connector.partitiontraits.CachedPartitionTraits;
 import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
 import com.starrocks.connector.partitiontraits.HivePartitionTraits;
@@ -102,7 +103,7 @@ public abstract class ConnectorPartitionTraits {
      */
     public static ConnectorPartitionTraits buildWithCache(ConnectContext ctx, Table table) {
         ConnectorPartitionTraits delegate = buildWithoutCache(table);
-        if (ctx != null && ctx.getQueryMVContext() != null) {
+        if (Config.enable_mv_query_context_cache && ctx != null && ctx.getQueryMVContext() != null) {
             QueryMaterializationContext queryMVContext = ctx.getQueryMVContext();
             Cache<Object, Object> cache = queryMVContext.getMvQueryContextCache();
             return new CachedPartitionTraits(cache, delegate, queryMVContext.getQueryCacheStats());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -82,6 +82,13 @@ public abstract class ConnectorPartitionTraits {
         return TRAITS_TABLE.containsKey(tableType);
     }
 
+    public static boolean isSupportPCTRefresh(Table.TableType tableType) {
+        if (!isSupported(tableType)) {
+            return false;
+        }
+        return TRAITS_TABLE.get(tableType).get().isSupportPCTRefresh();
+    }
+
     public static ConnectorPartitionTraits build(Table.TableType tableType) {
         return Preconditions.checkNotNull(TRAITS_TABLE.get(tableType),
                 "traits not supported: " + tableType).get();
@@ -127,6 +134,8 @@ public abstract class ConnectorPartitionTraits {
     public String getTableName() {
         return table.getName();
     }
+
+    public abstract boolean isSupportPCTRefresh();
 
     /**
      * Build a partition key for the table, some of them have specific representations for null values

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -115,6 +115,11 @@ public class CachedPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return delegate.isSupportPCTRefresh();
+    }
+
+    @Override
     public boolean supportPartitionRefresh() {
         return delegate.supportPartitionRefresh();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DeltaLakePartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DeltaLakePartitionTraits.java
@@ -36,6 +36,11 @@ public class DeltaLakePartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return false;
+    }
+
+    @Override
     public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                 MaterializedView.AsyncRefreshContext context) {
         // TODO: implement

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
@@ -37,6 +37,11 @@ public class HivePartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return true;
+    }
+
+    @Override
     public PartitionKey createEmptyKey() {
         return new HivePartitionKey();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
@@ -35,6 +35,11 @@ public class HudiPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return false;
+    }
+
+    @Override
     public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                 MaterializedView.AsyncRefreshContext context) {
         // TODO: implement

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -46,6 +46,11 @@ public class IcebergPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return true;
+    }
+
+    @Override
     public String getTableName() {
         return ((IcebergTable) table).getRemoteTableName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
@@ -47,6 +47,11 @@ public class JDBCPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return true;
+    }
+
+    @Override
     public List<PartitionInfo> getPartitions(List<String> partitionNames) {
         JDBCTable jdbcTable = (JDBCTable) table;
         return GlobalStateMgr.getCurrentState().getMetadataMgr().

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/KuduPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/KuduPartitionTraits.java
@@ -30,6 +30,11 @@ public class KuduPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return false;
+    }
+
+    @Override
     public PartitionKey createEmptyKey() {
         return new KuduPartitionKey();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OdpsPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OdpsPartitionTraits.java
@@ -25,6 +25,11 @@ public class OdpsPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return false;
+    }
+
+    @Override
     public PartitionKey createEmptyKey() {
         return new OdpsPartitionKey();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -49,6 +49,11 @@ public class OlapPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return true;
+    }
+
+    @Override
     public boolean supportPartitionRefresh() {
         // TODO: check partition types
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/PaimonPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/PaimonPartitionTraits.java
@@ -37,6 +37,11 @@ public class PaimonPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public boolean isSupportPCTRefresh() {
+        return true;
+    }
+
+    @Override
     public PartitionKey createEmptyKey() {
         return new PaimonPartitionKey();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1481,7 +1481,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             }
             LOG.info("Collect olap base table {}'s refreshed partition infos: {}", baseTable.getName(), partitionInfos);
             return partitionInfos;
-        } else if (ConnectorPartitionTraits.isSupported(baseTable.getType())) {
+        } else if (ConnectorPartitionTraits.isSupportPCTRefresh(baseTable.getType())) {
             return getSelectedPartitionInfos(baseTable, Lists.newArrayList(refreshedPartitionNames), baseTableInfo);
         } else {
             // FIXME: base table does not support partition-level refresh and does not update the meta

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
@@ -45,7 +45,7 @@ public class TableSnapshotInfo {
     }
 
     public long getId() {
-        return baseTableInfo.getTableId();
+        return baseTable.getId();
     }
 
     public String getName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -236,8 +236,8 @@ public class MvRewritePreprocessor {
             Set<Table> queryTables = MvUtils.getAllTables(queryOptExpression).stream().collect(Collectors.toSet());
             logMVParams(connectContext, queryTables);
 
-            QueryMaterializationContext queryMaterializationContext = connectContext.getQueryMVContext() != null ?
-                    connectContext.getQueryMVContext() : new QueryMaterializationContext();
+            // use a new context rather than reuse the existed context to avoid cache conflict.
+            QueryMaterializationContext queryMaterializationContext = new QueryMaterializationContext();
             try {
                 // 1. get related mvs for all input tables
                 Set<MaterializedView> relatedMVs = getRelatedMVs(queryTables, context.getOptimizerConfig().isRuleBased());
@@ -268,10 +268,10 @@ public class MvRewritePreprocessor {
                 // To avoid disturbing queries without mv, only initialize materialized view context
                 // when there are candidate mvs.
                 if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
+                    // it's safe used in the optimize context here since the query mv context is not shared across the
+                    // connect-context.
                     context.setQueryMaterializationContext(queryMaterializationContext);
-                    if (Config.enable_mv_query_context_cache) {
-                        connectContext.setQueryMVContext(queryMaterializationContext);
-                    }
+                    connectContext.setQueryMVContext(queryMaterializationContext);
                 }
 
                 // initialize mv rewrite strategy finally

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -269,7 +269,9 @@ public class MvRewritePreprocessor {
                 // when there are candidate mvs.
                 if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
                     context.setQueryMaterializationContext(queryMaterializationContext);
-                    connectContext.setQueryMVContext(queryMaterializationContext);
+                    if (Config.enable_mv_query_context_cache) {
+                        connectContext.setQueryMVContext(queryMaterializationContext);
+                    }
                 }
 
                 // initialize mv rewrite strategy finally

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -189,6 +189,7 @@ public class Optimizer {
         } finally {
             // make sure clear caches in OptimizerContext
             context.clear();
+            connectContext.setQueryMVContext(null);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -14,8 +14,18 @@
 
 package com.starrocks.connector;
 
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.catalog.Table;
 import com.starrocks.connector.paimon.Partition;
 import com.starrocks.connector.partitiontraits.DefaultTraits;
+import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
+import com.starrocks.connector.partitiontraits.HivePartitionTraits;
+import com.starrocks.connector.partitiontraits.HudiPartitionTraits;
+import com.starrocks.connector.partitiontraits.IcebergPartitionTraits;
+import com.starrocks.connector.partitiontraits.JDBCPartitionTraits;
+import com.starrocks.connector.partitiontraits.KuduPartitionTraits;
+import com.starrocks.connector.partitiontraits.OdpsPartitionTraits;
+import com.starrocks.connector.partitiontraits.OlapPartitionTraits;
 import com.starrocks.connector.partitiontraits.PaimonPartitionTraits;
 import mockit.Mock;
 import mockit.MockUp;
@@ -25,6 +35,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class ConnectorPartitionTraitsTest {
 
@@ -46,5 +57,33 @@ public class ConnectorPartitionTraitsTest {
         Optional<Long> result = new PaimonPartitionTraits().maxPartitionRefreshTs();
         Assert.assertTrue(result.isPresent());
         Assert.assertEquals(200L, result.get().longValue());
+    }
+
+    @Test
+    public void testisSupportPCTRefresh() {
+        Assert.assertTrue(new OlapPartitionTraits().isSupportPCTRefresh());
+        Assert.assertTrue(new HivePartitionTraits().isSupportPCTRefresh());
+        Assert.assertTrue(new IcebergPartitionTraits().isSupportPCTRefresh());
+        Assert.assertTrue(new PaimonPartitionTraits().isSupportPCTRefresh());
+        Assert.assertTrue(new JDBCPartitionTraits().isSupportPCTRefresh());
+        Assert.assertFalse(new HudiPartitionTraits().isSupportPCTRefresh());
+        Assert.assertFalse(new OdpsPartitionTraits().isSupportPCTRefresh());
+        Assert.assertFalse(new KuduPartitionTraits().isSupportPCTRefresh());
+        Assert.assertFalse(new DeltaLakePartitionTraits().isSupportPCTRefresh());
+
+        final Set<Table.TableType> supportedTableTypes = ImmutableSet.of(
+                Table.TableType.OLAP,
+                Table.TableType.MATERIALIZED_VIEW,
+                Table.TableType.CLOUD_NATIVE,
+                Table.TableType.CLOUD_NATIVE_MATERIALIZED_VIEW,
+                Table.TableType.HIVE,
+                Table.TableType.ICEBERG,
+                Table.TableType.PAIMON,
+                Table.TableType.JDBC
+        );
+        for (Table.TableType tableType : Table.TableType.values()) {
+            Assert.assertEquals(supportedTableTypes.contains(tableType),
+                    ConnectorPartitionTraits.isSupportPCTRefresh(tableType));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -356,7 +356,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
                     Assert.assertTrue(queryCacheStats != null);
                     queryCacheStats.getCounter().forEach((key, value) -> {
                         if (key.contains("cache_partitionNames")) {
-                            Assert.assertEquals(2L, value.longValue());
+                            Assert.assertEquals(1L, value.longValue());
                         } else if (key.contains("cache_getPartitionKeyRange")) {
                             Assert.assertEquals(3L, value.longValue());
                         } else {


### PR DESCRIPTION
## Why I'm doing:

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7940
https://github.com/StarRocks/StarRocksTest/issues/7946
https://github.com/StarRocks/StarRocksTest/issues/7944


## What I'm doing:

- Add `isSupportPCTRefresh` api for each ConnectorPartitionTraits and use it to decide whether the table type can support pct refresh;
- Add `enable_mv_query_context_cache` to control whether to use mv query context to avoid  bad cases, (true by default)


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
