### PR TITLE
[BugFix] Fix replaying task run bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -73,10 +73,13 @@ public class Constants {
         public boolean isSuccessState() {
             return this.equals(TaskRunState.SUCCESS) || this.equals(TaskRunState.MERGED);
         }
-    }
 
-    public static boolean isFinishState(TaskRunState state) {
-        return state.equals(TaskRunState.SUCCESS) || state.equals(TaskRunState.FAILED) || state.equals(TaskRunState.MERGED);
+        /**
+         * Whether the task run state is a finish state
+         */
+        public boolean isFinishState() {
+            return isSuccessState() || this.equals(TaskRunState.FAILED);
+        }
     }
 
     // Used to determine the scheduling order of Pending TaskRun to Running TaskRun

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -756,12 +756,8 @@ public class TaskManager implements MemoryTrackable {
     }
 
     public void replayCreateTaskRun(TaskRunStatus status) {
-
-        if (status.getState() == Constants.TaskRunState.SUCCESS ||
-                status.getState() == Constants.TaskRunState.FAILED) {
-            if (System.currentTimeMillis() > status.getExpireTime()) {
-                return;
-            }
+        if (status.getState().isFinishState() && System.currentTimeMillis() > status.getExpireTime()) {
+            return;
         }
         LOG.debug("replayCreateTaskRun:" + status);
 
@@ -840,6 +836,9 @@ public class TaskManager implements MemoryTrackable {
                 status.setProgress(100);
                 status.setFinishTime(statusChange.getFinishTime());
                 taskRunManager.getTaskRunHistory().addHistory(status);
+            } else {
+                LOG.warn("Illegal TaskRun queryId:{} status transform from {} to {}",
+                        statusChange.getQueryId(), fromStatus, toStatus);
             }
         } else if (fromStatus == Constants.TaskRunState.RUNNING &&
                 (toStatus == Constants.TaskRunState.SUCCESS || toStatus == Constants.TaskRunState.FAILED)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -168,7 +168,10 @@ public class TaskRunManager implements MemoryTrackable {
                     mergedTaskRuns.add(oldTaskRun);
                 }
             }
-            if (!taskRunScheduler.addPendingTaskRun(taskRun)) {
+
+            // recheck it again to avoid pending task run is too much
+            long validPendingCount = taskRunScheduler.getPendingQueueCount();
+            if (validPendingCount >= Config.task_runs_queue_length || !taskRunScheduler.addPendingTaskRun(taskRun)) {
                 LOG.warn("failed to offer task: {}", taskRun);
                 return false;
             }
@@ -176,7 +179,7 @@ public class TaskRunManager implements MemoryTrackable {
             // if it 's not replay, update the status of the old TaskRun to MERGED in FOLLOWER/LEADER.
             // if it is replay, no need to update the status of the old TaskRun because follower FE cannot
             // update edit log.
-            if (!isReplay && !mergedTaskRuns.isEmpty()) {
+            if (!isReplay) {
                 // TODO: support batch update to reduce the number of edit logs.
                 for (TaskRun oldTaskRun : mergedTaskRuns) {
                     oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
@@ -185,6 +188,14 @@ public class TaskRunManager implements MemoryTrackable {
                             oldTaskRun.getStatus().getState(), Constants.TaskRunState.MERGED);
                     GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
                     // update the state of the old TaskRun to MERGED in LEADER
+                    oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
+                    taskRunScheduler.removePendingTaskRun(oldTaskRun, Constants.TaskRunState.MERGED);
+                    taskRunHistory.addHistory(oldTaskRun.getStatus());
+                }
+            } else {
+                for (TaskRun oldTaskRun : mergedTaskRuns) {
+                    // update the state of the old TaskRun to MERGED in LEADER
+                    oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
                     oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
                     taskRunScheduler.removePendingTaskRun(oldTaskRun, Constants.TaskRunState.MERGED);
                     taskRunHistory.addHistory(oldTaskRun.getStatus());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -335,8 +335,7 @@ public class TaskRunStatus implements Writable {
 
     public Constants.TaskRunState getLastRefreshState() {
         if (isRefreshFinished()) {
-            Preconditions.checkArgument(Constants.isFinishState(state),
-                    String.format("state %s must be finish state", state));
+            Preconditions.checkArgument(state.isFinishState(), String.format("state %s must be finish state", state));
             return state;
         } else {
             // {@code processStartTime == 0} means taskRun have not been scheduled, its state should be pending.

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskTest.java
@@ -32,9 +32,25 @@ public class TaskTest {
 
     @Test
     public void testTaskRunState() {
-        Assert.assertFalse(Constants.isFinishState(Constants.TaskRunState.PENDING));
-        Assert.assertFalse(Constants.isFinishState(Constants.TaskRunState.RUNNING));
-        Assert.assertTrue(Constants.isFinishState(Constants.TaskRunState.FAILED));
-        Assert.assertTrue(Constants.isFinishState(Constants.TaskRunState.SUCCESS));
+        Assert.assertFalse(Constants.TaskRunState.PENDING.isFinishState());
+        Assert.assertFalse(Constants.TaskRunState.RUNNING.isFinishState());
+        Assert.assertTrue(Constants.TaskRunState.FAILED.isFinishState());
+        Assert.assertTrue(Constants.TaskRunState.SUCCESS.isFinishState());
+    }
+
+    @Test
+    public void testConstantTaskState() {
+        // whether it's a finished state
+        Assert.assertEquals(true, Constants.TaskRunState.FAILED.isFinishState());
+        Assert.assertEquals(true, Constants.TaskRunState.MERGED.isFinishState());
+        Assert.assertEquals(true, Constants.TaskRunState.SUCCESS.isFinishState());
+        Assert.assertEquals(false, Constants.TaskRunState.PENDING.isFinishState());
+        Assert.assertEquals(false, Constants.TaskRunState.RUNNING.isFinishState());
+        // whether it's a success state
+        Assert.assertEquals(false, Constants.TaskRunState.FAILED.isSuccessState());
+        Assert.assertEquals(true, Constants.TaskRunState.MERGED.isSuccessState());
+        Assert.assertEquals(true, Constants.TaskRunState.SUCCESS.isSuccessState());
+        Assert.assertEquals(false, Constants.TaskRunState.PENDING.isSuccessState());
+        Assert.assertEquals(false, Constants.TaskRunState.RUNNING.isSuccessState());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
- No check pending queue size in replay pending task run
## What I'm doing:
- Recheck pending queue size in replay pending task run
- Remove from pending queue directly if the pending task run is merged.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
