### PR TITLE
[Enhancement] No need to cache the file stats when enable_delta_column_statistics is false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -110,7 +110,7 @@ public class DeltaLakeFileStats {
             return;
         }
 
-        // TODO: Currently not set avg size, will be optimized laster.
+        // TODO: Currently not set avg size, will be optimized later.
         // builder.setAverageRowSize(xxx);
         builder.setType(ColumnStatistic.StatisticType.UNKNOWN);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -210,13 +210,18 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                                     "Delta table feature [deletion vectors] is not supported");
                         }
 
-                        FileScanTask fileScanTask = ScanFileUtils.convertFromRowToFileScanTask(
-                                enableCollectColumnStatistics(connectContext), scanFileRow);
-                        files.add(fileScanTask);
+                        if (enableCollectColumnStatistics(connectContext)) {
+                            FileScanTask fileScanTask = ScanFileUtils.convertFromRowToFileScanTask(
+                                    true, scanFileRow);
+                            files.add(fileScanTask);
 
-                        try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.updateDeltaLakeFileStats")) {
-                            statisticProvider.updateFileStats(deltaLakeTable, key, fileScanTask,
-                                    nonPartitionPrimitiveColumns);
+                            try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.updateDeltaLakeFileStats")) {
+                                statisticProvider.updateFileStats(deltaLakeTable, key, fileScanTask,
+                                        nonPartitionPrimitiveColumns);
+                            }
+                        } else {
+                            FileScanTask fileScanTask = ScanFileUtils.convertFromRowToFileScanTask(false, scanFileRow);
+                            files.add(fileScanTask);
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -59,7 +59,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -71,13 +70,13 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     private final String catalogName;
     private final DeltaMetastoreOperations deltaOps;
     private final HdfsEnvironment hdfsEnvironment;
-    private final Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor;
-    private final Map<PredicateSearchKey, List<Row>> splitTasks = new ConcurrentHashMap<>();
+    private final DeltaLakeCacheUpdateProcessor cacheUpdateProcessor;
+    private final Map<PredicateSearchKey, List<FileScanTask>> splitTasks = new ConcurrentHashMap<>();
     private final Set<PredicateSearchKey> scannedTables = new HashSet<>();
     private final DeltaStatisticProvider statisticProvider = new DeltaStatisticProvider();
 
     public DeltaLakeMetadata(HdfsEnvironment hdfsEnvironment, String catalogName, DeltaMetastoreOperations deltaOps,
-                             Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor) {
+                             DeltaLakeCacheUpdateProcessor cacheUpdateProcessor) {
         this.hdfsEnvironment = hdfsEnvironment;
         this.catalogName = catalogName;
         this.deltaOps = deltaOps;
@@ -125,7 +124,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
         triggerDeltaLakePlanFilesIfNeeded(key, table, operator);
 
-        List<Row> scanTasks = splitTasks.get(key);
+        List<FileScanTask> scanTasks = splitTasks.get(key);
         if (scanTasks == null) {
             throw new StarRocksConnectorException("Missing iceberg split task for table:[{}.{}]. predicate:[{}]",
                     dbName, tableName, operator);
@@ -151,7 +150,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
         triggerDeltaLakePlanFilesIfNeeded(key, deltaLakeTable, predicate);
 
-        List<Row> deltaLakeScanTasks = splitTasks.get(key);
+        List<FileScanTask> deltaLakeScanTasks = splitTasks.get(key);
         if (deltaLakeScanTasks == null) {
             throw new StarRocksConnectorException("Missing delta split task for table:[{}.{}]. predicate:[{}]",
                     dbName, table, predicate);
@@ -197,7 +196,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                         schema.get(column).getDataType().toString())
                         && !partitionColumns.contains(column)).collect(toImmutableList());
 
-        List<Row> files = Lists.newArrayList();
+        List<FileScanTask> files = Lists.newArrayList();
 
         try (CloseableIterator<FilteredColumnarBatch> scanFilesAsBatches = scan.getScanFiles(engine, true)) {
             while (scanFilesAsBatches.hasNext()) {
@@ -210,13 +209,14 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                             ErrorReport.reportValidateException(ErrorCode.ERR_BAD_TABLE_ERROR, ErrorType.UNSUPPORTED,
                                     "Delta table feature [deletion vectors] is not supported");
                         }
-                        files.add(scanFileRow);
 
-                        if (enableCollectColumnStatistics(connectContext)) {
-                            try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.updateDeltaLakeFileStats")) {
-                                statisticProvider.updateFileStats(deltaLakeTable, key, scanFileRow,
-                                        nonPartitionPrimitiveColumns);
-                            }
+                        FileScanTask fileScanTask = ScanFileUtils.convertFromRowToFileScanTask(
+                                enableCollectColumnStatistics(connectContext), scanFileRow);
+                        files.add(fileScanTask);
+
+                        try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.updateDeltaLakeFileStats")) {
+                            statisticProvider.updateFileStats(deltaLakeTable, key, fileScanTask,
+                                    nonPartitionPrimitiveColumns);
                         }
                     }
                 }
@@ -268,7 +268,9 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
     @Override
     public void refreshTable(String srDbName, Table table, List<String> partitionNames, boolean onlyCachedPartitions) {
-        cacheUpdateProcessor.ifPresent(processor -> processor.refreshTable(srDbName, table, onlyCachedPartitions));
+        if (cacheUpdateProcessor != null) {
+            cacheUpdateProcessor.refreshTable(srDbName, table, onlyCachedPartitions);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -57,7 +57,8 @@ public class DeltaLakeMetadataFactory {
                 metastore instanceof CachingDeltaLakeMetastore, metastoreType);
 
         Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
-        return new DeltaLakeMetadata(hdfsEnvironment, catalogName, metastoreOperations, cacheUpdateProcessor);
+        return new DeltaLakeMetadata(hdfsEnvironment, catalogName, metastoreOperations,
+                cacheUpdateProcessor.orElse(null));
     }
 
     public synchronized Optional<DeltaLakeCacheUpdateProcessor> getCacheUpdateProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeRemoteFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeRemoteFileDesc.java
@@ -15,23 +15,22 @@
 package com.starrocks.connector.delta;
 
 import com.starrocks.connector.RemoteFileDesc;
-import io.delta.kernel.data.Row;
 
 import java.util.List;
 
 public class DeltaLakeRemoteFileDesc extends RemoteFileDesc {
-    private final List<Row> deltaLakeSplitsInfo;
+    private final List<FileScanTask> deltaLakeSplitsInfo;
 
-    private DeltaLakeRemoteFileDesc(List<Row> deltaLakeSplitsInfo) {
+    private DeltaLakeRemoteFileDesc(List<FileScanTask> deltaLakeSplitsInfo) {
         super(null, null, 0, 0, null);
         this.deltaLakeSplitsInfo = deltaLakeSplitsInfo;
     }
 
-    public static DeltaLakeRemoteFileDesc createDeltaLakeRemoteFileDesc(List<Row> deltaLakeSplitsInfo) {
+    public static DeltaLakeRemoteFileDesc createDeltaLakeRemoteFileDesc(List<FileScanTask> deltaLakeSplitsInfo) {
         return new DeltaLakeRemoteFileDesc(deltaLakeSplitsInfo);
     }
 
-    public List<Row> getDeltaLakeScanTasks() {
+    public List<FileScanTask> getDeltaLakeScanTasks() {
         return deltaLakeSplitsInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeStats.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Map;
 
-public class DeltaLakeStatsStruct {
+public class DeltaLakeStats {
     @SerializedName(value = "numRecords")
     public long numRecords;
 
@@ -31,7 +31,7 @@ public class DeltaLakeStatsStruct {
     @SerializedName(value = "nullCount")
     public Map<String, Object> nullCount;
 
-    public DeltaLakeStatsStruct(long numRecords) {
+    public DeltaLakeStats(long numRecords) {
         this.numRecords = numRecords;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -21,13 +21,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
-import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.types.StructType;
-import io.delta.kernel.utils.FileStatus;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,32 +31,26 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_ORDINAL;
-
 public class DeltaStatisticProvider {
-    private static final Logger LOG = LogManager.getLogger(DeltaStatisticProvider.class);
     private final Map<PredicateSearchKey, DeltaLakeFileStats> deltaLakeFileStatsMap = new HashMap<>();
 
     public DeltaStatisticProvider() {}
 
     public Statistics getCardinalityStats(Map<ColumnRefOperator, Column> columnRefOperatorColumnMap,
-                                          List<Row> fileScanTasks) {
+                                          List<FileScanTask> fileScanTasks) {
         Statistics.Builder builder = Statistics.builder();
         long cardinality = 0;
         Set<String> currentFiles = new HashSet<>();
 
-        for (Row file : fileScanTasks) {
-            FileStatus status = InternalScanFileUtils.getAddFileStatus(file);
-            String path = status.getPath();
+        for (FileScanTask file : fileScanTasks) {
+            String path = file.getFileStatus().getPath();
 
             if (currentFiles.contains(path)) {
                 continue;
             }
             currentFiles.add(path);
 
-            Row addFileEntry = getAddFileEntry(file);
-            long rows = ScanFileUtils.getFileRows(addFileEntry);
-            cardinality += rows;
+            cardinality += file.getRecords();
         }
 
         return builder.setOutputRowCount(cardinality)
@@ -69,26 +58,23 @@ public class DeltaStatisticProvider {
                 .build();
     }
 
-    public void updateFileStats(DeltaLakeTable table, PredicateSearchKey key, Row file,
+    public void updateFileStats(DeltaLakeTable table, PredicateSearchKey key, FileScanTask file,
                                 List<String> nonPartitionPrimitiveColumn) {
         StructType schema = table.getDeltaMetadata().getSchema();
 
-        FileStatus status = InternalScanFileUtils.getAddFileStatus(file);
-
-        Row addFileEntry = getAddFileEntry(file);
-        DeltaLakeStatsStruct fileStat = ScanFileUtils.getColumnStatistics(addFileEntry);
+        DeltaLakeStatsStruct fileStat = file.getStats();
 
         DeltaLakeFileStats fileStats;
         if (deltaLakeFileStatsMap.containsKey(key)) {
             fileStats = deltaLakeFileStatsMap.get(key);
             fileStats.incrementRecordCount(fileStat.numRecords);
-            fileStats.incrementSize(status.getSize());
+            fileStats.incrementSize(file.getFileSize());
             updateSummaryMin(fileStats, fileStat.minValues, fileStat.nullCount, fileStat.numRecords);
             updateSummaryMax(fileStats, fileStat.maxValues, fileStat.nullCount, fileStat.numRecords);
             fileStats.updateNullCount(fileStat.nullCount, nonPartitionPrimitiveColumn);
         } else {
             fileStats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumn, fileStat.numRecords,
-                    status.getSize(), fileStat.minValues, fileStat.maxValues, fileStat.nullCount);
+                    file.getFileSize(), fileStat.minValues, fileStat.maxValues, fileStat.nullCount);
             deltaLakeFileStatsMap.put(key, fileStats);
         }
     }
@@ -130,14 +116,6 @@ public class DeltaStatisticProvider {
         builder.addColumnStatistics(buildColumnStatistics(schema, columnRefOperatorColumnMap, deltaLakeFileStats));
 
         return builder.build();
-    }
-
-    private static Row getAddFileEntry(Row file) {
-        if (file.isNullAt(ADD_FILE_ORDINAL)) {
-            throw new IllegalArgumentException("There is no `add` entry in the scan file row");
-        } else {
-            return file.getStruct(ADD_FILE_ORDINAL);
-        }
     }
 
     public Map<ColumnRefOperator, ColumnStatistic> buildUnknownColumnStatistics(Set<ColumnRefOperator> columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -62,7 +62,7 @@ public class DeltaStatisticProvider {
                                 List<String> nonPartitionPrimitiveColumn) {
         StructType schema = table.getDeltaMetadata().getSchema();
 
-        DeltaLakeStatsStruct fileStat = file.getStats();
+        DeltaLakeStats fileStat = file.getStats();
 
         DeltaLakeFileStats fileStats;
         if (deltaLakeFileStatsMap.containsKey(key)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -69,11 +69,10 @@ public class DeltaUtils {
                                                        Configuration configuration, long createTime) {
         DefaultEngine deltaEngine = DefaultEngine.create(configuration);
 
-        Table deltaTable = null;
-        SnapshotImpl snapshot = null;
+        SnapshotImpl snapshot;
 
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "DeltaLake.getSnapshot")) {
-            deltaTable = Table.forPath(deltaEngine, path);
+            Table deltaTable = Table.forPath(deltaEngine, path);
             snapshot = (SnapshotImpl) deltaTable.getLatestSnapshot(deltaEngine);
         } catch (TableNotFoundException e) {
             LOG.error("Failed to find Delta table for {}.{}.{}, {}", catalog, dbName, tblName, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -18,11 +18,13 @@ import io.delta.kernel.utils.FileStatus;
 
 import java.util.Map;
 
+// FileScanTask represents an AddFile file in DeltaLake.
+// TODO: The file representations of different Catalogs will be unified later.
 public class FileScanTask {
-    private FileStatus fileStatus = null;
-    private long records = 0;
-    private Map<String, String> partitionValues = null;
-    private DeltaLakeStats stats = null;
+    private final FileStatus fileStatus;
+    private final long records;
+    private final Map<String, String> partitionValues;
+    private final DeltaLakeStats stats;
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues) {
         this.fileStatus = fileStatus;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -22,7 +22,7 @@ public class FileScanTask {
     private FileStatus fileStatus = null;
     private long records = 0;
     private Map<String, String> partitionValues = null;
-    private DeltaLakeStatsStruct stats = null;
+    private DeltaLakeStats stats = null;
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues) {
         this.fileStatus = fileStatus;
@@ -32,7 +32,7 @@ public class FileScanTask {
     }
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues,
-                        DeltaLakeStatsStruct stats) {
+                        DeltaLakeStats stats) {
         this.fileStatus = fileStatus;
         this.records = records;
         this.partitionValues = partitionValues;
@@ -43,7 +43,7 @@ public class FileScanTask {
         return this.fileStatus;
     }
 
-    public DeltaLakeStatsStruct getStats() {
+    public DeltaLakeStats getStats() {
         return this.stats;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -18,7 +18,7 @@ import io.delta.kernel.utils.FileStatus;
 
 import java.util.Map;
 
-// FileScanTask represents an AddFile file in DeltaLake.
+// FileScanTask represents one `AddFile` in DeltaLake.
 // TODO: The file representations of different Catalogs will be unified later.
 public class FileScanTask {
     private final FileStatus fileStatus;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -27,10 +27,7 @@ public class FileScanTask {
     private final DeltaLakeStats stats;
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues) {
-        this.fileStatus = fileStatus;
-        this.records = records;
-        this.partitionValues = partitionValues;
-        this.stats = null;
+        this(fileStatus, records, partitionValues, null);
     }
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import io.delta.kernel.utils.FileStatus;
+
+import java.util.Map;
+
+public class FileScanTask {
+    private FileStatus fileStatus = null;
+    private long records = 0;
+    private Map<String, String> partitionValues = null;
+    private DeltaLakeStatsStruct stats = null;
+
+    public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues) {
+        this.fileStatus = fileStatus;
+        this.records = records;
+        this.partitionValues = partitionValues;
+        this.stats = null;
+    }
+
+    public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues,
+                        DeltaLakeStatsStruct stats) {
+        this.fileStatus = fileStatus;
+        this.records = records;
+        this.partitionValues = partitionValues;
+        this.stats = stats;
+    }
+
+    public FileStatus getFileStatus() {
+        return this.fileStatus;
+    }
+
+    public DeltaLakeStatsStruct getStats() {
+        return this.stats;
+    }
+
+    public long getFileSize() {
+        return this.fileStatus.getSize();
+    }
+
+    public long getRecords() {
+        return this.records;
+    }
+
+    public Map<String, String> getPartitionValues() {
+        return partitionValues;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -45,13 +45,13 @@ public class ScanFileUtils {
         return records.numRecords;
     }
 
-    public static DeltaLakeStatsStruct getColumnStatistics(Row file) {
+    public static DeltaLakeStats getColumnStatistics(Row file) {
         String stats = file.getString(ADD_FILE_STATS_ORDINAL);
         if (stats == null) {
             throw new IllegalArgumentException("There is no `stats` entry in the add file row");
         }
 
-        DeltaLakeStatsStruct statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeStatsStruct.class);
+        DeltaLakeStats statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeStats.class);
         if (statistics == null) {
             throw new IllegalArgumentException("There is no entry in the stats row");
         }
@@ -73,7 +73,7 @@ public class ScanFileUtils {
 
         FileScanTask fileScanTask;
         if (needStats) {
-            DeltaLakeStatsStruct stats = ScanFileUtils.getColumnStatistics(addFileRow);
+            DeltaLakeStats stats = ScanFileUtils.getColumnStatistics(addFileRow);
             fileScanTask = new FileScanTask(fileStatus, stats.numRecords, partitionValues, stats);
         } else {
             long records = ScanFileUtils.getFileRows(addFileRow);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -31,6 +31,7 @@ import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.delta.DeltaLakeRemoteFileDesc;
 import com.starrocks.connector.delta.DeltaUtils;
+import com.starrocks.connector.delta.FileScanTask;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -147,15 +148,13 @@ public class DeltaLakeScanNode extends ScanNode {
             return;
         }
 
-        List<Row> splitsInfo = remoteFileDesc.getDeltaLakeScanTasks();
-        for (Row row : splitsInfo) {
-            FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(row);
-            Map<String, String> partitionValueMap = InternalScanFileUtils.getPartitionValues(row);
+        List<FileScanTask> splitsInfo = remoteFileDesc.getDeltaLakeScanTasks();
+        for (FileScanTask row : splitsInfo) {
             List<String> partitionValues = new ArrayList<>();
-            partitionValueMap.forEach((key, value) -> partitionValues.add(value));
+            row.getPartitionValues().forEach((key, value) -> partitionValues.add(value));
             PartitionKey partitionKey = PartitionUtil.createPartitionKey(partitionValues,
                     deltaLakeTable.getPartitionColumns(), deltaLakeTable);
-            addPartitionLocations(partitionKeys, partitionKey, descTbl, fileStatus, deltaMetadata);
+            addPartitionLocations(partitionKeys, partitionKey, descTbl, row.getFileStatus(), deltaMetadata);
         }
 
         scanNodePredicates.setSelectedPartitionIds(partitionKeys.values());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -149,12 +149,12 @@ public class DeltaLakeScanNode extends ScanNode {
         }
 
         List<FileScanTask> splitsInfo = remoteFileDesc.getDeltaLakeScanTasks();
-        for (FileScanTask row : splitsInfo) {
+        for (FileScanTask split : splitsInfo) {
             List<String> partitionValues = new ArrayList<>();
-            row.getPartitionValues().forEach((key, value) -> partitionValues.add(value));
+            split.getPartitionValues().forEach((key, value) -> partitionValues.add(value));
             PartitionKey partitionKey = PartitionUtil.createPartitionKey(partitionValues,
                     deltaLakeTable.getPartitionColumns(), deltaLakeTable);
-            addPartitionLocations(partitionKeys, partitionKey, descTbl, row.getFileStatus(), deltaMetadata);
+            addPartitionLocations(partitionKeys, partitionKey, descTbl, split.getFileStatus(), deltaMetadata);
         }
 
         scanNodePredicates.setSelectedPartitionIds(partitionKeys.values());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -71,7 +71,7 @@ public class DeltaLakeMetadataTest {
                 CachingDeltaLakeMetastore.createQueryLevelInstance(hmsBackedDeltaMetastore, 10000), false,
                 MetastoreType.HMS);
 
-        deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps, Optional.empty());
+        deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps, null);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -237,8 +237,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         Options catalogOptions = new Options();
         catalogOptions.set(CatalogOptions.WAREHOUSE, warehouse);
         CatalogContext catalogContext = CatalogContext.create(catalogOptions);
-        Catalog catalog = CatalogFactory.createCatalog(catalogContext);
-        return catalog;
+        return CatalogFactory.createCatalog(catalogContext);
     }
 
     private static void mockPaimonCatalogImpl(MockedMetadataMgr metadataMgr, String warehouse) throws Exception {
@@ -256,13 +255,6 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         PaimonMetadata paimonMetadata =
                 new PaimonMetadata(MOCK_PAIMON_CATALOG_NAME, new HdfsEnvironment(), paimonNativeCatalog);
         metadataMgr.registerMockedMetadata(MOCK_PAIMON_CATALOG_NAME, paimonMetadata);
-    }
-
-    public static void mockKuduCatalog(ConnectContext ctx) throws DdlException {
-        GlobalStateMgr gsmMgr = ctx.getGlobalStateMgr();
-        MockedMetadataMgr metadataMgr = new MockedMetadataMgr(gsmMgr.getLocalMetastore(), gsmMgr.getConnectorMgr());
-        gsmMgr.setMetadataMgr(metadataMgr);
-        mockKuduCatalogImpl(metadataMgr);
     }
 
     private static void mockKuduCatalogImpl(MockedMetadataMgr metadataMgr) throws DdlException {
@@ -291,7 +283,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
                 MOCK_TABLE_MAP = new CaseInsensitiveMap<>();
 
         public MockedDeltaLakeMetadata() {
-            super(null, null, null, Optional.empty());
+            super(null, null, null, null);
 
             long tableId = GlobalStateMgr.getCurrentState().getNextId();
             List<Column> columns = ImmutableList.<Column>builder()
@@ -319,7 +311,6 @@ public class ConnectorPlanTestBase extends PlanTestBase {
 
     private static void mockDeltaLakeCatalog(MockedMetadataMgr metadataMgr) throws Exception {
         final String catalogName = MockedDeltaLakeMetadata.MOCKED_CATALOG_NAME;
-        final String dbName = MockedDeltaLakeMetadata.MOCKED_DB_NAME;
         CatalogMgr catalogMgr = GlobalStateMgr.getCurrentState().getCatalogMgr();
 
         // create catalog


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

No need to cache the file stats when enable_delta_column_statistics is false.

The purpose of doing this is to optimize memory usage, when there is so many files.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
