### PR TITLE
[Feature] Support to record external table access

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2993,4 +2993,29 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean show_execution_groups = true;
+
+    @ConfField(mutable = true)
+    public static long table_access_collector_repo_check_interval_sec = 60;
+
+    /*
+     * Maximum table access collector 's buffer, if buffer is large than this threshold, FE will flush buffer's statistics to BE
+     * */
+    @ConfField(mutable = true)
+    public static long table_access_collector_max_flight_bytes = 20 * 1024 * 1024; // 20MB
+
+    /*
+     * How often to flush the table access collector's buffer to BE
+     * */
+    @ConfField(mutable = true)
+    public static long table_access_collector_flush_sec = 60; // 60s
+
+    /*
+     * How long to clear stale table access statistics in BE,
+     * `table_access_statistics_keep_sec` determines how long ago the stats are stale
+     * */
+    @ConfField(mutable = true)
+    public static long table_access_collector_clean_sec = 60; // 60s
+
+    @ConfField(mutable = true)
+    public static long table_access_statistics_keep_sec = 30 * 24 * 60 * 60; // 30 day
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2995,7 +2995,7 @@ public class Config extends ConfigBase {
     public static boolean show_execution_groups = true;
 
     @ConfField(mutable = true)
-    public static long table_access_collector_repo_check_interval_sec = 60;
+    public static long table_access_collector_repo_check_interval_sec = 60; // 60s
 
     /*
      * Maximum table access collector 's buffer, if buffer is large than this threshold, FE will flush buffer's statistics to BE
@@ -3007,14 +3007,14 @@ public class Config extends ConfigBase {
      * How often to flush the table access collector's buffer to BE
      * */
     @ConfField(mutable = true)
-    public static long table_access_collector_flush_sec = 60; // 60s
+    public static long table_access_collector_flush_sec = 10 * 60; // 10min
 
     /*
      * How long to clear stale table access statistics in BE,
      * `table_access_statistics_keep_sec` determines how long ago the stats are stale
      * */
     @ConfField(mutable = true)
-    public static long table_access_collector_clean_sec = 60; // 60s
+    public static long table_access_collector_clean_sec = 10 * 60; // 10min
 
     @ConfField(mutable = true)
     public static long table_access_statistics_keep_sec = 30 * 24 * 60 * 60; // 30 day

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/collector/AccessLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/collector/AccessLog.java
@@ -1,0 +1,97 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+public class AccessLog {
+    private final String catalogName;
+    private final String dbName;
+    private final String tableName;
+    private final String partitionName;
+    private final String columnName;
+    private final long accessTimeSec;
+    private final long count;
+
+    public AccessLog(String catalogName, String dbName, String tableName, String partitionName,
+                     String columnName, long accessTimeSec) {
+        this(catalogName, dbName, tableName, partitionName, columnName, accessTimeSec, 1);
+    }
+
+    public AccessLog(String catalogName, String dbName, String tableName, String partitionName,
+                     String columnName, long accessTimeSec, long count) {
+        this.catalogName = catalogName;
+        this.dbName = dbName;
+        this.tableName = tableName;
+        this.partitionName = partitionName;
+        this.columnName = columnName;
+        this.accessTimeSec = accessTimeSec;
+        this.count = count;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public String getPartitionName() {
+        return partitionName;
+    }
+
+    public long getAccessTimeSec() {
+        return accessTimeSec;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AccessLog)) {
+            return false;
+        }
+
+        AccessLog accessLog = (AccessLog) o;
+        return accessTimeSec == accessLog.accessTimeSec && count == accessLog.count &&
+                catalogName.equals(accessLog.catalogName) && dbName.equals(accessLog.dbName) &&
+                tableName.equals(accessLog.tableName) && partitionName.equals(accessLog.partitionName) &&
+                columnName.equals(accessLog.columnName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = catalogName.hashCode();
+        result = 31 * result + dbName.hashCode();
+        result = 31 * result + tableName.hashCode();
+        result = 31 * result + partitionName.hashCode();
+        result = 31 * result + columnName.hashCode();
+        result = 31 * result + Long.hashCode(accessTimeSec);
+        result = 31 * result + Long.hashCode(count);
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollector.java
@@ -1,0 +1,236 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnAccessPath;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.HudiTable;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.thrift.TAccessPathType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class TableAccessCollector {
+
+    private static final Logger LOG = LogManager.getLogger(TableAccessCollector.class);
+
+    public static void collectFromPhysicalPlan(OptExpression expr, boolean enableFullCollect) {
+        CollectorOptVisitor visitor = new CollectorOptVisitor(enableFullCollect);
+        expr.getOp().accept(visitor, expr, null);
+        List<AccessLog> logs = visitor.getAccessLogs();
+        TableAccessCollectorStorage.getInstance().addAccessLogs(logs);
+    }
+
+    private static class CollectorOptVisitor extends OptExpressionVisitor<Void, Void> {
+        private final boolean enableFullCollect;
+        private final List<AccessLog> accessLogs = new LinkedList<>();
+        private final long curAccessTimeSec;
+
+        private CollectorOptVisitor(boolean enableFullCollect) {
+            this.enableFullCollect = enableFullCollect;
+            // only accurate to hour, to reduce cardinality
+            this.curAccessTimeSec = System.currentTimeMillis() / 1000 / 3600 * 3600;
+        }
+
+        @Override
+        public Void visit(OptExpression optExpression, Void context) {
+            for (OptExpression input : optExpression.getInputs()) {
+                input.getOp().accept(this, input, null);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitPhysicalScan(OptExpression optExpression, Void context) {
+            PhysicalScanOperator scanOperator = (PhysicalScanOperator) optExpression.getOp();
+            Table table = scanOperator.getTable();
+            String catalogName;
+            String dbName;
+            String tblName;
+            switch (scanOperator.getOpType()) {
+                case PHYSICAL_HIVE_SCAN:
+                    HiveTable hiveTable = (HiveTable) table;
+                    catalogName = hiveTable.getCatalogName();
+                    dbName = hiveTable.getDbName();
+                    tblName = hiveTable.getTableName();
+                    break;
+                case PHYSICAL_ICEBERG_SCAN:
+                    IcebergTable icebergTable = (IcebergTable) table;
+                    catalogName = icebergTable.getCatalogName();
+                    dbName = icebergTable.getRemoteDbName();
+                    tblName = icebergTable.getRemoteTableName();
+                    break;
+                case PHYSICAL_HUDI_SCAN:
+                    HudiTable hudiTable = (HudiTable) table;
+                    catalogName = hudiTable.getCatalogName();
+                    dbName = hudiTable.getDbName();
+                    tblName = hudiTable.getTableName();
+                    break;
+                case PHYSICAL_DELTALAKE_SCAN:
+                    DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
+                    catalogName = deltaLakeTable.getCatalogName();
+                    dbName = deltaLakeTable.getDbName();
+                    tblName = deltaLakeTable.getTableName();
+                    break;
+                case PHYSICAL_PAIMON_SCAN:
+                    PaimonTable paimonTable = (PaimonTable) table;
+                    catalogName = paimonTable.getCatalogName();
+                    dbName = paimonTable.getDbName();
+                    tblName = paimonTable.getTableName();
+                    break;
+                default:
+                    return null;
+            }
+
+            // ignore full table scan
+            if (!enableFullCollect && checkIsFullColumnScan(table, scanOperator)) {
+                return null;
+            }
+
+            ScanOperatorPredicates predicates = null;
+            try {
+                // ScanOperatorPredicates maybe nullptr
+                predicates = scanOperator.getScanOperatorPredicates();
+            } catch (AnalysisException e) {
+                LOG.warn("Failed to get ScanOperatorPredicates", e);
+            }
+            if (predicates == null) {
+                LOG.warn("ScanOperatorPredicates can't be null");
+                return null;
+            }
+
+            // ignore full partition scan
+            if (!enableFullCollect && checkIsFullPartitionScan(predicates)) {
+                return null;
+            }
+
+            List<PartitionKey> partitionKeyList = predicates.getSelectedPartitionKeys();
+            List<String> partitionNameLists = table.getPartitionColumnNames();
+
+            ImmutableList.Builder<Column> complexTypeColumns = ImmutableList.builder();
+
+            for (Map.Entry<ColumnRefOperator, Column> entry : scanOperator.getColRefToColumnMetaMap().entrySet()) {
+                Column column = entry.getValue();
+                if (column.getType().isComplexType()) {
+                    complexTypeColumns.add(column);
+                    continue;
+                }
+
+                // for none-partition table, partitionKeyList is one element with empty partition key
+                Preconditions.checkArgument(!partitionKeyList.isEmpty(), "PartitionKey must existed.");
+                for (PartitionKey partitionKey : partitionKeyList) {
+                    accessLogs.add(new AccessLog(catalogName, dbName, tblName,
+                            PartitionUtil.toHivePartitionName(partitionNameLists, partitionKey), column.getName(),
+                            curAccessTimeSec));
+                }
+            }
+
+            // start to handle complex type's column
+            // deduplicate ColumnAccessPath by column name
+            Map<String, ColumnAccessPath> name2AccessPath = new HashMap<>();
+            for (ColumnAccessPath accessPath : scanOperator.getColumnAccessPaths()) {
+                name2AccessPath.put(accessPath.getPath(), accessPath);
+            }
+            ImmutableList.Builder<String> complexTypeColumnsBuilder = ImmutableList.builder();
+            for (Column complexTypeColumn : complexTypeColumns.build()) {
+                ColumnAccessPath accessPath = name2AccessPath.get(complexTypeColumn.getName());
+                if (accessPath != null) {
+                    handleColumnAccessPath("", accessPath, complexTypeColumnsBuilder);
+                } else {
+                    complexTypeColumnsBuilder.add(complexTypeColumn.getName());
+                }
+            }
+
+            for (String columnName : complexTypeColumnsBuilder.build()) {
+                // for none-partition table, partitionKeyList is one element with empty partition key
+                Preconditions.checkArgument(!partitionKeyList.isEmpty(), "PartitionKey must existed.");
+                for (PartitionKey partitionKey : partitionKeyList) {
+                    accessLogs.add(new AccessLog(catalogName, dbName, tblName,
+                            PartitionUtil.toHivePartitionName(partitionNameLists, partitionKey), columnName,
+                            curAccessTimeSec));
+                }
+            }
+
+            return null;
+        }
+
+        private List<AccessLog> getAccessLogs() {
+            return accessLogs;
+        }
+
+        private void handleColumnAccessPath(String prefix, ColumnAccessPath columnAccessPath,
+                                            ImmutableList.Builder<String> builder) {
+            // todo, only support map_keys() and struct subfield
+            if (columnAccessPath.getType() == TAccessPathType.ROOT) {
+                prefix = columnAccessPath.getPath();
+            } else if (columnAccessPath.getType() == TAccessPathType.FIELD) {
+                prefix = prefix + "." + columnAccessPath.getPath();
+            } else if (columnAccessPath.getType() == TAccessPathType.KEY) {
+                prefix = String.format("map_keys(%s)", prefix);
+            } else {
+                builder.add(prefix);
+                return;
+            }
+
+            if (!columnAccessPath.hasChildPath()) {
+                builder.add(prefix);
+                return;
+            }
+
+            for (ColumnAccessPath child : columnAccessPath.getChildren()) {
+                handleColumnAccessPath(prefix, child, builder);
+            }
+        }
+
+
+        private boolean checkIsFullColumnScan(Table table, PhysicalScanOperator scanOperator) {
+            int totalColumns = table.getColumns().size();
+            // If it has only one column, ignore check
+            if (totalColumns == 1) {
+                return false;
+            }
+            int usedColumns = scanOperator.getUsedColumns().size();
+            return usedColumns == totalColumns;
+        }
+
+        private boolean checkIsFullPartitionScan(ScanOperatorPredicates scanOperatorPredicates) {
+            if (scanOperatorPredicates.getSelectedPartitionIds().size() == 1) {
+                // for none-partition table, it has one partition id
+                return false;
+            }
+            return scanOperatorPredicates.getSelectedPartitionIds().size() ==
+                    scanOperatorPredicates.getIdToPartitionKey().size();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollectorConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollectorConstants.java
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+public class TableAccessCollectorConstants {
+    // constants for table_access_statistics table
+    public static final String TABLE_ACCESS_STATISTICS_TABLE_NAME = "table_access_statistics";
+    public static final String CATALOG_NAME = "catalog_name";
+    public static final String DATABASE_NAME = "database_name";
+    public static final String TABLE_NAME = "table_name";
+    public static final String PARTITION_NAME = "partition_name";
+    public static final String COLUMN_NAME = "column_name";
+    public static final String ACCESS_TIME_NAME = "access_time";
+    public static final String COUNT_NAME = "count";
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollectorRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollectorRepo.java
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.privilege.PrivilegeBuiltinConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.statistic.StatsConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.text.SimpleDateFormat;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TableAccessCollectorRepo extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(TableAccessCollectorRepo.class);
+    private static final int INSERT_BATCH_SIZE = 5000;
+    private long lastFlushTimestamp = 0L;
+    private long lastCleanTimestamp = 0L;
+
+    public TableAccessCollectorRepo() {
+        super("TableAccessCollectorRepo", Config.table_access_collector_repo_check_interval_sec * 1000);
+        lastFlushTimestamp = System.currentTimeMillis();
+        lastCleanTimestamp = System.currentTimeMillis();
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (isSatisfyFlushCondition()) {
+            flushStorageToBE();
+        }
+        if (isSatisfyCleanCondition()) {
+            clearStaleStats();
+        }
+    }
+
+    private boolean isSatisfyFlushCondition() {
+        if ((System.currentTimeMillis() - lastFlushTimestamp) >
+                Config.table_access_collector_flush_sec * 1000) {
+            return true;
+        }
+
+        if (TableAccessCollectorStorage.getInstance().getEstimateMemorySize() >=
+                Config.table_access_collector_max_flight_bytes) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isSatisfyCleanCondition() {
+        if ((System.currentTimeMillis() - lastCleanTimestamp) >
+                Config.table_access_collector_clean_sec * 1000) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public void flushStorageToBE() {
+        LOG.info("TableAccessCollectorRepo start to flush data");
+
+        lastFlushTimestamp = System.currentTimeMillis();
+
+        List<AccessLog> accessLogs = TableAccessCollectorStorage.getInstance().exportAccessLogs();
+
+        try {
+            InsertSQLBuilder insertSQLBuilder = new InsertSQLBuilder();
+            // because we have insert limit 'expr_children_limit'(default value is 10,000) in FE conf, so we need to insert batch by batch
+            for (AccessLog accessLog : accessLogs) {
+                if (insertSQLBuilder.size() < INSERT_BATCH_SIZE) {
+                    insertSQLBuilder.addAccessLog(accessLog);
+                } else {
+                    String insertSQL = insertSQLBuilder.build();
+                    executeSQL(insertSQL);
+                    insertSQLBuilder.clear();
+                }
+            }
+
+            // handle remain rows in InsertSQLBuilder
+            if (insertSQLBuilder.size() > 0) {
+                String insertSQL = insertSQLBuilder.build();
+                executeSQL(insertSQL);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to flush data to BE, error msg is ", e);
+        }
+    }
+
+    private void clearStaleStats() {
+        LOG.info("TableAccessCollectorRepo start to drop outdated statistics");
+        lastCleanTimestamp = System.currentTimeMillis();
+
+        try {
+            String dropSQL = DeleteSQLBuilder.buildDeleteStatsSQL();
+            executeSQL(dropSQL);
+        } catch (Exception e) {
+            LOG.warn("Failed to drop outdated data, error msg is ", e);
+        }
+    }
+
+    private void executeSQL(String sql) throws Exception {
+        LOG.debug("execute sql: {}", sql);
+        buildConnectContext().executeSql(sql);
+    }
+
+    private ConnectContext buildConnectContext() {
+        ConnectContext context = new ConnectContext();
+        // Note: statistics query does not register query id to QeProcessorImpl::coordinatorMap,
+        // but QeProcessorImpl::reportExecStatus will check query id,
+        // So we must disable report query status from BE to FE
+        context.getSessionVariable().setEnableProfile(false);
+        context.setStatisticsContext(true);
+        context.setDatabase(StatsConstants.STATISTICS_DB_NAME);
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+        context.setQualifiedUser(UserIdentity.ROOT.getUser());
+        context.setQueryId(UUIDUtil.genUUID());
+        context.setStartTime();
+        return context;
+    }
+
+    @VisibleForTesting
+    public static class DeleteSQLBuilder {
+        private static final String CLEAN_SQL_TEMPLATE = "DELETE FROM `%s`.`%s`.`%s` WHERE `%s` <= '%s'";
+
+        public static String buildDeleteStatsSQL() {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            String deleteTime = simpleDateFormat.format(
+                    System.currentTimeMillis() - Config.table_access_statistics_keep_sec * 1000L);
+            return String.format(CLEAN_SQL_TEMPLATE, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    StatsConstants.STATISTICS_DB_NAME,
+                    TableAccessCollectorConstants.TABLE_ACCESS_STATISTICS_TABLE_NAME,
+                    TableAccessCollectorConstants.ACCESS_TIME_NAME,
+                    deleteTime);
+        }
+    }
+
+    @VisibleForTesting
+    public static class InsertSQLBuilder {
+        private final String targetCatalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+        private final String targetDbName = StatsConstants.STATISTICS_DB_NAME;
+        private final String targetTblName = TableAccessCollectorConstants.TABLE_ACCESS_STATISTICS_TABLE_NAME;
+        private final List<String> values = new LinkedList<>();
+
+        public void addAccessLog(AccessLog accessLog) {
+            String s = String.format("('%s', '%s', '%s', '%s', '%s', from_unixtime(%d, 'yyyy-MM-dd HH:mm:ss'), %d)",
+                    accessLog.getCatalogName(), accessLog.getDbName(), accessLog.getTableName(),
+                    accessLog.getPartitionName(), accessLog.getColumnName(), accessLog.getAccessTimeSec(),
+                    accessLog.getCount());
+            values.add(s);
+        }
+
+        public void clear() {
+            values.clear();
+        }
+
+        public int size() {
+            return values.size();
+        }
+
+        public String build() {
+            Preconditions.checkArgument(size() > 0, "InsertSQLBuilder must contains at least one AccessLog");
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("INSERT INTO `%s`.`%s`.`%s` VALUES ", targetCatalogName, targetDbName,
+                    targetTblName));
+            sb.append(String.join(", ", values));
+            return sb.toString();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollectorStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/collector/TableAccessCollectorStorage.java
@@ -1,0 +1,219 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class TableAccessCollectorStorage {
+    private static final TableAccessCollectorStorage STORAGE = new TableAccessCollectorStorage();
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final CatalogMapping catalogMapping = new CatalogMapping();
+    private long estimateMemorySize = 0L;
+
+    public static TableAccessCollectorStorage getInstance() {
+        return STORAGE;
+    }
+
+    public void addAccessLogs(List<AccessLog> accessLogs) {
+        writeLock();
+
+        try {
+            for (AccessLog accessLog : accessLogs) {
+                catalogMapping.update(accessLog);
+            }
+        } finally {
+            writeUnLock();
+        }
+    }
+
+    public long getEstimateMemorySize() {
+        readLock();
+
+        try {
+            return estimateMemorySize;
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public List<AccessLog> exportAccessLogs() {
+        writeLock();
+        try {
+            List<AccessLog> accessLogs = new LinkedList<>();
+            if (estimateMemorySize == 0) {
+                return accessLogs;
+            }
+
+            // catalog level
+            for (Map.Entry<String, DbMapping> catalogEntry : catalogMapping.mapping.entrySet()) {
+                final String catalogName = catalogEntry.getKey();
+                final DbMapping dbMapping = catalogEntry.getValue();
+                // db level
+                for (Map.Entry<String, TblMapping> dbEntry : dbMapping.mapping.entrySet()) {
+                    final String dbName = dbEntry.getKey();
+                    final TblMapping tblMapping = dbEntry.getValue();
+                    // tbl level
+                    for (Map.Entry<String, PartitionMapping> tblEntry : tblMapping.mapping.entrySet()) {
+                        final String tblName = tblEntry.getKey();
+                        final PartitionMapping partitionMapping = tblEntry.getValue();
+                        // partition level
+                        for (Map.Entry<String, ColumnMapping> partitionEntry : partitionMapping.mapping.entrySet()) {
+                            final String partitionName = partitionEntry.getKey();
+                            final ColumnMapping columnMapping = partitionEntry.getValue();
+                            // column level
+                            for (Map.Entry<String, AccessTimeMapping> columnEntry : columnMapping.mapping.entrySet()) {
+                                String columnName = columnEntry.getKey();
+                                final AccessTimeMapping accessTimeMapping = columnEntry.getValue();
+                                // access time level
+                                for (Map.Entry<Long, Long> accessTimeEntry : accessTimeMapping.mapping.entrySet()) {
+                                    long accessTime = accessTimeEntry.getKey();
+                                    long count = accessTimeEntry.getValue();
+
+                                    accessLogs.add(
+                                            new AccessLog(catalogName, dbName, tblName, partitionName, columnName,
+                                                    accessTime, count));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return accessLogs;
+        } finally {
+            catalogMapping.clear();
+            estimateMemorySize = 0L;
+            writeUnLock();
+        }
+    }
+
+    private void readLock() {
+        this.lock.readLock().lock();
+    }
+
+    private void readUnlock() {
+        this.lock.readLock().unlock();
+    }
+
+    private void writeLock() {
+        this.lock.writeLock().lock();
+    }
+
+    private void writeUnLock() {
+        this.lock.writeLock().unlock();
+    }
+
+    private class CatalogMapping {
+        private final Map<String, DbMapping> mapping = new HashMap<>();
+
+        private void update(AccessLog accessLog) {
+            String catalogName = accessLog.getCatalogName();
+            DbMapping dbMapping = mapping.get(catalogName);
+            if (dbMapping == null) {
+                dbMapping = new DbMapping();
+                mapping.put(catalogName, dbMapping);
+                estimateMemorySize += catalogName.length();
+            }
+            dbMapping.update(accessLog);
+        }
+
+        private void clear() {
+            mapping.clear();
+        }
+    }
+
+    private class DbMapping {
+        private final Map<String, TblMapping> mapping = new HashMap<>();
+
+        private void update(AccessLog accessLog) {
+            String dbName = accessLog.getDbName();
+            TblMapping tblMapping = mapping.get(dbName);
+            if (tblMapping == null) {
+                tblMapping = new TblMapping();
+                mapping.put(dbName, tblMapping);
+                estimateMemorySize += dbName.length();
+            }
+            tblMapping.update(accessLog);
+        }
+    }
+
+    private class TblMapping {
+        private final Map<String, PartitionMapping> mapping = new HashMap<>();
+
+        private void update(AccessLog accessLog) {
+            String tblName = accessLog.getTableName();
+            PartitionMapping partitionMapping = mapping.get(tblName);
+            if (partitionMapping == null) {
+                partitionMapping = new PartitionMapping();
+                mapping.put(tblName, partitionMapping);
+                estimateMemorySize += tblName.length();
+            }
+            partitionMapping.update(accessLog);
+        }
+    }
+
+    private class PartitionMapping {
+        private final Map<String, ColumnMapping> mapping = new HashMap<>();
+
+        private void update(AccessLog accessLog) {
+            String partitionName = accessLog.getPartitionName();
+            ColumnMapping columnMapping = mapping.get(partitionName);
+            if (columnMapping == null) {
+                columnMapping = new ColumnMapping();
+                mapping.put(partitionName, columnMapping);
+                estimateMemorySize += partitionName.length();
+            }
+            columnMapping.update(accessLog);
+        }
+    }
+
+    private class ColumnMapping {
+        private final Map<String, AccessTimeMapping> mapping = new HashMap<>();
+
+        private void update(AccessLog accessLog) {
+            String columnName = accessLog.getColumnName();
+            AccessTimeMapping accessTimeMapping = mapping.get(columnName);
+            if (accessTimeMapping == null) {
+                accessTimeMapping = new AccessTimeMapping();
+                mapping.put(columnName, accessTimeMapping);
+                estimateMemorySize += columnName.length();
+            }
+            accessTimeMapping.update(accessLog);
+        }
+    }
+
+    private class AccessTimeMapping {
+        private final Map<Long, Long> mapping = new HashMap<>();
+
+        private void update(AccessLog accessLog) {
+            long accessTime = accessLog.getAccessTimeSec();
+            Long count = mapping.get(accessTime);
+            if (count == null) {
+                count = accessLog.getCount();
+                // key(long) + value(long) = 8bytes + 8bytes = 16bytes
+                estimateMemorySize += 16;
+            } else {
+                count += accessLog.getCount();
+            }
+            mapping.put(accessTime, count);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -470,6 +470,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_DATACACHE_ASYNC_POPULATE_MODE = "enable_datacache_async_populate_mode";
     public static final String ENABLE_DATACACHE_IO_ADAPTOR = "enable_datacache_io_adaptor";
     public static final String DATACACHE_EVICT_PROBABILITY = "datacache_evict_probability";
+    public static final String ENABLE_COLLECT_TABLE_ACCESS_STATISTICS = "enable_collect_table_access_statistic";
+    public static final String ENABLE_FULL_COLLECT_TABLE_ACCESS_STATISTICS = "enable_full_collect_table_access_statistics";
 
     // The following configurations will be deprecated, and we use the `datacache` suffix instead.
     // But it is temporarily necessary to keep them for a period of time to be compatible with
@@ -1613,6 +1615,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_POPULATE_DATACACHE, alias = ENABLE_POPULATE_BLOCK_CACHE)
     private boolean enablePopulateDataCache = true;
 
+    @VariableMgr.VarAttr(name = ENABLE_COLLECT_TABLE_ACCESS_STATISTICS, flag = VariableMgr.INVISIBLE)
+    private boolean enableCollectTableAccessStatistics = false;
+
+    // By default, we will ignore full (table/partition) scan
+    @VariableMgr.VarAttr(name = ENABLE_FULL_COLLECT_TABLE_ACCESS_STATISTICS, flag = VariableMgr.INVISIBLE)
+    private boolean enableFullCollectTableAccessStatistics = false;
+
     @VariableMgr.VarAttr(name = CATALOG, flag = VariableMgr.SESSION_ONLY)
     private String catalog = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
 
@@ -2285,6 +2294,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setDatacacheTTLSeconds(long datacacheTTLSeconds) {
         this.datacacheTTLSeconds = datacacheTTLSeconds;
+    }
+
+    public void setEnableCollectTableAccessStatistics(boolean enableCollectTableAccessStatistics) {
+        this.enableCollectTableAccessStatistics = enableCollectTableAccessStatistics;
+    }
+
+    public boolean isEnableCollectTableAccessStatistics() {
+        return this.enableCollectTableAccessStatistics;
+    }
+
+    public void setEnableFullCollectTableAccessStatistics(boolean enableFullCollectTableAccessStatistics) {
+        this.enableFullCollectTableAccessStatistics = enableFullCollectTableAccessStatistics;
+    }
+
+    public boolean isEnableFullCollectTableAccessStatistics() {
+        return this.enableFullCollectTableAccessStatistics;
     }
 
     public boolean isCboUseDBLock() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -112,6 +112,7 @@ import com.starrocks.connector.hive.events.MetastoreEventsProcessor;
 import com.starrocks.consistency.ConsistencyChecker;
 import com.starrocks.consistency.LockChecker;
 import com.starrocks.consistency.MetaRecoveryDaemon;
+import com.starrocks.datacache.collector.TableAccessCollectorRepo;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.HAProtocol;
 import com.starrocks.ha.LeaderInfo;
@@ -304,6 +305,7 @@ public class GlobalStateMgr {
     private Daemon replayer;
     private Daemon timePrinter;
     private final EsRepository esRepository;  // it is a daemon, so add it here
+    private final TableAccessCollectorRepo tableAccessCollectorRepo;
     private final MetastoreEventsProcessor metastoreEventsProcessor;
     private final ConnectorTableMetadataProcessor connectorTableMetadataProcessor;
 
@@ -641,6 +643,7 @@ public class GlobalStateMgr {
         this.resourceGroupMgr = new ResourceGroupMgr();
 
         this.esRepository = new EsRepository();
+        this.tableAccessCollectorRepo = new TableAccessCollectorRepo();
         this.metastoreEventsProcessor = new MetastoreEventsProcessor();
         this.connectorTableMetadataProcessor = new ConnectorTableMetadataProcessor();
 
@@ -1356,6 +1359,7 @@ public class GlobalStateMgr {
         labelCleaner.start();
         // ES state store
         esRepository.start();
+        tableAccessCollectorRepo.start();
 
         if (Config.enable_hms_events_incremental_sync) {
             metastoreEventsProcessor.start();
@@ -2073,6 +2077,10 @@ public class GlobalStateMgr {
 
     public EsRepository getEsRepository() {
         return esRepository;
+    }
+
+    public TableAccessCollectorRepo getTableAccessCollectorRepo() {
+        return tableAccessCollectorRepo;
     }
 
     public MetastoreEventsProcessor getMetastoreEventsProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -31,6 +31,7 @@ import com.starrocks.common.DuplicatedRequestException;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.datacache.collector.TableAccessCollector;
 import com.starrocks.http.HttpConnectContext;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ResultSink;
@@ -225,6 +226,13 @@ public class StatementPlanner {
                     new ColumnRefSet(logicalPlan.getOutputColumn()),
                     columnRefFactory);
         }
+        if (session.getSessionVariable().isEnableCollectTableAccessStatistics()) {
+            try (Timer ignored = Tracers.watchScope("CollectTableAccessStatistics")) {
+                TableAccessCollector.collectFromPhysicalPlan(optimizedPlan,
+                        session.getSessionVariable().isEnableFullCollectTableAccessStatistics());
+            }
+        }
+
         try (Timer ignored = Tracers.watchScope("ExecPlanBuild")) {
             // 3. Build fragment exec plan
             /*

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/DeltaLakeScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/DeltaLakeScanImplementationRule.java
@@ -36,6 +36,7 @@ public class DeltaLakeScanImplementationRule extends ImplementationRule {
         LogicalDeltaLakeScanOperator logicalDeltaLakeScanOperator = (LogicalDeltaLakeScanOperator) input.getOp();
         PhysicalDeltaLakeScanOperator physicalDeltaLakeScan =
                 new PhysicalDeltaLakeScanOperator(logicalDeltaLakeScanOperator);
+        physicalDeltaLakeScan.setColumnAccessPaths(logicalDeltaLakeScanOperator.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalDeltaLakeScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/FileScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/FileScanImplementationRule.java
@@ -35,6 +35,7 @@ public class FileScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalFileScanOperator scan = (LogicalFileScanOperator) input.getOp();
         PhysicalFileScanOperator physicalFileScan = new PhysicalFileScanOperator(scan);
+        physicalFileScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalFileScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HiveScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HiveScanImplementationRule.java
@@ -35,6 +35,7 @@ public class HiveScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalHiveScanOperator scan = (LogicalHiveScanOperator) input.getOp();
         PhysicalHiveScanOperator physicalHiveScan = new PhysicalHiveScanOperator(scan);
+        physicalHiveScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalHiveScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HudiScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HudiScanImplementationRule.java
@@ -34,6 +34,7 @@ public class HudiScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalHudiScanOperator scan = (LogicalHudiScanOperator) input.getOp();
         PhysicalHudiScanOperator physicalHudiScan = new PhysicalHudiScanOperator(scan);
+        physicalHudiScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalHudiScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/IcebergScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/IcebergScanImplementationRule.java
@@ -36,6 +36,7 @@ public class IcebergScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalIcebergScanOperator scan = (LogicalIcebergScanOperator) input.getOp();
         PhysicalIcebergScanOperator physicalIcebergScan = new PhysicalIcebergScanOperator(scan);
+        physicalIcebergScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalIcebergScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/KuduScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/KuduScanImplementationRule.java
@@ -35,6 +35,7 @@ public class KuduScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalKuduScanOperator scan = (LogicalKuduScanOperator) input.getOp();
         PhysicalKuduScanOperator physicalKuduScan = new PhysicalKuduScanOperator(scan);
+        physicalKuduScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalKuduScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OdpsScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OdpsScanImplementationRule.java
@@ -35,6 +35,7 @@ public class OdpsScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalOdpsScanOperator scan = (LogicalOdpsScanOperator) input.getOp();
         PhysicalOdpsScanOperator physicalOdpsScan = new PhysicalOdpsScanOperator(scan);
+        physicalOdpsScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalOdpsScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PaimonScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PaimonScanImplementationRule.java
@@ -35,6 +35,7 @@ public class PaimonScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalPaimonScanOperator scan = (LogicalPaimonScanOperator) input.getOp();
         PhysicalPaimonScanOperator physicalPaimonScan = new PhysicalPaimonScanOperator(scan);
+        physicalPaimonScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalPaimonScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.catalog.AggregateType;
@@ -47,6 +48,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.PartitionInfo;
+import com.starrocks.datacache.collector.TableAccessCollectorConstants;
 import com.starrocks.load.EtlStatus;
 import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.streamload.StreamLoadTxnCommitAttachment;
@@ -407,6 +409,21 @@ public class StatisticUtils {
                             true, ColumnDef.DefaultValueDef.NOT_SET, ""),
                     new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
             );
+        } else if (tableName.equals(TableAccessCollectorConstants.TABLE_ACCESS_STATISTICS_TABLE_NAME)) {
+            ScalarType accessTimeType = ScalarType.createType(PrimitiveType.DATETIME);
+            ScalarType countType = ScalarType.createType(PrimitiveType.BIGINT);
+
+            return ImmutableList.of(
+                    new ColumnDef(TableAccessCollectorConstants.CATALOG_NAME, new TypeDef(catalogNameType)),
+                    new ColumnDef(TableAccessCollectorConstants.DATABASE_NAME, new TypeDef(dbNameType)),
+                    new ColumnDef(TableAccessCollectorConstants.TABLE_NAME, new TypeDef(tableNameType)),
+                    new ColumnDef(TableAccessCollectorConstants.PARTITION_NAME, new TypeDef(partitionNameType)),
+                    new ColumnDef(TableAccessCollectorConstants.COLUMN_NAME, new TypeDef(columnNameType)),
+                    new ColumnDef(TableAccessCollectorConstants.ACCESS_TIME_NAME, new TypeDef(accessTimeType)),
+                    // agg sum() column
+                    new ColumnDef(TableAccessCollectorConstants.COUNT_NAME, new TypeDef(countType), false,
+                            AggregateType.SUM, false,
+                            new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), ""));
         } else {
             throw new StarRocksPlannerException("Not support stats table " + tableName, ErrorType.INTERNAL_ERROR);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -384,6 +384,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         List<FieldSchema> cols = Lists.newArrayList();
         cols.add(new FieldSchema("col_int", "int", null));
         cols.add(new FieldSchema("col_struct", "struct<c0: int, c1: struct<c11: int>>", null));
+        cols.add(new FieldSchema("col_array", "array<int>", null));
+        cols.add(new FieldSchema("col_map", "map<int, struct<c1: int>>", null));
         StorageDescriptor sd =
                 new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS, "", false,
                         -1, null, Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap());
@@ -1186,6 +1188,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
 
         List<FieldSchema> cols = Lists.newArrayList();
         cols.add(new FieldSchema("age", "int", null));
+        cols.add(new FieldSchema("name", "string", null));
         StorageDescriptor sd =
                 new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS,
                         "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/collector/TableAccessCollectorRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/collector/TableAccessCollectorRepoTest.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class TableAccessCollectorRepoTest {
+    @Test
+    public void testDeleteSQLBuilder() {
+        String sql = TableAccessCollectorRepo.DeleteSQLBuilder.buildDeleteStatsSQL();
+        Assert.assertTrue(sql.contains(
+                "DELETE FROM `default_catalog`.`_statistics_`.`table_access_statistics` WHERE `access_time` <="));
+    }
+
+    @Test
+    public void testInsertSQLBuilder() {
+        List<AccessLog> accessLogs = new LinkedList<>();
+        accessLogs.add(new AccessLog("c", "d", "t", "", "col1.a", 1719908852, 10));
+        accessLogs.add(new AccessLog("c", "d", "t", "par", "col", 1719908862, 1));
+
+        TableAccessCollectorRepo.InsertSQLBuilder builder = new TableAccessCollectorRepo.InsertSQLBuilder();
+        for (AccessLog accessLog : accessLogs) {
+            builder.addAccessLog(accessLog);
+        }
+
+        Assert.assertEquals(2, builder.size());
+        Assert.assertEquals("INSERT INTO `default_catalog`.`_statistics_`.`table_access_statistics` " +
+                "VALUES ('c', 'd', 't', '', 'col1.a', from_unixtime(1719908852, 'yyyy-MM-dd HH:mm:ss'), 10), " +
+                "('c', 'd', 't', 'par', 'col', from_unixtime(1719908862, 'yyyy-MM-dd HH:mm:ss'), 1)", builder.build());
+        builder.clear();
+        Assert.assertEquals(0, builder.size());
+        Assert.assertThrows(IllegalArgumentException.class, builder::build);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/collector/TableAccessCollectorStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/collector/TableAccessCollectorStorageTest.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class TableAccessCollectorStorageTest {
+
+    @Test
+    public void testAddAccessLogs() {
+        TableAccessCollectorStorage storage = new TableAccessCollectorStorage();
+        List<AccessLog> accessLogs = new LinkedList<>();
+        accessLogs.add(new AccessLog("catalog", "db", "table", "partition", "column1", 1));
+        accessLogs.add(new AccessLog("catalog", "db", "table", "partition", "column1", 1, 2));
+        accessLogs.add(new AccessLog("catalog", "db", "table", "partition", "column2", 1));
+        accessLogs.add(new AccessLog("catalog", "db", "tbl", "par", "column", 2, 3));
+        storage.addAccessLogs(accessLogs);
+        Assert.assertEquals(97, storage.getEstimateMemorySize());
+        List<AccessLog> export = storage.exportAccessLogs();
+        Assert.assertEquals(3, export.size());
+        for (int i = 0; i < export.size(); i++) {
+            AccessLog accessLog = export.get(i);
+            if (i == 0) {
+                Assert.assertEquals(new AccessLog("catalog", "db", "table", "partition", "column1", 1, 3), accessLog);
+            } else if (i == 1) {
+                Assert.assertEquals(new AccessLog("catalog", "db", "table", "partition", "column2", 1, 1), accessLog);
+            } else if (i == 2) {
+                Assert.assertEquals(new AccessLog("catalog", "db", "tbl", "par", "column", 2, 3), accessLog);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/collector/TableAccessCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/collector/TableAccessCollectorTest.java
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache.collector;
+
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TableAccessCollectorTest extends PlanTestBase {
+
+    private final TableAccessCollectorStorage storage = TableAccessCollectorStorage.getInstance();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        AnalyzeTestUtil.setConnectContext(connectContext);
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+    }
+
+    @Before
+    public void before() {
+        connectContext.getSessionVariable().setEnableCollectTableAccessStatistics(true);
+    }
+
+    @After
+    public void clearDataCacheMgr() {
+        connectContext.getSessionVariable().setEnableCollectTableAccessStatistics(false);
+    }
+
+    @Test
+    public void testIgnorePolicy() throws Exception {
+        getFragmentPlan("select * from hive0.datacache_db.normal_table;");
+        getFragmentPlan("select * from hive0.datacache_db.single_partition_table;");
+        getFragmentPlan("select * from hive0.datacache_db.multi_partition_table;");
+        Assert.assertEquals(0, storage.getEstimateMemorySize());
+        Assert.assertEquals(0, storage.exportAccessLogs().size());
+
+        connectContext.getSessionVariable().setEnableFullCollectTableAccessStatistics(true);
+        getFragmentPlan("select * from hive0.datacache_db.normal_table;");
+        Assert.assertEquals(103, storage.getEstimateMemorySize());
+        List<AccessLog> accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals(0, storage.getEstimateMemorySize());
+        Assert.assertEquals(3, accessLogs.size());
+
+        connectContext.getSessionVariable().setEnableFullCollectTableAccessStatistics(false);
+    }
+
+    @Test
+    public void testPartitionScan() throws Exception {
+        getFragmentPlan("select r_name from hive0.datacache_db.normal_table;");
+        getFragmentPlan("select r_name from hive0.datacache_db.normal_table;");
+        List<AccessLog> accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals(1, accessLogs.size());
+        AccessLog accessLog = accessLogs.get(0);
+        Assert.assertEquals("hive0", accessLog.getCatalogName());
+        Assert.assertEquals("datacache_db", accessLog.getDbName());
+        Assert.assertEquals("normal_table", accessLog.getTableName());
+        Assert.assertEquals("", accessLog.getPartitionName());
+        Assert.assertEquals("r_name", accessLog.getColumnName());
+        Assert.assertEquals(2, accessLog.getCount());
+
+        getFragmentPlan(
+                "select name from hive0.datacache_db.multi_partition_table where l_shipdate='1998-01-04' and l_orderkey=5;");
+        Assert.assertEquals(144, storage.getEstimateMemorySize());
+        accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals(3, accessLogs.size());
+    }
+
+    @Test
+    public void testComplexType() throws Exception {
+        getFragmentPlan("select col_struct.c0 from hive0.subfield_db.subfield;");
+        List<AccessLog> accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals(1, accessLogs.size());
+        Assert.assertEquals("col_struct.c0", accessLogs.get(0).getColumnName());
+
+        getFragmentPlan("select col_struct.c0, col_struct.c1.c11 from hive0.subfield_db.subfield;");
+        accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals(2, accessLogs.size());
+        Assert.assertEquals("col_struct.c1.c11", accessLogs.get(0).getColumnName());
+        Assert.assertEquals("col_struct.c0", accessLogs.get(1).getColumnName());
+
+        getFragmentPlan("select col_array[1] from hive0.subfield_db.subfield;");
+        accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals("col_array", accessLogs.get(0).getColumnName());
+
+        getFragmentPlan("select map_values(col_map)[1].c1 from hive0.subfield_db.subfield;");
+        accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals("col_map", accessLogs.get(0).getColumnName());
+
+        getFragmentPlan("select map_keys(col_map)[1] from hive0.subfield_db.subfield;");
+        accessLogs = storage.exportAccessLogs();
+        Assert.assertEquals("map_keys(col_map)", accessLogs.get(0).getColumnName());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -231,8 +231,8 @@ public class SkewJoinTest extends PlanTestBase {
         assertCContains(sqlPlan, "HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 10: rand_col = 17: rand_col\n" +
-                "  |  equal join conjunct: 9: expr = 3: c1");
+                "  |  equal join conjunct: 12: rand_col = 19: rand_col\n" +
+                "  |  equal join conjunct: 11: expr = 5: c1");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Support to record external access to detect hot spot in external table.

## What I'm doing:
Support to record struct subfield, map_keys.

Will ignore record all columns/partitions scan by default, except when you `set enable_full_collect_table_access_statistics=true`

Will only count `QueryStatement`, omitted `InsertStmt`, `cache select`,  etc.

Will only count `Hudi`, `Iceberg`, `Hive`, `Paimon`, DeltaLake` catalog's query.

When you want to record external table access, you need to `set enable_collect_table_access_statistic=true`, then you can retrieve access statistics in `default_catalog._statistics_.table_access_statistics`. You can use SQL to analyze which column/partition is a hot spot. Then use `cache select` to load it into datacache in advance.

For example, execute below SQL to retrieve must hot columns.
```sql 
SELECT `catalog_name`, `database_name`, `table_name`, `partition_name`, GROUP_CONCAT(column_name SEPARATOR ', ') AS `column_names`, `count` 
FROM table_access_statistics GROUP BY `catalog_name`, `database_name`, `table_name`, `partition_name`, `access_time`, `count` 
ORDER BY `count` DESC;
```

This feature will not be released to the public yet, and it will take some time to verify its feasibility.

## Code structure
`TableAccessCollectorRepo`: manage insert statistics, and clean stale statistics.
`TableAccessCollectorStorage`: manage access log in memory. Use prefix tree to save memory.

Fixes #47772

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
