### PR TITLE
[BugFix] follower sync dictionary refresh state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
@@ -69,6 +69,10 @@ public class Dictionary implements Writable {
 
     private Map<String, String> properties = Maps.newHashMap();
 
+    // =============== Runtime parameter ===========================
+    // This parameters are serialized ONLY use for sync refresh state from leader
+    // to follower. When FE restart, all kinds of this runtime parameter will be
+    // reset.
     @SerializedName(value = "lastSuccessRefreshTime")
     private long lastSuccessRefreshTime = 0;
     @SerializedName(value = "lastSuccessFinishedTime")
@@ -81,6 +85,7 @@ public class Dictionary implements Writable {
     private String runtimeErrMsg;
     @SerializedName(value = "lastSuccessVersion")
     private long lastSuccessVersion = 0;
+    // =============== Runtime parameter ===========================
 
     public Dictionary(long dictionaryId, String dictionaryName, String queryableObject,
                       String catalogName, String dbName, List<String> dictionaryKeys,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
@@ -22,7 +22,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataInput;
@@ -33,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class Dictionary implements Writable, GsonPostProcessable {
+public class Dictionary implements Writable {
     // Dictionary properties
     public static final String PROPERTIES_DICTIONARY_WARM_UP = "dictionary_warm_up";
     public static final String PROPERTIES_DICTIONARY_MEMORY_LIMIT = "dictionary_memory_limit";
@@ -64,15 +63,24 @@ public class Dictionary implements Writable, GsonPostProcessable {
     private List<String> dictionaryKeys = Lists.newArrayList();
     @SerializedName(value = "dictionaryValues")
     private List<String> dictionaryValues = Lists.newArrayList();
+
+    @SerializedName(value = "nextSchedulableTime")
     private AtomicLong nextSchedulableTime = new AtomicLong(Long.MAX_VALUE); // ms
 
     private Map<String, String> properties = Maps.newHashMap();
 
+    @SerializedName(value = "lastSuccessRefreshTime")
     private long lastSuccessRefreshTime = 0;
+    @SerializedName(value = "lastSuccessFinishedTime")
     private long lastSuccessFinishedTime = 0;
+    @SerializedName(value = "state")
     private DictionaryState state = DictionaryState.UNINITIALIZED;
+    @SerializedName(value = "stateBeforeRefresh")
     private DictionaryState stateBeforeRefresh = null;
+    @SerializedName(value = "runtimeErrMsg")
     private String runtimeErrMsg;
+    @SerializedName(value = "lastSuccessVersion")
+    private long lastSuccessVersion = 0;
 
     public Dictionary(long dictionaryId, String dictionaryName, String queryableObject,
                       String catalogName, String dbName, List<String> dictionaryKeys,
@@ -305,6 +313,11 @@ public class Dictionary implements Writable, GsonPostProcessable {
         this.setErrorMsg("");
         this.state = DictionaryState.UNINITIALIZED;
         this.stateBeforeRefresh = null;
+        this.lastSuccessRefreshTime = 0;
+        this.lastSuccessFinishedTime = 0;
+        this.lastSuccessVersion = 0;
+        this.updateNextSchedulableTime(this.getRefreshInterval());
+        this.setLastSuccessVersion(0);
     }
 
     public synchronized void setRefreshing() {
@@ -336,6 +349,19 @@ public class Dictionary implements Writable, GsonPostProcessable {
 
     public synchronized void setErrorMsg(String msg) {
         runtimeErrMsg = msg;
+    }
+
+    public void setLastSuccessVersion(long lastSuccessVersion) {
+        this.lastSuccessVersion = lastSuccessVersion;
+    }
+
+    public long getLastSuccessVersion() {
+        return this.lastSuccessVersion;
+    }
+
+    public boolean isRefreshing() {
+        return this.state == DictionaryState.REFRESHING ||
+                    this.state == DictionaryState.COMMITTING;
     }
 
     public synchronized void resetStateBeforeRefresh() {
@@ -392,12 +418,6 @@ public class Dictionary implements Writable, GsonPostProcessable {
         }
         info.add(runtimeErrMsg);
         return info;
-    }
-
-    @Override
-    public void gsonPostProcess() throws IOException {
-        this.resetState();
-        this.updateNextSchedulableTime(this.getRefreshInterval());
     }
 
     public static Dictionary read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -31,6 +31,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.persist.DictionaryMgrInfo;
 import com.starrocks.persist.DropDictionaryInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -79,7 +80,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -101,9 +101,6 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
     private Set<Long> unfinishedRefreshTasks = Sets.newHashSet();
     private final Set<Long> runningRefreshTasks = Sets.newHashSet();
 
-    // use last successful txn id as next readable version
-    private ConcurrentHashMap<Long, Long> dictionaryIdTolastSuccessVersion = new ConcurrentHashMap<>();
-
     private final Lock lock = new ReentrantLock();
 
     private final ExecutorService executor =
@@ -112,28 +109,46 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
 
     public DictionaryMgr() {}
 
-    // single thread execution
+    public void syncDictionaryMeta(List<Dictionary> dictionaries) {
+        if (dictionaries.size() == 0 || !GlobalStateMgr.getCurrentState().isLeader()) {
+            return;
+        }
+
+        logModify(this.nextTxnId, this.nextDictionaryId, dictionaries);        
+    }
+
     public void scheduleTasks() {
         lock.lock();
         try {
+            if (!GlobalStateMgr.getCurrentState().isLeader()) {
+                return;
+            }
+
+            List<Dictionary> syncDictionaries = Lists.newArrayList();
             for (Map.Entry<Long, Dictionary> entry : dictionariesMapById.entrySet()) {
                 long id = entry.getKey();
                 Dictionary dictionary = dictionariesMapById.get(id);
                 // regular schedule
-                if (dictionary.getNextSchedulableTime() <= System.currentTimeMillis() &&
-                        !unfinishedRefreshTasks.contains(id)) {
+                if ((dictionary.getNextSchedulableTime() <= System.currentTimeMillis() &&
+                        !unfinishedRefreshTasks.contains(id)) ||
+                            // follower -> leader when dictionary is refreshing.
+                            (dictionary.isRefreshing() && !runningRefreshTasks.contains(id))) {
                     unfinishedRefreshTasks.add(id);
                     dictionary.setRefreshing();
                     dictionary.updateNextSchedulableTime(dictionary.getRefreshInterval());
+                    syncDictionaries.add(dictionary);
                 }
             }
+            syncDictionaryMeta(syncDictionaries);
+
             for (Long dictionaryId : unfinishedRefreshTasks) {
                 // new added task
                 if (!runningRefreshTasks.contains(dictionaryId)) {
                     resigerUnfinishedToRunningUnlocked(dictionaryId);
 
                     RefreshDictionaryCacheWorker task =
-                            new RefreshDictionaryCacheWorker(dictionariesMapById.get(dictionaryId), getAndIncrementTxnId());
+                            new RefreshDictionaryCacheWorker(dictionariesMapById.get(dictionaryId),
+                                    getAndIncrementTxnIdUnlocked());
                     try {
                         submit(task);
                     } catch (RejectedExecutionException e) {
@@ -250,6 +265,9 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             unfinishedRefreshTasks.add(dictionary.getDictionaryId());
             dictionary.setRefreshing();
             dictionary.updateNextSchedulableTime(dictionary.getRefreshInterval());
+            List<Dictionary> syncDictionary = Lists.newArrayList();
+            syncDictionary.add(dictionary);
+            syncDictionaryMeta(syncDictionary);
         } finally {
             lock.unlock();
         }
@@ -283,7 +301,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             dictionariesMapById.put(dictionary.getDictionaryId(), dictionary);
             dictionariesIdMapByName.put(dictionary.getDictionaryName(), dictionary.getDictionaryId());
             // init for every dictionary
-            dictionaryIdTolastSuccessVersion.put(dictionary.getDictionaryId(), 0L);
+            dictionary.setLastSuccessVersion(0L);
         } finally {
             lock.unlock();
         }
@@ -327,23 +345,32 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         runningRefreshTasks.add(dictionaryId);
     }
 
-    // single thread execution
-    public long getAndIncrementTxnId() {
+    public long getAndIncrementTxnIdUnlocked() {
         long curTxnId = nextTxnId;
-        logModify(this.nextTxnId + 1, this.nextDictionaryId);
+        logModify(this.nextTxnId + 1, this.nextDictionaryId, null);
         ++nextTxnId;
         return curTxnId;
     }
 
-    public synchronized void updateLastSuccessTxnId(long dictionaryId, long txnId) {
-        dictionaryIdTolastSuccessVersion.put(dictionaryId, txnId);
+    public void updateLastSuccessTxnId(long dictionaryId, long txnId) {
+        lock.lock();
+        try {
+            this.dictionariesMapById.get(dictionaryId).setLastSuccessVersion(txnId);
+        } finally {
+            lock.unlock();
+        }
     }
 
-    private synchronized long getAndIncrementDictionaryId() {
-        long curDictionaryId = nextDictionaryId;
-        logModify(this.nextTxnId, nextDictionaryId + 1);
-        ++nextDictionaryId;
-        return curDictionaryId;
+    private long getAndIncrementDictionaryId() {
+        lock.lock();
+        try {
+            long curDictionaryId = nextDictionaryId;
+            logModify(this.nextTxnId, nextDictionaryId + 1, null);
+            ++nextDictionaryId;
+            return curDictionaryId;
+        } finally {
+            lock.unlock();
+        }
     }
 
     public Map<Long, Dictionary> getDictionariesMapById() {
@@ -367,11 +394,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
     }
 
     public long getLastSuccessTxnId(long dictionaryId) {
-        return dictionaryIdTolastSuccessVersion.get(dictionaryId);
-    }
-
-    public ConcurrentHashMap<Long, Long> getDictionaryIdTolastSuccessVersion() {
-        return dictionaryIdTolastSuccessVersion;
+        return dictionariesMapById.get(dictionaryId).getLastSuccessVersion();
     }
 
     private Coordinator.Factory getCoordinatorFactory() {
@@ -456,13 +479,30 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
     public void replayModifyDictionaryMgr(DictionaryMgrInfo info) {
         long newNextTxnId = info.getNextTxnId();
         long newNextDictionaryId = info.getNextDictionaryId();
-        
+        List<Dictionary> dictionaries = info.getDictionaries();
+
         if (newNextTxnId > this.nextTxnId) {
             this.nextTxnId = newNextTxnId;
         }
 
         if (newNextDictionaryId > this.nextDictionaryId) {
             this.nextDictionaryId = newNextDictionaryId;
+        }
+
+        // only replay for the follower sync
+        if (!GlobalStateMgr.isCheckpointThread() &&
+                (GlobalStateMgr.getCurrentState().getFeType() == FrontendNodeType.FOLLOWER ||
+                 GlobalStateMgr.getCurrentState().getFeType() == FrontendNodeType.OBSERVER) &&
+                    dictionaries != null && !dictionaries.isEmpty()) {
+            lock.lock();
+            try {
+                for (Dictionary dictionary : dictionaries) {
+                    // update dictionary object state
+                    dictionariesMapById.put(dictionary.getDictionaryId(), dictionary);
+                }
+            } finally {
+                lock.unlock();
+            }
         }
     }
 
@@ -480,7 +520,6 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         this.dictionariesIdMapByName = data.getDictionariesIdMapByName();
         this.nextTxnId = data.getNextTxnId();
         this.nextDictionaryId = data.getNextDictionaryId();
-        this.dictionaryIdTolastSuccessVersion = data.getDictionaryIdTolastSuccessVersion();
     }
 
     @Override
@@ -494,7 +533,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         try {
             for (Map.Entry<Long, Dictionary> entry : dictionariesMapById.entrySet()) {
                 // init for every dictionary
-                dictionaryIdTolastSuccessVersion.put(entry.getKey(), 0L);
+                entry.getValue().resetState();
             }
         } finally {
             lock.unlock(); 
@@ -503,8 +542,13 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
 
     // This function is used to log the modification for some extra meta data for
     // dictionaryMgr.
-    private void logModify(long nextTxnId, long nextDictionaryId) {
-        DictionaryMgrInfo info = new DictionaryMgrInfo(nextTxnId, nextDictionaryId);
+    private void logModify(long nextTxnId, long nextDictionaryId, List<Dictionary> dictionaries) {
+        DictionaryMgrInfo info = null;
+        if (dictionaries == null) {
+            info = new DictionaryMgrInfo(nextTxnId, nextDictionaryId);
+        } else {
+            info = new DictionaryMgrInfo(nextTxnId, nextDictionaryId, dictionaries);
+        }
         GlobalStateMgr.getCurrentState().getEditLog().logModifyDictionaryMgr(info);
     }
 
@@ -641,6 +685,9 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
                 return;
             }
             dictionary.setCommitting();
+            List<Dictionary> syncDictionary = Lists.newArrayList();
+            syncDictionary.add(dictionary);
+            GlobalStateMgr.getCurrentState().getDictionaryMgr().syncDictionaryMeta(syncDictionary);
 
             PProcessDictionaryCacheRequest request = new PProcessDictionaryCacheRequest();
             request.dictId = dictionary.getDictionaryId();
@@ -664,6 +711,9 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
                 dictionary.setCancelled();
                 dictionary.setErrorMsg(errMsg);
             }
+            List<Dictionary> syncDictionary = Lists.newArrayList();
+            syncDictionary.add(dictionary);
+            GlobalStateMgr.getCurrentState().getDictionaryMgr().syncDictionaryMeta(syncDictionary);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/persist/DictionaryMgrInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/DictionaryMgrInfo.java
@@ -14,7 +14,9 @@
 
 package com.starrocks.persist;
 
+import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Dictionary;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -22,16 +24,27 @@ import com.starrocks.persist.gson.GsonUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 
 public class DictionaryMgrInfo implements Writable {
     @SerializedName(value = "nextTxnId")
     private long nextTxnId = 1L;
     @SerializedName(value = "nextDictionaryId")
     private long nextDictionaryId = 1L;
+    @SerializedName(value = "dictionaries")
+    private List<Dictionary> dictionaries = Lists.newArrayList();
 
     public DictionaryMgrInfo(long nextTxnId, long nextDictionaryId) {
         this.nextTxnId = nextTxnId;
         this.nextDictionaryId = nextDictionaryId;
+    }
+
+    public DictionaryMgrInfo(long nextTxnId, long nextDictionaryId, List<Dictionary> dictionaries) {
+        this.nextTxnId = nextTxnId;
+        this.nextDictionaryId = nextDictionaryId;
+        if (dictionaries != null) {
+            this.dictionaries = dictionaries;
+        }
     }
 
     public DictionaryMgrInfo() {}
@@ -42,6 +55,10 @@ public class DictionaryMgrInfo implements Writable {
 
     public long getNextDictionaryId() {
         return nextDictionaryId;
+    }
+
+    public List<Dictionary> getDictionaries() {
+        return this.dictionaries;
     }
 
     public static DictionaryMgrInfo read(DataInput in) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -136,7 +136,7 @@ public class DictionaryMgrTest {
     public void testFollower() throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getCurrentState().isLeader();
+                globalStateMgr.isLeader();
                 minTimes = 0;
                 result = false;
             }


### PR DESCRIPTION
## Why I'm doing:
In the current implementations, follower will not be synced any information about the dictionary refreshing which is a problem.

## What I'm doing:
Reuse dictionaryMgrInfo and DICTIONARY_MODIFY log to save the dictionary state information.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7961

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
