### PR TITLE
[BugFix] fix several correctness issues about cloud native pk index

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -34,7 +34,7 @@
 
 namespace starrocks::lake {
 
-Status KeyValueMerger::merge(const std::string& key, const std::string& value) {
+Status KeyValueMerger::merge(const std::string& key, const std::string& value, uint64_t max_rss_rowid) {
     IndexValuesWithVerPB index_value_ver;
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
@@ -47,8 +47,17 @@ Status KeyValueMerger::merge(const std::string& key, const std::string& value) {
     auto index_value = build_index_value(index_value_ver.values(0));
     if (_key == key) {
         if (_index_value_vers.empty()) {
+            _max_rss_rowid = max_rss_rowid;
             _index_value_vers.emplace_front(version, index_value);
-        } else if (version > _index_value_vers.front().first) {
+        } else if ((version > _index_value_vers.front().first) ||
+                   (version == _index_value_vers.front().first && max_rss_rowid > _max_rss_rowid)) {
+            // NOTICE: we need both version and max_rss_rowid here to decide the order of keys.
+            // Consider the following two scenarios:
+            // 1. Same keys are from two different Rowsets, and we can decide their order by version recorded
+            //    in Rowset.
+            // 2. Same keys are from same Rowset, and they have same version. Now we use `max_rss_rowid` in sst to
+            //    decide their order.
+            _max_rss_rowid = max_rss_rowid;
             std::list<std::pair<int64_t, IndexValue>> t;
             t.emplace_front(version, index_value);
             _index_value_vers.swap(t);
@@ -56,6 +65,7 @@ Status KeyValueMerger::merge(const std::string& key, const std::string& value) {
     } else {
         flush();
         _key = key;
+        _max_rss_rowid = max_rss_rowid;
         _index_value_vers.emplace_front(version, index_value);
     }
     return Status::OK();
@@ -84,10 +94,7 @@ void KeyValueMerger::flush() {
 }
 
 LakePersistentIndex::LakePersistentIndex(TabletManager* tablet_mgr, int64_t tablet_id)
-        : PersistentIndex(""),
-          _memtable(std::make_unique<PersistentIndexMemtable>()),
-          _tablet_mgr(tablet_mgr),
-          _tablet_id(tablet_id) {}
+        : PersistentIndex(""), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
 
 LakePersistentIndex::~LakePersistentIndex() {
     _memtable->clear();
@@ -95,6 +102,7 @@ LakePersistentIndex::~LakePersistentIndex() {
 }
 
 Status LakePersistentIndex::init(const PersistentIndexSstableMetaPB& sstable_meta) {
+    uint64_t max_rss_rowid = 0;
     for (auto& sstable_pb : sstable_meta.sstables()) {
         ASSIGN_OR_RETURN(auto rf,
                          fs::new_random_access_file(_tablet_mgr->sst_location(_tablet_id, sstable_pb.filename())));
@@ -105,7 +113,11 @@ Status LakePersistentIndex::init(const PersistentIndexSstableMetaPB& sstable_met
         auto sstable = std::make_unique<PersistentIndexSstable>();
         RETURN_IF_ERROR(sstable->init(std::move(rf), sstable_pb, block_cache->cache()));
         _sstables.emplace_back(std::move(sstable));
+        max_rss_rowid = std::max(max_rss_rowid, sstable_pb.max_rss_rowid());
     }
+    // create memtable with previous rebuild `max_rss_rowid`,
+    // to make sure we can generate sst order by `max_rss_rowid`.
+    _memtable = std::make_unique<PersistentIndexMemtable>(max_rss_rowid);
     return Status::OK();
 }
 
@@ -358,6 +370,8 @@ Status LakePersistentIndex::prepare_merging_iterator(
         auto merging_sstable = std::make_shared<PersistentIndexSstable>();
         RETURN_IF_ERROR(merging_sstable->init(std::move(rf), sstable_pb, nullptr, false /** no filter **/));
         merging_sstables->push_back(merging_sstable);
+        // Pass `max_rss_rowid` to iterator, will be used when compaction.
+        read_options.max_rss_rowid = sstable_pb.max_rss_rowid();
         sstable::Iterator* iter = merging_sstable->new_iterator(read_options);
         iters.emplace_back(iter);
         // add input sstable.
@@ -374,9 +388,11 @@ Status LakePersistentIndex::prepare_merging_iterator(
 
 Status LakePersistentIndex::merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder,
                                            bool base_level_merge) {
-    auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), builder, base_level_merge);
+    auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), iter_ptr->max_rss_rowid(), builder,
+                                                   base_level_merge);
     while (iter_ptr->Valid()) {
-        RETURN_IF_ERROR(merger->merge(iter_ptr->key().to_string(), iter_ptr->value().to_string()));
+        RETURN_IF_ERROR(
+                merger->merge(iter_ptr->key().to_string(), iter_ptr->value().to_string(), iter_ptr->max_rss_rowid()));
         iter_ptr->Next();
     }
     RETURN_IF_ERROR(iter_ptr->status());

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -40,10 +40,14 @@ using IndexValueWithVer = std::pair<int64_t, IndexValue>;
 
 class KeyValueMerger {
 public:
-    explicit KeyValueMerger(const std::string& key, sstable::TableBuilder* builder, bool merge_base_level)
-            : _key(std::move(key)), _builder(builder), _merge_base_level(merge_base_level) {}
+    explicit KeyValueMerger(const std::string& key, uint64_t max_rss_rowid, sstable::TableBuilder* builder,
+                            bool merge_base_level)
+            : _key(std::move(key)),
+              _max_rss_rowid(max_rss_rowid),
+              _builder(builder),
+              _merge_base_level(merge_base_level) {}
 
-    Status merge(const std::string& key, const std::string& value);
+    Status merge(const std::string& key, const std::string& value, uint64_t max_rss_rowid);
 
     void finish() { flush(); }
 
@@ -52,6 +56,7 @@ private:
 
 private:
     std::string _key;
+    uint64_t _max_rss_rowid = 0;
     sstable::TableBuilder* _builder;
     std::list<IndexValueWithVer> _index_value_vers;
     // If do merge base level, that means we can delete NullIndexValue items safely.

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -268,7 +268,7 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
         for (const auto& each : collect_del_files) {
             rowset->add_del_files()->CopyFrom(each);
         }
-        _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + rowset->segments_size());
+        _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + std::max(1, rowset->segments_size()));
     }
 
     VLOG(2) << fmt::format(

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -255,7 +255,11 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
     }
 
     // add output rowset
-    if (op_compaction.has_output_rowset() && op_compaction.output_rowset().segments_size() > 0) {
+    if (op_compaction.has_output_rowset() &&
+        (op_compaction.output_rowset().segments_size() > 0 || !collect_del_files.empty())) {
+        // NOTICE: we need output rowset in two scenarios:
+        // 1. We have output segments after compactions.
+        // 2. We need del files to rebuild cloud native PK index.
         auto rowset = _tablet_meta->add_rowsets();
         rowset->CopyFrom(op_compaction.output_rowset());
         rowset->set_id(_tablet_meta->next_rowset_id());

--- a/be/src/storage/sstable/iterator.h
+++ b/be/src/storage/sstable/iterator.h
@@ -60,6 +60,9 @@ public:
     // If an error has occurred, return it.  Else return an ok status.
     virtual Status status() const = 0;
 
+    // Return the max rss_rowid the iterator contains.
+    virtual uint64_t max_rss_rowid() const { return 0; };
+
     // Clients are allowed to register function/arg1/arg2 triples that
     // will be invoked when this iterator is destroyed.
     //

--- a/be/src/storage/sstable/iterator_wrapper.h
+++ b/be/src/storage/sstable/iterator_wrapper.h
@@ -46,6 +46,10 @@ public:
         assert(iter_);
         return iter_->status();
     }
+    uint64_t max_rss_rowid() const {
+        assert(iter_);
+        return iter_->max_rss_rowid();
+    }
     void Next() {
         assert(iter_);
         iter_->Next();

--- a/be/src/storage/sstable/merger.cpp
+++ b/be/src/storage/sstable/merger.cpp
@@ -123,6 +123,11 @@ public:
         return status;
     }
 
+    uint64_t max_rss_rowid() const override {
+        assert(Valid());
+        return current_->max_rss_rowid();
+    }
+
 private:
     // Which direction is the iterator moving?
     enum Direction { kForward, kReverse };

--- a/be/src/storage/sstable/options.h
+++ b/be/src/storage/sstable/options.h
@@ -122,6 +122,8 @@ struct ReadOptions {
     // Callers may wish to set this field to false for bulk scans.
     bool fill_cache = true;
 
+    uint64_t max_rss_rowid = 0;
+
     ReadIOStat* stat = nullptr;
 };
 

--- a/be/src/storage/sstable/two_level_iterator.cpp
+++ b/be/src/storage/sstable/two_level_iterator.cpp
@@ -121,6 +121,8 @@ public:
         }
     }
 
+    uint64_t max_rss_rowid() const override { return options_.max_rss_rowid; }
+
 private:
     void SaveError(const Status& s) {
         if (status_.ok() && !s.ok()) status_ = s;

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -89,6 +89,7 @@ TEST_F(LakePersistentIndexTest, test_basic_api) {
     }
     auto tablet_id = _tablet_metadata->id();
     auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata->sstable_meta()));
     ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
     // insert duplicate should return error
     // ASSERT_FALSE(index->insert(N, key_slices.data(), values.data(), 0).ok());
@@ -178,6 +179,7 @@ TEST_F(LakePersistentIndexTest, test_replace) {
 
     auto tablet_id = _tablet_metadata->id();
     auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata->sstable_meta()));
     ASSERT_OK(index->insert(N, key_slices.data(), values.data(), false));
 
     //replace
@@ -207,6 +209,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     total_keys.reserve(M * N);
     auto tablet_id = _tablet_metadata->id();
     auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata->sstable_meta()));
     int k = 0;
     for (int i = 0; i < M; ++i) {
         vector<Key> keys;
@@ -305,6 +308,7 @@ TEST_F(LakePersistentIndexTest, test_compaction_strategy) {
 TEST_F(LakePersistentIndexTest, test_insert_delete) {
     auto tablet_id = _tablet_metadata->id();
     auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata->sstable_meta()));
 
     auto l0_max_mem_usage = config::l0_max_mem_usage;
     config::l0_max_mem_usage = 10;

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -329,6 +329,8 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_local_pk_consistency) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyConsistencyTest, LakePrimaryKeyConsistencyTest,
-                         ::testing::Values(PrimaryKeyParam{.persistent_index_type = PersistentIndexTypePB::LOCAL}));
+                         ::testing::Values(PrimaryKeyParam{.persistent_index_type = PersistentIndexTypePB::LOCAL},
+                                           PrimaryKeyParam{
+                                                   .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1297,6 +1297,10 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels2) {
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels3) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
     std::vector<std::pair<ChunkPtr, std::vector<uint32_t>>> chunks;
     //delete * 2
     chunks.push_back(gen_data_and_index(kChunkSize, 0, false, false));

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1296,6 +1296,70 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels2) {
     EXPECT_EQ(kChunkSize, read_rows(tablet_id, version));
 }
 
+TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels3) {
+    std::vector<std::pair<ChunkPtr, std::vector<uint32_t>>> chunks;
+    //delete * 2
+    chunks.push_back(gen_data_and_index(kChunkSize, 0, false, false));
+    chunks.push_back(gen_data_and_index(kChunkSize, 1, true, false));
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // publish two delete on different txn
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[1].first), chunks[1].second.data(), chunks[1].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // compact
+    {
+        auto old_val = config::lake_pk_compaction_min_input_segments;
+        config::lake_pk_compaction_min_input_segments = 1;
+        int64_t txn_id = next_id();
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+        ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+        EXPECT_EQ(100, task_context->progress.value());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        config::lake_pk_compaction_min_input_segments = old_val;
+    }
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).del_files_size(), 2);
+}
+
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,
                          ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
                                            PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE}));


### PR DESCRIPTION
## Why I'm doing:
I found two correctness issues about cloud native pk index when running PK deterministic random test:
1. When handle major compaction, we merge same keys only by versions, and it's not complete. For example, we have same keys cross two segments in same `Rowset`, they have same version but we still need the `max_rss_rowid` to decide the order of these keys.
2. When compaction merge several Rowsets with only del files, it won't generate output Rowset now, so we will loss the del files to rebuild the index. So we need to generate output Rowset when merge Rowsets with only del files.

## What I'm doing:
Fix these two issues.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
