### PR TITLE
[BugFix] Reject rename col which is referenced in rollup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -142,7 +142,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -142,9 +142,12 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 public class AlterJobMgr {
@@ -862,6 +865,9 @@ public class AlterJobMgr {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().renamePartition(db, table, partitionRenameClause);
                 break;
             } else if (alterClause instanceof ColumnRenameClause) {
+                Set<String> modifiedColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+                modifiedColumns.add(((ColumnRenameClause) alterClause).getColName());
+                schemaChangeHandler.checkModifiedColumWithMaterializedViews(table, modifiedColumns);
                 GlobalStateMgr.getCurrentState().getLocalMetastore().renameColumn(db, table, (ColumnRenameClause) alterClause);
                 break;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1971,7 +1971,7 @@ public class SchemaChangeHandler extends AlterHandler {
      * Check related synchronous materialized views before modified columns, throw exceptions
      * if modified columns affect the related rollup/synchronous mvs.
      */
-    private void checkModifiedColumWithMaterializedViews(OlapTable olapTable,
+    public void checkModifiedColumWithMaterializedViews(OlapTable olapTable,
                                                          Set<String> modifiedColumns) throws DdlException {
         if (modifiedColumns == null || modifiedColumns.isEmpty()) {
             return;


### PR DESCRIPTION
## Why I'm doing:
Before renaming a column, delete the associated rollups, just like dropping a column.

## What I'm doing:

Fixes #42823

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
