### PR TITLE
[Refactor] move `getRemotePartitions` into RemoteFileOperations class

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -163,8 +163,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<RemoteFileInfo> getRemoteFileInfoForPartitions(Table table, List<String> partitionNames) {
-        return normal.getRemoteFileInfoForPartitions(table, partitionNames);
+    public List<RemoteFileInfo> getRemotePartitions(Table table, List<String> partitionNames) {
+        return normal.getRemotePartitions(table, partitionNames);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -164,7 +164,7 @@ public interface ConnectorMetadata {
         return Lists.newArrayList();
     }
 
-    default List<RemoteFileInfo> getRemoteFileInfoForPartitions(Table table, List<String> partitionNames) {
+    default List<RemoteFileInfo> getRemotePartitions(Table table, List<String> partitionNames) {
         return Lists.newArrayList();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/DirectoryBasedUpdateArbitrator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/DirectoryBasedUpdateArbitrator.java
@@ -34,7 +34,7 @@ public class DirectoryBasedUpdateArbitrator extends TableUpdateArbitrator {
             partitionNameToFetch = partitionNames.subList(partitionNames.size() - partitionLimit, partitionNames.size());
         }
         List<RemoteFileInfo> remoteFileInfos =
-                GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfoForPartitions(table, partitionNameToFetch);
+                GlobalStateMgr.getCurrentState().getMetadataMgr().getRemotePartitions(table, partitionNameToFetch);
         for (int i = 0; i < partitionNameToFetch.size(); i++) {
             RemoteFileInfo remoteFileInfo = remoteFileInfos.get(i);
             List<RemoteFileDesc> remoteFileDescs = remoteFileInfo.getFiles();

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -755,12 +755,12 @@ public class MetadataMgr {
         return ImmutableList.copyOf(files.build());
     }
 
-    public List<RemoteFileInfo> getRemoteFileInfoForPartitions(Table table, List<String> partitionNames) {
+    public List<RemoteFileInfo> getRemotePartitions(Table table, List<String> partitionNames) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
         ImmutableSet.Builder<RemoteFileInfo> files = ImmutableSet.builder();
         if (connectorMetadata.isPresent()) {
             try {
-                connectorMetadata.get().getRemoteFileInfoForPartitions(table, partitionNames)
+                connectorMetadata.get().getRemotePartitions(table, partitionNames)
                         .forEach(files::add);
             } catch (Exception e) {
                 LOG.error("Failed to list partition directory's metadata on catalog [{}], table [{}]",

--- a/fe/fe-core/src/test/java/com/starrocks/connector/DirectoryBasedUpdateArbitratorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/DirectoryBasedUpdateArbitratorTest.java
@@ -83,7 +83,7 @@ public class DirectoryBasedUpdateArbitratorTest {
                 result = metadataMgr;
                 minTimes = 0;
 
-                metadataMgr.getRemoteFileInfoForPartitions((Table) any, (List<String>) any);
+                metadataMgr.getRemotePartitions((Table) any, (List<String>) any);
                 result = remoteFileInfos;
                 minTimes = 0;
             }
@@ -115,7 +115,7 @@ public class DirectoryBasedUpdateArbitratorTest {
                 result = metadataMgr;
                 minTimes = 0;
 
-                metadataMgr.getRemoteFileInfoForPartitions((Table) any, (List<String>) any);
+                metadataMgr.getRemotePartitions((Table) any, (List<String>) any);
                 result = remoteFileInfos;
                 minTimes = 0;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -26,9 +27,11 @@ import com.starrocks.connector.hive.HiveWriteUtils;
 import com.starrocks.connector.hive.MockedRemoteFileSystem;
 import com.starrocks.connector.hive.Partition;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
+import com.starrocks.connector.hive.TextFileFormatDesc;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
@@ -130,7 +133,6 @@ public class RemoteFileOperationsTest {
                         " Failed to get file system on path hdfs://hadoop01:9000/tmp/starrocks/queryid",
                 () -> ops.asyncRenameFiles(futures, new AtomicBoolean(true), writePath, targetPath, fileNames));
 
-
         RemoteFileOperations ops1 = new RemoteFileOperations(cachingFileIO, executorToLoad, Executors.newSingleThreadExecutor(),
                 false, true, new Configuration());
 
@@ -202,7 +204,8 @@ public class RemoteFileOperationsTest {
                 StarRocksConnectorException.class,
                 "Unable to rename from hdfs://hadoop01:9000/tmp/starrocks/queryid to " +
                         "hdfs://hadoop01:9000/user/hive/warehouse/test.db/t1. msg: target directory already exists",
-                () -> ops.renameDirectory(writePath, targetPath, () -> {}));
+                () -> ops.renameDirectory(writePath, targetPath, () -> {
+                }));
     }
 
     @Test
@@ -216,7 +219,6 @@ public class RemoteFileOperationsTest {
         CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 10);
         RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
                 false, true, new Configuration());
-
 
         Path writePath = new Path("hdfs://hadoop01:9000/tmp/starrocks/queryid");
         Path targetPath = new Path("hdfs://hadoop01:9000/user/hive/warehouse/test.db/t1");
@@ -241,7 +243,8 @@ public class RemoteFileOperationsTest {
         ExceptionChecker.expectThrowsWithMsg(
                 StarRocksConnectorException.class,
                 "Failed to rename",
-                () -> ops.renameDirectory(writePath, targetPath, () -> {}));
+                () -> ops.renameDirectory(writePath, targetPath, () -> {
+                }));
     }
 
     @Test
@@ -272,5 +275,38 @@ public class RemoteFileOperationsTest {
                 StarRocksConnectorException.class,
                 "file name or query id is invalid",
                 () -> ops.removeNotCurrentQueryFiles(targetPath, "aaa"));
+    }
+
+    @Test
+    public void testGetRemotePartitions() {
+        List<String> partitionNames = Lists.newArrayList("dt=20200101", "dt=20200102", "dt=20200103");
+        List<Partition> partitionList = Lists.newArrayList();
+        List<FileStatus> fileStatusList = Lists.newArrayList();
+        long modificationTime = 1000;
+        for (String name : partitionNames) {
+            Map<String, String> parameters = Maps.newHashMap();
+            TextFileFormatDesc formatDesc = new TextFileFormatDesc("a", "b", "c", "d");
+            String fullPath = "hdfs://path_to_table/" + name;
+            Partition partition = new Partition(parameters, RemoteFileInputFormat.PARQUET, formatDesc, fullPath, true);
+            partitionList.add(partition);
+
+            Path filePath = new Path(fullPath + "/00000_0");
+            FileStatus fileStatus = new FileStatus(100000, false, 1, 256, modificationTime++, filePath);
+            fileStatusList.add(fileStatus);
+        }
+
+        FileStatus[] fileStatuses = fileStatusList.toArray(new FileStatus[0]);
+
+        new MockUp<RemoteFileOperations>() {
+            @Mock
+            public FileStatus[] getFileStatus(Path... paths) {
+                return fileStatuses;
+            }
+        };
+
+        RemoteFileOperations ops = new RemoteFileOperations(null, null, null,
+                false, true, null);
+        List<RemoteFileInfo> remoteFileInfos = ops.getRemotePartitions(partitionList);
+        Assert.assertEquals(3, remoteFileInfos.size());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

method `getRemotePartitions` should belong to `RemoteFileOperations` class,  not `HiveMetadata` class.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
