### PR TITLE
[BugFix] Bump simdjson to 3.9.4 and Fix struct field columns inconsistent when loading from bad json

### DIFF
--- a/be/src/formats/json/struct_column.cpp
+++ b/be/src/formats/json/struct_column.cpp
@@ -42,12 +42,12 @@ Status add_struct_column(Column* column, const TypeDescriptor& type_desc, const 
             simdjson::ondemand::value* field_value_ptr = nullptr;
             if (err == simdjson::SUCCESS) {
                 field_value_ptr = &field_value;
-            } else if (err == simdjson::NO_SUCH_FIELD) {
-                // nullptr
-            } else {
+            } else if (err != simdjson::NO_SUCH_FIELD) {
+                // if returns error, the struct field columns may be inconsistent.
+                // so fill null if error.
                 auto err_msg = strings::Substitute("Failed to parse value, field=$0.$1, error=$2", name, field_name,
                                                    simdjson::error_message(err));
-                return Status::DataQualityError(err_msg);
+                LOG(WARNING) << err_msg;
             }
             RETURN_IF_ERROR(add_nullable_column(field_column.get(), field_type_desc, name, field_value_ptr, true));
         }

--- a/be/test/formats/json/map_column_test.cpp
+++ b/be/test/formats/json/map_column_test.cpp
@@ -47,7 +47,7 @@ TEST_F(AddMapColumnTest, test_bad_json) {
     auto column = ColumnHelper::create_column(type_desc, false);
 
     simdjson::ondemand::parser parser;
-    auto json = R"(  { "key1": "foo", "key2": "bar", "key3": "baz"   )"_padded;
+    auto json = R"(  { "key1": "foo", "key2": "bar" "key3": "baz"  } )"_padded;
     auto doc = parser.iterate(json);
     simdjson::ondemand::value val = doc.get_value();
 

--- a/be/test/formats/json/numeric_column_test.cpp
+++ b/be/test/formats/json/numeric_column_test.cpp
@@ -103,7 +103,7 @@ TEST_F(AddNumericColumnTest, test_add_int64_overflow) {
     auto doc = parser.iterate(json);
     simdjson::ondemand::value val = doc.find_field("f_int64");
     auto st = add_numeric_column<int64_t>(column.get(), t, "f_int64", &val);
-    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_TRUE(st.is_invalid_argument());
 }
 
 TEST_F(AddNumericColumnTest, test_add_int64_overflow2) {
@@ -112,6 +112,19 @@ TEST_F(AddNumericColumnTest, test_add_int64_overflow2) {
 
     simdjson::ondemand::parser parser;
     auto json = R"(  { "f_int64": 9223372036854775808} )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_int64");
+
+    auto st = add_numeric_column<int64_t>(column.get(), t, "f_int64", &val);
+    ASSERT_TRUE(st.is_invalid_argument());
+}
+
+TEST_F(AddNumericColumnTest, test_add_int64_overflow3) {
+    auto column = FixedLengthColumn<int64_t>::create();
+    TypeDescriptor t(TYPE_BIGINT);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_int64": 18446744073709551616} )"_padded;
     auto doc = parser.iterate(json);
     simdjson::ondemand::value val = doc.find_field("f_int64");
 
@@ -134,9 +147,7 @@ TEST_F(AddNumericColumnTest, test_add_int128) {
     ASSERT_EQ("[9223372036854775808]", column->debug_string());
 }
 
-// Currently simdjson can not parse number < -9223372036854775808 (lower bound of int64_t)
-// or > 18446744073709551615 (upper bound of uint64_t)
-TEST_F(AddNumericColumnTest, test_add_int128_invalid) {
+TEST_F(AddNumericColumnTest, test_add_int128_big_integer) {
     auto column = FixedLengthColumn<int128_t>::create();
     TypeDescriptor t(TYPE_LARGEINT);
 
@@ -146,14 +157,17 @@ TEST_F(AddNumericColumnTest, test_add_int128_invalid) {
     simdjson::ondemand::value val = doc.find_field("f_int128");
 
     auto st = add_numeric_column<int128_t>(column.get(), t, "f_int128", &val);
-    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[-9223372036854775809]", column->debug_string());
 
+    column->reset_column();
     json = R"(  { "f_int128": 18446744073709551616} )"_padded;
     doc = parser.iterate(json);
     val = doc.find_field("f_int128");
 
     st = add_numeric_column<int128_t>(column.get(), t, "f_int128", &val);
-    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[18446744073709551616]", column->debug_string());
 }
 
 } // namespace starrocks

--- a/be/test/formats/json/struct_column_test.cpp
+++ b/be/test/formats/json/struct_column_test.cpp
@@ -55,6 +55,22 @@ TEST_F(AddStructColumnTest, test_bad_json) {
     EXPECT_EQ("{key1:'foo',key2:'bar',key3:NULL}", column->debug_string());
 }
 
+TEST_F(AddStructColumnTest, test_bad_json2) {
+    TypeDescriptor type_desc = TypeDescriptor::create_struct_type(
+            {"key1", "key2", "key3"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_json_type(),
+                                       TypeDescriptor::create_varchar_type(10)});
+    auto column = ColumnHelper::create_column(type_desc, false);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "key1": "foo", "key2": {a:1,b:2}, "key3": "bar"}   )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.get_value();
+
+    EXPECT_OK(add_struct_column(column.get(), type_desc, "root_key", &val));
+
+    EXPECT_EQ("{key1:'foo',key2:NULL,key3:NULL}", column->debug_string());
+}
+
 TEST_F(AddStructColumnTest, test_field_not_found) {
     TypeDescriptor type_desc = TypeDescriptor::create_struct_type(
             {"key1", "key2"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(10)});

--- a/be/test/formats/json/struct_column_test.cpp
+++ b/be/test/formats/json/struct_column_test.cpp
@@ -50,7 +50,9 @@ TEST_F(AddStructColumnTest, test_bad_json) {
     auto doc = parser.iterate(json);
     simdjson::ondemand::value val = doc.get_value();
 
-    EXPECT_STATUS(Status::DataQualityError(""), add_struct_column(column.get(), type_desc, "root_key", &val));
+    EXPECT_OK(add_struct_column(column.get(), type_desc, "root_key", &val));
+
+    EXPECT_EQ("{key1:'foo',key2:'bar',key3:NULL}", column->debug_string());
 }
 
 TEST_F(AddStructColumnTest, test_field_not_found) {

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -63,7 +63,7 @@ export TP_JAR_DIR=$TP_INSTALL_DIR/lib/jar
 # Definitions for architecture-related thirdparty
 MACHINE_TYPE=$(uname -m)
 # handle mac m1 platform, change arm64 to aarch64
-if [[ "${MACHINE_TYPE}" == "arm64" ]]; then 
+if [[ "${MACHINE_TYPE}" == "arm64" ]]; then
     MACHINE_TYPE="aarch64"
 fi
 
@@ -163,10 +163,10 @@ RAPIDJSON_SOURCE=rapidjson-1.1.0
 RAPIDJSON_MD5SUM="badd12c511e081fec6c89c43a7027bce"
 
 # simdjson
-SIMDJSON_DOWNLOAD="https://github.com/simdjson/simdjson/archive/refs/tags/v2.2.0.tar.gz"
-SIMDJSON_NAME=simdjson-v2.2.0.tar.gz
-SIMDJSON_SOURCE=simdjson-2.2.0
-SIMDJSON_MD5SUM="9bd0ced53281484d8842a9429065943d"
+SIMDJSON_DOWNLOAD="https://github.com/simdjson/simdjson/archive/refs/tags/v3.9.4.tar.gz"
+SIMDJSON_NAME=simdjson-v3.9.4.tar.gz
+SIMDJSON_SOURCE=simdjson-3.9.4
+SIMDJSON_MD5SUM="bdc1dfcb2a89dc0c09e8370808a946f5"
 
 # curl
 CURL_DOWNLOAD="https://curl.se/download/curl-8.4.0.tar.gz"


### PR DESCRIPTION
## Why I'm doing:
1. struct field columns may be inconsistent when parsing partial field failed.
2. `find_field_unordered` will crash in current simdjson version when loading from bad json.
```
#0  std::__uniq_ptr_impl<simdjson::internal::dom_parser_implementation, std::default_delete<simdjson::internal::dom_parser_implementation> >::_M_ptr (this=0x8) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:173
#1  std::unique_ptr<simdjson::internal::dom_parser_implementation, std::default_delete<simdjson::internal::dom_parser_implementation> >::get (this=0x8) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:422
#2  std::unique_ptr<simdjson::internal::dom_parser_implementation, std::default_delete<simdjson::internal::dom_parser_implementation> >::operator-> (this=0x8) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:416
#3  simdjson::fallback::ondemand::json_iterator::end_position (this=0x7fb36e049540) at /home/disk3/sr-deps/thirdparty/installed/include/simdjson/generic/ondemand/json_iterator-inl.h:193
#4  simdjson::fallback::ondemand::json_iterator::skip_child (this=0x7fb36e049540, parent_depth=<optimized out>) at /home/disk3/sr-deps/thirdparty/installed/include/simdjson/generic/ondemand/json_iterator-inl.h:126
#5  simdjson::fallback::ondemand::value_iterator::skip_child (this=<optimized out>) at /home/disk3/sr-deps/thirdparty/installed/include/simdjson/generic/ondemand/value_iterator-inl.h:693
#6  simdjson::fallback::ondemand::value_iterator::find_field_unordered_raw (key=<error reading variable: Cannot create a lazy string with address 0x0, and a non-zero length.>, this=<optimized out>) at /home/disk3/sr-deps/thirdparty/installed/include/simdjson/generic/ondemand/value_iterator-inl.h:306
#7  simdjson::fallback::ondemand::object::find_field_unordered(std::basic_string_view<char, std::char_traits<char> >) & (key=<error reading variable: Cannot create a lazy string with address 0x0, and a non-zero length.>, this=<optimized out>) at /home/disk3/sr-deps/thirdparty/installed/include/simdjson/generic/ondemand/object-inl.h:7
#8  starrocks::add_struct_column (column=0x7fb376e46330, type_desc=..., name="k2", value=value@entry=0x7fb34e6f7090) at be/src/formats/json/struct_column.cpp:42
#9  0x00000000075bdb0f in starrocks::add_adaptive_nullable_struct_column (column=0x7fb376e46380, type_desc=..., name="k2", value=0x7fb34e6f7090) at be/src/formats/json/nullable_column.cpp:255
#10 starrocks::add_adpative_nullable_column (column=0x7fb376e46380, type_desc=..., name="k2", value=...) at be/src/formats/json/nullable_column.cpp:404
#11 starrocks::add_adaptive_nullable_column (column=0x7fb376e46380, type_desc=..., name="k2", value=value@entry=0x7fb34e6f7090, invalid_as_null=true) at be/src/formats/json/nullable_column.cpp:456
#12 0x00000000075812fa in starrocks::JsonReader::_construct_column (this=0x7fb376e5d000, value=..., column=0x7fb376e31b30, column@entry=0x7fb376e5d000, type_desc=..., col_name=<error reading variable: Cannot access memory at address 0x8>) at be/src/exec/json_scanner.cpp:812
#13 starrocks::JsonReader::_construct_row_without_jsonpath (this=this@entry=0x7fb376e5d000, row=row@entry=0x7fb34e6f71c0, chunk=chunk@entry=0x7fb376e4d010) at be/src/exec/json_scanner.cpp:563
#14 0x00000000075865d3 in starrocks::JsonReader::_construct_row (this=0x7fb376e5d000, row=0x7fb34e6f71c0, chunk=0x7fb376e4d010) at be/src/exec/json_scanner.cpp:656
#15 starrocks::JsonReader::_read_rows<starrocks::JsonDocumentStreamParser> (this=this@entry=0x7fb376e5d000, chunk=chunk@entry=0x7fb376e4d010, rows_to_read=rows_to_read@entry=4096, rows_read=rows_read@entry=0x7fb34e6f72c4) at be/src/exec/json_scanner.cpp:459
#16 0x000000000757f062 in starrocks::JsonReader::read_chunk (this=0x7fb376e5d000, chunk=0x7fb376e4d010, rows_to_read=4096) at be/src/exec/json_scanner.cpp:426
```

## What I'm doing:
1. bump simdjson to 3.9.4 to fix `find_field_unordered` crash.
2. fill null if error to avoid inconsistent struct field columns.
4. support big integer(<-9223372036854775808 and >18446744073709551615).

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7982

#45406 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
