### PR TITLE
[Enhancement] support archive task run history

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -346,33 +346,28 @@ public class Config extends ConfigBase {
     @ConfField
     public static int label_clean_interval_second = 4 * 3600; // 4 hours
 
-    @ConfField(mutable = true, comment = "Internal of task background jobs")
+    /////////////////////////////////////////////////    Task   ///////////////////////////////////////////////////
+    @ConfField(mutable = true, comment = "Interval of task background jobs")
     public static int task_check_interval_second = 60; // 1 minute
 
-    /**
-     * for task set expire time
-     */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "task ttl")
     public static int task_ttl_second = 24 * 3600;         // 1 day
 
-    /**
-     * for task run set expire time
-     */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "task run ttl")
     public static int task_runs_ttl_second = 7 * 24 * 3600;     // 7 day
 
-    /**
-     * max history task num kept
-     */
-    @ConfField(mutable = true)
     @Deprecated
+    @ConfField(mutable = true, comment = "[DEPRECATED as enable_task_history_archive] max number of task run history. ")
     public static int task_runs_max_history_number = 10000;
 
     @ConfField(mutable = true, comment = "Minimum schedule interval of a task")
     public static int task_min_schedule_interval_s = 10;
 
-    @ConfField(mutable = true, comment = "Whether enable the task archive functionality")
-    public static boolean enable_task_archive = true;
+    @ConfField(mutable = true, comment = "Interval of TableKeeper daemon")
+    public static int table_keeper_interval_second = 30;
+
+    @ConfField(mutable = true, comment = "Whether enable the task history archive feature")
+    public static boolean enable_task_history_archive = true;
 
     /**
      * The max keep time of some kind of jobs.
@@ -380,9 +375,6 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int history_job_keep_max_second = 7 * 24 * 3600; // 7 days
-
-    @ConfField(mutable = true, comment = "Interval of TableKeeper daemon")
-    public static int table_keeper_interval_second = 30;
 
     /**
      * the transaction will be cleaned after transaction_clean_interval_second seconds if the transaction is visible or aborted

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -359,12 +359,13 @@ public class Config extends ConfigBase {
      * for task run set expire time
      */
     @ConfField(mutable = true)
-    public static int task_runs_ttl_second = 24 * 3600;     // 1 day
+    public static int task_runs_ttl_second = 7 * 24 * 3600;     // 7 day
 
     /**
      * max history task num kept
      */
     @ConfField(mutable = true)
+    @Deprecated
     public static int task_runs_max_history_number = 10000;
 
     @ConfField(mutable = true, comment = "Minimum schedule interval of a task")

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -346,12 +346,8 @@ public class Config extends ConfigBase {
     @ConfField
     public static int label_clean_interval_second = 4 * 3600; // 4 hours
 
-    /**
-     * For Task framework do some background operation like cleanup Task/TaskRun.
-     * It will run every *task_check_interval_second* to do background job.
-     */
-    @ConfField
-    public static int task_check_interval_second = 1 * 3600; // 1 hour
+    @ConfField(mutable = true, comment = "Internal of task background jobs")
+    public static int task_check_interval_second = 60; // 1 minute
 
     /**
      * for task set expire time
@@ -373,6 +369,9 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, comment = "Minimum schedule interval of a task")
     public static int task_min_schedule_interval_s = 10;
+
+    @ConfField(mutable = true, comment = "Whether enable the task archive functionality")
+    public static boolean enable_task_archive = true;
 
     /**
      * The max keep time of some kind of jobs.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -381,6 +381,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int history_job_keep_max_second = 7 * 24 * 3600; // 7 days
 
+    @ConfField(mutable = true, comment = "Interval of TableKeeper daemon")
+    public static int table_keeper_interval_second = 30;
+
     /**
      * the transaction will be cleaned after transaction_clean_interval_second seconds if the transaction is visible or aborted
      * we should make this interval as short as possible and each clean cycle as soon as possible

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -141,6 +141,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.mv.MVEpoch;
 import com.starrocks.scheduler.mv.MVMaintenanceJob;
+import com.starrocks.scheduler.persist.ArchiveTaskRunsLog;
 import com.starrocks.scheduler.persist.DropTaskRunsLog;
 import com.starrocks.scheduler.persist.DropTasksLog;
 import com.starrocks.scheduler.persist.TaskRunPeriodStatusChange;
@@ -785,6 +786,11 @@ public class JournalEntity implements Writable {
                 data = DropTaskRunsLog.read(in);
                 isRead = true;
                 break;
+            case OperationType.OP_ARCHIVE_TASK_RUNS: {
+                data = ArchiveTaskRunsLog.read(in);
+                isRead = true;
+                break;
+            }
             case OperationType.OP_CREATE_SMALL_FILE:
             case OperationType.OP_DROP_SMALL_FILE: {
                 data = SmallFile.read(in);

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
@@ -82,7 +82,6 @@ public class RepoExecutor {
         try {
             ConnectContext context = createConnectContext();
 
-            // TODO: use json sink protocol, instead of statistic protocol
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.HTTP_PROTOCAL);
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -573,6 +573,9 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_ALTER_TASK = 10085;
 
+    @IgnorableOnReplayFailed
+    public static final short OP_ARCHIVE_TASK_RUNS = 10086;
+
     // materialized view 10091 ~ 10100
     @IgnorableOnReplayFailed
     public static final short OP_RENAME_MATERIALIZED_VIEW = 10091;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -41,6 +41,7 @@ import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.scheduler.persist.TaskSchedule;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -642,10 +642,8 @@ public class TaskManager implements MemoryTrackable {
                 .forEach(taskRunList::add);
 
         // history task runs
-        List<TaskRunStatus> historyTaskRuns = taskRunManager.getTaskRunHistory().getAllHistory();
-        historyTaskRuns.stream()
-                .filter(t -> isTaskRunStatusMatched(t, params))
-                .forEach(taskRunList::add);
+        taskRunList.addAll(taskRunManager.getTaskRunHistory().lookupHistory(params));
+
         return taskRunList;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -668,9 +668,9 @@ public class TaskManager implements MemoryTrackable {
                 .forEach(task -> mvNameRunStatusMap.computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList()).add(task));
 
         // Add a batch of task runs with the same job id
-        taskRunManager.getTaskRunHistory().getAllHistory().stream()
-                .filter(u -> dbName == null || u.getDbName().equals(dbName))
-                .filter(task -> taskNames == null || taskNames.contains(task.getTaskName()))
+        // TODO: only lookup the first and last task in this job
+        taskRunManager.getTaskRunHistory().lookupHistoryByTaskNames(dbName, taskNames)
+                .stream()
                 .filter(task -> isSameTaskRunJob(task, mvNameRunStatusMap))
                 .forEach(task -> mvNameRunStatusMap
                         .computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList())

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -602,43 +602,20 @@ public class TaskManager implements MemoryTrackable {
         writer.close();
     }
 
-    private boolean isTaskRunStatusMatched(TaskRunStatus taskRunStatus, TGetTasksParams params) {
-        if (params == null) {
-            return true;
-        }
-        String dbName = params.db;
-        if (dbName != null && !dbName.equals(taskRunStatus.getDbName())) {
-            return false;
-        }
-        String taskName = params.task_name;
-        if (taskName != null && !taskName.equalsIgnoreCase(taskRunStatus.getTaskName())) {
-            return false;
-        }
-        String queryId = params.query_id;
-        if (queryId != null && !queryId.equalsIgnoreCase(taskRunStatus.getQueryId())) {
-            return false;
-        }
-        String state = params.state;
-        if (state != null && !state.equalsIgnoreCase(taskRunStatus.getState().name())) {
-            return false;
-        }
-        return true;
-    }
-
     public List<TaskRunStatus> getMatchedTaskRunStatus(TGetTasksParams params) {
         List<TaskRunStatus> taskRunList = Lists.newArrayList();
         // pending task runs
         List<TaskRun> pendingTaskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
         pendingTaskRuns.stream()
                 .map(TaskRun::getStatus)
-                .filter(t -> isTaskRunStatusMatched(t, params))
+                .filter(t -> t.match(params))
                 .forEach(taskRunList::add);
 
         // running task runs
         Set<TaskRun> runningTaskRuns = taskRunScheduler.getCopiedRunningTaskRuns();
         runningTaskRuns.stream()
                 .map(TaskRun::getStatus)
-                .filter(t -> isTaskRunStatusMatched(t, params))
+                .filter(t -> t.match(params))
                 .forEach(taskRunList::add);
 
         // history task runs

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -803,7 +803,7 @@ public class TaskManager implements MemoryTrackable {
 
     public void replayDropTaskRuns(List<String> queryIdList) {
         for (String queryId : ListUtils.emptyIfNull(queryIdList)) {
-            taskRunManager.getTaskRunHistory().removeTask(queryId);
+            taskRunManager.getTaskRunHistory().removeTaskByQueryId(queryId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -23,6 +23,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.QueryableReentrantLock;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -74,6 +74,13 @@ public class TableKeeper {
         }
     }
 
+    /**
+     * Is the table ready for insert
+     */
+    public synchronized boolean isReady() {
+        return databaseExisted && tableExisted;
+    }
+
     public boolean checkDatabaseExists() {
         return GlobalStateMgr.getCurrentState().getDb(databaseName) != null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -1,0 +1,187 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+/**
+ * Keeper:
+ * 1. Create the table for the history storage
+ * 2. Cleanup stale history
+ */
+public class TableKeeper {
+
+    private static final Logger LOG = LogManager.getLogger(TableKeeper.class);
+
+    private final String databaseName;
+    private final String tableName;
+    private final String createTableSql;
+    private final int tableReplicas;
+
+    private boolean databaseExisted = false;
+    private boolean tableExisted = false;
+    private boolean tableCorrected = false;
+
+    public TableKeeper(String database, String table, String createTable, int expectedReplicas) {
+        this.databaseName = database;
+        this.tableName = table;
+        this.createTableSql = createTable;
+        this.tableReplicas = expectedReplicas;
+    }
+
+    public synchronized void run() {
+        try {
+            if (!databaseExisted) {
+                databaseExisted = checkDatabaseExists();
+                if (!databaseExisted) {
+                    LOG.warn("database not exists: " + databaseName);
+                    return;
+                }
+            }
+            if (!tableExisted) {
+                createTable();
+                LOG.info("table created: " + tableName);
+                tableExisted = true;
+            }
+            if (!tableCorrected && correctTable()) {
+                LOG.info("table corrected: " + tableName);
+                tableCorrected = true;
+            }
+        } catch (Exception e) {
+            LOG.error("error happens in Keeper: {}", e.getMessage(), e);
+        }
+    }
+
+    public boolean checkDatabaseExists() {
+        return GlobalStateMgr.getCurrentState().getDb(databaseName) != null;
+    }
+
+    public void createTable() throws UserException {
+        RepoExecutor.getInstance().executeDDL(createTableSql);
+    }
+
+    public boolean correctTable() {
+        int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
+        int replica = GlobalStateMgr.getCurrentState()
+                .mayGetDb(databaseName)
+                .flatMap(db -> db.mayGetTable(tableName))
+                .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
+                .orElse((short) 1);
+        if (numBackends < tableReplicas) {
+            LOG.info("not enough backends in the cluster, expected {} but got {}",
+                    tableReplicas, numBackends);
+            return false;
+        }
+        if (replica < tableReplicas) {
+            String sql = alterTableReplicas();
+            RepoExecutor.getInstance().executeDDL(sql);
+        } else {
+            LOG.info("table {} already has {} replicas, no need to alter replication_num",
+                    tableName, replica);
+        }
+        return true;
+    }
+
+    private String alterTableReplicas() {
+        return String.format("ALTER TABLE %s.%s SET ('replication_num'='%d')",
+                databaseName, tableName, tableReplicas);
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getCreateTableSql() {
+        return createTableSql;
+    }
+
+    public int getTableReplicas() {
+        return tableReplicas;
+    }
+
+    public boolean isDatabaseExisted() {
+        return databaseExisted;
+    }
+
+    public boolean isTableExisted() {
+        return tableExisted;
+    }
+
+    public boolean isTableCorrected() {
+        return tableCorrected;
+    }
+
+    public void setDatabaseExisted(boolean databaseExisted) {
+        this.databaseExisted = databaseExisted;
+    }
+
+    public void setTableExisted(boolean tableExisted) {
+        this.tableExisted = tableExisted;
+    }
+
+    public void setTableCorrected(boolean tableCorrected) {
+        this.tableCorrected = tableCorrected;
+    }
+
+    public static TableKeeperDaemon startDaemon() {
+        return new TableKeeperDaemon();
+    }
+
+    /**
+     * The daemon thread running the TableKeeper
+     */
+    public static class TableKeeperDaemon extends FrontendDaemon {
+
+        private final List<TableKeeper> keeperList = Lists.newArrayList();
+
+        TableKeeperDaemon() {
+            super("TableKeeper", Config.table_keeper_interval_second * 1000L);
+
+            keeperList.add(TaskRunHistoryTable.createKeeper());
+            // TODO: add FileListPipeRepo
+            // TODO: add statistic table
+        }
+
+        @Override
+        protected void runAfterCatalogReady() {
+            if (!GlobalStateMgr.getCurrentState().isLeader()) {
+                return;
+            }
+            setInterval(Config.table_keeper_interval_second * 1000L);
+
+            for (TableKeeper keeper : keeperList) {
+                try {
+                    keeper.run();
+                } catch (Exception e) {
+                    LOG.warn("error in TableKeeper: ", e);
+                }
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -157,7 +157,9 @@ public class TableKeeper {
     }
 
     public static TableKeeperDaemon startDaemon() {
-        return new TableKeeperDaemon();
+        TableKeeperDaemon daemon = TableKeeperDaemon.getInstance();
+        daemon.start();
+        return daemon;
     }
 
     /**
@@ -165,6 +167,7 @@ public class TableKeeper {
      */
     public static class TableKeeperDaemon extends FrontendDaemon {
 
+        private static final TableKeeperDaemon INSTANCE = new TableKeeperDaemon();
         private final List<TableKeeper> keeperList = Lists.newArrayList();
 
         TableKeeperDaemon() {
@@ -173,6 +176,10 @@ public class TableKeeper {
             keeperList.add(TaskRunHistoryTable.createKeeper());
             // TODO: add FileListPipeRepo
             // TODO: add statistic table
+        }
+
+        public static TableKeeperDaemon getInstance() {
+            return INSTANCE;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -23,7 +23,6 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TGetTasksParams;
 import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,7 +79,11 @@ public class TaskRunHistory {
     }
 
     public List<TaskRunStatus> lookupHistoryByTaskNames(String dbName, Set<String> taskNames) {
-        throw new NotImplementedException("TOOD");
+        List<TaskRunStatus> inMemory = getInMemoryHistory().stream()
+                .filter(x -> x.matchByTaskName(dbName, taskNames))
+                .collect(Collectors.toList());
+
+        return ListUtils.union(inMemory, historyTable.lookupByTaskNames(dbName, taskNames));
     }
 
     public List<TaskRunStatus> lookupHistory(TGetTasksParams params) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -20,6 +20,7 @@ import com.starrocks.common.Config;
 import com.starrocks.scheduler.persist.ArchiveTaskRunsLog;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TGetTasksParams;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,10 +70,13 @@ public class TaskRunHistory {
 
     // Reserve historyTaskRunMap values to keep the last insert at the first.
     public List<TaskRunStatus> getAllHistory() {
-        List<TaskRunStatus> historyRunStatus =
-                new ArrayList<>(historyTaskRunMap.values());
+        List<TaskRunStatus> historyRunStatus = new ArrayList<>(historyTaskRunMap.values());
         Collections.reverse(historyRunStatus);
         return historyRunStatus;
+    }
+
+    public List<TaskRunStatus> lookupHistory(TGetTasksParams params) {
+        return historyTable.lookup(params);
     }
 
     // TODO: make it thread safe

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -125,7 +125,7 @@ public class TaskRunHistory {
     }
 
     private boolean isEnableArchiveHistory() {
-        return Config.enable_task_archive && !FeConstants.runningUnitTest;
+        return Config.enable_task_history_archive && !FeConstants.runningUnitTest;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -189,7 +189,7 @@ public class TaskRunHistory {
      * Keep only limited task runs to save memory usage
      */
     public void forceGC() {
-        if (!isEnableArchiveHistory()) {
+        if (isEnableArchiveHistory()) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -22,6 +22,7 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TGetTasksParams;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -30,6 +31,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TaskRunHistory {
@@ -73,6 +75,10 @@ public class TaskRunHistory {
         List<TaskRunStatus> historyRunStatus = new ArrayList<>(historyTaskRunMap.values());
         Collections.reverse(historyRunStatus);
         return historyRunStatus;
+    }
+
+    public List<TaskRunStatus> lookupHistoryByTaskNames(String dbName, Set<String> taskNames) {
+        throw new NotImplementedException("TOOD");
     }
 
     public List<TaskRunStatus> lookupHistory(TGetTasksParams params) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-package com.starrocks.scheduler;
+package com.starrocks.scheduler.history;
 
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -94,14 +94,14 @@ public class TaskRunHistoryTable {
     private static final String LOOKUP =
             "SELECT history_content_json " + "FROM " + TABLE_FULL_NAME + " WHERE ";
 
-    private static final TableKeeper keeper = new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE, TABLE_REPLICAS);
+    private static final TableKeeper KEEPER = new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE, TABLE_REPLICAS);
 
     public static TableKeeper createKeeper() {
-        return keeper;
+        return KEEPER;
     }
 
     private void checkTableReady() {
-        if (!FeConstants.runningUnitTest && !keeper.isReady()) {
+        if (!FeConstants.runningUnitTest && !KEEPER.isReady()) {
             throw new IllegalStateException("The table is not ready: " + TABLE_NAME);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -140,7 +140,6 @@ public class TaskRunHistoryTable {
             }).collect(Collectors.joining(", "));
 
             String sql = insert + values;
-            System.err.println(sql);
             RepoExecutor.getInstance().executeDML(sql);
         }
     }
@@ -177,7 +176,7 @@ public class TaskRunHistoryTable {
                     + Strings.quote(ClusterNamespace.getFullName(dbName)));
         }
         if (CollectionUtils.isNotEmpty(taskNames)) {
-            String values = taskNames.stream().map(Strings::quote).collect(Collectors.joining(","));
+            String values = taskNames.stream().sorted().map(Strings::quote).collect(Collectors.joining(","));
             predicates.add(" task_name IN (" + values + ")");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -138,7 +138,7 @@ public class TaskRunHistoryTable {
 
     public List<TaskRunStatus> lookup(TGetTasksParams params) {
         if (params == null) {
-            return null;
+            return Lists.newArrayList();
         }
         String sql = LOOKUP;
         List<String> predicates = Lists.newArrayList("TRUE");

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -146,6 +146,9 @@ public class TaskRunHistoryTable {
     }
 
     public List<TaskRunStatus> lookup(TGetTasksParams params) {
+        if (params == null) {
+            return null;
+        }
         String sql = LOOKUP;
         List<String> predicates = Lists.newArrayList("TRUE");
         if (StringUtils.isNotEmpty(params.getDb())) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -1,0 +1,149 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.thrift.TResultBatch;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.util.Strings;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.text.MessageFormat;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * History storage that leverage a regular starrocks table to store the data.
+ * By default, using the time-based garbage collection strategy, which keep 7days' history
+ */
+public class TaskRunHistoryTable {
+
+    public static final String DATABASE_NAME = StatsConstants.STATISTICS_DB_NAME;
+    public static final String TABLE_NAME = "task_run_history";
+    public static final String TABLE_FULL_NAME = DATABASE_NAME + "." + TABLE_NAME;
+    public static final int TABLE_REPLICAS = 3;
+    public static final String CREATE_TABLE =
+            String.format("CREATE TABLE IF NOT EXISTS %s (" +
+                    // identifiers
+                    "task_id bigint NOT NULL, " +
+                    "task_run_id string NOT NULL, " +
+                    "create_time datetime NOT NULL, " +
+                    "task_name string NOT NULL, " +
+
+                    // times
+                    "finish_time datetime NOT NULL, " +
+                    "expire_time datetime NOT NULL, " +
+
+                    // content in JSON format
+                    "history_content_json JSON NOT NULL" +
+                    ")" +
+
+                    // properties
+                    "PRIMARY KEY (task_id, task_run_id, create_time) " +
+                    "PARTITION BY RANGE(create_time)() " +
+                    "DISTRIBUTED BY HASH(task_id) BUCKETS 8 " +
+                    "PROPERTIES(" +
+                    "'replication_num' = '1'," +
+                    "'dynamic_partition.time_unit' = 'DAY', " +
+                    "'dynamic_partition.start' = '-7', " +
+                    "'dynamic_partition.end' = '3', " +
+                    "'dynamic_partition.prefix' = 'p' " +
+                    ") ", TABLE_FULL_NAME);
+
+    private static final String COLUMN_LIST = "task_id, task_run_id, task_name, " +
+            "create_time, finish_time, expire_time, " +
+            "history_content_json ";
+    private static final String INSERT_SQL_TEMPLATE = "INSERT INTO {0} " +
+            "(task_id, task_run_id, task_name, " +
+            "create_time, finish_time, expire_time, " +
+            "history_content_json) " +
+            "VALUES({1}, {2}, {3}, {4}, {5}, {6}, {7})";
+    private static final String SELECT_BY_TASK_NAME =
+            "SELECT history_content_json FROM " + TABLE_FULL_NAME + " WHERE task_name = {0}";
+    private static final String SELECT_ALL = "SELECT history_content_json FROM " + TABLE_FULL_NAME;
+    private static final String COUNT_TASK_RUNS = "SELECT count(*) as cnt FROM " + TABLE_FULL_NAME;
+
+    public static TableKeeper createKeeper() {
+        return new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE, TABLE_REPLICAS);
+    }
+
+    public void addHistory(TaskRunStatus status, boolean isReplay) {
+        if (isReplay) {
+            return;
+        }
+
+        String createTime =
+                Strings.quote(DateUtils.formatTimeStampInMill(status.getCreateTime(), ZoneId.systemDefault()));
+        String finishTime =
+                Strings.quote(DateUtils.formatTimeStampInMill(status.getFinishTime(), ZoneId.systemDefault()));
+        String expireTime =
+                Strings.quote(DateUtils.formatTimeStampInMill(status.getExpireTime(), ZoneId.systemDefault()));
+
+        final String sql = MessageFormat.format(INSERT_SQL_TEMPLATE, TABLE_FULL_NAME,
+                String.valueOf(status.getTaskId()), Strings.quote(status.getStartTaskRunId()),
+                Strings.quote(status.getTaskName()),
+                createTime, finishTime, expireTime, Strings.quote(status.toJSON()));
+        RepoExecutor.getInstance().executeDML(sql);
+    }
+
+    public List<TaskRunStatus> getTaskByName(String taskName) {
+        final String sql = MessageFormat.format(SELECT_BY_TASK_NAME, Strings.quote(taskName));
+        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        return TaskRunStatus.fromResultBatch(batch);
+    }
+
+    public void replayTaskRunChange(String queryId, TaskRunStatusChange change) {
+    }
+
+    public void gc() {
+        // TableBasedHistory could do the gc by itself
+    }
+
+    public void forceGC() {
+        // TODO
+    }
+
+    // TODO: don't return all history, which is very expensive
+    public List<TaskRunStatus> getAllHistory() {
+        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(SELECT_ALL);
+        return TaskRunStatus.fromResultBatch(batch);
+    }
+
+    public long getTaskRunCount() {
+        List<TResultBatch> batches = RepoExecutor.getInstance().executeDQL(COUNT_TASK_RUNS);
+        if (CollectionUtils.isNotEmpty(batches)) {
+            try {
+                ByteBuffer buffer = batches.get(0).getRows().get(0);
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                JsonArray obj = (JsonArray) JsonParser.parseString(jsonString);
+                return obj.get(0).getAsInt();
+            } catch (Exception e) {
+                throw new IllegalStateException("failed to parse json result: " + batches);
+            }
+        }
+        return 0;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -55,7 +55,7 @@ public class TaskRunHistoryTable {
                     "task_run_id string NOT NULL, " +
                     "create_time datetime NOT NULL, " +
 
-                            // indexed columns
+                    // indexed columns
                     "task_name string NOT NULL, " +
                             "task_state STRING NOT NULL, " +
 
@@ -69,7 +69,7 @@ public class TaskRunHistoryTable {
 
                     // properties
                     "PRIMARY KEY (task_id, task_run_id, create_time) " +
-                            "PARTITION BY date_trunc('DAY', create_time) " +
+                    "PARTITION BY date_trunc('DAY', create_time) " +
                     "DISTRIBUTED BY HASH(task_id) BUCKETS 8 " +
                             "PROPERTIES( " +
                             "'replication_num' = '1', " +

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/ArchiveTaskRunsLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/ArchiveTaskRunsLog.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+
+public class ArchiveTaskRunsLog implements Writable {
+
+    @SerializedName("taskRuns")
+    private List<String> taskRuns;
+
+    public ArchiveTaskRunsLog(List<String> taskRuns) {
+        this.taskRuns = taskRuns;
+    }
+
+    public List<String> getTaskRuns() {
+        return taskRuns;
+    }
+
+    public static ArchiveTaskRunsLog read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), ArchiveTaskRunsLog.class);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -24,11 +24,19 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TResultBatch;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.ListUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class TaskRunStatus implements Writable {
@@ -407,5 +415,38 @@ public class TaskRunStatus implements Writable {
                 ", mergeRedundant=" + mergeRedundant +
                 ", extraMessage=" + getExtraMessage() +
                 '}';
+    }
+
+    public String toJSON() {
+        return GsonUtils.GSON.toJson(this);
+    }
+
+    public static TaskRunStatus fromJson(String json) {
+        return GsonUtils.GSON.fromJson(json, TaskRunStatus.class);
+    }
+
+    static class TaskRunStatusJSONRecord {
+        /**
+         * Only one item in the array, like:
+         * { data: [ {TaskRunStatus} ] }
+         */
+        @SerializedName("data")
+        public List<TaskRunStatus> data;
+
+        public static TaskRunStatusJSONRecord fromJson(String json) {
+            return GsonUtils.GSON.fromJson(json, TaskRunStatusJSONRecord.class);
+        }
+    }
+
+    public static List<TaskRunStatus> fromResultBatch(List<TResultBatch> batches) {
+        List<TaskRunStatus> res = new ArrayList<>();
+        for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                res.addAll(ListUtils.emptyIfNull(TaskRunStatusJSONRecord.fromJson(jsonString).data));
+            }
+        }
+        return res;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -24,6 +24,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -381,6 +382,30 @@ public class TaskRunStatus implements Writable {
             return 0L;
         }
     }
+
+    public boolean match(TGetTasksParams params) {
+        if (params == null) {
+            return true;
+        }
+        String dbName = params.db;
+        if (dbName != null && !dbName.equals(getDbName())) {
+            return false;
+        }
+        String taskName = params.task_name;
+        if (taskName != null && !taskName.equalsIgnoreCase(getTaskName())) {
+            return false;
+        }
+        String queryId = params.query_id;
+        if (queryId != null && !queryId.equalsIgnoreCase(getQueryId())) {
+            return false;
+        }
+        String state = params.state;
+        if (state != null && !state.equalsIgnoreCase(getState().name())) {
+            return false;
+        }
+        return true;
+    }
+
 
     public static TaskRunStatus read(DataInput in) throws IOException {
         String json = Text.readString(in);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -29,6 +29,7 @@ import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 
 import java.io.DataInput;
@@ -39,6 +40,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TaskRunStatus implements Writable {
 
@@ -381,6 +383,16 @@ public class TaskRunStatus implements Writable {
         } else {
             return 0L;
         }
+    }
+
+    public boolean matchByTaskName(String dbName, Set<String> taskNames) {
+        if (dbName != null && !dbName.equals(getDbName())) {
+            return false;
+        }
+        if (CollectionUtils.isNotEmpty(taskNames) && !taskNames.contains(getTaskName())) {
+            return false;
+        }
+        return true;
     }
 
     public boolean match(TGetTasksParams params) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -450,6 +450,9 @@ public class TaskRunStatus implements Writable {
         return GsonUtils.GSON.fromJson(json, TaskRunStatus.class);
     }
 
+    /**
+     * Only used for deserialization of ResultBatch
+     */
     static class TaskRunStatusJSONRecord {
         /**
          * Only one item in the array, like:

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1675,6 +1675,7 @@ public class GlobalStateMgr {
             @Override
             protected void runAfterCatalogReady() {
                 doTaskBackgroundJob();
+                setInterval(Config.task_check_interval_second * 1000L);
             }
         };
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -189,6 +189,7 @@ import com.starrocks.replication.ReplicationMgr;
 import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.scheduler.MVActiveChecker;
 import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.scheduler.mv.MVJobExecutor;
 import com.starrocks.scheduler.mv.MaterializedViewMgr;
 import com.starrocks.sql.analyzer.Analyzer;
@@ -302,6 +303,7 @@ public class GlobalStateMgr {
     private FrontendDaemon labelCleaner; // To clean old LabelInfo, ExportJobInfos
     private FrontendDaemon txnTimeoutChecker; // To abort timeout txns
     private FrontendDaemon taskCleaner;   // To clean expire Task/TaskRun
+    private FrontendDaemon tableKeeper;   // Maintain internal history tables
     private JournalWriter journalWriter; // leader only: write journal log
     private Daemon replayer;
     private Daemon timePrinter;
@@ -1087,6 +1089,7 @@ public class GlobalStateMgr {
 
             // 6. start task cleaner thread
             createTaskCleaner();
+            createTableKeeper();
 
             // 7. init starosAgent
             if (RunMode.isSharedDataMode() && !starOSAgent.init(null)) {
@@ -1674,6 +1677,10 @@ public class GlobalStateMgr {
                 doTaskBackgroundJob();
             }
         };
+    }
+
+    public void createTableKeeper() {
+        tableKeeper = TableKeeper.startDaemon();
     }
 
     public void createTxnTimeoutChecker() {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -855,7 +855,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         TaskManager taskManager = globalStateMgr.getTaskManager();
-        List<TaskRunStatus> taskRunList = taskManager.getMatchedTaskRunStatus(null);
+        List<TaskRunStatus> taskRunList = taskManager.getMatchedTaskRunStatus(params);
 
         for (TaskRunStatus status : taskRunList) {
             if (status.getDbName() == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -434,8 +434,6 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(materializedView.isActive());
             // test sync
             testFullCreateSync(materializedView, baseTable);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
         } finally {
             dropMv("mv1");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -68,6 +68,7 @@ import com.starrocks.catalog.system.information.MaterializedViewsSystemTable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -130,6 +131,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -160,6 +162,11 @@ public class ShowExecutorTest {
 
     @Mocked
     MetadataMgr metadataMgr;
+
+    @BeforeClass
+    public static void beforeClass() {
+        FeConstants.runningUnitTest = true;
+    }
 
     @Before
     public void setUp() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -500,7 +500,7 @@ public class TaskManagerTest {
         }
         Config.task_runs_max_history_number = 20;
         taskRunManager.getTaskRunHistory().forceGC();
-        Assert.assertEquals(20, taskRunManager.getTaskRunHistory().getAllHistory().size());
+        Assert.assertEquals(20, taskRunManager.getTaskRunHistory().getInMemoryHistory().size());
         Config.task_runs_max_history_number = 10000;
     }
 
@@ -515,7 +515,7 @@ public class TaskManagerTest {
         }
         Config.task_runs_max_history_number = 20;
         taskRunManager.getTaskRunHistory().forceGC();
-        Assert.assertEquals(10, taskRunManager.getTaskRunHistory().getAllHistory().size());
+        Assert.assertEquals(10, taskRunManager.getTaskRunHistory().getInMemoryHistory().size());
         Config.task_runs_max_history_number = 10000;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -491,6 +491,7 @@ public class TaskManagerTest {
 
     @Test
     public void testForceGC() {
+        Config.enable_task_history_archive = false;
         TaskRunManager taskRunManager = new TaskRunManager();
         for (int i = 0; i < 100; i++) {
             TaskRunStatus taskRunStatus = new TaskRunStatus();
@@ -502,6 +503,7 @@ public class TaskManagerTest {
         taskRunManager.getTaskRunHistory().forceGC();
         Assert.assertEquals(20, taskRunManager.getTaskRunHistory().getInMemoryHistory().size());
         Config.task_runs_max_history_number = 10000;
+        Config.enable_task_history_archive = true;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -79,7 +79,7 @@ class TableBasedTaskRunHistoryTest {
         TaskRunStatus status = new TaskRunStatus();
         status.setStartTaskRunId("aaa");
         status.setTaskName("t1");
-        history.addHistory(status, false);
+        history.addHistory(status);
 
         // getTaskByName
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -1,0 +1,162 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TResultBatch;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TableBasedTaskRunHistoryTest {
+
+    @BeforeAll
+    public static void beforeAll() {
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Test
+    public void testTaskRunStatusSerialization() {
+        TaskRunStatus status = new TaskRunStatus();
+        String json = status.toJSON();
+        assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
+                        "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\"," +
+                        "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
+                        "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{},\"executeOption\":" +
+                        "{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}" +
+                        ",\"useTableBasedHistory\":false}",
+                json);
+
+        TaskRunStatus b = TaskRunStatus.fromJson(json);
+        assertEquals(status.toJSON(), b.toJSON());
+    }
+
+    @Test
+    public void testCRUD(@Mocked RepoExecutor repo) {
+        new Expectations() {
+            {
+                repo.executeDML(("INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, " +
+                        "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'aaa', 't1', " +
+                        "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', '{\"startTaskRunId\":" +
+                        "\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0,\"expireTime\":0,\"priority\":0," +
+                        "\"mergeRedundant\":false,\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0," +
+                        "\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":" +
+                        "{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
+                        "\"basePartitionsToRefreshMap\":{},\"executeOption\":{\"priority\":0,\"isMergeRedundant\":" +
+                        "false,\"isManual\":false,\"isSync\":false,\"isReplay\":false}},\"useTableBasedHistory\":" +
+                        "false}')"));
+            }
+        };
+
+        TaskRunHistoryTable history = new TaskRunHistoryTable();
+        TaskRunStatus status = new TaskRunStatus();
+        status.setStartTaskRunId("aaa");
+        status.setTaskName("t1");
+        history.addHistory(status, false);
+
+        // getTaskByName
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json " +
+                        "FROM _statistics_.task_run_history WHERE task_name = 't1'");
+            }
+        };
+        history.getTaskByName("t1");
+
+        // getAllHistory
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history");
+            }
+        };
+        history.getAllHistory();
+
+        // getTaskRunCount
+        TResultBatch batch = new TResultBatch();
+        batch.setRows(Lists.newArrayList(ByteBuffer.wrap("[123]".getBytes())));
+        List<TResultBatch> resultBatch = Lists.newArrayList(batch);
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT count(*) as cnt FROM _statistics_.task_run_history");
+                result = resultBatch;
+            }
+        };
+        assertEquals(123, history.getTaskRunCount());
+    }
+
+    @Test
+    public void testKeeper(@Mocked RepoExecutor repo) {
+        TableKeeper keeper = TaskRunHistoryTable.createKeeper();
+        assertEquals(StatsConstants.STATISTICS_DB_NAME, keeper.getDatabaseName());
+        assertEquals(TaskRunHistoryTable.TABLE_NAME, keeper.getTableName());
+        assertEquals(TaskRunHistoryTable.CREATE_TABLE, keeper.getCreateTableSql());
+        assertEquals(TaskRunHistoryTable.TABLE_REPLICAS, keeper.getTableReplicas());
+
+        // database not exists
+        new Expectations() {
+            {
+                keeper.checkDatabaseExists();
+                result = false;
+            }
+        };
+        keeper.run();
+        assertFalse(keeper.isDatabaseExisted());
+
+        // create table
+        keeper.setDatabaseExisted(true);
+        new Expectations() {
+            {
+                repo.executeDDL(
+                        "CREATE TABLE IF NOT EXISTS _statistics_.task_run_history (task_id bigint NOT NULL, " +
+                                "task_run_id string NOT NULL, create_time datetime NOT NULL, task_name string NOT NULL, " +
+                                "finish_time datetime NOT NULL, expire_time datetime NOT NULL, " +
+                                "history_content_json JSON NOT NULL)PRIMARY KEY (task_id, task_run_id, create_time) " +
+                                "PARTITION BY RANGE(create_time)() DISTRIBUTED BY HASH(task_id) BUCKETS 8 " +
+                                "PROPERTIES('replication_num' = '1','dynamic_partition.time_unit' = 'DAY', " +
+                                "'dynamic_partition.start' = '-7', 'dynamic_partition.end' = '3', " +
+                                "'dynamic_partition.prefix' = 'p' ) ");
+            }
+        };
+        keeper.run();
+        assertTrue(keeper.isTableExisted());
+        assertFalse(keeper.isTableCorrected());
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public int getTotalBackendNumber() {
+                return 3;
+            }
+        };
+        // correct table replicas
+        keeper.run();
+        assertTrue(keeper.isTableCorrected());
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -48,12 +48,11 @@ public class TaskRunHistoryTest {
         TaskRunStatus status = new TaskRunStatus();
         String json = status.toJSON();
         assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
-                        "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0," +
-                        "\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false," +
-                        "\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
-                        "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0,\"executeOption\":{\"priority\":0," +
-                        "\"isMergeRedundant\":true,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}",
-                json);
+                "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0," +
+                "\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false," +
+                "\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
+                "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0,\"executeOption\":{\"priority\":0," +
+                "\"isMergeRedundant\":true,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}", json);
 
         TaskRunStatus b = TaskRunStatus.fromJson(json);
         assertEquals(status.toJSON(), b.toJSON());
@@ -169,15 +168,13 @@ public class TaskRunHistoryTest {
         keeper.setDatabaseExisted(true);
         new Expectations() {
             {
-                repo.executeDDL(
-                        "CREATE TABLE IF NOT EXISTS _statistics_.task_run_history (task_id bigint NOT NULL, " +
-                                "task_run_id string NOT NULL, create_time datetime NOT NULL, " +
-                                "task_name string NOT NULL, task_state STRING NOT NULL, finish_time datetime NOT NULL, " +
-                                "expire_time datetime NOT NULL, history_content_json JSON NOT NULL)PRIMARY KEY " +
-                                "(task_id, task_run_id, create_time) PARTITION BY date_trunc('DAY', create_time) " +
-                                "DISTRIBUTED BY HASH(task_id) BUCKETS 8 PROPERTIES( 'replication_num' = '1', " +
-                                "'partition_live_number' = '7')"
-                );
+                repo.executeDDL("CREATE TABLE IF NOT EXISTS _statistics_.task_run_history (task_id bigint NOT NULL, " +
+                        "task_run_id string NOT NULL, create_time datetime NOT NULL, " +
+                        "task_name string NOT NULL, task_state STRING NOT NULL, finish_time datetime NOT NULL, " +
+                        "expire_time datetime NOT NULL, history_content_json JSON NOT NULL)PRIMARY KEY " +
+                        "(task_id, task_run_id, create_time) PARTITION BY date_trunc('DAY', create_time) " +
+                        "DISTRIBUTED BY HASH(task_id) BUCKETS 8 PROPERTIES( 'replication_num' = '1', " +
+                        "'partition_live_number' = '7')");
             }
         };
         keeper.run();
@@ -226,7 +223,17 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDML(
-                        "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, task_state, create_time, finish_time, expire_time, history_content_json) VALUES(0, 'null', 't2', 'SUCCESS', '1970-01-01 08:00:00', '1970-01-01 08:00:00', '2024-07-05 15:38:00', '{\"queryId\":\"q2\",\"taskId\":0,\"taskName\":\"t2\",\"createTime\":0,\"expireTime\":1720165080904,\"priority\":0,\"mergeRedundant\":false,\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"SUCCESS\",\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{},\"processStartTime\":0,\"executeOption\":{\"priority\":0,\"isMergeRedundant\":true,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}')");
+                        "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, task_state, " +
+                                "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'null', 't2'," +
+                                " 'SUCCESS', '1970-01-01 08:00:00', '1970-01-01 08:00:00', '2024-07-05 15:38:00', " +
+                                "'{\"queryId\":\"q2\",\"taskId\":0,\"taskName\":\"t2\",\"createTime\":0," +
+                                "\"expireTime\":1720165080904,\"priority\":0,\"mergeRedundant\":false," +
+                                "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0," +
+                                "\"state\":\"SUCCESS\",\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false," +
+                                "\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
+                                "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0," +
+                                "\"executeOption\":{\"priority\":0,\"isMergeRedundant\":true,\"isManual\":false," +
+                                "\"isSync\":false,\"isReplay\":false}}}')");
 
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.scheduler.history;
 
 import com.google.common.collect.Lists;
-import com.starrocks.common.FeConstants;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.statistic.StatsConstants;
@@ -25,7 +24,6 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -36,11 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaskRunHistoryTest {
-
-    @BeforeAll
-    public static void beforeAll() {
-        FeConstants.runningUnitTest = true;
-    }
 
     @Test
     public void testTaskRunStatusSerialization() {
@@ -135,13 +128,13 @@ class TaskRunHistoryTest {
             {
                 repo.executeDDL(
                         "CREATE TABLE IF NOT EXISTS _statistics_.task_run_history (task_id bigint NOT NULL, " +
-                                "task_run_id string NOT NULL, create_time datetime NOT NULL, task_name string NOT NULL, " +
-                                "finish_time datetime NOT NULL, expire_time datetime NOT NULL, " +
-                                "history_content_json JSON NOT NULL)PRIMARY KEY (task_id, task_run_id, create_time) " +
-                                "PARTITION BY RANGE(create_time)() DISTRIBUTED BY HASH(task_id) BUCKETS 8 " +
-                                "PROPERTIES('replication_num' = '1','dynamic_partition.time_unit' = 'DAY', " +
-                                "'dynamic_partition.start' = '-7', 'dynamic_partition.end' = '3', " +
-                                "'dynamic_partition.prefix' = 'p' ) ");
+                                "task_run_id string NOT NULL, create_time datetime NOT NULL, " +
+                                "task_name string NOT NULL, finish_time datetime NOT NULL, " +
+                                "expire_time datetime NOT NULL, history_content_json JSON NOT NULL)PRIMARY KEY " +
+                                "(task_id, task_run_id, create_time) PARTITION BY date_trunc('DAY', create_time) " +
+                                "DISTRIBUTED BY HASH(task_id) BUCKETS 8 PROPERTIES( 'replication_num' = '1', " +
+                                "'partition_live_number' = '7')"
+                );
             }
         };
         keeper.run();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -291,7 +291,7 @@ public class TaskRunHistoryTest {
 
     @Test
     public void testDisableArchiveHistory() {
-        Config.enable_task_archive = false;
+        Config.enable_task_history_archive = false;
         TaskRunHistory history = new TaskRunHistory();
 
         // prepare
@@ -314,6 +314,6 @@ public class TaskRunHistoryTest {
         history.vacuum();
         Assert.assertEquals(0, history.getInMemoryHistory().size());
 
-        Config.enable_task_archive = true;
+        Config.enable_task_history_archive = true;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class TableBasedTaskRunHistoryTest {
+class TaskRunHistoryTest {
 
     @BeforeAll
     public static void beforeAll() {
@@ -47,11 +47,11 @@ class TableBasedTaskRunHistoryTest {
         TaskRunStatus status = new TaskRunStatus();
         String json = status.toJSON();
         assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
-                        "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\"," +
-                        "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
-                        "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{},\"executeOption\":" +
-                        "{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}" +
-                        ",\"useTableBasedHistory\":false}",
+                        "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0," +
+                        "\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false," +
+                        "\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
+                        "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0,\"executeOption\":{\"priority\":0," +
+                        "\"isMergeRedundant\":true,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}",
                 json);
 
         TaskRunStatus b = TaskRunStatus.fromJson(json);
@@ -62,16 +62,16 @@ class TableBasedTaskRunHistoryTest {
     public void testCRUD(@Mocked RepoExecutor repo) {
         new Expectations() {
             {
-                repo.executeDML(("INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, " +
+                repo.executeDML("INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, " +
                         "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'aaa', 't1', " +
-                        "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', '{\"startTaskRunId\":" +
-                        "\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0,\"expireTime\":0,\"priority\":0," +
-                        "\"mergeRedundant\":false,\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0," +
-                        "\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":" +
-                        "{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
-                        "\"basePartitionsToRefreshMap\":{},\"executeOption\":{\"priority\":0,\"isMergeRedundant\":" +
-                        "false,\"isManual\":false,\"isSync\":false,\"isReplay\":false}},\"useTableBasedHistory\":" +
-                        "false}')"));
+                        "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
+                        "'{\"startTaskRunId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
+                        "\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false,\"source\":\"CTAS\"," +
+                        "\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\"," +
+                        "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
+                        "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{}," +
+                        "\"processStartTime\":0,\"executeOption\":{\"priority\":0,\"isMergeRedundant\":true," +
+                        "\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}')");
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -42,6 +42,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.proc.ReplicasProcNode;
 import com.starrocks.common.util.KafkaUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -137,6 +138,7 @@ public class PrivilegeCheckerTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
         UtFrameUtils.createMinStarRocksCluster();
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);
@@ -178,6 +180,7 @@ public class PrivilegeCheckerTest {
         authorizationManager.initBuiltinRolesAndUsers();
         ctxToRoot();
         createUsers();
+        //        FeConstants.runningUnitTest = true;
     }
 
     private static void createMvForTest(ConnectContext connectContext) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -180,7 +180,6 @@ public class PrivilegeCheckerTest {
         authorizationManager.initBuiltinRolesAndUsers();
         ctxToRoot();
         createUsers();
-        //        FeConstants.runningUnitTest = true;
     }
 
     private static void createMvForTest(ConnectContext connectContext) throws Exception {


### PR DESCRIPTION
## Why I'm doing:
- In-memory storage of TaskRunHistory is not cost-efficient, even caused memory issue in some cases


## What I'm doing:

- Implement the archive history:
  - Use an OlapTable to store the finished tasks, and lookup this table for retrieval 
  - Use the memory & editlog as primary storage, and this history table as secondary storage, to guarantee the compatibility and insert performance


Configuration:
- add config `enable_task_history_archive`: whether enable the feature. if not it would be compatible with previous 
- deprecate config `task_runs_max_history_number`: no need to use this limitation


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
