### PR TITLE
[Feature] List Partition For AMV(Part 3): Support nullable partition columns for list partition table/materialized view

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -14,8 +14,6 @@
 
 #include "exec/tablet_info.h"
 
-#include <thrift/protocol/TDebugProtocol.h>
-
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "exprs/expr.h"

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/tablet_info.h"
 
+#include <thrift/protocol/TDebugProtocol.h>
+
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
@@ -26,6 +28,8 @@
 namespace starrocks {
 
 static const std::string LOAD_OP_COLUMN = "__op";
+// NOTE: This value should keep the same with the value in FE's `STARROCKS_DEFAULT_PARTITION_VALUE` constant.
+static const std::string STARROCKS_DEFAULT_PARTITION_VALUE = "__DEFAULT_PARTITION__";
 
 struct VectorCompare {
     bool operator()(const std::vector<std::string>& a, const std::vector<std::string>& b) const {
@@ -329,20 +333,37 @@ Status OlapTablePartitionParam::_create_partition_keys(const std::vector<TExprNo
         return Status::InternalError(fmt::format("partition expr size {} not equal partition column size {}",
                                                  t_exprs.size(), _partition_columns.size()));
     }
+    DCHECK_EQ(_partition_slot_descs.size(), _partition_columns.size());
 
     for (int i = 0; i < t_exprs.size(); i++) {
         const TExprNode& t_expr = t_exprs[i];
         const auto& type_desc = TypeDescriptor::from_thrift(t_expr.type);
         const auto type = type_desc.type;
+        bool is_nullable = _partition_slot_descs[i]->is_nullable();
         if (_partition_columns[i] == nullptr) {
-            _partition_columns[i] = ColumnHelper::create_column(type_desc, false);
+            _partition_columns[i] = ColumnHelper::create_column(type_desc, is_nullable);
+        }
+        if (is_nullable) {
+            auto column = ColumnHelper::as_raw_column<NullableColumn>(_partition_columns[i]);
+            // handle null partition value
+            if (t_expr.node_type == TExprNodeType::NULL_LITERAL) {
+                DCHECK(t_expr.is_nullable);
+                DCHECK(is_nullable);
+                column->append_nulls(1);
+                continue;
+            } else {
+                // append not null value
+                column->mutable_null_column()->append(0);
+            }
         }
 
+        // unwrap nullable column since partition column can be nullable
+        auto* partition_data_column = ColumnHelper::get_data_column(_partition_columns[i].get());
         switch (type) {
         case TYPE_DATE: {
             DateValue v;
             if (v.from_string(t_expr.date_literal.value.c_str(), t_expr.date_literal.value.size())) {
-                auto* column = down_cast<DateColumn*>(_partition_columns[i].get());
+                auto* column = down_cast<DateColumn*>(partition_data_column);
                 column->get_data().emplace_back(v);
             } else {
                 std::stringstream ss;
@@ -354,7 +375,7 @@ Status OlapTablePartitionParam::_create_partition_keys(const std::vector<TExprNo
         case TYPE_DATETIME: {
             TimestampValue v;
             if (v.from_string(t_expr.date_literal.value.c_str(), t_expr.date_literal.value.size())) {
-                auto* column = down_cast<TimestampColumn*>(_partition_columns[i].get());
+                auto* column = down_cast<TimestampColumn*>(partition_data_column);
                 column->get_data().emplace_back(v);
             } else {
                 std::stringstream ss;
@@ -364,22 +385,22 @@ Status OlapTablePartitionParam::_create_partition_keys(const std::vector<TExprNo
             break;
         }
         case TYPE_TINYINT: {
-            auto* column = down_cast<Int8Column*>(_partition_columns[i].get());
+            auto* column = down_cast<Int8Column*>(partition_data_column);
             column->get_data().emplace_back(t_expr.int_literal.value);
             break;
         }
         case TYPE_SMALLINT: {
-            auto* column = down_cast<Int16Column*>(_partition_columns[i].get());
+            auto* column = down_cast<Int16Column*>(partition_data_column);
             column->get_data().emplace_back(t_expr.int_literal.value);
             break;
         }
         case TYPE_INT: {
-            auto* column = down_cast<Int32Column*>(_partition_columns[i].get());
+            auto* column = down_cast<Int32Column*>(partition_data_column);
             column->get_data().emplace_back(t_expr.int_literal.value);
             break;
         }
         case TYPE_BIGINT: {
-            auto* column = down_cast<Int64Column*>(_partition_columns[i].get());
+            auto* column = down_cast<Int64Column*>(partition_data_column);
             column->get_data().emplace_back(t_expr.int_literal.value);
             break;
         }
@@ -390,7 +411,7 @@ Status OlapTablePartitionParam::_create_partition_keys(const std::vector<TExprNo
             if (parse_result != StringParser::PARSE_SUCCESS) {
                 val = MAX_INT128;
             }
-            auto* column = down_cast<Int128Column*>(_partition_columns[i].get());
+            auto* column = down_cast<Int128Column*>(partition_data_column);
             column->get_data().emplace_back(val);
             break;
         }
@@ -398,12 +419,12 @@ Status OlapTablePartitionParam::_create_partition_keys(const std::vector<TExprNo
             int len = t_expr.string_literal.value.size();
             const char* str_val = t_expr.string_literal.value.c_str();
             Slice value(str_val, len);
-            auto* column = down_cast<BinaryColumn*>(_partition_columns[i].get());
+            auto* column = down_cast<BinaryColumn*>(partition_data_column);
             column->append(value);
             break;
         }
         case TYPE_BOOLEAN: {
-            auto* column = down_cast<BooleanColumn*>(_partition_columns[i].get());
+            auto* column = down_cast<BooleanColumn*>(partition_data_column);
             column->get_data().emplace_back(t_expr.bool_literal.value);
             break;
         }
@@ -418,6 +439,7 @@ Status OlapTablePartitionParam::_create_partition_keys(const std::vector<TExprNo
 
     part_key->columns = &_partition_columns;
     part_key->index = _partition_columns[0]->size() - 1;
+    VLOG(3) << "create partition key:" << part_key->debug_string();
     return Status::OK();
 }
 
@@ -472,6 +494,7 @@ Status OlapTablePartitionParam::add_partitions(const std::vector<TOlapTableParti
         if (t_part.__isset.in_keys) {
             for (auto& in_key : part->in_keys) {
                 _partitions_map[&in_key].push_back(part->id);
+                VLOG(1) << "add automatic partition:" << part->id << ", in_key:" << in_key.debug_string();
             }
         } else {
             _partitions_map[&part->end_key].push_back(part->id);
@@ -506,6 +529,112 @@ Status OlapTablePartitionParam::remove_partitions(const std::vector<int64_t>& pa
     return Status::OK();
 }
 
+Status OlapTablePartitionParam::find_tablets_with_list_partition(
+        Chunk* chunk, std::vector<OlapTablePartition*>* partitions, std::vector<uint32_t>* indexes,
+        std::vector<uint8_t>* selection, std::vector<int>* invalid_row_indexs,
+        std::vector<std::vector<std::string>>* partition_not_exist_row_values) {
+    ChunkRow row;
+    row.columns = &partition_columns;
+    row.index = 0;
+    std::vector<Column*> partition_data_columns;
+    partition_data_columns.reserve(partition_columns.size());
+    for (auto& column : *(row.columns)) {
+        partition_data_columns.emplace_back(ColumnHelper::get_data_column(column.get()));
+    }
+    bool is_list_partition = _t_param.partitions[0].__isset.in_keys;
+    int partition_column_size = partition_columns.size();
+    for (size_t i = 0; i < num_rows; ++i) {
+        OlapTablePartition* part = nullptr;
+        if (!((*selection)[i])) {
+            continue;
+        }
+        row.index = i;
+        // list partition
+        auto it = _partitions_map.find(&row);
+        if (it != _partitions_map.end() &&
+            (part = _partitions[it->second[(*indexes)[i] % it->second.size()]]) != nullptr &&
+            _part_contains(part, &row)) {
+            (*partitions)[i] = part;
+            (*indexes)[i] = (*indexes)[i] % part->num_buckets;
+        } else {
+            if (partition_not_exist_row_values) {
+                auto partition_value_items = std::make_unique<std::vector<std::string>>();
+                for (int j = 0; j < partition_column_size; ++j) {
+                    auto& raw_column = (*(row.columns))[j];
+                    if (raw_column->is_null(i)) {
+                        partition_value_items->emplace_back(STARROCKS_DEFAULT_PARTITION_VALUE);
+                    } else {
+                        partition_value_items->emplace_back(partition_data_columns[j]->raw_item_value(i));
+                    }
+                }
+                auto r = partition_columns_set.insert(*partition_value_items);
+                if (r.second) {
+                    (*partition_not_exist_row_values).emplace_back(*partition_value_items);
+                }
+            } else {
+                VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
+                        << row.debug_string();
+                (*partitions)[i] = nullptr;
+                (*selection)[i] = 0;
+                if (invalid_row_indexs != nullptr) {
+                    invalid_row_indexs->emplace_back(i);
+                }
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status OlapTablePartitionParam::find_tablets_with_range_partition(
+        Chunk* chunk, std::vector<OlapTablePartition*>* partitions, std::vector<uint32_t>* indexes,
+        std::vector<uint8_t>* selection, std::vector<int>* invalid_row_indexs,
+        std::vector<std::vector<std::string>>* partition_not_exist_row_values) {
+    ChunkRow row;
+    row.columns = &partition_columns;
+    row.index = 0;
+    for (size_t i = 0; i < num_rows; ++i) {
+        OlapTablePartition* part = nullptr;
+        if (!((*selection)[i])) {
+            continue;
+        }
+        row.index = i;
+        // range partition
+        auto it = _partitions_map.upper_bound(&row);
+        if (it != _partitions_map.end() &&
+            (part = _partitions[it->second[(*indexes)[i] % it->second.size()]]) != nullptr &&
+            _part_contains(part, &row)) {
+            (*partitions)[i] = part;
+            (*indexes)[i] = (*indexes)[i] % part->num_buckets;
+        } else {
+            if (partition_not_exist_row_values) {
+                // only support single column partition for range partition now
+                if (partition_columns.size() != 1) {
+                    return Status::InternalError("automatic partition only support single column partition.");
+                }
+                auto partition_value_items = std::make_unique<std::vector<std::string>>();
+                for (auto& column : *row.columns) {
+                    VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
+                            << row.debug_string();
+                    partition_value_items->emplace_back(column->raw_item_value(i));
+                }
+                auto r = partition_columns_set.insert(*partition_value_items);
+                if (r.second) {
+                    (*partition_not_exist_row_values).emplace_back(*partition_value_items);
+                }
+            } else {
+                VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
+                        << row.debug_string();
+                (*partitions)[i] = nullptr;
+                (*selection)[i] = 0;
+                if (invalid_row_indexs != nullptr) {
+                    invalid_row_indexs->emplace_back(i);
+                }
+            }
+        }
+    }
+    return Status::OK();
+}
+
 Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTablePartition*>* partitions,
                                              std::vector<uint32_t>* indexes, std::vector<uint8_t>* selection,
                                              std::vector<int>* invalid_row_indexs, int64_t txn_id,
@@ -531,81 +660,13 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
             }
         }
 
-        ChunkRow row;
-        row.columns = &partition_columns;
-        row.index = 0;
         bool is_list_partition = _t_param.partitions[0].__isset.in_keys;
-        for (size_t i = 0; i < num_rows; ++i) {
-            OlapTablePartition* part = nullptr;
-            if ((*selection)[i]) {
-                row.index = i;
-                if (is_list_partition) {
-                    // list partition
-                    auto it = _partitions_map.find(&row);
-                    if (it != _partitions_map.end() &&
-                        (part = _partitions[it->second[(*indexes)[i] % it->second.size()]]) != nullptr &&
-                        _part_contains(part, &row)) {
-                        (*partitions)[i] = part;
-                        (*indexes)[i] = (*indexes)[i] % part->num_buckets;
-                    } else {
-                        if (partition_not_exist_row_values) {
-                            auto partition_value_items = std::make_unique<std::vector<std::string>>();
-                            for (auto& column : *row.columns) {
-                                VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
-                                        << row.debug_string();
-                                partition_value_items->emplace_back(column->raw_item_value(i));
-                            }
-                            auto r = partition_columns_set.insert(*partition_value_items);
-                            if (r.second) {
-                                (*partition_not_exist_row_values).emplace_back(*partition_value_items);
-                            }
-                        } else {
-                            VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
-                                    << row.debug_string();
-                            (*partitions)[i] = nullptr;
-                            (*selection)[i] = 0;
-                            if (invalid_row_indexs != nullptr) {
-                                invalid_row_indexs->emplace_back(i);
-                            }
-                        }
-                    }
-                } else {
-                    // range partition
-                    auto it = _partitions_map.upper_bound(&row);
-                    if (it != _partitions_map.end() &&
-                        (part = _partitions[it->second[(*indexes)[i] % it->second.size()]]) != nullptr &&
-                        _part_contains(part, &row)) {
-                        (*partitions)[i] = part;
-                        (*indexes)[i] = (*indexes)[i] % part->num_buckets;
-                    } else {
-                        if (partition_not_exist_row_values) {
-                            // only support single column partition for range partition now
-                            if (partition_columns.size() != 1) {
-                                return Status::InternalError(
-                                        "automatic partition only support single column partition.");
-                            }
-                            auto partition_value_items = std::make_unique<std::vector<std::string>>();
-                            for (auto& column : *row.columns) {
-                                VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
-                                        << row.debug_string();
-                                partition_value_items->emplace_back(column->raw_item_value(i));
-                            }
-                            auto r = partition_columns_set.insert(*partition_value_items);
-                            if (r.second) {
-                                (*partition_not_exist_row_values).emplace_back(*partition_value_items);
-                            }
-                        } else {
-                            VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
-                                    << row.debug_string();
-                            (*partitions)[i] = nullptr;
-                            (*selection)[i] = 0;
-                            if (invalid_row_indexs != nullptr) {
-                                invalid_row_indexs->emplace_back(i);
-                            }
-                        }
-                    }
-                }
-            }
+        if (is_list_partition) {
+            return find_tablets_with_list_partition(chunk, partitions, indexes, selection, invalid_row_indexs,
+                                                    partition_not_exist_row_values);
+        } else {
+            return find_tablets_with_range_partition(chunk, partitions, indexes, selection, invalid_row_indexs,
+                                                     partition_not_exist_row_values);
         }
     } else {
         if (_partitions_map.empty()) {

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "column/column.h"
+#include "column/column_helper.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "gen_cpp/Descriptors_types.h"
@@ -193,13 +194,45 @@ struct PartionKeyComparator {
         DCHECK_EQ(lhs->columns->size(), rhs->columns->size());
 
         for (size_t i = 0; i < lhs->columns->size(); ++i) {
-            int cmp = (*lhs->columns)[i]->compare_at(lhs->index, rhs->index, *(*rhs->columns)[i], -1);
+            int cmp = _compare_at((*lhs->columns)[i], (*rhs->columns)[i], lhs->index, rhs->index);
             if (cmp != 0) {
                 return cmp < 0;
             }
         }
         // equal, return false
         return false;
+    }
+
+private:
+    Column* _get_data_column(const ColumnPtr& column) const {
+        if (column->is_nullable()) {
+            auto v = ColumnHelper::as_raw_column<NullableColumn>(column);
+            return v->data_column().get();
+        } else {
+            return column.get();
+        }
+    }
+
+    int _compare_at(const ColumnPtr& lc, const ColumnPtr& rc, uint32_t l_idx, uint32_t r_idx) const {
+        if (!lc->is_nullable() && !rc->is_nullable()) {
+            return lc->compare_at(l_idx, r_idx, *rc, -1);
+        } else {
+            bool is_l_null = lc->is_null(l_idx);
+            bool is_r_null = rc->is_null(r_idx);
+            if (!is_l_null && !is_r_null) {
+                Column* ldc = _get_data_column(lc);
+                Column* rdc = _get_data_column(rc);
+                return ldc->compare_at(l_idx, r_idx, *rdc, -1);
+            } else {
+                if (is_l_null && is_r_null) {
+                    return 0;
+                } else if (is_l_null) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        }
     }
 };
 
@@ -239,6 +272,36 @@ public:
     const TOlapTablePartitionParam& param() const { return _t_param; }
 
 private:
+    /**
+     * @brief  find tablets with range partition table
+     * @param chunk  input chunk
+     * @param partitions  output partitions
+     * @param indexes  output partition indexes
+     * @param selection  chunk's selection
+     * @param invalid_row_indexs output invalid row indexs
+     * @param partition_not_exist_row_values  output partition not exist row values
+     * @return Status 
+     */
+    Status _find_tablets_with_range_partition(Chunk* chunk, std::vector<OlapTablePartition*>* partitions,
+                                              std::vector<uint32_t>* indexes, std::vector<uint8_t>* selection,
+                                              std::vector<int>* invalid_row_indexs,
+                                              std::vector<std::vector<std::string>>* partition_not_exist_row_values);
+
+    /**
+     * @brief  find tablets with list partition table
+     * @param chunk  input chunk
+     * @param partitions  output partitions
+     * @param indexes  output partition indexes
+     * @param selection  chunk's selection
+     * @param invalid_row_indexs output invalid row indexs
+     * @param partition_not_exist_row_values  output partition not exist row values
+     * @return Status 
+     */
+    Status _find_tablets_with_list_partition(Chunk* chunk, std::vector<OlapTablePartition*>* partitions,
+                                             std::vector<uint32_t>* indexes, std::vector<uint8_t>* selection,
+                                             std::vector<int>* invalid_row_indexs,
+                                             std::vector<std::vector<std::string>>* partition_not_exist_row_values);
+
     Status _create_partition_keys(const std::vector<TExprNode>& t_exprs, ChunkRow* part_key);
 
     void _compute_hashes(Chunk* chunk, std::vector<uint32_t>* indexes);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -51,6 +51,7 @@ import java.util.stream.Collectors;
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
 
 public class ListPartitionInfo extends PartitionInfo {
+
     private static final Logger LOG = LogManager.getLogger(ListPartitionInfo.class);
 
     @SerializedName("partitionColumns")
@@ -112,8 +113,8 @@ public class ListPartitionInfo extends PartitionInfo {
         for (String value : values) {
             //there only one partition column for single partition list
             Type type = idToColumn.get(partitionColumnIds.get(0)).getType();
-            LiteralExpr literalExpr = new PartitionValue(value).getValue(type);
-            partitionValues.add(literalExpr);
+            LiteralExpr partitionValue = new PartitionValue(value).getValue(type);
+            partitionValues.add(partitionValue);
         }
         this.idToLiteralExprValues.put(partitionId, partitionValues);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_REPLICATION_NUM;
 
 public class ListPartitionInfo extends PartitionInfo {
-
     private static final Logger LOG = LogManager.getLogger(ListPartitionInfo.class);
 
     @SerializedName("partitionColumns")
@@ -113,8 +112,8 @@ public class ListPartitionInfo extends PartitionInfo {
         for (String value : values) {
             //there only one partition column for single partition list
             Type type = idToColumn.get(partitionColumnIds.get(0)).getType();
-            LiteralExpr partitionValue = new PartitionValue(value).getValue(type);
-            partitionValues.add(partitionValue);
+            LiteralExpr literalExpr = new PartitionValue(value).getValue(type);
+            partitionValues.add(literalExpr);
         }
         this.idToLiteralExprValues.put(partitionId, partitionValues);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -18,6 +18,7 @@ package com.starrocks.scheduler.mv;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.IsNullPredicate;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -143,7 +144,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             return null;
         }
 
-        List<LiteralExpr> sourceTablePartitionList = Lists.newArrayList();
+        List<Expr> sourceTablePartitionList = Lists.newArrayList();
         List<Column> partitionCols = refBaseTable.getPartitionColumns();
         Map<Table, Column> partitionTableAndColumn = mv.getRelatedPartitionTableAndColumn();
         if (partitionTableAndColumn == null || !partitionTableAndColumn.containsKey(refBaseTable)) {
@@ -152,6 +153,8 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         Column refPartitionColumn = partitionTableAndColumn.get(table);
         int refIndex = ListPartitionDiffer.getRefBaseTableIdx(refBaseTable, refPartitionColumn);
         Type partitionType = partitionCols.get(refIndex).getType();
+
+        boolean isContainsNullPartition = false;
         for (String tablePartitionName : refBaseTablePartitionNames) {
             PListCell cell = baseListPartitionMap.get(tablePartitionName);
             for (List<String> values : cell.getPartitionItems()) {
@@ -159,11 +162,22 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                     return null;
                 }
                 LiteralExpr partitionValue = new PartitionValue(values.get(refIndex)).getValue(partitionType);
+                if (partitionValue.isConstantNull()) {
+                    isContainsNullPartition = true;
+                    continue;
+                }
                 sourceTablePartitionList.add(partitionValue);
             }
         }
-        List<Expr> partitionPredicates = MvUtils.convertList(mvPartitionSlotRef, sourceTablePartitionList);
-        return Expr.compoundOr(partitionPredicates);
+        Expr inPredicate = MvUtils.convertToInPredicate(mvPartitionSlotRef, sourceTablePartitionList);
+        // NOTE: If target partition values contain `null partition`, the generated predicate should
+        // contain `is null` predicate rather than `in (null) or = null` because the later one is not correct.
+        if (isContainsNullPartition) {
+            IsNullPredicate isNullPredicate = new IsNullPredicate(mvPartitionSlotRef, false);
+            return Expr.compoundOr(Lists.newArrayList(inPredicate, isNullPredicate));
+        } else {
+            return inPredicate;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3036,9 +3036,6 @@ public class LocalMetastore implements ConnectorMetadata {
 
         // create partition info
         PartitionInfo partitionInfo = buildPartitionInfo(stmt);
-        if (partitionInfo instanceof ListPartitionInfo && stmt.getPartitionColumn().isAllowNull()) {
-            throw new DdlException("List partition columns must not be nullable in Materialized view for now.");
-        }
         // create distribution info
         DistributionDesc distributionDesc = stmt.getDistributionDesc();
         Preconditions.checkNotNull(distributionDesc);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -813,11 +813,6 @@ public class MaterializedViewAnalyzer {
                     throw new SemanticException("Materialized view partition column in partition exp " +
                             "must be base table partition column");
                 }
-                // TODO: only support not null list partitions
-                if (slotRef.isNullable()) {
-                    throw new SemanticException("Materialized view partition column only support not null list partition " +
-                            "columns for now");
-                }
             } else {
                 throw new SemanticException("Materialized view related base table partition type: " +
                         partitionInfo.getType().name() + " not supports");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
@@ -101,12 +101,6 @@ public class ListPartitionDesc extends PartitionDesc {
     public void analyze(List<ColumnDef> columnDefs, Map<String, String> tableProperties) throws AnalysisException {
         // analyze partition columns
         List<ColumnDef> columnDefList = this.analyzePartitionColumns(columnDefs);
-        for (ColumnDef columnDef : columnDefList) {
-            if (columnDef.isAllowNull()) {
-                throw new AnalysisException("The list partition column does not support allow null currently, column:["
-                        + columnDef.getName() + "] should be set to not null.");
-            }
-        }
         // analyze single list property
         this.analyzeSingleListPartition(tableProperties, columnDefList);
         // analyze multi list partition

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
@@ -29,7 +29,7 @@ import java.time.LocalTime;
 
 public class PartitionValue implements ParseNode {
     // default partition value for `NULL` value
-    public static final String STARROCKS_DEFAULT_PARTITION_VALUE = "__DEFAULT_PARTITION__";
+    public static final String STARROCKS_DEFAULT_PARTITION_VALUE = "__STARROCKS_DEFAULT_PARTITION__";
 
     public static final PartitionValue MAX_VALUE = new PartitionValue();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
@@ -63,7 +63,7 @@ public class PartitionValue implements ParseNode {
      * @param type partition column type
      */
     public LiteralExpr getValue(Type type) throws AnalysisException {
-        if (value.equals(STARROCKS_DEFAULT_PARTITION_VALUE)) {
+        if (value != null && value.equalsIgnoreCase(STARROCKS_DEFAULT_PARTITION_VALUE)) {
             return NullLiteral.create(type);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
@@ -27,6 +28,9 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class PartitionValue implements ParseNode {
+    // default partition value for `NULL` value
+    public static final String STARROCKS_DEFAULT_PARTITION_VALUE = "__DEFAULT_PARTITION__";
+
     public static final PartitionValue MAX_VALUE = new PartitionValue();
 
     private final NodePosition pos;
@@ -54,7 +58,15 @@ public class PartitionValue implements ParseNode {
         return ofDateTime(LocalDateTime.of(date, LocalTime.MIN));
     }
 
+    /**
+     * Convert to string value to literal expr which needs to handle null value
+     * @param type partition column type
+     */
     public LiteralExpr getValue(Type type) throws AnalysisException {
+        if (value.equals(STARROCKS_DEFAULT_PARTITION_VALUE)) {
+            return NullLiteral.create(type);
+        }
+
         if (isMax()) {
             return LiteralExpr.createInfinity(type, true);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -48,7 +48,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.ListPartitionPruner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -264,7 +263,7 @@ public class OptOlapPartitionPruner {
         partitionValueToIds.put(value, partitionIdSet);
     }
 
-    private static List<Long> listPartitionPrune(OlapTable olapTable, @NotNull ListPartitionInfo listPartitionInfo,
+    private static List<Long> listPartitionPrune(OlapTable olapTable, ListPartitionInfo listPartitionInfo,
                                                  LogicalOlapScanOperator operator) {
 
         Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -981,7 +981,8 @@ public class MvUtils {
         if (values == null || values.isEmpty()) {
             return new BoolLiteral(true);
         }
-        return new InPredicate(slotRef, values, false);
+        // to avoid duplicate values
+        return new InPredicate(slotRef, Lists.newArrayList(Sets.newHashSet(values)), false);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -24,10 +24,12 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.ParseNode;
@@ -97,6 +99,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
@@ -968,13 +971,34 @@ public class MvUtils {
         return rangeParts;
     }
 
-    public static List<Expr> convertList(Expr slotRef, List<LiteralExpr> values) {
-        List<Expr> listPart = Lists.newArrayList();
-        for (LiteralExpr value : values) {
-            BinaryPredicate predicate = new BinaryPredicate(BinaryType.EQ, slotRef, value);
-            listPart.add(predicate);
+    /**
+     * Convert partition range to IN predicate
+     * @param slotRef the comparison column
+     * @param values the target partition values
+     * @return in predicate
+     */
+    public static Expr convertToInPredicate(Expr slotRef, List<Expr> values) {
+        if (values == null || values.isEmpty()) {
+            return new BoolLiteral(true);
         }
-        return listPart;
+        return new InPredicate(slotRef, values, false);
+    }
+
+    /**
+     * Convert partition range to IN predicate scalar operator
+     * @param col the comparison operator
+     * @param values the target scalar operators
+     * @return in predicate scalar operator
+     */
+    public static ScalarOperator convertToInPredicate(ScalarOperator col,
+                                                      List<ScalarOperator> values) {
+        if (values == null || values.isEmpty()) {
+            return ConstantOperator.TRUE;
+        }
+        List<ScalarOperator> inArgs = Lists.newArrayList();
+        inArgs.add(col);
+        inArgs.addAll(values);
+        return new InPredicateOperator(false, inArgs);
     }
 
     public static List<Range<PartitionKey>> mergeRanges(List<Range<PartitionKey>> ranges) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -7048,11 +7048,19 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 createPos(context));
     }
 
+    public List<String> parseListPartitionValueList(StarRocksParser.ListPartitionValueListContext valueListContext) {
+        return valueListContext.listPartitionValue().stream().map(x -> {
+            if (x.NULL() != null) {
+                return PartitionValue.STARROCKS_DEFAULT_PARTITION_VALUE;
+            } else {
+                return ((StringLiteral) visit(x.string())).getStringValue();
+            }
+        }).collect(toList());
+    }
+
     @Override
     public ParseNode visitSingleItemListPartitionDesc(StarRocksParser.SingleItemListPartitionDescContext context) {
-        List<String> values =
-                context.stringList().string().stream().map(c -> ((StringLiteral) visit(c)).getStringValue())
-                        .collect(toList());
+        List<String> values = parseListPartitionValueList(context.listPartitionValueList());
         boolean ifNotExists = context.IF() != null;
         Map<String, String> properties = null;
         if (context.propertyList() != null) {
@@ -7069,13 +7077,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitMultiItemListPartitionDesc(StarRocksParser.MultiItemListPartitionDescContext context) {
         boolean ifNotExists = context.IF() != null;
-        List<List<String>> multiValues = new ArrayList<>();
-        for (StarRocksParser.StringListContext stringListContext : context.stringList()) {
-            List<String> values =
-                    stringListContext.string().stream().map(c -> ((StringLiteral) visit(c)).getStringValue())
-                            .collect(toList());
-            multiValues.add(values);
-        }
+        List<List<String>> multiValues = context.listPartitionValueList().stream()
+                .map(l -> parseListPartitionValueList(l))
+                .collect(toList());
         Map<String, String> properties = null;
         if (context.propertyList() != null) {
             properties = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2381,11 +2381,19 @@ listPartitionDesc
     ;
 
 singleItemListPartitionDesc
-    : PARTITION (IF NOT EXISTS)? identifier VALUES IN stringList propertyList?
+    : PARTITION (IF NOT EXISTS)? identifier VALUES IN listPartitionValueList propertyList?
     ;
 
 multiItemListPartitionDesc
-    : PARTITION (IF NOT EXISTS)? identifier VALUES IN '(' stringList (',' stringList)* ')' propertyList?
+    : PARTITION (IF NOT EXISTS)? identifier VALUES IN '(' listPartitionValueList (',' listPartitionValueList)* ')' propertyList?
+    ;
+
+listPartitionValueList
+    : '(' listPartitionValue (',' listPartitionValue)* ')'
+    ;
+
+listPartitionValue
+    : NULL | string
     ;
 
 stringList

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -3751,6 +3751,37 @@ public class CreateMaterializedViewTest {
         starRocksAssert.dropTable("list_partition_tbl1");
     }
 
+
+    @Test
+    public void testCreateMaterializedViewOnListPartitionTables3() {
+        String createSQL = "CREATE TABLE test.list_partition_tbl1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM;";
+        starRocksAssert.withTable(
+                createSQL,
+                () -> {
+                    String sql = "create materialized view list_partition_mv1 " +
+                            "partition by (province) " +
+                            "distributed by hash(dt, province) buckets 10 " +
+                            "as select dt, province, avg(age) from list_partition_tbl1 group by dt, province;";
+                    try {
+                        UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    } catch (Exception e) {
+                        Assert.fail(e.getMessage());
+                    }
+                });
+    }
+
     @Test
     public void testCreateMaterializedViewWithTableAlias1() throws Exception {
         String sql = "create materialized view mv1 " +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -168,7 +168,7 @@ public class CreateTableTest {
                         + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1');"));
 
         ExceptionChecker.expectThrowsNoException(
-                () -> createTable("create table test.lp_tbl1\n" + "(k1 bigint, k2 varchar(16)," +
+                () -> createTable("create table test.list_lp_tbl1\n" + "(k1 bigint, k2 varchar(16)," +
                         " dt varchar(10))\n duplicate key(k1)\n"
                         + "partition by list(k2, dt)\n" + "(partition p1 values in ((\"2022-04-01\", \"shanghai\")) )\n"
                         + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1');"));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -168,6 +168,12 @@ public class CreateTableTest {
                         + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1');"));
 
         ExceptionChecker.expectThrowsNoException(
+                () -> createTable("create table test.lp_tbl1\n" + "(k1 bigint, k2 varchar(16)," +
+                        " dt varchar(10))\n duplicate key(k1)\n"
+                        + "partition by list(k2, dt)\n" + "(partition p1 values in ((\"2022-04-01\", \"shanghai\")) )\n"
+                        + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1');"));
+
+        ExceptionChecker.expectThrowsNoException(
                 () -> createTable("create table test.lp_tbl2\n" + "(k1 bigint, k2 varchar(16), dt varchar(10))\n" +
                         "duplicate key(k1)\n"
                         + "partition by range(k1)\n" + "(partition p1 values [(\"1\"), (MAXVALUE)) )\n"

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -344,7 +344,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                             PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
                                     "     PREAGGREGATION: ON\n" +
-                                    "     PREDICATES: 4: province IN ('beijing', 'chongqing')\n" +
+                                    "     PREDICATES: 4: province IN ('chongqing', 'beijing')\n" +
                                     "     partitions=1/2");
 
                             Collection<Partition> partitions = materializedView.getPartitions();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -141,7 +141,9 @@ public class PlanTestNoneDBBase {
         } else if (predicate.contains("PREDICATES: ") && predicate.contains(" IN ")) {
             // normalize in predicate values' order
             String[] splitArray = predicate.split(" IN ");
-            Preconditions.checkArgument(splitArray.length == 2);
+            if (splitArray.length != 2) {
+                return predicate;
+            }
             String first = splitArray[0];
             String second = splitArray[1];
             String predicates = second.substring(1, second.length() - 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -138,6 +138,20 @@ public class PlanTestNoneDBBase {
             sb.append(sorted);
             sb.append("])");
             return sb.toString();
+        } else if (predicate.contains("PREDICATES: ") && predicate.contains(" IN ")) {
+            // normalize in predicate values' order
+            String[] splitArray = predicate.split(" IN ");
+            Preconditions.checkArgument(splitArray.length == 2);
+            String first = splitArray[0];
+            String second = splitArray[1];
+            String predicates = second.substring(1, second.length() - 1);
+            String sorted = Arrays.stream(predicates.split(", ")).sorted().collect(Collectors.joining(","));
+            StringBuilder sb = new StringBuilder();
+            sb.append(first);
+            sb.append(" IN (");
+            sb.append(sorted);
+            sb.append(")");
+            return sb.toString();
         } else {
             return predicate;
         }

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
@@ -1,0 +1,598 @@
+-- name: test_mv_refresh_list_partitions_with_nullable
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")),
+     PARTITION p5 VALUES IN ((NULL, NULL)) 
+)
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);
+-- result:
+-- !result
+CREATE TABLE t4 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province) 
+DISTRIBUTED BY RANDOM BUCKETS 1;
+-- result:
+-- !result
+INSERT INTO t4 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, 21, '2024-01-03');
+-- result:
+-- !result
+CREATE TABLE t5 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province, dt) 
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t5 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select id, dt, province, age from t3 where id > 1;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2	2024-01-01	guangdong	20
+3	2024-01-02	guangdong	20
+4	None	None	None
+-- !result
+function: check_hit_materialized_view("select id, dt, province, age from t3 where id > 1;", "test_mv1")
+-- result:
+None
+-- !result
+select id, dt, province, age from t3 where id > 1 order by 1, 2;
+-- result:
+2	2024-01-01	guangdong	20
+3	2024-01-02	guangdong	20
+4	None	None	None
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select id, dt, province, age from t3 where id > 1;", "test_mv1")
+-- result:
+None
+-- !result
+select id, dt, province, age from t3 where id > 1 order by 1, 2;
+-- result:
+2	2024-01-01	beijing	20
+2	2024-01-01	guangdong	20
+3	2024-01-02	guangdong	20
+4	None	None	None
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+2024-01-03	None	21
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      "partition_ttl_number" = "1",
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	100
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      "partition_ttl_number" = "1",
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+None	None	None
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	100
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      "partition_ttl_number" = "1",
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+None	None	None
+2024-01-01	beijing	140
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table t3;
+-- result:
+-- !result
+drop table t4;
+-- result:
+-- !result
+drop table t5;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
@@ -1,0 +1,274 @@
+-- name: test_mv_refresh_list_partitions_with_nullable
+
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")),
+     PARTITION p5 VALUES IN ((NULL, NULL)) 
+)
+DISTRIBUTED BY RANDOM;
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);
+
+CREATE TABLE t4 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province) 
+DISTRIBUTED BY RANDOM BUCKETS 1;
+INSERT INTO t4 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, 21, '2024-01-03');
+
+CREATE TABLE t5 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province, dt) 
+DISTRIBUTED BY RANDOM;
+INSERT INTO t5 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);
+
+--------- t3 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select id, dt, province, age from t3 where id > 1;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select id, dt, province, age from t3 where id > 1;", "test_mv1")
+select id, dt, province, age from t3 where id > 1 order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select id, dt, province, age from t3 where id > 1;", "test_mv1")
+select id, dt, province, age from t3 where id > 1 order by 1, 2;
+
+drop materialized view test_mv1;
+
+--------- t3 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t3 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 group by dt, province order by 1, 2;
+
+drop materialized view test_mv1;
+
+--------- t4 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t4 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t5 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t6 ---------
+-- test sync refresh & partition_refresh_number= -1 && partition_ttl_number =1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      'partition_refresh_number' = '-1',
+      "partition_ttl_number" = "1",
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      "partition_ttl_number" = "1",
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+      "partition_ttl_number" = "1",
+      'session.enable_insert_strict' = 'true',
+      "replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+drop table t3;
+drop table t4;
+drop table t5;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Support  nullable partition columns for list partition table
```
CREATE TABLE t3 (
      id BIGINT,
      province VARCHAR(64),
      age SMALLINT,
      dt VARCHAR(10)
)
DUPLICATE KEY(id)
PARTITION BY LIST (province, dt) (
     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")),
     PARTITION p5 VALUES IN ((NULL, NULL)) 
)
DISTRIBUTED BY RANDOM;
INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);

CREATE TABLE t4 (
      id BIGINT,
      province VARCHAR(64),
      age SMALLINT,
      dt VARCHAR(10)
)
DUPLICATE KEY(id)
PARTITION BY (province) 
DISTRIBUTED BY RANDOM BUCKETS 1;
INSERT INTO t4 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, 21, '2024-01-03');

CREATE TABLE t5 (
      id BIGINT,
      province VARCHAR(64),
      age SMALLINT,
      dt VARCHAR(10)
)
DUPLICATE KEY(id)
PARTITION BY (province, dt) 
DISTRIBUTED BY RANDOM;
INSERT INTO t5 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);
```

- Support to Create Materialized View With Nullable Partition Column
```
create materialized view test_mv1
partition by dt
REFRESH DEFERRED MANUAL
distributed by hash(dt, province) buckets 10 
PROPERTIES (
      'partition_refresh_number' = '-1',
      'session.enable_insert_strict' = 'true',
      "replication_num" = "1"
) 
as select id, dt, province, age from t3 where id > 1;
refresh materialized view  test_mv1 with sync mode;


create materialized view test_mv1
partition by dt
REFRESH DEFERRED MANUAL
distributed by hash(dt, province) buckets 10 
PROPERTIES (
      'partition_refresh_number' = '-1',
      'session.enable_insert_strict' = 'true',
      "replication_num" = "1"
) 
as select dt, province, sum(age) from t3 group by dt, province;
refresh materialized view  test_mv1 with sync mode;
```


Fixes https://github.com/StarRocks/starrocks/issues/46087

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
