### PR TITLE
[BugFix] Fix the bug of get min/max string stats for string type in DeltaLake catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeAddFileStatsSerDe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeAddFileStatsSerDe.java
@@ -18,10 +18,34 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Map;
 
-public class DeltaLakeStats {
+// This class is used to deserialize AddFileStats in metadata. Example:
+// "stats":
+//      "{
+//          \"numRecords\":1,
+//          \"minValues\":
+//          {
+//              \"c1\":1,
+//              \"c2\":11,
+//              \"c3\":\"111\"
+//          },
+//          \"maxValues\":
+//          {
+//              \"c1\":1,
+//              \"c2\":11,
+//              \"c3\":\"111\"
+//          },
+//          \"nullCount\":
+//          {
+//              \"c1\":0,
+//              \"c2\":0,
+//              \"c3\":0
+//          }
+//       }"
+public class DeltaLakeAddFileStatsSerDe {
     @SerializedName(value = "numRecords")
     public long numRecords;
 
+    // The key of map is column name
     @SerializedName(value = "minValues")
     public Map<String, Object> minValues;
 
@@ -31,8 +55,8 @@ public class DeltaLakeStats {
     @SerializedName(value = "nullCount")
     public Map<String, Object> nullCount;
 
-    public DeltaLakeStats(long numRecords, Map<String, Object> minValues, Map<String, Object> maxValues,
-                          Map<String, Object> nullCount) {
+    public DeltaLakeAddFileStatsSerDe(long numRecords, Map<String, Object> minValues,
+                                      Map<String, Object> maxValues, Map<String, Object> nullCount) {
         this.numRecords = numRecords;
         this.minValues = minValues;
         this.maxValues = maxValues;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -38,6 +38,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,9 +76,9 @@ public class DeltaLakeFileStats {
             this.corruptedStats = null;
             this.hasValidColumnMetrics = false;
         } else {
-            this.minValues = fileStat.minValues;
-            this.maxValues = fileStat.maxValues;
-            this.nullCounts = fileStat.nullCount;
+            this.minValues = new HashMap<>(fileStat.minValues);
+            this.maxValues = new HashMap<>(fileStat.maxValues);
+            this.nullCounts = new HashMap<>(fileStat.nullCount);
             this.corruptedStats = nonPartitionPrimitiveColumns.stream()
                     .filter(col -> !minValues.containsKey(col) &&
                             (!nullCounts.containsKey(col) || ((Double) nullCounts.get(col)).longValue() != recordCount))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -63,7 +63,7 @@ public class DeltaLakeFileStats {
     private boolean hasValidColumnMetrics;
 
     public DeltaLakeFileStats(StructType schema, List<String> nonPartitionPrimitiveColumns,
-                              DeltaLakeStats fileStat, long fileSize) {
+                              DeltaLakeAddFileStatsSerDe fileStat, long fileSize) {
         this.schema = schema;
         this.nonPartitionPrimitiveColumns = nonPartitionPrimitiveColumns;
         this.recordCount = fileStat.numRecords;
@@ -155,7 +155,7 @@ public class DeltaLakeFileStats {
         return builder.build();
     }
 
-    public void update(DeltaLakeStats stat, long fileSize) {
+    public void update(DeltaLakeAddFileStatsSerDe stat, long fileSize) {
         this.recordCount += stat.numRecords;
         this.size += fileSize;
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -108,10 +108,10 @@ public class DeltaLakeFileStats {
         Type colType = col.getType();
 
         // set default value
-        builder.setType(ColumnStatistic.StatisticType.UNKNOWN);
+        builder.setNullsFraction(0);
         builder.setAverageRowSize(colType.getTypeSize());
         builder.setDistinctValuesCount(1);
-        builder.setNullsFraction(0);
+        builder.setType(ColumnStatistic.StatisticType.UNKNOWN);
 
         if (schema == null) {
             return builder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeStats.java
@@ -31,7 +31,11 @@ public class DeltaLakeStats {
     @SerializedName(value = "nullCount")
     public Map<String, Object> nullCount;
 
-    public DeltaLakeStats(long numRecords) {
+    public DeltaLakeStats(long numRecords, Map<String, Object> minValues, Map<String, Object> maxValues,
+                          Map<String, Object> nullCount) {
         this.numRecords = numRecords;
+        this.minValues = minValues;
+        this.maxValues = maxValues;
+        this.nullCount = nullCount;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -62,7 +62,7 @@ public class DeltaStatisticProvider {
                                 List<String> nonPartitionPrimitiveColumn) {
         StructType schema = table.getDeltaMetadata().getSchema();
 
-        DeltaLakeStats fileStat = file.getStats();
+        DeltaLakeAddFileStatsSerDe fileStat = file.getStats();
 
         DeltaLakeFileStats fileStats;
         if (deltaLakeFileStatsMap.containsKey(key)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -24,14 +24,14 @@ public class FileScanTask {
     private final FileStatus fileStatus;
     private final long records;
     private final Map<String, String> partitionValues;
-    private final DeltaLakeStats stats;
+    private final DeltaLakeAddFileStatsSerDe stats;
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues) {
         this(fileStatus, records, partitionValues, null);
     }
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues,
-                        DeltaLakeStats stats) {
+                        DeltaLakeAddFileStatsSerDe stats) {
         this.fileStatus = fileStatus;
         this.records = records;
         this.partitionValues = partitionValues;
@@ -42,7 +42,7 @@ public class FileScanTask {
         return this.fileStatus;
     }
 
-    public DeltaLakeStats getStats() {
+    public DeltaLakeAddFileStatsSerDe getStats() {
         return this.stats;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -45,13 +45,13 @@ public class ScanFileUtils {
         return records.numRecords;
     }
 
-    public static DeltaLakeStats getColumnStatistics(Row file) {
+    public static DeltaLakeAddFileStatsSerDe getColumnStatistics(Row file) {
         String stats = file.getString(ADD_FILE_STATS_ORDINAL);
         if (stats == null) {
             throw new IllegalArgumentException("There is no `stats` entry in the add file row");
         }
 
-        DeltaLakeStats statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeStats.class);
+        DeltaLakeAddFileStatsSerDe statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeAddFileStatsSerDe.class);
         if (statistics == null) {
             throw new IllegalArgumentException("There is no entry in the stats row");
         }
@@ -73,7 +73,7 @@ public class ScanFileUtils {
 
         FileScanTask fileScanTask;
         if (needStats) {
-            DeltaLakeStats stats = ScanFileUtils.getColumnStatistics(addFileRow);
+            DeltaLakeAddFileStatsSerDe stats = ScanFileUtils.getColumnStatistics(addFileRow);
             fileScanTask = new FileScanTask(fileStatus, stats.numRecords, partitionValues, stats);
         } else {
             long records = ScanFileUtils.getFileRows(addFileRow);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
@@ -1,0 +1,166 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DeltaLakeFileStatsTest {
+    private StructType schema;
+
+    private static void checkColumnStatisticsEqual(ColumnStatistic left, ColumnStatistic right) {
+        Assert.assertEquals(left.toString(), right.toString());
+        Assert.assertEquals(left.getMinString(), right.getMinString());
+        Assert.assertEquals(left.getMaxString(), right.getMaxString());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        schema = new StructType()
+                .add("c_int", IntegerType.INTEGER)
+                .add("c_char", StringType.STRING)
+                .add("c_string", StringType.STRING);
+    }
+
+    @Test
+    public void testGetMinMaxString() {
+        Map<String, Object> minValues = new HashMap<>() {
+            {
+                put("c_char", "char_111");
+                put("c_string", "string_111");
+            }
+        };
+
+        Map<String, Object> maxValues = new HashMap<>() {
+            {
+                put("c_char", "char_999");
+                put("c_string", "string_999");
+            }
+        };
+
+        Map<String, Object> nullCounts = new HashMap<>() {
+            {
+                put("c_char", 0d);
+                put("c_string", 0d);
+            }
+        };
+
+        List<String> nonPartitionPrimitiveColumns = new ArrayList<>() {
+            {
+                add("c_int");
+                add("c_char");
+                add("c_string");
+            }
+        };
+
+        DeltaLakeStats stat = new DeltaLakeStats(10, minValues, maxValues, nullCounts);
+        DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat, 4096);
+
+        ColumnStatistic columnStatistic = stats.fillColumnStats(new Column("c_char", Type.CHAR));
+        ColumnStatistic checkStatistic = new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                0, 16, 1, null, ColumnStatistic.StatisticType.UNKNOWN);
+        checkStatistic.setMinString("char_111");
+        checkStatistic.setMaxString("char_999");
+        checkColumnStatisticsEqual(checkStatistic, columnStatistic);
+
+        columnStatistic = stats.fillColumnStats(new Column("c_string", Type.STRING));
+        checkStatistic = new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                0, 16, 1, null, ColumnStatistic.StatisticType.UNKNOWN);
+        checkStatistic.setMinString("string_111");
+        checkStatistic.setMaxString("string_999");
+        checkColumnStatisticsEqual(checkStatistic, columnStatistic);
+    }
+
+    @Test
+    public void testUpdateStringStats() {
+        Map<String, Object> minValues1 = new HashMap<>() {
+            {
+                put("c_string", "string_111");
+            }
+        };
+        Map<String, Object> minValues2 = new HashMap<>() {
+            {
+                put("c_string", "string_000");
+            }
+        };
+        Map<String, Object> minValues3 = new HashMap<>() {
+            {
+                put("c_string", "string_222");
+            }
+        };
+
+        Map<String, Object> maxValues1 = new HashMap<>() {
+            {
+                put("c_string", "string_555");
+            }
+        };
+        Map<String, Object> maxValues2 = new HashMap<>() {
+            {
+                put("c_string", "string_444");
+            }
+        };
+        Map<String, Object> maxValues3 = new HashMap<>() {
+            {
+                put("c_string", "string_666");
+            }
+        };
+
+        Map<String, Object> nullCounts1 = new HashMap<>() {
+            {
+                put("c_string", 0d);
+            }
+        };
+        Map<String, Object> nullCounts2 = new HashMap<>() {
+            {
+                put("c_string", 0d);
+            }
+        };
+        Map<String, Object> nullCounts3 = new HashMap<>() {
+            {
+                put("c_string", 0d);
+            }
+        };
+
+        List<String> nonPartitionPrimitiveColumns = new ArrayList<>();
+        nonPartitionPrimitiveColumns.add("c_string");
+
+        DeltaLakeStats stat1 = new DeltaLakeStats(10, minValues1, maxValues1, nullCounts1);
+        DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat1, 4096);
+
+        DeltaLakeStats stat2 = new DeltaLakeStats(10, minValues2, maxValues2, nullCounts2);
+        stats.update(stat2, 4096);
+
+        DeltaLakeStats stat3 = new DeltaLakeStats(10, minValues3, maxValues3, nullCounts3);
+        stats.update(stat3, 4096);
+
+        ColumnStatistic checkStatistic = new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                0, 16, 1, null, ColumnStatistic.StatisticType.UNKNOWN);
+        checkStatistic.setMinString("string_000");
+        checkStatistic.setMaxString("string_666");
+        checkColumnStatisticsEqual(checkStatistic, stats.fillColumnStats(new Column("c_string", Type.STRING)));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
@@ -77,7 +77,7 @@ public class DeltaLakeFileStatsTest {
             }
         };
 
-        DeltaLakeStats stat = new DeltaLakeStats(10, minValues, maxValues, nullCounts);
+        DeltaLakeAddFileStatsSerDe stat = new DeltaLakeAddFileStatsSerDe(10, minValues, maxValues, nullCounts);
         DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat, 4096);
 
         ColumnStatistic columnStatistic = stats.fillColumnStats(new Column("c_char", Type.CHAR));
@@ -148,13 +148,13 @@ public class DeltaLakeFileStatsTest {
         List<String> nonPartitionPrimitiveColumns = new ArrayList<>();
         nonPartitionPrimitiveColumns.add("c_string");
 
-        DeltaLakeStats stat1 = new DeltaLakeStats(10, minValues1, maxValues1, nullCounts1);
+        DeltaLakeAddFileStatsSerDe stat1 = new DeltaLakeAddFileStatsSerDe(10, minValues1, maxValues1, nullCounts1);
         DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat1, 4096);
 
-        DeltaLakeStats stat2 = new DeltaLakeStats(10, minValues2, maxValues2, nullCounts2);
+        DeltaLakeAddFileStatsSerDe stat2 = new DeltaLakeAddFileStatsSerDe(10, minValues2, maxValues2, nullCounts2);
         stats.update(stat2, 4096);
 
-        DeltaLakeStats stat3 = new DeltaLakeStats(10, minValues3, maxValues3, nullCounts3);
+        DeltaLakeAddFileStatsSerDe stat3 = new DeltaLakeAddFileStatsSerDe(10, minValues3, maxValues3, nullCounts3);
         stats.update(stat3, 4096);
 
         ColumnStatistic checkStatistic = new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,


### PR DESCRIPTION
## Why I'm doing:

BUG1: `MinString`/`MaxString` of `ColumnStatistics` is not really set.
BUG2: The `MinValue`/`MaxValue` need be deep copy, otherwise the `MinValue`/`MaxValue` of `ScanFileScan` will be modified.

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
