### PR TITLE
[Enhancement] Improve kafka authentication error message

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -158,7 +158,7 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
 
 Status KafkaDataConsumer::assign_topic_partitions(const std::map<int32_t, int64_t>& begin_partition_offset,
                                                   const std::string& topic, StreamLoadContext* ctx) {
-    DCHECK(_k_consumer);
+    DCHECK(_k_consumer && !_k_consumer->closed());
     // create TopicPartitions
     std::stringstream ss;
     std::vector<RdKafka::TopicPartition*> topic_partitions;
@@ -191,6 +191,7 @@ Status KafkaDataConsumer::assign_topic_partitions(const std::map<int32_t, int64_
 }
 
 Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* queue, int64_t max_running_time_ms) {
+    DCHECK(!_k_consumer->closed());
     _last_visit_time = time(nullptr);
     int64_t left_time = max_running_time_ms;
     LOG(INFO) << "start kafka consumer: " << _id << ", grp: " << _grp_id << ", max running time(ms): " << left_time;
@@ -294,6 +295,7 @@ Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* q
 Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_ids,
                                                std::vector<int64_t>* beginning_offsets,
                                                std::vector<int64_t>* latest_offsets, int timeout) {
+    DCHECK(!_k_consumer->closed());
     _last_visit_time = time(nullptr);
     beginning_offsets->reserve(partition_ids->size());
     latest_offsets->reserve(partition_ids->size());
@@ -322,6 +324,7 @@ Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_i
 }
 
 Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids, int timeout) {
+    DCHECK(!_k_consumer->closed());
     _last_visit_time = time(nullptr);
     // create topic conf
     RdKafka::Conf* tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
@@ -404,6 +407,7 @@ Status KafkaDataConsumer::cancel(StreamLoadContext* ctx) {
 Status KafkaDataConsumer::reset() {
     std::unique_lock<std::mutex> l(_lock);
     _cancelled = false;
+    DCHECK(!_k_consumer->closed());
     _k_consumer->unassign();
     _non_eof_partition_count = 0;
     _k_event_cb.reset_error_msg();
@@ -412,6 +416,7 @@ Status KafkaDataConsumer::reset() {
 
 // The offsets is the last consumed message for every partition. We need to +1 when we commit offset.
 Status KafkaDataConsumer::commit(const std::string& topic, const std::map<int32_t, int64_t>& offsets) {
+    DCHECK(!_k_consumer->closed());
     std::vector<RdKafka::TopicPartition*> topic_partitions;
     // delete TopicPartition finally
     auto tp_deleter = [&topic_partitions]() {

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -344,6 +344,10 @@ Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids
     RdKafka::Metadata* metadata = nullptr;
     RdKafka::ErrorCode err = _k_consumer->metadata(false /* all_topics */, topic, &metadata, timeout);
     if (err != RdKafka::ERR_NO_ERROR) {
+        if (_k_event_cb.get_error_msg().empty()) {
+            // some authentication errors event can only be triggered when the consumer is closed.
+            _k_consumer->close();
+        }
         std::stringstream ss;
         ss << "failed to get kafka topic: " << _topic << " meta, err: " << RdKafka::err2str(err) << ", "
            << _k_event_cb.get_error_msg();

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -149,7 +149,10 @@ public:
     ~KafkaDataConsumer() override {
         VLOG(3) << "deconstruct consumer";
         if (_k_consumer) {
-            _k_consumer->close();
+            // consumer may be already closed when get partition meta failed
+            if (!_k_consumer->closed()) {
+                _k_consumer->close();
+            }
             delete _k_consumer;
             _k_consumer = nullptr;
         }

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -116,6 +116,7 @@ Status RoutineLoadTaskExecutor::get_kafka_partition_meta(const PKafkaMetaProxyRe
     }
 
     Status st = std::static_pointer_cast<KafkaDataConsumer>(consumer)->get_partition_meta(partition_ids, timeout_ms);
+    // if get partition meta failed, should not return consumer because the KafkaConsumer may be closed.
     if (st.ok()) {
         _data_consumer_pool.return_consumer(consumer);
     }


### PR DESCRIPTION
## Why I'm doing:

kafka server uses `sasl_ssl` but create routine load job with `security.protocol = sasl_plaintext`

```
ErrorReason{errCode = 4, msg='Job failed to fetch all current partition with error [failed to get kafka topic: test meta, err: Local: Broker transport failure, , BE: TNetworkAddress(hostname:127.0.0.1, port:8060)]'}
```

## What I'm doing:

the authentication errors event only be triggered when the consumer is closed.
close consumer and wait the errors event when message is empty.

```
ErrorReason{errCode = 4, msg='Job failed to fetch all current partition with error [failed to get kafka topic: test meta, err: Local: Broker transport failure, event: 127.0.0.1:9092/bootstrap: Disconnected while requesting ApiVersion: might be caused by incorrect security.protocol configuration (connecting to a SSL listener?) or broker version is < 0.10 (see api.version.request) (after 5003ms in state APIVERSION_QUERY), BE: TNetworkAddress(hostname:127.0.0.1, port:8060)]'}
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
