### PR TITLE
[UT] Add enable_mv_refresh_insert_strict config and fix mv unstable test cases

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2862,6 +2862,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Whether enable to cache mv query context or not")
     public static boolean enable_mv_query_context_cache = true;
 
+    @ConfField(mutable = true, comment = "Whether enable strict insert in mv refresh or not by default")
+    public static boolean enable_mv_refresh_insert_strict = false;
+
     /**
      * Whether analyze the mv after refresh in async mode.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -22,7 +22,6 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
@@ -136,6 +135,9 @@ public abstract class ConnectorPartitionTraits {
         return table.getName();
     }
 
+    /**
+     * Whether this table support partition-granular refresh as ref-table
+     */
     public abstract boolean isSupportPCTRefresh();
 
     /**
@@ -144,11 +146,6 @@ public abstract class ConnectorPartitionTraits {
     public abstract PartitionKey createEmptyKey();
 
     public abstract String getDbName();
-
-    /**
-     * Whether this table support partition-granular refresh as ref-table
-     */
-    public abstract boolean supportPartitionRefresh();
 
     public abstract PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException;
 
@@ -197,16 +194,4 @@ public abstract class ConnectorPartitionTraits {
      */
     public abstract Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                          MaterializedView.AsyncRefreshContext context);
-
-    /**
-     * Check whether the base table's partition has changed or not.
-     * </p>
-     * NOTE: If the base table is materialized view, partition is overwritten each time, so we need to compare
-     * version and modified time.
-     */
-    public static boolean isBaseTableChanged(Partition partition,
-                                             MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo) {
-        return partition.getVisibleVersion() != mvRefreshedPartitionInfo.getVersion()
-                || partition.getVisibleVersionTime() > mvRefreshedPartitionInfo.getLastRefreshTime();
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -120,11 +120,6 @@ public class CachedPartitionTraits extends DefaultTraits {
     }
 
     @Override
-    public boolean supportPartitionRefresh() {
-        return delegate.supportPartitionRefresh();
-    }
-
-    @Override
     public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException {
         return delegate.createPartitionKeyWithType(values, types);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -44,10 +44,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public abstract class DefaultTraits extends ConnectorPartitionTraits  {
-    @Override
-    public boolean supportPartitionRefresh() {
-        return false;
-    }
 
     @Override
     public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
@@ -27,11 +27,6 @@ import java.util.Optional;
 public class HivePartitionTraits extends DefaultTraits {
 
     @Override
-    public boolean supportPartitionRefresh() {
-        return true;
-    }
-
-    @Override
     public String getDbName() {
         return ((HiveMetaStoreTable) table).getDbName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -35,12 +35,6 @@ import java.util.Optional;
 public class IcebergPartitionTraits extends DefaultTraits {
 
     @Override
-    public boolean supportPartitionRefresh() {
-        // TODO: refine the check
-        return true;
-    }
-
-    @Override
     public String getDbName() {
         return ((IcebergTable) table).getRemoteDbName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
@@ -31,12 +31,6 @@ import java.util.Optional;
 public class JDBCPartitionTraits extends DefaultTraits {
 
     @Override
-    public boolean supportPartitionRefresh() {
-        // TODO: refine check
-        return true;
-    }
-
-    @Override
     public String getDbName() {
         return ((JDBCTable) table).getDbName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -54,12 +54,6 @@ public class OlapPartitionTraits extends DefaultTraits {
     }
 
     @Override
-    public boolean supportPartitionRefresh() {
-        // TODO: check partition types
-        return true;
-    }
-
-    @Override
     public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
         if (!((OlapTable) table).getPartitionInfo().isRangePartition()) {
             throw new IllegalArgumentException("Must be range partitioned table");
@@ -90,7 +84,7 @@ public class OlapPartitionTraits extends DefaultTraits {
             List<String> baseTablePartitionInfos = Lists.newArrayList();
             for (String p : baseTable.getVisiblePartitionNames()) {
                 Partition partition = baseTable.getPartition(p);
-                baseTablePartitionInfos.add(String.format("%s:%s:%s", p, partition.getVisibleVersion(),
+                baseTablePartitionInfos.add(String.format("%s:%s:%s:%s", p, partition.getId(), partition.getVisibleVersion(),
                         partition.getVisibleVersionTime()));
             }
             LOG.debug("baseTable: {}, baseTablePartitions:{}, mvBaseTableVisibleVersionMap: {}",
@@ -120,8 +114,7 @@ public class OlapPartitionTraits extends DefaultTraits {
                 result.add(basePartitionName);
             } else {
                 // Ignore partitions if mv's partition is the same with the basic table.
-                if (mvRefreshedPartitionInfo.getId() == basePartition.getId()
-                        && !isBaseTableChanged(basePartition, mvRefreshedPartitionInfo)) {
+                if (!isBaseTableChanged(basePartition, mvRefreshedPartitionInfo)) {
                     continue;
                 }
 
@@ -130,6 +123,19 @@ public class OlapPartitionTraits extends DefaultTraits {
             }
         }
         return result;
+    }
+
+    /**
+     * Check whether the base table's partition has changed or not.
+     * </p>
+     * NOTE: If the base table is materialized view, partition is overwritten each time, so we need to compare
+     * version and modified time.
+     */
+    public static boolean isBaseTableChanged(Partition partition,
+                                             MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo) {
+        return mvRefreshedPartitionInfo.getId() != partition.getId()
+                || partition.getVisibleVersion() != mvRefreshedPartitionInfo.getVersion()
+                || partition.getVisibleVersionTime() > mvRefreshedPartitionInfo.getLastRefreshTime();
     }
 
     public List<Column> getPartitionColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/PaimonPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/PaimonPartitionTraits.java
@@ -26,12 +26,6 @@ import java.util.Optional;
 public class PaimonPartitionTraits extends DefaultTraits {
 
     @Override
-    public boolean supportPartitionRefresh() {
-        // TODO: refine the check
-        return true;
-    }
-
-    @Override
     public String getDbName() {
         return ((PaimonTable) table).getDbName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -545,7 +545,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // set enable_insert_strict by default
         if (!isMVPropertyContains(SessionVariable.ENABLE_INSERT_STRICT)) {
-            mvSessionVariable.setEnableInsertStrict(false);
+            mvSessionVariable.setEnableInsertStrict(Config.enable_mv_refresh_insert_strict);
         }
         // enable profile by default for mv refresh task
         if (!isMVPropertyContains(SessionVariable.ENABLE_PROFILE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -182,18 +182,18 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         Set<String> mvListPartitionNames = getMVPartitionNamesWithTTL(mv, start, end, partitionTTLNumber, isAutoRefresh);
 
         // check non-ref base tables
-        if (needsRefreshBasedOnNonRefTables(snapshotBaseTables)) {
+        if (force || needsRefreshBasedOnNonRefTables(snapshotBaseTables)) {
             if (start == null && end == null) {
                 // if non-partition table changed, should refresh all partitions of materialized view
                 return mvListPartitionNames;
             } else {
                 // If the user specifies the start and end ranges, and the non-partitioned table still changes,
                 // it should be refreshed according to the user-specified range, not all partitions.
-                return getMvPartitionNamesToRefresh(mvListPartitionNames, true);
+                return getMvPartitionNamesToRefresh(mvListPartitionNames);
             }
         } else {
             // check the ref base table
-            return getMvPartitionNamesToRefresh(mvListPartitionNames, force);
+            return getMvPartitionNamesToRefresh(mvListPartitionNames);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -128,7 +128,7 @@ public abstract class MVPCTRefreshPartitioner {
      * Check whether the base table is supported partition refresh or not.
      */
     public static boolean isPartitionRefreshSupported(Table baseTable) {
-        return ConnectorPartitionTraits.build(baseTable).supportPartitionRefresh();
+        return ConnectorPartitionTraits.isSupported(baseTable.getType());
     }
 
     /**
@@ -142,6 +142,8 @@ public abstract class MVPCTRefreshPartitioner {
         Set<String> result = Sets.newHashSet();
         Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMaps = mvContext.getRefBaseTableMVIntersectedPartitions();
         if (refBaseTableMVPartitionMaps == null || !refBaseTableMVPartitionMaps.containsKey(refBaseTable)) {
+            LOG.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
+                            "refBaseTableMVPartitionMaps: {}", refBaseTable, refBaseTableMVPartitionMaps);
             return null;
         }
         Map<String, Set<String>> refBaseTableMVPartitionMap = refBaseTableMVPartitionMaps.get(refBaseTable);
@@ -159,17 +161,15 @@ public abstract class MVPCTRefreshPartitioner {
     /**
      * Get mv partitions to refresh based on the ref base table partitions.
      * @param mvPartitionNames all mv partition names
-     * @param force whether it's force refresh or not
      * @return mv partitions to refresh based on the ref base table partitions
      */
-    protected Set<String> getMvPartitionNamesToRefresh(Set<String> mvPartitionNames,
-                                                       boolean force) {
+    protected Set<String> getMvPartitionNamesToRefresh(Set<String> mvPartitionNames) {
         Set<String> result = Sets.newHashSet();
         Map<Table, Column> refBaseTableAndColumns = mv.getRelatedPartitionTableAndColumn();
         for (Map.Entry<Table, Column> e : refBaseTableAndColumns.entrySet()) {
             Table baseTable = e.getKey();
             // refresh all mv partitions when the ref base table is not supported partition refresh
-            if (force || !isPartitionRefreshSupported(baseTable)) {
+            if (!isPartitionRefreshSupported(baseTable)) {
                 LOG.info("The ref base table {} is not supported partition refresh, refresh all " +
                         "partitions of mv {}: {}", baseTable.getName(), mv.getName(), mvPartitionNames);
                 return mvPartitionNames;
@@ -184,6 +184,8 @@ public abstract class MVPCTRefreshPartitioner {
             }
             Set<String> refBaseTablePartitionNames = mvBaseTableUpdateInfo.getToRefreshPartitionNames();
             if (refBaseTablePartitionNames.isEmpty()) {
+                LOG.info("The ref base table {} has no updated partitions, and no update related mv partitions: {}",
+                        baseTable.getName(), mvPartitionNames);
                 continue;
             }
 
@@ -191,7 +193,7 @@ public abstract class MVPCTRefreshPartitioner {
             Set<String> ans = getMvPartitionNamesToRefresh(baseTable, refBaseTablePartitionNames);
             if (ans == null) {
                 throw new DmlException(String.format("Find the corresponding mv partition names of ref base table %s failed," +
-                        "mv %s: ref partitions: %s", baseTable.getName(), mv.getName(), refBaseTablePartitionNames));
+                        " mv %s:, ref partitions: %s", baseTable.getName(), mv.getName(), refBaseTablePartitionNames));
             }
             ans.retainAll(mvPartitionNames);
             LOG.info("The ref base table {} has updated partitions: {}, the corresponding " +

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
@@ -168,17 +168,17 @@ public class MvRefreshConcurrencyTest extends MvRewriteTestBase {
 
     @Test
     @BenchmarkOptions(warmupRounds = 0, benchmarkRounds = 1)
-    public void testWithTables100_c16() {
+    public void testWithTables50_c16() {
         Config.task_runs_concurrency = 16;
-        testRefreshWithConcurrency(100, 100);
+        testRefreshWithConcurrency(50, 50);
         Config.task_runs_concurrency = 4;
     }
 
     @Test
     @BenchmarkOptions(warmupRounds = 0, benchmarkRounds = 1)
-    public void testWithTables100_c50() {
+    public void testWithTables50_c50() {
         Config.task_runs_concurrency = 50;
-        testRefreshWithConcurrency(100, 100);
+        testRefreshWithConcurrency(50, 50);
         Config.task_runs_concurrency = 4;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -271,7 +271,7 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
                     materializedView.getPartitions().stream().map(Partition::getName).sorted()
                             .collect(Collectors.toList());
             Assert.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
-            Assert.assertTrue(partitionVersionMap.get("p202308_202309") <
+            Assert.assertEquals(partitionVersionMap.get("p202308_202309").longValue(),
                     materializedView.getPartition("p202308_202309").getVisibleVersion());
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -406,11 +406,11 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
         Assert.assertEquals(2, materializedView.getPartition("p202204_202205").getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-05-06", true);
-        Assert.assertEquals(3, materializedView.getPartition("p202112_202201").getVisibleVersion());
-        Assert.assertEquals(3, materializedView.getPartition("p202201_202202").getVisibleVersion());
-        Assert.assertEquals(2, materializedView.getPartition("p202202_202203").getVisibleVersion());
+        Assert.assertEquals(2, materializedView.getPartition("p202112_202201").getVisibleVersion());
+        Assert.assertEquals(2, materializedView.getPartition("p202201_202202").getVisibleVersion());
+        Assert.assertEquals(1, materializedView.getPartition("p202202_202203").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p202203_202204").getVisibleVersion());
-        Assert.assertEquals(3, materializedView.getPartition("p202204_202205").getVisibleVersion());
+        Assert.assertEquals(2, materializedView.getPartition("p202204_202205").getVisibleVersion());
     }
 
     @Test
@@ -2421,9 +2421,12 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
                                 Map<String, List<TaskRunStatus>> taskNameJobStatusMap =
                                         tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, Set.of(mvTaskName));
                                 System.out.println(taskNameJobStatusMap);
-                                Assert.assertFalse(taskNameJobStatusMap.isEmpty());
-                                Assert.assertEquals(1, taskNameJobStatusMap.size());
                                 // refresh 4 times
+                                while (taskNameJobStatusMap.isEmpty() || taskNameJobStatusMap.get(mvTaskName).size() < 4) {
+                                    Thread.sleep(100);
+                                    taskNameJobStatusMap = tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, Set.of(mvTaskName));
+                                }
+                                Assert.assertEquals(1, taskNameJobStatusMap.size());
                                 Assert.assertEquals(4, taskNameJobStatusMap.get(mvTaskName).size());
 
                                 ShowMaterializedViewStatus status =

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1277,6 +1277,9 @@ public class UtFrameUtils {
         // task run will only refresh 1 partition and will produce wrong result.
         Config.default_mv_partition_refresh_number = -1;
 
+        // Enable mv refresh insert strict in test
+        Config.enable_mv_refresh_insert_strict = true;
+
         FeConstants.enablePruneEmptyOutputScan = false;
         FeConstants.runningUnitTest = true;
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union2
@@ -156,7 +156,10 @@ INSERT INTO u6 (id,dt) VALUES
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
 PARTITION BY date_trunc('day', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from u1
     union all
@@ -166,7 +169,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
 PARTITION BY dt
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from u3
     union all
@@ -177,7 +183,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
 PARTITION BY date_trunc('day', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from u1
     union all
@@ -195,7 +204,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
 PARTITION BY dt
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
 select dt 
 from (
@@ -216,7 +228,10 @@ from (
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
 PARTITION BY dt
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
 select dt 
 from (
@@ -237,7 +252,10 @@ from (
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
 PARTITION BY date_trunc('day', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from test_mv1
     union all
@@ -253,7 +271,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv7`
 PARTITION BY date_trunc('month', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from test_mv1
     union all
@@ -269,7 +290,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv8`
 PARTITION BY date_trunc('month', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
 select dt
 from (

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union2
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union2
@@ -139,7 +139,10 @@ INSERT INTO u6 (id,dt) VALUES
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
 PARTITION BY date_trunc('day', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from u1
     union all
@@ -148,7 +151,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
 PARTITION BY dt
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from u3
     union all
@@ -157,7 +163,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
 PARTITION BY date_trunc('day', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from u1
     union all
@@ -174,7 +183,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
 PARTITION BY dt
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
 select dt 
 from (
@@ -194,7 +206,10 @@ from (
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
 PARTITION BY dt
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
 select dt 
 from (
@@ -215,7 +230,10 @@ from (
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
 PARTITION BY date_trunc('day', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from test_mv1
     union all
@@ -230,7 +248,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv7`
 PARTITION BY date_trunc('month', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
     select dt from test_mv1
     union all
@@ -245,7 +266,10 @@ AS
 CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv8`
 PARTITION BY date_trunc('month', `dt`)
 DISTRIBUTED BY HASH(`dt`)
-REFRESH ASYNC 
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "session.enable_insert_strict" = "true"
+)
 AS 
 select dt
 from (


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Add `enable_mv_refresh_insert_strict` config to decide whether to enable insert strict by default or not and enable it in fe ut by default;
- Remove duplicated `supportPartitionRefresh` api by using `isSupportPCTRefresh` instead;
- Handle the same input partition name in computing range partition diff;
- Fix some unstable uts;


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
