### PR TITLE
[BugFix] didn't catch the exception in getAuthorizationInfo

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/http/BadHttpRequestTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/BadHttpRequestTest.java
@@ -60,6 +60,20 @@ public class BadHttpRequestTest extends StarRocksHttpTestCase {
         Assert.assertEquals(200, response.code());
     }
 
+    @Test
+    public void testInvalidAuthorityRequest() throws IOException {
+        RequestBody body = RequestBody.create(JSON, "{}");
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(String.format(STREAM_LOAD_URL_FORMAT, DB_NAME, TABLE_NAME))
+                .put(body)
+                .addHeader("Authorization", "Basic xxx")
+                .addHeader("label", UUID.randomUUID().toString())
+                .addHeader("Expect", "100-continue");
+        Request request = requestBuilder.build();
+        Response response = networkClient.newCall(request).execute();
+        Assert.assertEquals(401, response.code());
+    }
+
     @NotNull
     private Request createRequest(int columnTotalLength) {
         RequestBody body = RequestBody.create(JSON, "{}");


### PR DESCRIPTION
## Why I'm doing:
> when send abnormal Authorization, didn't response the normal content,
+ the demo like below:
```
curl -i --location --request PUT 'http://127.0.0.1:7030/api/database_test/tb_test/_stream_load' \
--header 'jsonpaths: ["$.id", "$.name", "$.dt"]' \
--header 'format: json' \
--header 'columns: id, name, dt, __op ='\''upsert'\''' \
--header 'strict_mode: true' \
--header 'Expect: 100-continue' \
--header 'Content-Type: text/plain' \
--header 'Authorization: Basic xxx' \
--data '{
    "id": "101",
    "name": "xhl",
    "dt": "2024-06-25"
}
{
    "id": "102",
    "name": "ly",
    "dt": "2024-06-25"
}'
```
+ the response like below:
```
curl: (52) Empty reply from server
```
## What I'm doing:
make the normal http resonse for all http api, like below
```
{"status":"FAILED","msg":"Need auth information."}
```
Fixes #47636

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
