### PR TITLE
[BugFix] check partition existence when committing job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -426,8 +426,8 @@ public class InsertOverwriteJobRunner {
         }
         try {
             OlapTable targetTable = checkAndGetTable(db, tableId);
-            checkSourcePartitionExistence(db, targetTable);
-            checkTmpPartitionExistence(db, targetTable);
+            checkSourcePartitionExistence(targetTable);
+            checkTmpPartitionExistence(targetTable);
 
             List<String> sourcePartitionNames = job.getSourcePartitionIds().stream()
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
@@ -496,7 +496,7 @@ public class InsertOverwriteJobRunner {
         }
         try {
             OlapTable targetTable = checkAndGetTable(db, tableId);
-            checkTmpPartitionExistence(db, targetTable);
+            checkTmpPartitionExistence(targetTable);
             List<String> tmpPartitionNames = job.getTmpPartitionIds().stream()
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
                     .collect(Collectors.toList());
@@ -518,13 +518,13 @@ public class InsertOverwriteJobRunner {
         }
     }
 
-    private void checkTmpPartitionExistence(Database db, Table targetTable) {
+    private void checkTmpPartitionExistence(Table targetTable) {
         if (job.getTmpPartitionIds().stream().anyMatch(id -> targetTable.getPartition(id) == null)) {
             throw new DmlException("partitions changed during insert, usually it's caused by concurrent jobs");
         }
     }
 
-    private void checkSourcePartitionExistence(Database db, Table targetTable) {
+    private void checkSourcePartitionExistence(Table targetTable) {
         if (job.getSourcePartitionIds().stream().anyMatch(id -> targetTable.getPartition(id) == null)) {
             throw new DmlException("partitions changed during insert, usually it's caused by concurrent jobs");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -154,7 +154,7 @@ public class InsertOverwriteJobRunnerTest {
             } catch (SQLException e) {
                 if (e.getMessage().contains("replace partitions failed: partitions changed during insert")) {
                     failedJobs.addAndGet(1);
-                } else {
+                } else if (!e.getMessage().contains("create partition failed")) {
                     throw new RuntimeException(e);
                 }
             }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Add a explicit check when committing the insert-overwrite job, to avoid the NPE

**Not doing**:
- This PR didn't resolve the conflict of concurrent overwrite jobs, which would still report an exception

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
