### PR TITLE
[Enhancement] Make mv default resource group configurable and add default_mv_resource_group_concurrency_limit

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1243,8 +1243,10 @@ CONF_mInt64(load_tablet_timeout_seconds, "60");
 CONF_mBool(enable_pk_value_column_zonemap, "true");
 
 // Used by default mv resource group
-CONF_Double(default_mv_resource_group_memory_limit, "0.8");
-CONF_Int32(default_mv_resource_group_cpu_limit, "1");
+CONF_mDouble(default_mv_resource_group_memory_limit, "0.8");
+CONF_mInt32(default_mv_resource_group_cpu_limit, "1");
+CONF_mInt32(default_mv_resource_group_concurrency_limit, "0");
+CONF_mDouble(default_mv_resource_group_spill_mem_limit_threshold, "0.8");
 
 // Max size of key columns size of primary key table, default value is 128 bytes
 CONF_mInt32(primary_key_limit_size, "128");

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -619,9 +619,11 @@ DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
 
     int64_t mv_cpu_limit = config::default_mv_resource_group_cpu_limit;
     double mv_memory_limit = config::default_mv_resource_group_memory_limit;
-    auto default_mv_wg = std::make_shared<WorkGroup>("default_mv_wg", WorkGroup::DEFAULT_MV_WG_ID,
-                                                     WorkGroup::DEFAULT_MV_VERSION, mv_cpu_limit, mv_memory_limit, 0,
-                                                     spill_mem_limit_threshold, WorkGroupType::WG_MV);
+    double mv_concurrency_limit = config::default_mv_resource_group_concurrency_limit;
+    double mv_spill_mem_limit_threshold = config::default_mv_resource_group_spill_mem_limit_threshold;
+    auto default_mv_wg = std::make_shared<WorkGroup>(
+            "default_mv_wg", WorkGroup::DEFAULT_MV_WG_ID, WorkGroup::DEFAULT_MV_VERSION, mv_cpu_limit, mv_memory_limit,
+            mv_concurrency_limit, mv_spill_mem_limit_threshold, WorkGroupType::WG_MV);
     WorkGroupManager::instance()->add_workgroup(default_mv_wg);
 }
 

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -607,24 +607,31 @@ size_t WorkGroupManager::normal_workgroup_cpu_hard_limit() const {
 
 /// DefaultWorkGroupInitialization.
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
+    auto default_wg = create_default_workgroup();
+    WorkGroupManager::instance()->add_workgroup(default_wg);
+
+    auto default_mv_wg = create_default_mv_workgroup();
+    WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+}
+
+std::shared_ptr<WorkGroup> DefaultWorkGroupInitialization::create_default_workgroup() {
     // The default workgroup can use all the resources of CPU and memory,
     // so set cpu_limit to max_executor_threads and memory_limit to 100%.
     int64_t cpu_limit = ExecEnv::GetInstance()->max_executor_threads();
     const double memory_limit = 1.0;
     const double spill_mem_limit_threshold = 1.0; // not enable spill mem limit threshold
-    auto default_wg =
-            std::make_shared<WorkGroup>("default_wg", WorkGroup::DEFAULT_WG_ID, WorkGroup::DEFAULT_VERSION, cpu_limit,
-                                        memory_limit, 0, spill_mem_limit_threshold, WorkGroupType::WG_DEFAULT);
-    WorkGroupManager::instance()->add_workgroup(default_wg);
+    return std::make_shared<WorkGroup>("default_wg", WorkGroup::DEFAULT_WG_ID, WorkGroup::DEFAULT_VERSION, cpu_limit,
+                                       memory_limit, 0, spill_mem_limit_threshold, WorkGroupType::WG_DEFAULT);
+}
 
+std::shared_ptr<WorkGroup> DefaultWorkGroupInitialization::create_default_mv_workgroup() {
     int64_t mv_cpu_limit = config::default_mv_resource_group_cpu_limit;
     double mv_memory_limit = config::default_mv_resource_group_memory_limit;
     double mv_concurrency_limit = config::default_mv_resource_group_concurrency_limit;
     double mv_spill_mem_limit_threshold = config::default_mv_resource_group_spill_mem_limit_threshold;
-    auto default_mv_wg = std::make_shared<WorkGroup>(
-            "default_mv_wg", WorkGroup::DEFAULT_MV_WG_ID, WorkGroup::DEFAULT_MV_VERSION, mv_cpu_limit, mv_memory_limit,
-            mv_concurrency_limit, mv_spill_mem_limit_threshold, WorkGroupType::WG_MV);
-    WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+    return std::make_shared<WorkGroup>("default_mv_wg", WorkGroup::DEFAULT_MV_WG_ID, WorkGroup::DEFAULT_MV_VERSION,
+                                       mv_cpu_limit, mv_memory_limit, mv_concurrency_limit,
+                                       mv_spill_mem_limit_threshold, WorkGroupType::WG_MV);
 }
 
 } // namespace starrocks::workgroup

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -317,6 +317,11 @@ private:
 class DefaultWorkGroupInitialization {
 public:
     DefaultWorkGroupInitialization();
+
+    // create or renew default group
+    std::shared_ptr<WorkGroup> create_default_workgroup();
+    // create or renew default mv group
+    std::shared_ptr<WorkGroup> create_default_mv_workgroup();
 };
 
 } // namespace workgroup

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -235,7 +235,35 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 tablet_manager->compaction_scheduler()->update_compact_threads(config::compact_threads);
             }
         });
-        _config_callback.emplace("sys_log_level", [&]() { update_logging(); });
+
+        _config_callback.emplace("default_mv_resource_group_memory_limit", [&]() {
+            LOG(INFO) << "set default_mv_resource_group_memory_limit:"
+                      << config::default_mv_resource_group_memory_limit;
+            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
+            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
+            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+        });
+        _config_callback.emplace("default_mv_resource_group_cpu_limit", [&]() {
+            LOG(INFO) << "set default_mv_resource_group_cpu_limit:" << config::default_mv_resource_group_cpu_limit;
+            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
+            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
+            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+        });
+        _config_callback.emplace("default_mv_resource_group_concurrency_limit", [&]() {
+            LOG(INFO) << "set default_mv_resource_group_concurrency_limit:"
+                      << config::default_mv_resource_group_concurrency_limit;
+            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
+            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
+            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+        });
+        _config_callback.emplace("default_mv_resource_group_spill_mem_limit_threshold", [&]() {
+            LOG(INFO) << "set default_mv_resource_group_spill_mem_limit_threshold:"
+                      << config::default_mv_resource_group_spill_mem_limit_threshold;
+            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
+            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
+            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+        });
+
 #ifdef USE_STAROS
         _config_callback.emplace("starlet_cache_thread_num", [&]() {
             if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_threadpool_size", value).empty()) {

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -241,27 +241,27 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                       << config::default_mv_resource_group_memory_limit;
             workgroup::DefaultWorkGroupInitialization default_wg_initializer;
             auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
         });
         _config_callback.emplace("default_mv_resource_group_cpu_limit", [&]() {
             LOG(INFO) << "set default_mv_resource_group_cpu_limit:" << config::default_mv_resource_group_cpu_limit;
             workgroup::DefaultWorkGroupInitialization default_wg_initializer;
             auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
         });
         _config_callback.emplace("default_mv_resource_group_concurrency_limit", [&]() {
             LOG(INFO) << "set default_mv_resource_group_concurrency_limit:"
                       << config::default_mv_resource_group_concurrency_limit;
             workgroup::DefaultWorkGroupInitialization default_wg_initializer;
             auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
         });
         _config_callback.emplace("default_mv_resource_group_spill_mem_limit_threshold", [&]() {
             LOG(INFO) << "set default_mv_resource_group_spill_mem_limit_threshold:"
                       << config::default_mv_resource_group_spill_mem_limit_threshold;
             workgroup::DefaultWorkGroupInitialization default_wg_initializer;
             auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            WorkGroupManager::instance()->add_workgroup(default_mv_wg);
+            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
         });
 
 #ifdef USE_STAROS


### PR DESCRIPTION

## Why I'm doing:


Make mv default resource group configurable

1. Update the default MV resource group: Refresh the MV task to occupy the upper limit of BE Memory usage, the default is 80%.
   ```sql
   UPDATE information_schema.be_configs SET VALUE="0.5" WHERE NAME="default_mv_resource_group_memory_limit";
   ```

2. Update the default MV resource group: Refresh the MV task to occupy a single BE CPU core by default, which is 1 Core.
   ```sql
   UPDATE information_schema.be_configs SET VALUE="4" WHERE NAME="default_mv_resource_group_cpu_limit";
   ```

3. Update the default MV resource group: Refresh the upper limit of concurrent MV refresh tasks on a single BE node, the default is 0, which means there is no limit on the number of concurrent tasks; when the refresh tasks exceed this limit, they will queue at the FE (Frontend) until all resources are below the threshold before executing the query.
   ```sql
   UPDATE information_schema.be_configs SET VALUE="4" WHERE NAME="default_mv_resource_group_concurrency_limit";
   ```

4. Update the default MV resource group: Refresh the memory usage threshold that triggers spilling to disk for MV tasks, the default is 80%.
   ```sql
   UPDATE information_schema.be_configs SET VALUE="0.5" WHERE NAME="default_mv_resource_group_spill_mem_limit_threshold";
   ```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
