### PR TITLE
[Enhancement] Support mv rewrite when select only with mv's group by key

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRollupUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRollupUtils.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
@@ -28,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 
@@ -59,6 +61,11 @@ public class AggregateFunctionRollupUtils {
             // Functions and rollup functions are not the same.
             .put(FunctionSet.BITMAP_AGG, FunctionSet.BITMAP_UNION)
             .put(FunctionSet.ARRAY_AGG_DISTINCT, FunctionSet.ARRAY_UNIQUE_AGG)
+            .build();
+
+    public static final Set<String> NON_CUMULATIVE_ROLLUP_FUNCTION_MAP = ImmutableSet.<String>builder()
+            .add(FunctionSet.MAX)
+            .add(FunctionSet.MIN)
             .build();
 
     public static final Map<String, String> REWRITE_ROLLUP_FUNCTION_MAP = ImmutableMap.<String, String>builder()
@@ -109,5 +116,15 @@ public class AggregateFunctionRollupUtils {
         } else {
             return oldColRef;
         }
+    }
+
+    public static boolean isNonCumulativeFunction(CallOperator aggCall) {
+        if (NON_CUMULATIVE_ROLLUP_FUNCTION_MAP.contains(aggCall.getFnName())) {
+            return true;
+        }
+        if (FunctionSet.COUNT.equals(aggCall.getFnName()) && aggCall.isDistinct()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -726,6 +726,11 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             return (CallOperator) targetColumn;
         } else {
             if (!targetColumn.isColumnRef()) {
+                if (targetColumn instanceof CallOperator
+                        && AggregateFunctionRollupUtils.isNonCumulativeFunction(aggCall)
+                        && equationRewriter.isColWithOnlyGroupByKeys(aggCall)) {
+                    return (CallOperator) targetColumn;
+                }
                 OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext.getMVName(),
                         "Rewrite aggregate rollup {} failed: only column-ref is supported after rewrite",
                         aggCall.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -70,6 +70,21 @@ public class EquationRewriter {
         this.underAggFunctionRewriteContext = underAggFunctionRewriteContext;
     }
 
+    public boolean isColWithOnlyGroupByKeys(ScalarOperator expr) {
+        if (expr.getChildren().isEmpty()) {
+            return expr.isConstant() || equationMap.containsKey(expr);
+        }
+        for (ScalarOperator e : expr.getChildren()) {
+            if (expr.isConstant() || equationMap.containsKey(e)) {
+                continue;
+            }
+            if (!isColWithOnlyGroupByKeys(e)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private final class EquivalentShuttle extends BaseScalarOperatorShuttle {
         private final EquivalentShuttleContext shuttleContext;
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -390,6 +390,22 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 String query = "select t1a, sum(t1b + 1) as total from test.test_all_type group by t1a;";
                 sql(query).nonMatch("mv0");
             }
+            {
+                String query = "select t1a, max(t1b), sum(t1f) as total from test.test_all_type group by t1a;";
+                sql(query).match("mv0");
+            }
+            {
+                String query = "select t1a, max(concat(t1b,'.')), sum(t1f) as total from test.test_all_type group by t1a;";
+                sql(query).match("mv0");
+            }
+            {
+                String query = "select t1a, min(substr(t1b,1)), sum(t1f) as total from test.test_all_type group by t1a;";
+                sql(query).match("mv0");
+            }
+            {
+                String query = "select t1a, count(distinct t1b), sum(t1f) as total from test.test_all_type group by t1a;";
+                sql(query).match("mv0");
+            }
         });
     }
 }


### PR DESCRIPTION
## Why I'm doing:

```sql
CREATE TABLE `test_pt` (
  `id` int(11) NULL COMMENT "id",
  `pt` date NOT NULL COMMENT "",
  `gmv` int(11) NULL COMMENT "gmv"
) ENGINE=OLAP
DUPLICATE KEY(`id`)
COMMENT "OLAP"
PARTITION BY date_trunc('day', pt)
DISTRIBUTED BY HASH(`pt`)
PROPERTIES (
"replication_num" = "1"
);

insert into test_pt values(1,'2024-06-28', 10);

CREATE MATERIALIZED VIEW `test_pt_mv` 
PARTITION BY (`pt`)
DISTRIBUTED BY RANDOM
REFRESH ASYNC START("2024-03-08 03:00:00") EVERY(INTERVAL 1 MINUTE)
PROPERTIES (
"replication_num" = "1"
)
AS SELECT pt, id, sum(gmv) AS sum_gmv
FROM test_pt
GROUP BY pt,id;

explain select pt,max(id),sum(gmv) from test_pt group by pt;
```
`select pt,max(id),sum(gmv) from test_pt group by pt` should be rewritten by `test_pt_mv`
## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
