### PR TITLE
[BugFix] cherry-pick RleEncoderV2 related code from ORC's github

### DIFF
--- a/be/src/formats/orc/apache-orc/c++/src/RLE.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/RLE.cc
@@ -108,4 +108,10 @@ void RleEncoder::recordPosition(PositionRecorder* recorder) const {
     recorder->add(static_cast<uint64_t>(numLiterals));
 }
 
+void RleEncoder::finishEncode() {
+    outputStream->BackUp(static_cast<int>(bufferLength - bufferPosition));
+    outputStream->finishStream();
+    bufferLength = bufferPosition = 0;
+}
+
 } // namespace orc

--- a/be/src/formats/orc/apache-orc/c++/src/RLE.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/RLE.hh
@@ -76,6 +76,13 @@ public:
 
     virtual void write(int64_t val) = 0;
 
+    /**
+     * Finalize the encoding process. This function should be called after all data required for
+     * encoding has been added. It ensures that any remaining data is processed and the final state
+     * of the encoder is set.
+     */
+    virtual void finishEncode();
+
 protected:
     std::unique_ptr<BufferedOutputStream> outputStream;
     size_t bufferPosition;

--- a/be/src/formats/orc/apache-orc/c++/src/RLEv2.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/RLEv2.hh
@@ -125,6 +125,8 @@ public:
 
     void write(int64_t val) override;
 
+    void finishEncode() override;
+
 private:
     const bool alignedBitPacking;
     uint32_t fixedRunLength;

--- a/be/src/formats/orc/apache-orc/c++/src/io/OutputStream.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/io/OutputStream.cc
@@ -64,6 +64,10 @@ void BufferedOutputStream::BackUp(int count) {
     }
 }
 
+void BufferedOutputStream::finishStream() {
+    // PASS
+}
+
 google::protobuf::int64 BufferedOutputStream::ByteCount() const {
     return static_cast<google::protobuf::int64>(dataBuffer->size());
 }

--- a/be/src/formats/orc/apache-orc/c++/src/io/OutputStream.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/io/OutputStream.hh
@@ -61,6 +61,7 @@ public:
     virtual void suppress();
 
     virtual bool isCompressed() const { return false; }
+    virtual void finishStream();
 };
 
 /**


### PR DESCRIPTION
## Why I'm doing:
<img width="624" alt="image" src="https://github.com/StarRocks/starrocks/assets/109201787/7ea6e199-403d-4db2-a77e-386b976b4e66">

<img width="615" alt="企业微信截图_0c74d37d-25a4-4556-8120-9783a7cd19da" src="https://github.com/StarRocks/starrocks/assets/109201787/54a48ff3-1687-4973-a1a5-281e0f76616e">

There's a bug when writting ORC file using patched-base to encode integers under following conditions:

1. option.min (the base in patched-base encoding) is a negative number
2. the bit width of abs(option.min) is exactly a multiple of 8

in that situation, the decode code in Figure 2 will mistakenly interprets the MSB as the sign bit, leading to the use of an incorrect base and resulting in incorrect outcomes.

be-ut before this pr:
![企业微信截图_4630d9a5-1e95-4302-92bd-3dd9fd01d8cd](https://github.com/user-attachments/assets/083eb44a-76f7-480b-9afe-b324563b8f81)

## What I'm doing:

I found that the [ORC codes](https://github.com/apache/orc) doesn't have this bug.
So I just merged the RleEncoderV2.h/cpp and little related chages into SR entirely.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
