### PR TITLE
[BugFix] fix bug of profile crash on ASAN

### DIFF
--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -42,6 +42,10 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
     std::string upper_name(_name);
     std::transform(upper_name.begin(), upper_name.end(), upper_name.begin(), ::toupper);
     std::string profile_name = strings::Substitute("$0 (plan_node_id=$1)", upper_name, _plan_node_id);
+    // some pipeline may have multiple limit operators with same plan_node_id, so add operator id to profile name
+    if (upper_name == "LIMIT") {
+        profile_name += " (operator id=" + std::to_string(id) + ")";
+    }
     _runtime_profile = std::make_shared<RuntimeProfile>(profile_name);
     _runtime_profile->set_metadata(_id);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -67,8 +67,8 @@ public class ExplainAnalyzer {
     private static final Logger LOG = LogManager.getLogger(ExplainAnalyzer.class);
 
     private static final int FINAL_SINK_PSEUDO_PLAN_NODE_ID = -1;
-    private static final Pattern PLAN_NODE_ID = Pattern.compile("^.*?\\(.*?plan_node_id=([-0-9]+)\\)$");
-    private static final Pattern PLAN_OP_NAME = Pattern.compile("^(.*?) \\(.*?plan_node_id=[-0-9]+\\)$");
+    private static final Pattern PLAN_NODE_ID = Pattern.compile("^.*?\\(.*?plan_node_id=([-0-9]+)\\).*$");
+    private static final Pattern PLAN_OP_NAME = Pattern.compile("^(.*?) \\(.*?plan_node_id=[-0-9]+\\).*$");
 
     // ANSI Characters
     private static final String ANSI_RESET = "\u001B[0m";

--- a/test/sql/test_profile/R/test_profile
+++ b/test/sql/test_profile/R/test_profile
@@ -62,6 +62,9 @@ Analyze profile succeeded
 Analyze profile succeeded
 Analyze profile succeeded
 Analyze profile succeeded
+Analyze profile succeeded
+Analyze profile succeeded
+Analyze profile succeeded
 -- !result
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_profile_non_default_variables.sh
 -- result:

--- a/test/sql/test_profile/R/test_profile
+++ b/test/sql/test_profile/R/test_profile
@@ -26,6 +26,33 @@ INSERT INTO `t0` (v1, v2, v3) values
     (2, 4, 12);
 -- result:
 -- !result
+CREATE TABLE `temp1` (
+  `v1` int(11) NOT NULL,
+  `v2` int(11) NOT NULL,
+  `v3` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `temp1` (v1, v2, v3) values
+    (1, 1, 1),
+    (1, 1, 2),
+    (1, 1, 3),
+    (1, 2, 4),
+    (1, 2, 5),
+    (1, 2, 6),
+    (2, 3, 7),
+    (2, 3, 8),
+    (2, 3, 9),
+    (2, 4, 10),
+    (2, 4, 11),
+    (2, 4, 12);
+-- result:
+-- !result
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_profile_analysis.sh
 -- result:
 0

--- a/test/sql/test_profile/T/test_profile
+++ b/test/sql/test_profile/T/test_profile
@@ -24,5 +24,29 @@ INSERT INTO `t0` (v1, v2, v3) values
     (2, 4, 11),
     (2, 4, 12);
 
+CREATE TABLE `temp1` (
+  `v1` int(11) NOT NULL,
+  `v2` int(11) NOT NULL,
+  `v3` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+INSERT INTO `temp1` (v1, v2, v3) values
+    (1, 1, 1),
+    (1, 1, 2),
+    (1, 1, 3),
+    (1, 2, 4),
+    (1, 2, 5),
+    (1, 2, 6),
+    (2, 3, 7),
+    (2, 3, 8),
+    (2, 3, 9),
+    (2, 4, 10),
+    (2, 4, 11),
+    (2, 4, 12);
+
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_profile_analysis.sh
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_profile_non_default_variables.sh

--- a/test/sql/test_profile/T/test_profile_analysis.sh
+++ b/test/sql/test_profile/T/test_profile_analysis.sh
@@ -29,3 +29,8 @@ EOF
 test_explain_analyze "${sql}"
 test_explain_analyze "set enable_runtime_adaptive_dop = true; ${sql}"
 test_explain_analyze "set enable_spill = true; set spill_mode = 'force'; ${sql}"
+
+sql=$(cat << EOF
+explain analyze select * from t0  left join[bucket] temp1 on t0.v1 = temp1.v1 limit 2;
+EOF
+)

--- a/test/sql/test_profile/T/test_profile_analysis.sh
+++ b/test/sql/test_profile/T/test_profile_analysis.sh
@@ -34,3 +34,6 @@ sql=$(cat << EOF
 explain analyze select * from t0  left join[bucket] temp1 on t0.v1 = temp1.v1 limit 2;
 EOF
 )
+test_explain_analyze "${sql}"
+test_explain_analyze "set enable_runtime_adaptive_dop = true; ${sql}"
+test_explain_analyze "set enable_spill = true; set spill_mode = 'force'; ${sql}"


### PR DESCRIPTION
## Why I'm doing:
one driver's profile has its' operators profiles, and store them in:
```
typedef std::map<std::string, RuntimeProfile*> ChildMap;
    ChildMap _child_map;
```
so every operator has unique profile name, which is "operator name" + plan node id.

right now group execution(https://github.com/StarRocks/starrocks/pull/44771) can has pipelines below:
```
scan1->limit1->local exchange sink1
local exchange sourc 4->limit4->join probe4->limit4
```
the first limit 4 is infered by limit1, they have same limit size, first limit4 can be used for short-circuit

so limit 4 is not unique anymore. so add opeartor id for limit, then pipeline become:

```
scan1->limit1(14)->local exchange sink1
local exchange sourc 4->limit4(17)->join probe4->limit4(18)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
