### PR TITLE
[Enhancement] optimize auto schedule to keep routine load stable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/InternalErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InternalErrorCode.java
@@ -36,7 +36,8 @@ public enum InternalErrorCode {
     TOO_MANY_FAILURE_ROWS_ERR(102),
     CREATE_TASKS_ERR(103),
     TASKS_ABORT_ERR(104),
-    SLOW_RUNNING_ERR(105);
+    SLOW_RUNNING_ERR(105),
+    CANNOT_RESUME_ERR(106);
 
     private long errCode;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1154,7 +1154,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                                 String msg = "be " + taskBeId + " abort task "
                                         + "with reason: " + txnStatusChangeReasonString;
                                 updateState(JobState.PAUSED,
-                                        new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg),
+                                        new ErrorReason(InternalErrorCode.CANNOT_RESUME_ERR, msg),
                                         false /* not replay */);
                                 return;
                             default:

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/ScheduleRule.java
@@ -68,7 +68,10 @@ public class ScheduleRule {
         /*
          * Handle all backends are down.
          */
-        if (jobRoutine.pauseReason != null && jobRoutine.pauseReason.getCode() == InternalErrorCode.REPLICA_FEW_ERR) {
+        if (jobRoutine.pauseReason != null
+                && jobRoutine.pauseReason.getCode() != InternalErrorCode.MANUAL_PAUSE_ERR
+                && jobRoutine.pauseReason.getCode() != InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR
+                && jobRoutine.pauseReason.getCode() != InternalErrorCode.CANNOT_RESUME_ERR) {
             int dead = deadBeCount();
             if (dead > Config.max_tolerable_backend_down_num) {
                 return false;


### PR DESCRIPTION
## Why I'm doing:
Currently, routine load job can be resumed automatically only when internal error code is `REPLICA_FEW_ERR`, this helps when BE is restarted or in a shutdown upgrade. However, other scenarios are not covered, such as:
- `TASKS_ABORT_ERR`: when encountered transitory `RPC` timeout
- `INTERNAL_ERR`: when failed to commit due to unforeseen error

## What I'm doing:
Weed out some states that cannot be resumed automatically when check auto schedule. In addition, add an internal error code `CANNOT_RESUME_ERR` to represent errors such as offset out of range that should resume job manually.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5