### PR TITLE
[BugFix] fix ngram_search crash

### DIFF
--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -55,6 +55,9 @@ struct RewritePredicateTreeVisitor {
     StatusOr<RewriteStatus> operator()(PredicateColumnNode& node, PredicateCompoundNode<ParentType>& parent) const {
         const auto* col_pred = node.col_pred();
         const auto cid = col_pred->column_id();
+        if (col_pred->is_index_filter_only()) {
+            return RewriteStatus::UNCHANGED;
+        }
 
         if (!_rewriter._need_rewrite[cid]) {
             return RewriteStatus::UNCHANGED;

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -55,6 +55,8 @@ struct RewritePredicateTreeVisitor {
     StatusOr<RewriteStatus> operator()(PredicateColumnNode& node, PredicateCompoundNode<ParentType>& parent) const {
         const auto* col_pred = node.col_pred();
         const auto cid = col_pred->column_id();
+        // index only filter only used for storage engine index filter
+        // after index filter,it's useless and will be thrown away in SegmentIterator::_init_column_predicates
         if (col_pred->is_index_filter_only()) {
             return RewriteStatus::UNCHANGED;
         }

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -57,7 +57,7 @@ struct RewritePredicateTreeVisitor {
         const auto cid = col_pred->column_id();
         // index only filter only used for storage engine index filter
         // after index filter,it's useless and will be thrown away in SegmentIterator::_init_column_predicates
-        if (col_pred->is_index_filter_only()) {
+        if (col_pred->is_index_filter_only() && col_pred->is_expr_predicate()) {
             return RewriteStatus::UNCHANGED;
         }
 

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -512,3 +512,50 @@ select sum(result) from ( select ngram_search("normal_string", "normal_string", 
 -- result:
 4097.0
 -- !result
+-- name: test_ngram_search_with_low_cardinality
+CREATE TABLE __row_util_1 (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_1 select generate_series from TABLE(generate_series(0, 5000));
+-- result:
+-- !result
+CREATE TABLE left_table (
+    id int,
+    nation string,
+    exsit_hot_value int
+)
+ENGINE=olap
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) buckets 32
+PROPERTIES (
+    "replication_num" = "1" 
+);
+-- result:
+-- !result
+insert into left_table 
+select
+    cast(rand() * 100000000 as int),
+    CASE 
+        WHEN RAND() > 0.8 THEN 'china'
+        WHEN RAND() > 0.6 THEN 'usa'
+        WHEN RAND() > 0.4 THEN 'russian'
+        WHEN RAND() > 0.2 THEN 'canada'
+        ELSE 'japan'
+    END,
+   case when RAND() > 0.99 THEN k1
+       ELSE k1 % 5 
+   END
+from __row_util_1;
+-- result:
+-- !result
+select sum(c0) > 500 from (select ngram_search(nation, 'china', 4) as c0 from left_table)t0;
+-- result:
+1
+-- !result

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -197,3 +197,45 @@ select ngram_search(date('2020-06-23'), "2020", 4);
 -- const value with two chunk
 select sum(result) from ( select ngram_search("normal_string", "normal_string", 5) as result from (   select generate_series    from TABLE(generate_series(0, 4097 - 1)) ) as t1) as t2;
 
+
+-- name: test_ngram_search_with_low_cardinality
+CREATE TABLE __row_util_1 (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into __row_util_1 select generate_series from TABLE(generate_series(0, 5000));
+
+
+-- id随机，nation低基数，exsit_hot_value中1%随机，99%的低基（只有5种取值）
+CREATE TABLE left_table (
+    id int,
+    nation string,
+    exsit_hot_value int
+)
+ENGINE=olap
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) buckets 32
+PROPERTIES (
+    "replication_num" = "1" 
+);
+
+insert into left_table 
+select
+    cast(rand() * 100000000 as int),
+    CASE 
+        WHEN RAND() > 0.8 THEN 'china'
+        WHEN RAND() > 0.6 THEN 'usa'
+        WHEN RAND() > 0.4 THEN 'russian'
+        WHEN RAND() > 0.2 THEN 'canada'
+        ELSE 'japan'
+    END,
+   case when RAND() > 0.99 THEN k1
+       ELSE k1 % 5 
+   END
+from __row_util_1;
+select sum(c0) > 500 from (select ngram_search(nation, 'china', 4) as c0 from left_table)t0;


### PR DESCRIPTION
## Why I'm doing:
right now ngram_search is designed only for pipeline thread, But when rewrite predicate for Low cardinality dictionary, scan thread will calculate ngram_search, which is root cause of crash. And ngram_search >= 0 is useless after index filter phase, so Low cardinality rewrite is not necessary.

## What I'm doing:
ngram search >= 0 is index only filter, whcih is used for index filter on storage engine, so we skip rewrite predicate for Low cardinality dictionary which is index only filter and colum_expr_predicate (right now only ngram_search>=0), because it is useless after get_row_range_by_bloom_filter.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
