### PR TITLE
[BugFix] forbid low cardinality optimization when cast string col to array<string>

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -567,6 +567,7 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     public void testArrayCharOnScan() throws Exception {
         String sql = "select array_slice(S_PHONE,-1,2) from supplier_nullable where S_SUPPKEY = 1";
         String plan = getFragmentPlan(sql);
+        System.out.println(plan);
         assertNotContains(plan, "DictDecode");
         assertContains(plan, "<slot 9> : array_slice(5: S_PHONE, -1, 2)");
     }
@@ -681,5 +682,25 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "\n" +
                 "  5:Decode\n" +
                 "  |  <dict id 19> : <string id 6>"));
+    }
+
+    @Test
+    public void testCastStringToArray() throws Exception {
+        String sql = "select cast( S_COMMENT as array<string>) from supplier_nullable";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan, plan.contains("1:Project\n" +
+                "  |  <slot 9> : CAST(7: S_COMMENT AS ARRAY<VARCHAR(65533)>)"));
+
+        sql = "select cast( S_COMMENT as array<string>) from supplier_nullable limit 1";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan, plan.contains("1:Project\n" +
+                "  |  <slot 9> : CAST(7: S_COMMENT AS ARRAY<VARCHAR(65533)>)\n" +
+                "  |  limit: 1"));
+
+        sql = "select cast( S_COMMENT as array<array<string>>) from supplier_nullable limit 1";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan, plan.contains("1:Project\n" +
+                "  |  <slot 9> : CAST(7: S_COMMENT AS ARRAY<ARRAY<VARCHAR(65533)>>)\n" +
+                "  |  limit: 1"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -567,7 +567,6 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     public void testArrayCharOnScan() throws Exception {
         String sql = "select array_slice(S_PHONE,-1,2) from supplier_nullable where S_SUPPKEY = 1";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         assertNotContains(plan, "DictDecode");
         assertContains(plan, "<slot 9> : array_slice(5: S_PHONE, -1, 2)");
     }

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -34,6 +34,32 @@ PROPERTIES (
 );
 -- result:
 -- !result
+CREATE TABLE `s4` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into s4 values
+(1, 12, '["abc", "bca"]'),
+(2, 22, '["abcd", "bca"]'),
+(3, 32, '["abcde", "bca"]'),
+(4, 42, '["abcdef", "bca"]'),
+(5, 52, '["abcdefg", "bca"]'),
+(6, 62, '["abcdefgh", "bca"]');
+-- result:
+-- !result
 insert into s2 values
 (28222, 724, ['Hubei', 'Ningxia', 'Sichuan', 'Zhejiang'], ['HK', 'BJ', 'GD', 'GS', 'LN']),
 (28231, 607, ['Yunnan', 'Inner Mongolia', 'Taiwan', 'Hunan'], ['JL', 'HUN', 'GZ', 'XJ', 'GZ']),
@@ -306,11 +332,15 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_1333f808bf6811eea33e00163e04d4c2.s1	analyze	status	OK
+test_db_84260182377211ef91112207f0c28981.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_1333f808bf6811eea33e00163e04d4c2.s2	analyze	status	OK
+test_db_84260182377211ef91112207f0c28981.s2	analyze	status	OK
+-- !result
+[UC] analyze full table s4;
+-- result:
+test_db_84260182377211ef91112207f0c28981.s4	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's1')
 -- result:
@@ -325,6 +355,10 @@ function: wait_global_dict_ready('a1', 's2')
 
 -- !result
 function: wait_global_dict_ready('a2', 's2')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('v3', 's4')
 -- result:
 
 -- !result
@@ -378,7 +412,7 @@ select array_max(s1.a2), array_distinct(s2.a1) from s1 join s2 on s1.v1 = s2.v1 
 JL	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]
 MO	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]
 -- !result
-select * from
+select * from 
 (select array_max(a1) x1 from s1) t1 join
 (select array_min(a1) x2 from s2) t2 on x1 = x2
 order by x1 limit 2;
@@ -496,7 +530,7 @@ insert into s3 select * from s3;
 -- !result
 [UC] analyze full table s3;
 -- result:
-test_db_133557b6bf6811eeb52600163e04d4c2.s3	analyze	status	OK
+test_db_84260362377211efaae82207f0c28981.s3	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's3')
 -- result:
@@ -529,14 +563,11 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 -- !result
-select count(a1[2]) from s3 where v3 = "GS";
--- result:
-384
--- !result
+select count(a1[2]) from s3 where v3 = "GS"; 
+
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
 -- result:
-28200	947	GY	["Hunan","Henan"]	["FJ","MO","HEB","JL"]
-28200	302	JL	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]	["JL","BJ"]
+384
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
 -- result:
@@ -559,4 +590,16 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS";
 -- result:
 384
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_84260362377211efaae82207f0c28981.s4'.")
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_84260362377211efaae82207f0c28981.s4'.")
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=true)*/ cast(v3 as array<string>) from s4 limit 1;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_84260362377211efaae82207f0c28981.s4'.")
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -306,11 +306,11 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_b769c0e6377311efa2bd2207f0c28981.s1	analyze	status	OK
+test_db_83043028377511ef83102207f0c28981.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_b769c0e6377311efa2bd2207f0c28981.s2	analyze	status	OK
+test_db_83043028377511ef83102207f0c28981.s2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's1')
 -- result:
@@ -522,11 +522,11 @@ insert into s4 values
 -- !result
 [UC] analyze full table s3;
 -- result:
-test_db_b769c208377311efb6682207f0c28981.s3	analyze	status	OK
+test_db_82fdffb4377511efb2bd2207f0c28981.s3	analyze	status	OK
 -- !result
 [UC] analyze full table s4;
 -- result:
-test_db_b769c208377311efb6682207f0c28981.s4	analyze	status	OK
+test_db_82fdffb4377511efb2bd2207f0c28981.s4	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's3')
 -- result:
@@ -563,11 +563,14 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 -- !result
-select count(a1[2]) from s3 where v3 = "GS"; 
-
-select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
+select count(a1[2]) from s3 where v3 = "GS";
 -- result:
 384
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
+-- result:
+28200	947	GY	["Hunan","Henan"]	["FJ","MO","HEB","JL"]
+28200	302	JL	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]	["JL","BJ"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
 -- result:
@@ -593,11 +596,11 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-["abcd","bca"]
+["abcdefg","bca"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-["abcdefg","bca"]
+["abcd","bca"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=true)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -332,15 +332,15 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_84260182377211ef91112207f0c28981.s1	analyze	status	OK
+test_db_ce2f9bf8377211ef86952207f0c28981.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_84260182377211ef91112207f0c28981.s2	analyze	status	OK
+test_db_ce2f9bf8377211ef86952207f0c28981.s2	analyze	status	OK
 -- !result
 [UC] analyze full table s4;
 -- result:
-test_db_84260182377211ef91112207f0c28981.s4	analyze	status	OK
+test_db_ce2f9bf8377211ef86952207f0c28981.s4	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's1')
 -- result:
@@ -530,7 +530,7 @@ insert into s3 select * from s3;
 -- !result
 [UC] analyze full table s3;
 -- result:
-test_db_84260362377211efaae82207f0c28981.s3	analyze	status	OK
+test_db_ce367b62377211efb4282207f0c28981.s3	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's3')
 -- result:
@@ -593,13 +593,13 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_84260362377211efaae82207f0c28981.s4'.")
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_ce367b62377211efb4282207f0c28981.s4'.")
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_84260362377211efaae82207f0c28981.s4'.")
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_ce367b62377211efb4282207f0c28981.s4'.")
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=true)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_84260362377211efaae82207f0c28981.s4'.")
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_ce367b62377211efb4282207f0c28981.s4'.")
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -513,11 +513,11 @@ PROPERTIES (
 -- !result
 insert into s4 values
 (1, 12, '["abc", "bca"]'),
-(2, 22, '["abcd", "bca"]'),
-(3, 32, '["abcde", "bca"]'),
-(4, 42, '["abcdef", "bca"]'),
-(5, 52, '["abcdefg", "bca"]'),
-(6, 62, '["abcdefgh", "bca"]');
+(2, 22, '["abc", "bca"]'),
+(3, 32, '["abc", "bca"]'),
+(4, 42, '["abc", "bca"]'),
+(5, 52, '["abc", "bca"]'),
+(6, 62, '["abc", "bca"]');
 -- result:
 -- !result
 [UC] analyze full table s3;
@@ -596,13 +596,13 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-["abcdefg","bca"]
+["abc", "bca"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-["abcd","bca"]
+["abc", "bca"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=true)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-["abcd","bca"]
+["abc", "bca"]
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -34,32 +34,6 @@ PROPERTIES (
 );
 -- result:
 -- !result
-CREATE TABLE `s4` (
-  `v1` bigint(20) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT "",
-  `v3` varchar(65533) NULL COMMENT ""
-) ENGINE=OLAP
-DUPLICATE KEY(`v1`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`v1`) BUCKETS 10
-PROPERTIES (
-"replication_num" = "1",
-"enable_persistent_index" = "false",
-"replicated_storage" = "false",
-"light_schema_change" = "true",
-"compression" = "LZ4"
-);
--- result:
--- !result
-insert into s4 values
-(1, 12, '["abc", "bca"]'),
-(2, 22, '["abcd", "bca"]'),
-(3, 32, '["abcde", "bca"]'),
-(4, 42, '["abcdef", "bca"]'),
-(5, 52, '["abcdefg", "bca"]'),
-(6, 62, '["abcdefgh", "bca"]');
--- result:
--- !result
 insert into s2 values
 (28222, 724, ['Hubei', 'Ningxia', 'Sichuan', 'Zhejiang'], ['HK', 'BJ', 'GD', 'GS', 'LN']),
 (28231, 607, ['Yunnan', 'Inner Mongolia', 'Taiwan', 'Hunan'], ['JL', 'HUN', 'GZ', 'XJ', 'GZ']),
@@ -332,15 +306,11 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_ce2f9bf8377211ef86952207f0c28981.s1	analyze	status	OK
+test_db_b769c0e6377311efa2bd2207f0c28981.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_ce2f9bf8377211ef86952207f0c28981.s2	analyze	status	OK
--- !result
-[UC] analyze full table s4;
--- result:
-test_db_ce2f9bf8377211ef86952207f0c28981.s4	analyze	status	OK
+test_db_b769c0e6377311efa2bd2207f0c28981.s2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's1')
 -- result:
@@ -355,10 +325,6 @@ function: wait_global_dict_ready('a1', 's2')
 
 -- !result
 function: wait_global_dict_ready('a2', 's2')
--- result:
-
--- !result
-function: wait_global_dict_ready('v3', 's4')
 -- result:
 
 -- !result
@@ -528,15 +494,49 @@ insert into s3 select * from s3;
 insert into s3 select * from s3;
 -- result:
 -- !result
+CREATE TABLE `s4` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into s4 values
+(1, 12, '["abc", "bca"]'),
+(2, 22, '["abcd", "bca"]'),
+(3, 32, '["abcde", "bca"]'),
+(4, 42, '["abcdef", "bca"]'),
+(5, 52, '["abcdefg", "bca"]'),
+(6, 62, '["abcdefgh", "bca"]');
+-- result:
+-- !result
 [UC] analyze full table s3;
 -- result:
-test_db_ce367b62377211efb4282207f0c28981.s3	analyze	status	OK
+test_db_b769c208377311efb6682207f0c28981.s3	analyze	status	OK
+-- !result
+[UC] analyze full table s4;
+-- result:
+test_db_b769c208377311efb6682207f0c28981.s4	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's3')
 -- result:
 
 -- !result
 function: wait_global_dict_ready('a2', 's3')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('v3', 's4')
 -- result:
 
 -- !result
@@ -593,13 +593,13 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_ce367b62377211efb4282207f0c28981.s4'.")
+["abcd","bca"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_ce367b62377211efb4282207f0c28981.s4'.")
+["abcdefg","bca"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=true)*/ cast(v3 as array<string>) from s4 limit 1;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_ce367b62377211efb4282207f0c28981.s4'.")
+["abcd","bca"]
 -- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -432,11 +432,11 @@ PROPERTIES (
 
 insert into s4 values
 (1, 12, '["abc", "bca"]'),
-(2, 22, '["abcd", "bca"]'),
-(3, 32, '["abcde", "bca"]'),
-(4, 42, '["abcdef", "bca"]'),
-(5, 52, '["abcdefg", "bca"]'),
-(6, 62, '["abcdefgh", "bca"]');
+(2, 22, '["abc", "bca"]'),
+(3, 32, '["abc", "bca"]'),
+(4, 42, '["abc", "bca"]'),
+(5, 52, '["abc", "bca"]'),
+(6, 62, '["abc", "bca"]');
 
 [UC] analyze full table s3;
 [UC] analyze full table s4;

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -33,6 +33,29 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
+CREATE TABLE `s4` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` varchar(65533)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+
+insert into s4 values
+(1, 12 '["abc", "bca"]'),
+(2, 22 '["abcd", "bca"]'),
+(3, 32 '["abcde", "bca"]'),
+(4, 42 '["abcdef", "bca"]'),
+(5, 52 '["abcdefg", "bca"]'),
+(6, 62 '["abcdefgh", "bca"]');
 
 insert into s2 values
 (28222, 724, ['Hubei', 'Ningxia', 'Sichuan', 'Zhejiang'], ['HK', 'BJ', 'GD', 'GS', 'LN']),
@@ -295,11 +318,13 @@ insert into s2 select * from s2;
 
 [UC] analyze full table s1;
 [UC] analyze full table s2;
+[UC] analyze full table s4;
 
 function: wait_global_dict_ready('a1', 's1')
 function: wait_global_dict_ready('a2', 's1')
 function: wait_global_dict_ready('a1', 's2')
 function: wait_global_dict_ready('a2', 's2')
+function: wait_global_dict_ready('v3', 's4')
 
 select * from s1 order by v1 limit 2;
 select * from s2 order by v1 limit 2;
@@ -450,3 +475,9 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS";
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=true)*/ cast(v3 as array<string>) from s4 limit 1;

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -33,30 +33,6 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
-CREATE TABLE `s4` (
-  `v1` bigint(20) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT "",
-  `v3` varchar(65533) NULL COMMENT ""
-) ENGINE=OLAP
-DUPLICATE KEY(`v1`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`v1`) BUCKETS 10
-PROPERTIES (
-"replication_num" = "1",
-"enable_persistent_index" = "false",
-"replicated_storage" = "false",
-"light_schema_change" = "true",
-"compression" = "LZ4"
-);
-
-insert into s4 values
-(1, 12, '["abc", "bca"]'),
-(2, 22, '["abcd", "bca"]'),
-(3, 32, '["abcde", "bca"]'),
-(4, 42, '["abcdef", "bca"]'),
-(5, 52, '["abcdefg", "bca"]'),
-(6, 62, '["abcdefgh", "bca"]');
-
 insert into s2 values
 (28222, 724, ['Hubei', 'Ningxia', 'Sichuan', 'Zhejiang'], ['HK', 'BJ', 'GD', 'GS', 'LN']),
 (28231, 607, ['Yunnan', 'Inner Mongolia', 'Taiwan', 'Hunan'], ['JL', 'HUN', 'GZ', 'XJ', 'GZ']),
@@ -318,13 +294,11 @@ insert into s2 select * from s2;
 
 [UC] analyze full table s1;
 [UC] analyze full table s2;
-[UC] analyze full table s4;
 
 function: wait_global_dict_ready('a1', 's1')
 function: wait_global_dict_ready('a2', 's1')
 function: wait_global_dict_ready('a1', 's2')
 function: wait_global_dict_ready('a2', 's2')
-function: wait_global_dict_ready('v3', 's4')
 
 select * from s1 order by v1 limit 2;
 select * from s2 order by v1 limit 2;
@@ -440,10 +414,36 @@ insert into s3 select * from s3;
 insert into s3 select * from s3;
 insert into s3 select * from s3;
 
+CREATE TABLE `s4` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+
+insert into s4 values
+(1, 12, '["abc", "bca"]'),
+(2, 22, '["abcd", "bca"]'),
+(3, 32, '["abcde", "bca"]'),
+(4, 42, '["abcdef", "bca"]'),
+(5, 52, '["abcdefg", "bca"]'),
+(6, 62, '["abcdefgh", "bca"]');
+
 [UC] analyze full table s3;
+[UC] analyze full table s4;
 
 function: wait_global_dict_ready('a1', 's3')
 function: wait_global_dict_ready('a2', 's3')
+function: wait_global_dict_ready('v3', 's4')
 
 
 select * from s3 order by v1 limit 2;

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -36,7 +36,7 @@ PROPERTIES (
 CREATE TABLE `s4` (
   `v1` bigint(20) NULL COMMENT "",
   `v2` int(11) NULL COMMENT "",
-  `v3` varchar(65533)> NULL COMMENT ""
+  `v3` varchar(65533) NULL COMMENT ""
 ) ENGINE=OLAP
 DUPLICATE KEY(`v1`)
 COMMENT "OLAP"
@@ -50,12 +50,12 @@ PROPERTIES (
 );
 
 insert into s4 values
-(1, 12 '["abc", "bca"]'),
-(2, 22 '["abcd", "bca"]'),
-(3, 32 '["abcde", "bca"]'),
-(4, 42 '["abcdef", "bca"]'),
-(5, 52 '["abcdefg", "bca"]'),
-(6, 62 '["abcdefgh", "bca"]');
+(1, 12, '["abc", "bca"]'),
+(2, 22, '["abcd", "bca"]'),
+(3, 32, '["abcde", "bca"]'),
+(4, 42, '["abcdef", "bca"]'),
+(5, 52, '["abcdefg", "bca"]'),
+(6, 62, '["abcdefgh", "bca"]');
 
 insert into s2 values
 (28222, 724, ['Hubei', 'Ningxia', 'Sichuan', 'Zhejiang'], ['HK', 'BJ', 'GD', 'GS', 'LN']),


### PR DESCRIPTION
## Why I'm doing:
When cast a low cardinality string column to array<string> type, the rewrite process mistakenly put it in dictdefine column. Actualy, we don't support a array<string> data as a new dict column.
```
mysql> explain select cast(v3 as array<string>) from s4 limit 1;
+------------------------------------------------------------------------------------+
| Explain String                                                                     |
+------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                    |
|  OUTPUT EXPRS:4: cast                                                              |
|   PARTITION: UNPARTITIONED                                                         |
|                                                                                    |
|   RESULT SINK                                                                      |
|                                                                                    |
|   3:Decode                                                                         |
|   |  <dict id 6> : <string id 4>                                                   |
|   |                                                                                |
|   2:EXCHANGE                                                                       |
|      limit: 1                                                                      |
|                                                                                    |
| PLAN FRAGMENT 1                                                                    |
|  OUTPUT EXPRS:                                                                     |
|   PARTITION: RANDOM                                                                |
|                                                                                    |
|   STREAM DATA SINK                                                                 |
|     EXCHANGE ID: 02                                                                |
|     UNPARTITIONED                                                                  |
|                                                                                    |
|   1:Project                                                                        |
|   |  <slot 6> : DictDefine(5: v3, [CAST(<place-holder> AS ARRAY<VARCHAR(65533)>)]) |
|   |  limit: 1                                                                      |
|   |                                                                                |
|   0:OlapScanNode                                                                   |
|      TABLE: s4                                                                     |
|      PREAGGREGATION: ON                                                            |
|      partitions=1/1                                                                |
|      rollup: s4                                                                    |
|      tabletRatio=10/10                                                             |
|      tabletList=47019,47021,47023,47025,47027,47029,47031,47033,47035,47037        |
|      cardinality=1                                                                 |
|      avgRowSize=33.0                                                               |
|      limit: 1                                                                      |
+------------------------------------------------------------------------------------+
34 rows in set (0.00 sec)

*** Aborted at 1719813268 (unix time) try "date -d @1719813268" if you are using GNU date ***
PC: @          0x81df29f starrocks::DictOptimizeParser::_eval_and_rewrite()
*** SIGSEGV (@0x180000002d) received by PID 4117232 (TID 0x7fee4a209640) from PID 45; stack trace: ***
    @          0xbf16c8a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fef3cc04bcb os::Linux::chained_handler()
    @     0x7fef3cc09a2d JVM_handle_linux_signal
    @     0x7fef3cbfd538 signalHandler()
    @     0x7fef3bd32520 (unknown)
    @          0x81df29f starrocks::DictOptimizeParser::_eval_and_rewrite()
    @          0x81e0a7f starrocks::DictOptimizeParser::eval_dict_expr()
    @          0x6fa9076 starrocks::pipeline::DictDecodeOperatorFactory::prepare()
    @          0x6d89dad starrocks::pipeline::NormalExecutionGroup::prepare_pipelines()
    @          0x51ed536 starrocks::pipeline::FragmentContext::prepare_all_pipelines()
    @          0x80eaaa6 starrocks::pipeline::FragmentExecutor::_prepare_pipeline_driver()
    @          0x80ee624 starrocks::pipeline::FragmentExecutor::prepare()
    @          0x822c526 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment_by_pipeline()
    @          0x8232525 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @          0x823c0c8 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @          0x4f85dcd starrocks::PriorityThreadPool::work_thread()
    @          0xbec567b thread_proxy
    @     0x7fef3bd84ac3 (unknown)
    @     0x7fef3be16850 (unknown)
    @                0x0 (unknown)
```

## What I'm doing:
forbid low cardinality optimization when cast string col to array<string>
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
