### PR TITLE
[Enhancement] Make ORC writer compatible with hive reader

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -851,6 +851,8 @@ CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 CONF_Int32(orc_loading_buffer_size, "8388608");
 
 // orc writer
+// This is a workaround from SR side for a out-of-bound bug of hive orc reader.
+// Refer to https://issues.apache.org/jira/browse/ORC-125 for more detailed information.
 CONF_mInt32(orc_writer_version, "-1");
 
 // parquet reader

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -851,7 +851,7 @@ CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 CONF_Int32(orc_loading_buffer_size, "8388608");
 
 // orc writer
-CONF_mInt32(orc_writer_version, -1);
+CONF_mInt32(orc_writer_version, "-1");
 
 // parquet reader
 CONF_mBool(parquet_coalesce_read_enable, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -850,6 +850,9 @@ CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 // we'll read the whole file at once instead of reading a footer first.
 CONF_Int32(orc_loading_buffer_size, "8388608");
 
+// orc writer
+CONF_mInt32(orc_writer_version, -1);
+
 // parquet reader
 CONF_mBool(parquet_coalesce_read_enable, "true");
 CONF_Bool(parquet_late_materialization_enable, "true");

--- a/be/src/formats/orc/apache-orc/c++/src/Writer.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Writer.cc
@@ -18,6 +18,8 @@
 
 #include <memory>
 
+#include "common/config.h"
+
 #include "ColumnWriter.hh"
 #include "Timezone.hh"
 #include "orc/Common.hh"
@@ -386,7 +388,11 @@ void WriterImpl::init() {
     postScript.add_version(options.getFileVersion().getMajor());
     postScript.add_version(options.getFileVersion().getMinor());
 
-    postScript.set_writerversion(WriterVersion_ORC_135);
+    if (starrocks::config::orc_writer_version != -1) {
+        postScript.set_writerversion(starrocks::config::orc_writer_version);
+    } else {
+        postScript.set_writerversion(WriterVersion_ORC_135);
+    }
     postScript.set_magic("ORC");
 
     // Initialize first stripe

--- a/be/src/formats/orc/apache-orc/c++/src/Writer.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Writer.cc
@@ -18,10 +18,9 @@
 
 #include <memory>
 
-#include "common/config.h"
-
 #include "ColumnWriter.hh"
 #include "Timezone.hh"
+#include "common/config.h"
 #include "orc/Common.hh"
 #include "orc/OrcFile.hh"
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

For old hive reader, reading orc file written by high version writer leads to a out-of-bound exception.

![image](https://github.com/StarRocks/starrocks/assets/16740944/45364d61-b18c-4a97-b2fe-7b8705aac9ca)

This is a bug of hive reader. Refer to https://issues.apache.org/jira/browse/ORC-125 for more detailed information.

This PR provides a workaround from SR side. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
