### PR TITLE
[BugFix] Fix parse Mysql Client Protocol COM_CHANGE_USER with conn_attr error bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChangeUserPacket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChangeUserPacket.java
@@ -48,9 +48,13 @@ public class MysqlChangeUserPacket extends MysqlPacket {
         return database;
     }
 
+    public Map<String, String> getConnectAttributes() {
+        return connectAttributes;
+    }
+
     @Override
     public boolean readFrom(ByteBuffer buffer) {
-        // protocol refer to: https://dev.mysql.com/doc/internals/en/com-change-user.html
+        // protocol refer to: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_change_user.html
         if (2 > buffer.limit() || MysqlCommand.COM_CHANGE_USER.getCommandCode() != buffer.get(0)) {
             return false;
         }
@@ -83,8 +87,9 @@ public class MysqlChangeUserPacket extends MysqlPacket {
         // attribute map, no use now.
         if (0 < buffer.remaining() && capability.isConnectAttrs()) {
             connectAttributes = Maps.newHashMap();
-            long numPair = MysqlProto.readVInt(buffer);
-            for (long i = 0; i < numPair; ++i) {
+            long connectionAttributesLength = MysqlProto.readVInt(buffer);
+            int connAttrBeginPos = buffer.position();
+            while (buffer.position() < connAttrBeginPos + connectionAttributesLength) {
                 String key = new String(MysqlProto.readLenEncodedString(buffer));
                 String value = new String(MysqlProto.readLenEncodedString(buffer));
                 connectAttributes.put(key, value);

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChangeUserPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChangeUserPacketTest.java
@@ -44,6 +44,13 @@ public class MysqlChangeUserPacketTest {
         serializer.writeNulTerminateString("testDb");
         // character set
         serializer.writeInt2(33);
+        //plugin
+        serializer.writeNulTerminateString("");
+
+        //conn attribute
+        serializer.writeVInt(10);
+        serializer.writeLenEncodedString("key");
+        serializer.writeLenEncodedString("value");
 
         byteBuffer = serializer.toByteBuffer();
     }
@@ -54,6 +61,7 @@ public class MysqlChangeUserPacketTest {
         Assert.assertTrue(packet.readFrom(byteBuffer));
         Assert.assertEquals("testUser", packet.getUser());
         Assert.assertEquals("testDb", packet.getDb());
+        Assert.assertEquals("value", packet.getConnectAttributes().get("key"));
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:
refer : https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_change_user.html
## What I'm doing:
There is an error when parsing the conn_attr field of COM_CHANGE_USER, because that field is the length of the following attr, not the number of attrs.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
