### PR TITLE
[BugFix] Fix stats are not correct in skew join rule for partitioned hive table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -243,6 +243,27 @@ public class PartitionUtil {
         return filteredPartitionName;
     }
 
+
+    public static List<PartitionKey> getPartitionKeys(Table table) {
+        List<PartitionKey> partitionKeys = Lists.newArrayList();
+        if (table.isUnPartitioned()) {
+            partitionKeys.add(new PartitionKey());
+        } else {
+            List<String> partitionNames = getPartitionNames(table);
+            List<Column> partitionColumns = getPartitionColumns(table);
+            try {
+                for (String partitionName : partitionNames) {
+                    partitionKeys.add(
+                            createPartitionKey(toPartitionValues(partitionName), partitionColumns, table));
+                }
+            } catch (Exception e) {
+                LOG.error("Failed to get partition keys", e);
+                throw new StarRocksConnectorException("Failed to get partition keys", e);
+            }
+        }
+        return partitionKeys;
+    }
+
     public static List<Column> getPartitionColumns(Table table) {
         return ConnectorPartitionTraits.build(table).getPartitionColumns();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -25,6 +25,7 @@ import com.google.common.cache.RemovalListener;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.BasicTable;
@@ -688,22 +689,44 @@ public class MetadataMgr {
                                          ScalarOperator predicate,
                                          long limit) {
         // FIXME: In testing env, `_statistics_.external_column_statistics` is not created, ignore query columns stats from it.
-        Statistics statistics = FeConstants.runningUnitTest ? null :
+        // Get basic/histogram stats from internal statistics.
+        Statistics internalStatistics = FeConstants.runningUnitTest ? null :
                 getTableStatisticsFromInternalStatistics(table, columns);
-        if (statistics == null ||
-                statistics.getColumnStatistics().values().stream().allMatch(ColumnStatistic::hasNonStats)) {
+        if (internalStatistics == null ||
+                internalStatistics.getColumnStatistics().values().stream().allMatch(ColumnStatistic::isUnknown)) {
+            // Get basic stats from connector metadata.
             session.setObtainedFromInternalStatistics(false);
             // Avoid `analyze table` to collect table statistics from metadata.
             if (StatisticUtils.statisticTableBlackListCheck(table.getId())) {
-                return statistics;
+                return internalStatistics;
             } else {
                 Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
-                return connectorMetadata.map(metadata -> metadata.getTableStatistics(
+                Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
                         session, table, columns, partitionKeys, predicate, limit)).orElse(null);
+                if (connectorBasicStats != null && internalStatistics != null &&
+                        internalStatistics.getColumnStatistics().values().stream().anyMatch(
+                                columnStatistic -> columnStatistic.getHistogram() != null)) {
+                    // combine connector metadata basic stats and histogram from internal stats
+                    Map<ColumnRefOperator, ColumnStatistic> internalColumnStatsMap = internalStatistics.getColumnStatistics();
+                    Map<ColumnRefOperator, ColumnStatistic> combinedColumnStatsMap = Maps.newHashMap();
+                    connectorBasicStats.getColumnStatistics().forEach((key, value) -> {
+                        if (internalColumnStatsMap.containsKey(key)) {
+                            combinedColumnStatsMap.put(key, ColumnStatistic.buildFrom(value).
+                                    setHistogram(internalColumnStatsMap.get(key).getHistogram()).build());
+                        } else {
+                            combinedColumnStatsMap.put(key, value);
+                        }
+                    });
+
+                    return Statistics.builder().addColumnStatistics(combinedColumnStatsMap).
+                            setOutputRowCount(connectorBasicStats.getOutputRowCount()).build();
+                } else {
+                    return connectorBasicStats;
+                }
             }
         } else {
             session.setObtainedFromInternalStatistics(true);
-            return statistics;
+            return internalStatistics;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -717,9 +717,11 @@ public class Optimizer {
 
     private void skewJoinOptimize(OptExpression tree, TaskContext rootTaskContext) {
         SkewJoinOptimizeRule rule = new SkewJoinOptimizeRule();
-        // merge projects before calculate statistics
-        ruleRewriteOnlyOnce(tree, rootTaskContext, new MergeTwoProjectRule());
-        Utils.calculateStatistics(tree, rootTaskContext.getOptimizerContext());
+        if (context.getSessionVariable().isEnableStatsToOptimizeSkewJoin()) {
+            // merge projects before calculate statistics
+            ruleRewriteOnlyOnce(tree, rootTaskContext, new MergeTwoProjectRule());
+            Utils.calculateStatistics(tree, rootTaskContext.getOptimizerContext());
+        }
         if (ruleRewriteOnlyOnce(tree, rootTaskContext, rule)) {
             // skew join generate new join and on predicate, need to push down join on expression to child project again
             ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
@@ -46,6 +46,8 @@ public class ScanOperatorPredicates {
     private List<ScalarOperator> minMaxConjuncts = new ArrayList<>();
     // Map of columnRefOperator to column which column in minMaxConjuncts
     private Map<ColumnRefOperator, Column> minMaxColumnRefMap = Maps.newHashMap();
+    // flag to indicate whether if has pruned partition
+    private boolean hasPrunedPartition = false;
 
     public Map<Long, PartitionKey> getIdToPartitionKey() {
         return idToPartitionKey;
@@ -64,6 +66,7 @@ public class ScanOperatorPredicates {
     }
 
     public void setSelectedPartitionIds(Collection<Long> selectedPartitionIds) {
+        this.hasPrunedPartition = true;
         this.selectedPartitionIds = selectedPartitionIds;
     }
 
@@ -94,6 +97,10 @@ public class ScanOperatorPredicates {
 
     public Map<ColumnRefOperator, Column> getMinMaxColumnRefMap() {
         return minMaxColumnRefMap;
+    }
+
+    public boolean hasPrunedPartition() {
+        return hasPrunedPartition;
     }
 
     public void clear() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -288,4 +288,14 @@ public class SkewJoinTest extends PlanTestBase {
                 "  |  equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME\n" +
                 "  |  equal join conjunct: 1: C_CUSTKEY = 10: P_PARTKEY");
     }
+
+    @Test
+    public void testSkewJoinWithStats2() throws Exception {
+        // test hive partitioned table
+        String sql = "select l_returnflag, t3.c3 from hive0.partitioned_db.lineitem_par join hive0.partitioned_db.t3" +
+                " on l_returnflag = t3.c3";
+        String sqlPlan = getFragmentPlan(sql);
+        assertCContains(sqlPlan, "equal join conjunct: 21: rand_col = 28: rand_col\n" +
+                "  |  equal join conjunct: 9: l_returnflag = 19: c3", "cardinality=540034112");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
at skew join rule, row count in statistics is not correct when hive table is partitioned table
## What I'm doing:
1. Get all partition statistics at skew join rule (beacuse this rule run before prune partition rule, do not known the selected partitions)
2. If can not get basic statistics from internal statistics(_statistics_ db), get table statistics from connector metadata 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
