### PR TITLE
[Enhancement] Optimize the mem usage of collect stats for delta lake

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -63,13 +63,14 @@ public class DeltaLakeFileStats {
     private boolean hasValidColumnMetrics;
 
     public DeltaLakeFileStats(StructType schema, List<String> nonPartitionPrimitiveColumns,
-                              DeltaLakeAddFileStatsSerDe fileStat, long fileSize) {
+                              DeltaLakeAddFileStatsSerDe fileStat, long numRecords, long fileSize) {
         this.schema = schema;
         this.nonPartitionPrimitiveColumns = nonPartitionPrimitiveColumns;
-        this.recordCount = fileStat.numRecords;
+        this.recordCount = numRecords;
         this.size = fileSize;
 
-        if (fileStat.minValues == null || fileStat.maxValues == null || fileStat.nullCount == null) {
+        if (fileStat == null || fileStat.minValues == null || fileStat.maxValues == null
+                || fileStat.nullCount == null) {
             this.minValues = null;
             this.maxValues = null;
             this.nullCounts = null;
@@ -155,9 +156,13 @@ public class DeltaLakeFileStats {
         return builder.build();
     }
 
-    public void update(DeltaLakeAddFileStatsSerDe stat, long fileSize) {
-        this.recordCount += stat.numRecords;
+    public void update(DeltaLakeAddFileStatsSerDe stat, long numRecords, long fileSize) {
+        this.recordCount += numRecords;
         this.size += fileSize;
+
+        if (stat == null) {
+            return;
+        }
 
         if (!hasValidColumnMetrics) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -24,26 +24,15 @@ public class FileScanTask {
     private final FileStatus fileStatus;
     private final long records;
     private final Map<String, String> partitionValues;
-    private final DeltaLakeAddFileStatsSerDe stats;
 
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues) {
-        this(fileStatus, records, partitionValues, null);
-    }
-
-    public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues,
-                        DeltaLakeAddFileStatsSerDe stats) {
         this.fileStatus = fileStatus;
         this.records = records;
         this.partitionValues = partitionValues;
-        this.stats = stats;
     }
 
     public FileStatus getFileStatus() {
         return this.fileStatus;
-    }
-
-    public DeltaLakeAddFileStatsSerDe getStats() {
-        return this.stats;
     }
 
     public long getFileSize() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
@@ -78,7 +78,7 @@ public class DeltaLakeFileStatsTest {
         };
 
         DeltaLakeAddFileStatsSerDe stat = new DeltaLakeAddFileStatsSerDe(10, minValues, maxValues, nullCounts);
-        DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat, 4096);
+        DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat, 10, 4096);
 
         ColumnStatistic columnStatistic = stats.fillColumnStats(new Column("c_char", Type.CHAR));
         ColumnStatistic checkStatistic = new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
@@ -149,13 +149,13 @@ public class DeltaLakeFileStatsTest {
         nonPartitionPrimitiveColumns.add("c_string");
 
         DeltaLakeAddFileStatsSerDe stat1 = new DeltaLakeAddFileStatsSerDe(10, minValues1, maxValues1, nullCounts1);
-        DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat1, 4096);
+        DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat1, 10, 4096);
 
         DeltaLakeAddFileStatsSerDe stat2 = new DeltaLakeAddFileStatsSerDe(10, minValues2, maxValues2, nullCounts2);
-        stats.update(stat2, 4096);
+        stats.update(stat2, 10, 4096);
 
         DeltaLakeAddFileStatsSerDe stat3 = new DeltaLakeAddFileStatsSerDe(10, minValues3, maxValues3, nullCounts3);
-        stats.update(stat3, 4096);
+        stats.update(stat3, 10, 4096);
 
         ColumnStatistic checkStatistic = new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
                 0, 16, 1, null, ColumnStatistic.StatisticType.UNKNOWN);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

No need to cache the stats in `ScanFileTask`, just drop it after adding up.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
