### PR TITLE
[Enhancement] Replace list with set in DeltaLakeFileStats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStats.java
@@ -75,13 +75,13 @@ public class DeltaLakeFileStats {
             this.hasValidColumnMetrics = false;
         } else {
             this.minValues = fileStat.minValues.entrySet().stream()
-                    .filter(e -> !nonPartitionPrimitiveColumns.contains(e.getKey()))
+                    .filter(e -> nonPartitionPrimitiveColumns.contains(e.getKey()))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             this.maxValues = fileStat.maxValues.entrySet().stream()
-                    .filter(e -> !nonPartitionPrimitiveColumns.contains(e.getKey()))
+                    .filter(e -> nonPartitionPrimitiveColumns.contains(e.getKey()))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             this.nullCounts = fileStat.nullCount.entrySet().stream()
-                    .filter(e -> !nonPartitionPrimitiveColumns.contains(e.getKey()))
+                    .filter(e -> nonPartitionPrimitiveColumns.contains(e.getKey()))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             this.corruptedStats = nonPartitionPrimitiveColumns.stream()
                     .filter(col -> !minValues.containsKey(col) &&

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -62,8 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 
 public class DeltaLakeMetadata implements ConnectorMetadata {
@@ -195,10 +195,10 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         ScanBuilderImpl scanBuilder = (ScanBuilderImpl) snapshot.getScanBuilder(engine);
         ScanImpl scan = (ScanImpl) scanBuilder.withFilter(engine, deltaLakePredicate).build();
 
-        List<String> nonPartitionPrimitiveColumns = schema.fieldNames().stream()
+        Set<String> nonPartitionPrimitiveColumns = schema.fieldNames().stream()
                 .filter(column -> BasePrimitiveType.isPrimitiveType(
                         schema.get(column).getDataType().toString())
-                        && !partitionColumns.contains(column)).collect(toImmutableList());
+                        && !partitionColumns.contains(column)).collect(Collectors.toSet());
 
         List<FileScanTask> files = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -23,8 +23,8 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import io.delta.kernel.types.StructType;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class DeltaStatisticProvider {
     private final Map<PredicateSearchKey, DeltaLakeFileStats> deltaLakeFileStatsMap = new HashMap<>();
@@ -50,7 +50,7 @@ public class DeltaStatisticProvider {
     }
 
     public void updateFileStats(DeltaLakeTable table, PredicateSearchKey key, FileScanTask file,
-                                DeltaLakeAddFileStatsSerDe fileStatsSerDe, List<String> nonPartitionPrimitiveColumn) {
+                                DeltaLakeAddFileStatsSerDe fileStatsSerDe, Set<String> nonPartitionPrimitiveColumn) {
         StructType schema = table.getDeltaMetadata().getSchema();
 
         DeltaLakeFileStats fileStats;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeFileStatsTest.java
@@ -24,10 +24,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class DeltaLakeFileStatsTest {
     private StructType schema;
@@ -69,7 +69,7 @@ public class DeltaLakeFileStatsTest {
             }
         };
 
-        List<String> nonPartitionPrimitiveColumns = new ArrayList<>() {
+        Set<String> nonPartitionPrimitiveColumns = new HashSet<>() {
             {
                 add("c_int");
                 add("c_char");
@@ -145,8 +145,11 @@ public class DeltaLakeFileStatsTest {
             }
         };
 
-        List<String> nonPartitionPrimitiveColumns = new ArrayList<>();
-        nonPartitionPrimitiveColumns.add("c_string");
+        Set<String> nonPartitionPrimitiveColumns = new HashSet<>() {
+            {
+                add("c_string");
+            }
+        };
 
         DeltaLakeAddFileStatsSerDe stat1 = new DeltaLakeAddFileStatsSerDe(10, minValues1, maxValues1, nullCounts1);
         DeltaLakeFileStats stats = new DeltaLakeFileStats(schema, nonPartitionPrimitiveColumns, stat1, 10, 4096);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`NonPartitionPrimitiveColumns` of `DeltaLakeFileStats` often uses interface `contains` to check whether the column exists. 

Using List will cause performance problems.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
