### PR TITLE
[BugFix] fix cast invalid negative largeint to datetime error 

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -816,7 +816,13 @@ ColumnPtr cast_to_timestamp_fn(ColumnPtr& column) {
 
         auto value = viewer.value(row);
         TimestampValue tv;
-        bool ret = value > 0 && tv.from_timestamp_literal_with_check(value);
+        bool ret;
+        if constexpr (lt_is_decimalv2<FromType>) {
+            ret = value.value() > 0;
+        } else {
+            ret = value > 0;
+        }
+        ret = tv.from_timestamp_literal_with_check(value) && ret;
         if constexpr (AllowThrowException) {
             if (!ret) {
                 THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, (int64_t)value);
@@ -842,6 +848,7 @@ CUSTOMIZE_FN_CAST(TYPE_BIGINT, TYPE_DATETIME, cast_to_timestamp_fn);
 CUSTOMIZE_FN_CAST(TYPE_LARGEINT, TYPE_DATETIME, cast_to_timestamp_fn);
 CUSTOMIZE_FN_CAST(TYPE_FLOAT, TYPE_DATETIME, cast_to_timestamp_fn);
 CUSTOMIZE_FN_CAST(TYPE_DOUBLE, TYPE_DATETIME, cast_to_timestamp_fn);
+CUSTOMIZE_FN_CAST(TYPE_DECIMALV2, TYPE_DATETIME, cast_to_timestamp_fn);
 UNARY_FN_CAST(TYPE_DATE, TYPE_DATETIME, DateToTimestmap);
 // Time to datetime need rewrite CastExpr
 

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -72,12 +72,10 @@ struct CastFn {
 };
 
 // All cast implements
-#define SELF_CAST(FROM_TYPE)                                   \
-    template <bool AllowThrowException>                        \
-    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> { \
-        static ColumnPtr cast_fn(ColumnPtr& column) {          \
-            return column->clone();                            \
-        }                                                      \
+#define SELF_CAST(FROM_TYPE)                                                    \
+    template <bool AllowThrowException>                                         \
+    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> {                  \
+        static ColumnPtr cast_fn(ColumnPtr& column) { return column->clone(); } \
     };
 
 #define UNARY_FN_CAST(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                        \
@@ -1277,7 +1275,7 @@ DEFINE_STRING_UNARY_FN_WITH_IMPL(DoubleCastToString, v) {
     template <>                                                                                             \
     template <>                                                                                             \
     inline ColumnPtr StringUnaryFunction<CastToString>::evaluate<FROM_TYPE, TO_TYPE>(const ColumnPtr& v1) { \
-        auto& r1 = ColumnHelper::cast_to_raw<FROM_TYPE>(v1) -> get_data();                                  \
+        auto& r1 = ColumnHelper::cast_to_raw<FROM_TYPE>(v1)->get_data();                                    \
         auto result = RunTimeColumnType<TO_TYPE>::create();                                                 \
         auto& offset = result->get_offset();                                                                \
         offset.resize(v1->size() + 1);                                                                      \

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -822,7 +822,7 @@ ColumnPtr cast_to_timestamp_fn(ColumnPtr& column) {
         } else {
             ret = value > 0;
         }
-        ret = tv.from_timestamp_literal_with_check(value) && ret;
+        ret = ret && tv.from_timestamp_literal_with_check(value);
         if constexpr (AllowThrowException) {
             if (!ret) {
                 THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, (int64_t)value);

--- a/test/sql/test_cast/R/test_cast_to_datetime
+++ b/test/sql/test_cast/R/test_cast_to_datetime
@@ -1,0 +1,21 @@
+-- name: test_cast_to_datetime
+select cast(-18446744073709551494 AS DATETIME);
+-- result:
+None
+-- !result
+select cast(0 AS DATETIME);
+-- result:
+None
+-- !result
+select cast(1 AS DATETIME);
+-- result:
+None
+-- !result
+select cast(18446744073709551615 AS DATETIME);
+-- result:
+None
+-- !result
+select yearweek(-18446744073709551494);
+-- result:
+None
+-- !result

--- a/test/sql/test_cast/T/test_cast_to_datetime
+++ b/test/sql/test_cast/T/test_cast_to_datetime
@@ -1,0 +1,6 @@
+-- name: test_cast_to_datetime
+select cast(-18446744073709551494 AS DATETIME);
+select cast(0 AS DATETIME);
+select cast(1 AS DATETIME);
+select cast(18446744073709551615 AS DATETIME);
+select yearweek(-18446744073709551494);


### PR DESCRIPTION
## Why I'm doing:
cast negative number into datetime shoulc return null

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
