### PR TITLE
[BugFix] Fix duplicated column unique id in adding column when upgraded to 3.3 than downgraded to 3.2 for shared-data mode

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -67,6 +67,27 @@ static StorageAggregateType t_aggregation_type_to_field_aggregation_method(TAggr
     return STORAGE_AGGREGATE_NONE;
 }
 
+static Status validate_tablet_schema(const TabletSchemaPB& schema_pb) {
+#if !defined(NDEBUG) || defined(BE_TEST)
+    std::unordered_set<std::string> column_names;
+    std::unordered_set<int64_t> column_ids;
+    for (const auto& col : schema_pb.column()) {
+        DCHECK(col.has_unique_id()) << col.DebugString();
+        if (auto [it, ok] = column_ids.insert(col.unique_id()); !ok) {
+            LOG(ERROR) << "Duplicate column unique id: " << col.unique_id() << " schema: " << schema_pb.DebugString();
+            return Status::InvalidArgument("Duplicate column id found in tablet schema");
+        }
+        if (auto [it, ok] = column_names.insert(col.name()); !ok) {
+            LOG(ERROR) << "Duplicate column name: " << col.name() << " schema: " << schema_pb.DebugString();
+            return Status::InvalidArgument("Duplicate column name found in tablet schema");
+        }
+    }
+    return Status::OK();
+#else
+    return Status::OK();
+#endif
+}
+
 // This function is used to initialize ColumnPB for subfield like element of Array.
 static void init_column_pb_for_sub_field(ColumnPB* field) {
     const int32_t kFakeUniqueId = -1;
@@ -287,7 +308,7 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
     if (has_bf_columns && tablet_schema.__isset.bloom_filter_fpp) {
         schema->set_bf_fpp(tablet_schema.bloom_filter_fpp);
     }
-    return Status::OK();
+    return validate_tablet_schema(*schema);
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -348,7 +348,12 @@ Status Segment::_create_column_readers(SegmentFooterPB* footer) {
     std::unordered_map<uint32_t, uint32_t> column_id_to_footer_ordinal;
     for (uint32_t ordinal = 0, sz = footer->columns().size(); ordinal < sz; ++ordinal) {
         const auto& column_pb = footer->columns(ordinal);
-        column_id_to_footer_ordinal.emplace(column_pb.unique_id(), ordinal);
+        auto [it, ok] = column_id_to_footer_ordinal.emplace(column_pb.unique_id(), ordinal);
+        if (UNLIKELY(!ok)) {
+            LOG(ERROR) << "Duplicate column id=" << column_pb.unique_id() << " found between column '"
+                       << footer->columns(it->second).column_id() << "' and column '" << column_pb.column_id() << "'";
+            return Status::InternalError("Duplicate column id");
+        }
     }
 
     for (uint32_t ordinal = 0, sz = _tablet_schema->num_columns(); ordinal < sz; ++ordinal) {

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -138,6 +138,44 @@ TEST_F(LakeTabletManagerTest, create_tablet) {
     EXPECT_EQ(TPersistentIndexType::LOCAL, metadata->persistent_index_type());
 }
 
+TEST_F(LakeTabletManagerTest, create_tablet_with_duplicate_column_id_or_name) {
+    auto tablet_id = next_id();
+    auto schema_id = next_id();
+
+    TCreateTabletReq req;
+    req.tablet_id = tablet_id;
+    req.__set_version(1);
+    req.__set_version_hash(0);
+    req.__set_enable_persistent_index(true);
+    req.__set_persistent_index_type(TPersistentIndexType::LOCAL);
+    req.tablet_schema.__set_id(schema_id);
+    req.tablet_schema.__set_schema_hash(270068375);
+    req.tablet_schema.__set_short_key_column_count(2);
+    req.tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
+    TColumnType col_type;
+    col_type.__set_type(TPrimitiveType::SMALLINT);
+    req.tablet_schema.columns.resize(2);
+    auto& c0 = req.tablet_schema.columns[0];
+    c0.__set_is_key(true);
+    c0.__set_is_allow_null(false);
+    c0.__set_column_name("c0");
+    c0.__set_aggregation_type(TAggregationType::NONE);
+    c0.__set_col_unique_id(0);
+    c0.__set_column_type(col_type);
+    auto& c1 = req.tablet_schema.columns[1];
+    c1 = c0;
+    c1.__set_column_name("c1");
+    auto st = _tablet_manager->create_tablet(req);
+    ASSERT_EQ(TStatusCode::INVALID_ARGUMENT, st.code());
+    ASSERT_TRUE(MatchPattern(std::string(st.message()), "*Duplicate column id*")) << st.message();
+
+    c1.__set_col_unique_id(1);
+    c1.__set_column_name(c0.column_name);
+    st = _tablet_manager->create_tablet(req);
+    ASSERT_EQ(TStatusCode::INVALID_ARGUMENT, st.code());
+    ASSERT_TRUE(MatchPattern(std::string(st.message()), "*Duplicate column name*")) << st.message();
+}
+
 // NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, create_tablet_without_schema_file) {
     auto fs = FileSystem::Default();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -210,4 +210,10 @@ public class LakeTable extends OlapTable {
         }
         return TableType.OLAP.name();
     }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        super.gsonPostProcess();
+        setMaxColUniqueId(Column.COLUMN_UNIQUE_ID_INIT_VALUE);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
When upgraded to 3.3 than downgraded to 3.2, duplicated column unique ids will be generated in adding column in shared-data mode, causing be crash.

## What I'm doing:
1. Fix duplicated column unique id in adding column when upgraded to 3.3 than downgraded to 3.2 for shared-data mode.
2. Add duplicated column unique id checking, protect be from crash.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

