### PR TITLE
[BugFix] Fix replayBatchDeleteReplica failed when doing checkpoint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/BatchDeleteReplicaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/BatchDeleteReplicaInfo.java
@@ -24,15 +24,21 @@ public class BatchDeleteReplicaInfo extends JsonWriter {
     @SerializedName("bId")
     private long backendId;
 
+    // deprecated, reserved for rollback
+    @Deprecated
     @SerializedName("tablets")
     private List<Long> tablets;
+
+    @SerializedName("replicas")
+    private List<ReplicaPersistInfo> replicaInfoList;
 
     public BatchDeleteReplicaInfo() {
     }
 
-    public BatchDeleteReplicaInfo(long backendId, List<Long> tablets) {
+    public BatchDeleteReplicaInfo(long backendId, List<Long> tablets, List<ReplicaPersistInfo> replicaInfoList) {
         this.backendId = backendId;
         this.tablets = tablets;
+        this.replicaInfoList = replicaInfoList;
     }
 
     public long getBackendId() {
@@ -41,5 +47,9 @@ public class BatchDeleteReplicaInfo extends JsonWriter {
 
     public List<Long> getTablets() {
         return tablets;
+    }
+
+    public List<ReplicaPersistInfo> getReplicaInfoList() {
+        return replicaInfoList;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2673,44 +2673,12 @@ public class LocalMetastore implements ConnectorMetadata {
     }
 
     public void replayBatchDeleteReplica(BatchDeleteReplicaInfo info) {
-        for (long tabletId : info.getTablets()) {
-            TabletMeta meta = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletMeta(tabletId);
-            if (meta == null) {
-                continue;
+        if (info.getReplicaInfoList() != null) {
+            for (ReplicaPersistInfo persistInfo : info.getReplicaInfoList()) {
+                replayDeleteReplica(persistInfo);
             }
-            Database db = getDbIncludeRecycleBin(meta.getDbId());
-            if (db == null) {
-                LOG.warn("replay delete replica failed, db is null, meta: {}", meta);
-                continue;
-            }
-
-            Locker locker = new Locker();
-            locker.lockDatabase(db, LockType.WRITE);
-            try {
-                OlapTable olapTable = (OlapTable) getTableIncludeRecycleBin(db, meta.getTableId());
-                if (olapTable == null) {
-                    LOG.warn("replay delete replica failed, table is null, meta: {}", meta);
-                    continue;
-                }
-                PhysicalPartition partition = getPhysicalPartitionIncludeRecycleBin(olapTable, meta.getPartitionId());
-                if (partition == null) {
-                    LOG.warn("replay delete replica failed, partition is null, meta: {}", meta);
-                    continue;
-                }
-                MaterializedIndex materializedIndex = partition.getIndex(meta.getIndexId());
-                if (materializedIndex == null) {
-                    LOG.warn("replay delete replica failed, materializedIndex is null, meta: {}", meta);
-                    continue;
-                }
-                LocalTablet tablet = (LocalTablet) materializedIndex.getTablet(tabletId);
-                if (tablet == null) {
-                    LOG.warn("replay delete replica failed, tablet is null, meta: {}", meta);
-                    continue;
-                }
-                tablet.deleteReplicaByBackendId(info.getBackendId());
-            } finally {
-                locker.unLockDatabase(db, LockType.WRITE);
-            }
+        } else {
+            LOG.warn("invalid BatchDeleteReplicaInfo, replicaInfoList is null");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
TabletInvertedIndex is empty when a checkpoint is performed, so replay cannot rely on it.

## What I'm doing:
Record all the related ids in BatchDeleteReplicaInfo, instead of getting them from TabletInvertedIndex.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
