### PR TITLE
[Enhancement]still need check on num_row and avail_levels for debug mode fuzz

### DIFF
--- a/be/src/formats/parquet/level_codec.cpp
+++ b/be/src/formats/parquet/level_codec.cpp
@@ -64,7 +64,6 @@ Status LevelDecoder::parse(tparquet::Encoding::type encoding, level_t max_level,
 
 size_t LevelDecoder::_get_level_to_decode_batch_size(size_t row_num) {
     constexpr size_t min_level_batch_size = 4096;
-    constexpr size_t max_level_batch_size = 1024 * 1024;
     size_t levels_remaining = _levels_decoded - _levels_parsed;
     if (row_num <= levels_remaining) {
         return 0;
@@ -72,7 +71,6 @@ size_t LevelDecoder::_get_level_to_decode_batch_size(size_t row_num) {
 
     size_t levels_to_decode = std::max(min_level_batch_size, row_num - levels_remaining);
     levels_to_decode = std::min(levels_to_decode, static_cast<size_t>(_num_levels));
-    levels_to_decode = std::min(levels_to_decode, max_level_batch_size);
     return levels_to_decode;
 }
 

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -251,7 +251,7 @@ void OptionalStoredColumnReader::reset_levels() {
 
 Status OptionalStoredColumnReader::_decode_levels(size_t* num_rows, size_t* num_levels_parsed, level_t** def_levels) {
     size_t avail_levels = _reader->def_level_decoder().get_avail_levels(*num_rows, def_levels);
-    if (UNLIKELY(avail_levels == 0)) {
+    if (UNLIKELY(avail_levels == 0 || *num_rows > avail_levels)) {
         return Status::InternalError(
                 fmt::format("def levels need to parsed: {}, def levels parsed: {}", *num_rows, avail_levels));
     }


### PR DESCRIPTION
## Why I'm doing:
without num_rows > avail_levels check, there are a lot of fuzzing tests(illegal parquet files) crash
on DCHECK in debug mode.
consider that we have limit batch size in upper layer, remove limitation in level decoder and make 
sure for optional type num_rows >= avail_levels

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3 will do it manually
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
