### PR TITLE
[Feature] Support kill query by query_id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -93,6 +93,7 @@ public enum ErrorCode {
             "View's SELECT and view's field list have different column counts"),
     ERR_NO_DEFAULT_FOR_FIELD(1364, new byte[] {'H', 'Y', '0', '0', '0'},
             "Field '%s' is not null but doesn't have a default value"),
+    ERR_NO_SUCH_QUERY(1365, new byte[] {'H', 'Y', '0', '0', '0'}, "Unknown query id: %s"),
 
     ERR_CANNOT_USER(1396, new byte[] {'H', 'Y', '0', '0', '0'}, "Operation %s failed for %s"),
     ERR_NON_INSERTABLE_TABLE(1471, new byte[] {'H', 'Y', '0', '0', '0'},

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -840,6 +840,7 @@ public class ConnectProcessor {
         }
         result.setPacket(getResultPacket());
         result.setState(ctx.getState().getStateType().toString());
+        result.setErrorMsg(ctx.getState().getErrorMessage());
         if (executor != null) {
             if (executor.getProxyResultSet() != null) {  // show statement
                 result.setResultSet(executor.getProxyResultSet().tothrift());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1045,7 +1045,7 @@ public class StmtExecutor {
                     errorMsg = context.getState().getErrorMessage();
                 } catch (TTransportException e) {
                     errorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort();
-                    LOG.warn(e.getMessage(), e);
+                    LOG.warn(errorMsg, e);
                 } catch (Exception e) {
                     errorMsg = e.getMessage();
                     LOG.warn(e.getMessage(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -116,6 +116,7 @@ import com.starrocks.qe.QueryState.MysqlStateType;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.FeExecuteCoordinator;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
 import com.starrocks.sql.ExplainAnalyzer;
 import com.starrocks.sql.PrepareStmtPlanner;
 import com.starrocks.sql.StatementPlanner;
@@ -189,6 +190,7 @@ import com.starrocks.statistic.StatisticExecutor;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatisticsCollectJobFactory;
 import com.starrocks.statistic.StatsConstants;
+import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.TDescriptorTable;
@@ -212,6 +214,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.transport.TTransportException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -987,11 +990,20 @@ public class StmtExecutor {
     // Handle kill statement.
     private void handleKill() throws DdlException {
         KillStmt killStmt = (KillStmt) parsedStmt;
-        long id = killStmt.getConnectionId();
-        ConnectContext killCtx = context.getConnectScheduler().getContext(id);
-        if (killCtx == null) {
-            ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_THREAD, id);
+        if (killStmt.getQueryId() != null) {
+            handleKillQuery(killStmt.getQueryId());
+        } else {
+            long id = killStmt.getConnectionId();
+            ConnectContext killCtx = context.getConnectScheduler().getContext(id);
+            if (killCtx == null) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_THREAD, id);
+            }
+            handleKill(killCtx, killStmt.isConnectionKill());
         }
+    }
+
+    // Handle kill statement.
+    private void handleKill(ConnectContext killCtx, boolean killConnection) {
         Preconditions.checkNotNull(killCtx);
         if (context == killCtx) {
             // Suicide
@@ -1008,9 +1020,46 @@ public class StmtExecutor {
                             PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
                 }
             }
-            killCtx.kill(killStmt.isConnectionKill(), "killed by kill statement : " + originStmt);
+            killCtx.kill(killConnection, "killed by kill statement : " + originStmt);
         }
         context.getState().setOk();
+    }
+
+    // Handle kill running query statement.
+    private void handleKillQuery(String queryId) throws DdlException {
+        // > 0 means it is forwarded from other fe
+        if (context.getForwardTimes() == 0) {
+            String errorMsg = null;
+            // forward to all fe
+            for (Frontend fe : GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null /* all */)) {
+                LeaderOpExecutor leaderOpExecutor =
+                        new LeaderOpExecutor(Pair.create(fe.getHost(), fe.getRpcPort()), parsedStmt, originStmt,
+                                context, redirectStatus);
+                try {
+                    leaderOpExecutor.execute();
+                    // if query is successfully killed by this fe, it can return now
+                    if (context.getState().getStateType() == MysqlStateType.OK) {
+                        context.getState().setOk();
+                        return;
+                    }
+                    errorMsg = context.getState().getErrorMessage();
+                } catch (TTransportException e) {
+                    errorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort();
+                    LOG.warn(e.getMessage(), e);
+                } catch (Exception e) {
+                    errorMsg = e.getMessage();
+                    LOG.warn(e.getMessage(), e);
+                }
+            }
+            // if the queryId is not found in any fe, print the error message
+            context.getState().setError(errorMsg == null ? ErrorCode.ERR_UNKNOWN_ERROR.formatErrorMsg() : errorMsg);
+            return;
+        }
+        ConnectContext killCtx = ExecuteEnv.getInstance().getScheduler().findContextByQueryId(queryId);
+        if (killCtx == null) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_QUERY, queryId);
+        }
+        handleKill(killCtx, false);
     }
 
     // Process set statement.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1047,7 +1047,8 @@ public class StmtExecutor {
                     errorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort();
                     LOG.warn(errorMsg, e);
                 } catch (Exception e) {
-                    errorMsg = e.getMessage();
+                    errorMsg = "Failed to connect to fe " + fe.getHost() + ":" + fe.getRpcPort() + " due to " +
+                            e.getMessage();
                     LOG.warn(e.getMessage(), e);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/KillStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/KillStmt.java
@@ -21,14 +21,15 @@ import com.starrocks.sql.parser.NodePosition;
 /**
  * Representation of a Kill statement.
  * Acceptable syntax:
- * KILL [QUERY | CONNECTION] connection_id
+ * KILL [QUERY | CONNECTION] connection_id | query_id
  */
 public class KillStmt extends StatementBase {
-    private final boolean isConnectionKill;
-    private final long connectionId;
+    private boolean isConnectionKill;
+    private long connectionId;
+    private String queryId;
 
-    public KillStmt(boolean isConnectionKill, long connectionId) {
-        this(isConnectionKill, connectionId, NodePosition.ZERO);
+    public KillStmt(long connectionId, NodePosition pos) {
+        this(false, connectionId, pos);
     }
 
     public KillStmt(boolean isConnectionKill, long connectionId, NodePosition pos) {
@@ -37,12 +38,21 @@ public class KillStmt extends StatementBase {
         this.connectionId = connectionId;
     }
 
+    public KillStmt(String queryId, NodePosition pos) {
+        super(pos);
+        this.queryId = queryId;
+    }
+
     public boolean isConnectionKill() {
         return isConnectionKill;
     }
 
     public long getConnectionId() {
         return connectionId;
+    }
+
+    public String getQueryId() {
+        return queryId;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2362,10 +2362,17 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitKillStatement(StarRocksParser.KillStatementContext context) {
         NodePosition pos = createPos(context);
-        long id = Long.parseLong(context.INTEGER_VALUE().getText());
+        long id = context.connId != null ? Long.parseLong(context.connId.getText()) : -1;
+        String queryId = context.queryId != null ? ((StringLiteral) visit(context.queryId)).getStringValue() : null;
         if (context.QUERY() != null) {
-            return new KillStmt(false, id, pos);
+            if (queryId != null) {
+                return new KillStmt(queryId, pos);
+            }
+            return new KillStmt(id, pos);
         } else {
+            if (context.connId == null) {
+                throw new ParsingException(String.format("connection id %s should be a positive integer", queryId));
+            }
             return new KillStmt(true, id, pos);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2370,7 +2370,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
             return new KillStmt(id, pos);
         } else {
-            if (context.connId == null) {
+            if (queryId != null) {
                 throw new ParsingException(String.format("connection id %s should be a positive integer", queryId));
             }
             return new KillStmt(true, id, pos);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -683,7 +683,7 @@ adminSetPartitionVersion
     ;
 
 killStatement
-    : KILL (CONNECTION? | QUERY) INTEGER_VALUE
+    : KILL (CONNECTION? | QUERY) (connId=INTEGER_VALUE | queryId=string)
     ;
 
 syncStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/KillStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/KillStmtTest.java
@@ -47,7 +47,13 @@ public class KillStmtTest {
         String sql_3 = "kill connection 3";
         AnalyzeTestUtil.analyzeSuccess(sql_3);
 
-        String sql_4 = "kill q 4";
-        AnalyzeTestUtil.analyzeFail(sql_4);
+        String sql_4 = "kill query 'abc'";
+        AnalyzeTestUtil.analyzeSuccess(sql_4);
+
+        String sql_6 = "kill connection '1'";
+        AnalyzeTestUtil.analyzeFail(sql_6);
+
+        String sql_7 = "kill q 4";
+        AnalyzeTestUtil.analyzeFail(sql_7);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
@@ -1,0 +1,141 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.rpc.FrontendServiceProxy;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TMasterOpResult;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.channels.SocketChannel;
+import java.util.UUID;
+
+public class KillQueryHandleTest {
+
+    private static StarRocksAssert starRocksAssert;
+
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        connectContext = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        starRocksAssert = new StarRocksAssert(connectContext);
+    }
+
+    @Test
+    public void testKillStmt(@Mocked SocketChannel socketChannel) throws Exception {
+        // test killing query successfully
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        Assert.assertFalse(ctx1.isKilled());
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), false);
+        // isKilled is set
+        Assert.assertTrue(ctx1.isKilled());
+        Assert.assertEquals(QueryState.MysqlStateType.OK, ctx.getState().getStateType());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    @Test
+    public void testKillStmtWhenQueryIdNotFound(@Mocked SocketChannel socketChannel, @Mocked TMasterOpResult result)
+            throws Exception {
+        // test killing query is forwarded to fe and query not found
+        new MockUp<TMasterOpResult>() {
+            @Mock
+            public boolean isSetErrorMsg() {
+                return true;
+            }
+
+            @Mock
+            public String getErrorMsg() {
+                return "query xxx not found";
+            }
+        };
+        new MockUp(FrontendServiceProxy.class) {
+            @Mock
+            public <T> T call(TNetworkAddress address, int timeoutMs, int retryTimes,
+                              FrontendServiceProxy.MethodCallable<T> callable) throws Exception {
+                result.state = "ERR";
+                return (T) result;
+            }
+        };
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
+        Assert.assertEquals("query xxx not found", ctx.getState().getErrorMessage());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    @Test
+    public void testKillStmtWhenConnectionFail(@Mocked SocketChannel socketChannel) throws Exception {
+        // test killing query is forwarded to fe but fe is down
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
+        Assert.assertEquals("Failed to connect to fe 127.0.0.1:9020", ctx.getState().getErrorMessage());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    private ConnectContext prepareConnectContext(SocketChannel socketChannel) {
+        ConnectContext ctx1 = new ConnectContext(socketChannel) {
+            @Override
+            public void kill(boolean killConnection, String cancelledMessage) {
+                super.isKilled = true;
+            }
+        };
+        ctx1.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx1.setQualifiedUser("root");
+        ctx1.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        ctx1.setConnectionId(1);
+        ctx1.setQueryId(UUID.randomUUID());
+        ctx1.setConnectScheduler(ExecuteEnv.getInstance().getScheduler());
+
+        ExecuteEnv.getInstance().getScheduler().registerConnection(ctx1);
+        return ctx1;
+    }
+
+    private ConnectContext kill(String queryId, boolean forward) throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        ctx.setConnectScheduler(ExecuteEnv.getInstance().getScheduler());
+        // reset state
+        ctx.getState().reset();
+        ctx.setForwardTimes(0);
+        if (!forward) {
+            ctx.setForwardTimes(1);
+        }
+        StatementBase killStatement =
+                UtFrameUtils.parseStmtWithNewParser("kill query '" + queryId + "'", ctx);
+        StmtExecutor stmtExecutor = new StmtExecutor(starRocksAssert.getCtx(), killStatement);
+        stmtExecutor.execute();
+        return ctx;
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -826,6 +826,7 @@ struct TMasterOpResult {
 
     6: optional string resource_group_name;
     7: optional TAuditStatistics audit_statistics;
+    8: optional string errorMsg;
 }
 
 struct TIsMethodSupportedRequest {


### PR DESCRIPTION
## Why I'm doing:
User want to kill query id

## What I'm doing:
Allow killing query by query id in all running fe(leader, follower, observer).

Usage:
```sql

select ...;

-- find queryId
show proc '/current_queries';
kill query 'xx';

```

Fixes #47699 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
