### PR TITLE
[Enhancement] ignore untracked gen_cpp cmake-build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ StarRocksLex.tokens
 /Default/
 be/cmake-build*
 be/.vscode
+be/src/gen_cpp/cmake-build*
 be/src/gen_cpp/*.cc
 be/src/gen_cpp/*.cpp
 be/src/gen_cpp/*.h


### PR DESCRIPTION
## Why I'm doing:
When using a remote server to build `gen_cpp`, users will encounter below issue when submitting a new pr:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	be/src/gen_cpp/cmake-build-debug-remote-host/
```
## What I'm doing:

Add the `cmake-build` dir to `.gitignore`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
