### PR TITLE
[Enhancement] optimize the performance of refreshExternalTable stage of MV refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1205,6 +1205,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean materialized_view_refresh_ascending = true;
 
+    @ConfField(mutable = true, comment = "An internal optimization for external table refresh, " +
+            "only refresh affected partitions of external table, instead of all of them ")
+    public static boolean enable_materialized_view_external_table_precise_refresh = true;
+
     /**
      * Control whether to enable spill for all materialized views in the refresh mv.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -419,6 +419,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 syncPartitions();
                 Set<String> mvCandidatePartition = checkMvToRefreshedPartitions(context, true);
                 baseTableCandidatePartitions = getRefTableRefreshPartitions(mvCandidatePartition);
+            } catch (Exception e) {
+                // Since at here we sync partitions before the refreshExternalTable, the situation may happen that
+                // the base-table not exists before refreshExternalTable, so we just need to swallow this exception
+                if (!e.getMessage().contains("not exist")) {
+                    throw e;
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -676,8 +676,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             Set<String> basePartitions = baseTableCandidatePartitions.get(snapshotInfo);
             if (CollectionUtils.isNotEmpty(basePartitions)) {
                 // only refresh referenced partitions, to reduce metadata overhead
+                List<String> realPartitionNames = basePartitions.stream()
+                        .flatMap(name -> convertMVPartitionNameToRealPartitionName(table, name).stream())
+                        .collect(Collectors.toList());
                 connectContext.getGlobalStateMgr().getMetadataMgr().refreshTable(baseTableInfo.getCatalogName(),
-                        baseTableInfo.getDbName(), table, Lists.newArrayList(basePartitions), false);
+                        baseTableInfo.getDbName(), table, realPartitionNames, false);
             } else {
                 // refresh the whole table, which may be costly in extreme case
                 connectContext.getGlobalStateMgr().getMetadataMgr().refreshTable(baseTableInfo.getCatalogName(),

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -404,6 +404,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private RefreshJobStatus doRefreshMaterializedView(TaskRunContext context,
                                                        IMaterializedViewMetricsEntity mvEntity) throws Exception {
         // 0. Compute the base-table partitions to check for external table
+        syncPartitions();
         Set<String> mvCandidatePartition = checkMvToRefreshedPartitions(context, true);
         Map<TableSnapshotInfo, Set<String>> baseTableCandidatePartitions =
                 getRefTableRefreshPartitions(mvCandidatePartition);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
@@ -72,4 +72,22 @@ public class TableSnapshotInfo {
                 ", refreshedPartitionInfos=" + refreshedPartitionInfos +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TableSnapshotInfo that = (TableSnapshotInfo) o;
+        return Objects.equals(baseTableInfo, that.baseTableInfo) &&
+                Objects.equals(baseTable, that.baseTable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baseTableInfo, baseTable);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -258,7 +258,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
 
     @Override
     public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
-                                               Set<String> mvPotentialPartitionNames) {
+                                               Set<String> mvPotentialPartitionNames, boolean tentative) {
         Map<String, PListCell> mappedPartitionsToRefresh = Maps.newHashMap();
         Map<String, PListCell> listPartitionMap = mv.getListPartitionItems();
         for (String partitionName : mvPartitionsToRefresh) {
@@ -274,10 +274,12 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         if (result == null) {
             return;
         }
-        // partitionNameIter has just been traversed, and endPartitionName is not updated
-        // will cause endPartitionName == null
-        mvContext.setNextPartitionStart(result.first);
-        mvContext.setNextPartitionEnd(result.second);
+        if (!tentative) {
+            // partitionNameIter has just been traversed, and endPartitionName is not updated
+            // will cause endPartitionName == null
+            mvContext.setNextPartitionStart(result.first);
+            mvContext.setNextPartitionEnd(result.second);
+        }
     }
 
     private void addListPartitions(Database database, MaterializedView materializedView,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -78,7 +78,7 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     }
 
     public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
-                                               Set<String> mvPotentialPartitionNames) {
+                                               Set<String> mvPotentialPartitionNames, boolean tentative) {
         // do nothing
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -118,11 +118,14 @@ public abstract class MVPCTRefreshPartitioner {
 
     /**
      * Filter to refresh partitions by refresh number.
-     * @param mvPartitionsToRefresh: mv partitions to refresh.
-     * @param mvPotentialPartitionNames: mv potential partition names to check.
+     *
+     * @param mvPartitionsToRefresh     : mv partitions to refresh.
+     * @param mvPotentialPartitionNames : mv potential partition names to check.
+     * @param tentative see {@link com.starrocks.scheduler.PartitionBasedMvRefreshProcessor#checkMvToRefreshedPartitions}
      */
     public abstract void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
-                                                        Set<String> mvPotentialPartitionNames);
+                                                        Set<String> mvPotentialPartitionNames,
+                                                        boolean tentative);
 
     /**
      * Check whether the base table is supported partition refresh or not.

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -15,19 +15,24 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -42,6 +47,7 @@ import org.junit.runners.MethodSorters;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -1191,4 +1197,31 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
         starRocksAssert.dropMaterializedView("test_drop_partition_mv1");
     }
 
+    /**
+     * When refresh some partitions of MV, each refresh task should only refresh the corresponding partitions of base
+     * table instead of all of them
+     */
+    @Test
+    public void testRefreshExternalTable() throws Exception {
+        starRocksAssert.withRefreshedMaterializedView("create materialized view test_mv_external\n" +
+                "PARTITION BY date_trunc('day', l_shipdate) \n" +
+                "distributed by hash(l_orderkey) buckets 3\n" +
+                "refresh manual\n" +
+                " properties ('partition_refresh_number'='1') \n" +
+                "as SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+
+        List<List<String>> calls = Lists.newArrayList();
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public void refreshTable(String catalogName, String srDbName, Table table,
+                                     List<String> partitionNames, boolean onlyCachedPartitions) {
+                calls.add(partitionNames);
+            }
+        };
+
+        starRocksAssert.refreshMvPartition("refresh materialized view test_mv_external partition " +
+                " start('1998-01-01') end('1998-01-03')");
+        Assert.assertEquals(Lists.newArrayList(Lists.newArrayList("p19980101"),
+                Lists.newArrayList("p19980102")), calls);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -1203,10 +1203,10 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
      */
     @Test
     public void testRefreshExternalTablePrecise() throws Exception {
-        starRocksAssert.withRefreshedMaterializedView("create materialized view test_mv_external\n" +
+        starRocksAssert.withMaterializedView("create materialized view test_mv_external\n" +
                 "PARTITION BY date_trunc('day', l_shipdate) \n" +
                 "distributed by hash(l_orderkey) buckets 3\n" +
-                "refresh manual\n" +
+                "refresh deferred manual\n" +
                 " properties ('partition_refresh_number'='1') \n" +
                 "as SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
 
@@ -1220,10 +1220,13 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
         };
 
         starRocksAssert.refreshMvPartition("refresh materialized view test_mv_external partition " +
-                " start('1998-01-01') end('1998-01-03')");
-        Assert.assertEquals(Lists.newArrayList(
+                " start('1998-01-01') end('1998-01-04')");
+        Assert.assertEquals(
+                Lists.newArrayList(
                         Lists.newArrayList("l_shipdate=1998-01-01"),
-                        Lists.newArrayList("l_shipdate=1998-01-02")),
+                        Lists.newArrayList("l_shipdate=1998-01-02"),
+                        Lists.newArrayList("l_shipdate=1998-01-03")
+                ),
                 calls);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -1202,7 +1202,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
      * table instead of all of them
      */
     @Test
-    public void testRefreshExternalTable() throws Exception {
+    public void testRefreshExternalTablePrecise() throws Exception {
         starRocksAssert.withRefreshedMaterializedView("create materialized view test_mv_external\n" +
                 "PARTITION BY date_trunc('day', l_shipdate) \n" +
                 "distributed by hash(l_orderkey) buckets 3\n" +
@@ -1221,7 +1221,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
         starRocksAssert.refreshMvPartition("refresh materialized view test_mv_external partition " +
                 " start('1998-01-01') end('1998-01-03')");
-        Assert.assertEquals(Lists.newArrayList(Lists.newArrayList("p19980101"),
-                Lists.newArrayList("p19980102")), calls);
+        Assert.assertEquals(Lists.newArrayList(
+                        Lists.newArrayList("l_shipdate=1998-01-01"),
+                        Lists.newArrayList("l_shipdate=1998-01-02")),
+                calls);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -2869,6 +2869,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
                     Set<String> mvRefreshProfileKeys = ImmutableSet.of(
                             "MVRefreshPrepare",
                             "MVRefreshDoWholeRefresh",
+                            "MVRefreshComputeCandidatePartitions",
                             "MVRefreshSyncAndCheckPartitions",
                             "MVRefreshExternalTable",
                             "MVRefreshSyncPartitions",
@@ -2902,7 +2903,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
                     );
                     for (Map.Entry<String, String> e : result.entrySet()) {
                         System.out.println(e.getKey() + ": " + e.getValue());
-                        Assert.assertTrue(mvRefreshProfileKeys.stream().anyMatch(k -> e.getKey().contains(k)));
+                        Assert.assertTrue("not expected: " + e.getKey(),
+                                mvRefreshProfileKeys.stream().anyMatch(k -> e.getKey().contains(k)));
                     }
                 });
     }


### PR DESCRIPTION
## Why I'm doing:

For MV on DataLake, `MetadataMgr::refreshTable` call can be costly if the external table has a lot of partitions.

To optimize it, we can optimize that call into a `MetadataMgr::refreshTable(partitionNames)`, so we don't need to refresh all partitions each time.

Experimental result:
- For 10000 Hive partitions
- Before: the MetadataMgr.refreshTable takes 1.8s 
- After: the MetadataMgr.refreshTable takes 60ms


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
