### PR TITLE
[Enhancement] support phased schedule

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/exec")
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/exec")
 
 set(EXEC_FILES
+    capture_version_node.cpp
     data_sink.cpp
     empty_set_node.cpp
     exec_node.cpp
@@ -166,6 +167,7 @@ set(EXEC_FILES
     sorting/sort_column.cpp
     sorting/sort_permute.cpp
     connector_scan_node.cpp
+    pipeline/capture_version_operator.cpp
     pipeline/exchange/exchange_merge_sort_source_operator.cpp
     pipeline/exchange/exchange_parallel_merge_source_operator.cpp
     pipeline/exchange/exchange_sink_operator.cpp

--- a/be/src/exec/capture_version_node.cpp
+++ b/be/src/exec/capture_version_node.cpp
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/capture_version_node.h"
+
+#include "exec/pipeline/capture_version_operator.h"
+#include "exec/pipeline/pipeline_builder.h"
+
+namespace starrocks {
+
+pipeline::OpFactories CaptureVersionNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
+    return OpFactories{std::make_shared<pipeline::CaptureVersionOpFactory>(context->next_operator_id(), id())};
+}
+
+StatusOr<pipeline::MorselQueueFactoryPtr> CaptureVersionNode::scan_range_to_morsel_queue_factory(
+        const std::vector<TScanRangeParams>& scan_ranges) {
+    pipeline::Morsels morsels;
+    for (const auto& scan_range : scan_ranges) {
+        morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(id(), scan_range));
+    }
+    auto morsel_queue = std::make_unique<pipeline::FixedMorselQueue>(std::move(morsels));
+    return std::make_unique<pipeline::SharedMorselQueueFactory>(std::move(morsel_queue), 1);
+}
+
+} // namespace starrocks

--- a/be/src/exec/capture_version_node.h
+++ b/be/src/exec/capture_version_node.h
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/exec_node.h"
+#include "exec/scan_node.h"
+
+namespace starrocks {
+class CaptureVersionNode final : public ExecNode {
+public:
+    CaptureVersionNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
+            : ExecNode(pool, tnode, descs) {}
+    ~CaptureVersionNode() override = default;
+
+    StatusOr<pipeline::MorselQueueFactoryPtr> scan_range_to_morsel_queue_factory(
+            const std::vector<TScanRangeParams>& global_scan_ranges);
+
+    pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
+};
+} // namespace starrocks

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -50,6 +50,7 @@
 #include "exec/aggregate/distinct_streaming_node.h"
 #include "exec/analytic_node.h"
 #include "exec/assert_num_rows_node.h"
+#include "exec/capture_version_node.h"
 #include "exec/connector_scan_node.h"
 #include "exec/cross_join_node.h"
 #include "exec/dict_decode_node.h"
@@ -74,6 +75,7 @@
 #include "exec/union_node.h"
 #include "exprs/dictionary_get_expr.h"
 #include "exprs/expr_context.h"
+#include "gen_cpp/PlanNodes_types.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -562,6 +564,10 @@ Status ExecNode::create_vectorized_node(starrocks::RuntimeState* state, starrock
     }
     case TPlanNodeType::STREAM_AGG_NODE: {
         *node = pool->add(new StreamAggregateNode(pool, tnode, descs));
+        return Status::OK();
+    }
+    case TPlanNodeType::CAPTURE_VERSION_NODE: {
+        *node = pool->add(new CaptureVersionNode(pool, tnode, descs));
         return Status::OK();
     }
     default:

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -87,6 +87,9 @@ public:
     int estimated_max_concurrent_chunks() const;
 
     static StatusOr<TabletSharedPtr> get_tablet(const TInternalScanRange* scan_range);
+    static StatusOr<std::vector<RowsetSharedPtr>> capture_tablet_rowsets(const TabletSharedPtr& tablet,
+                                                                         const TInternalScanRange* scan_range);
+
     static int compute_priority(int32_t num_submitted_tasks);
 
     int io_tasks_per_scan_operator() const override {

--- a/be/src/exec/pipeline/capture_version_operator.cpp
+++ b/be/src/exec/pipeline/capture_version_operator.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/capture_version_operator.h"
+
+#include "common/logging.h"
+#include "exec/olap_scan_node.h"
+#include "runtime/runtime_state.h"
+#include "storage/rowset/rowset.h"
+#include "util/defer_op.h"
+
+namespace starrocks::pipeline {
+Status CaptureVersionOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(SourceOperator::prepare(state));
+    _capture_tablet_rowsets_timer = ADD_TIMER(_unique_metrics, "CaptureTabletRowsetsTime");
+
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> CaptureVersionOperator::pull_chunk(RuntimeState* state) {
+    // do capture rowset here
+    auto defer = DeferOp([this]() { _is_finished = true; });
+    std::vector<std::vector<RowsetSharedPtr>> tablet_rowsets;
+
+    {
+        SCOPED_TIMER(_capture_tablet_rowsets_timer);
+        auto scan_rages = _morsel_queue->prepare_olap_scan_ranges();
+        std::vector<std::vector<RowsetSharedPtr>> tablet_rowsets;
+        VLOG_QUERY << "capture rowset scan_ranges nums:" << scan_rages.size();
+        for (auto& scan_range : scan_rages) {
+            ASSIGN_OR_RETURN(TabletSharedPtr tablet, OlapScanNode::get_tablet(scan_range));
+            ASSIGN_OR_RETURN(auto rowset, OlapScanNode::capture_tablet_rowsets(tablet, scan_range));
+            tablet_rowsets.emplace_back(std::move(rowset));
+        }
+        //
+        _rowset_release_guard = MultiRowsetReleaseGuard(std::move(tablet_rowsets), adopt_acquire_t{});
+    }
+    return nullptr;
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/capture_version_operator.h
+++ b/be/src/exec/pipeline/capture_version_operator.h
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/pipeline/source_operator.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::pipeline {
+
+// CaptureVersion returns an empty result set.
+class CaptureVersionOperator final : public SourceOperator {
+public:
+    CaptureVersionOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence)
+            : SourceOperator(factory, id, "capture_version", plan_node_id, false, driver_sequence) {}
+
+    ~CaptureVersionOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    bool has_output() const override { return !_is_finished; }
+
+    bool is_finished() const override { return _is_finished; }
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+private:
+    MultiRowsetReleaseGuard _rowset_release_guard;
+    RuntimeProfile::Counter* _capture_tablet_rowsets_timer = nullptr;
+    bool _is_finished{};
+};
+
+class CaptureVersionOpFactory final : public SourceOperatorFactory {
+public:
+    CaptureVersionOpFactory(int32_t id, int32_t plan_node_id)
+            : SourceOperatorFactory(id, "capture_version", plan_node_id) {}
+
+    ~CaptureVersionOpFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<CaptureVersionOperator>(this, _id, _plan_node_id, driver_sequence);
+    }
+
+    bool with_morsels() const override { return true; }
+
+    SourceOperatorFactory::AdaptiveState adaptive_initial_state() const override { return AdaptiveState::ACTIVE; }
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -14,15 +14,20 @@
 
 #include "exec/pipeline/fragment_context.h"
 
+#include <memory>
+
 #include "exec/data_sink.h"
 #include "exec/pipeline/group_execution/execution_group.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
 #include "exec/pipeline/stream_pipeline_driver.h"
 #include "exec/workgroup/work_group.h"
+#include "runtime/client_cache.h"
 #include "runtime/data_stream_mgr.h"
 #include "runtime/exec_env.h"
 #include "runtime/stream_load/stream_load_context.h"
 #include "runtime/stream_load/transaction_mgr.h"
+#include "util/threadpool.h"
+#include "util/thrift_rpc_helper.h"
 #include "util/time.h"
 
 namespace starrocks::pipeline {
@@ -84,6 +89,37 @@ void FragmentContext::count_down_execution_group(size_t val) {
     finish();
     auto status = final_status();
     state->exec_env()->wg_driver_executor()->report_exec_state(query_ctx, this, status, true, true);
+
+    if (_report_when_finish) {
+        /// TODO: report fragment finish to BE coordinator
+        TReportFragmentFinishResponse res;
+        TReportFragmentFinishParams params;
+        params.__set_query_id(query_id());
+        params.__set_fragment_instance_id(fragment_instance_id());
+        // params.query_id = query_id();
+        // params.fragment_instance_id = fragment_instance_id();
+        const auto& fe_addr = state->fragment_ctx()->fe_addr();
+
+        class RpcRunnable : public Runnable {
+        public:
+            RpcRunnable(const TNetworkAddress& fe_addr, const TReportFragmentFinishResponse& res,
+                        const TReportFragmentFinishParams& params)
+                    : fe_addr(fe_addr), res(res), params(params) {}
+            const TNetworkAddress fe_addr;
+            TReportFragmentFinishResponse res;
+            const TReportFragmentFinishParams params;
+
+            void run() override {
+                (void)ThriftRpcHelper::rpc<FrontendServiceClient>(
+                        fe_addr.hostname, fe_addr.port,
+                        [&](FrontendServiceConnection& client) { client->reportFragmentFinish(res, params); });
+            }
+        };
+        //
+        std::shared_ptr<Runnable> runnable;
+        runnable = std::make_shared<RpcRunnable>(fe_addr, res, params);
+        (void)state->exec_env()->streaming_load_thread_pool()->submit(runnable);
+    }
 
     destroy_pass_through_chunk_buffer();
 

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -169,6 +169,8 @@ public:
     bool enable_group_execution() const { return _enable_group_execution; }
     void set_enable_group_execution(bool enable_group_execution) { _enable_group_execution = enable_group_execution; }
 
+    void set_report_when_finish(bool report) { _report_when_finish = report; }
+
 private:
     bool _enable_group_execution = false;
     // Id of this query
@@ -227,6 +229,8 @@ private:
 
     RuntimeProfile::Counter* _jit_counter = nullptr;
     RuntimeProfile::Counter* _jit_timer = nullptr;
+
+    bool _report_when_finish{};
 };
 
 class FragmentContextManager {

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 
 #include "common/config.h"
+#include "exec/capture_version_node.h"
 #include "exec/cross_join_node.h"
 #include "exec/exchange_node.h"
 #include "exec/exec_node.h"
@@ -103,6 +104,9 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
     }
 
     _query_ctx = exec_env->query_context_mgr()->get_or_register(query_id);
+    if (_query_ctx == nullptr) {
+        return Status::Cancelled("Query has been cancelled");
+    }
     _query_ctx->set_exec_env(exec_env);
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);
@@ -254,6 +258,8 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
         exec_env->runtime_filter_worker()->open_query(query_id, query_options, *runtime_filter_params, true);
     }
     _fragment_ctx->prepare_pass_through_chunk_buffer();
+    _fragment_ctx->set_report_when_finish(request.unique().params.__isset.report_when_finish &&
+                                          request.unique().params.report_when_finish);
 
     auto* obj_pool = runtime_state->obj_pool();
     // Set up desc tbl
@@ -506,6 +512,15 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
         }
     }
 
+    std::vector<ExecNode*> capture_version_nodes;
+    plan->collect_nodes(TPlanNodeType::CAPTURE_VERSION_NODE, &capture_version_nodes);
+    for (auto* node : capture_version_nodes) {
+        const std::vector<TScanRangeParams>& scan_ranges = request.scan_ranges_of_node(node->id());
+        ASSIGN_OR_RETURN(auto morsel_queue_factory,
+                         down_cast<CaptureVersionNode*>(node)->scan_range_to_morsel_queue_factory(scan_ranges));
+        morsel_queue_factories.emplace(node->id(), std::move(morsel_queue_factory));
+    }
+
     if (_wg && _wg->big_query_scan_rows_limit() > 0) {
         if (logical_scan_limit >= 0 && logical_scan_limit <= _wg->big_query_scan_rows_limit()) {
             _query_ctx->set_scan_limit(std::max(_wg->big_query_scan_rows_limit(), physical_scan_limit));
@@ -747,7 +762,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
             LOG(WARNING) << "Prepare fragment failed: " << print_id(request.common().params.query_id)
                          << " fragment_instance_id=" << print_id(request.fragment_instance_id())
                          << " is_stream_pipeline=" << request.is_stream_pipeline()
-                         << " backend_num=" << request.backend_num() << " fragment= " << request.common().fragment;
+                         << " backend_num=" << request.backend_num();
+            VLOG_QUERY << "Prepare fragment failed fragment=" << request.common().fragment;
         }
     });
 

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -100,6 +100,7 @@ FragmentContextManager* QueryContext::fragment_mgr() {
 }
 
 void QueryContext::cancel(const Status& status) {
+    _is_cancelled = true;
     _fragment_mgr->cancel(status);
 }
 
@@ -337,6 +338,16 @@ QueryContextManager::~QueryContextManager() {
     }
 }
 
+#define RETURN_NULL_IF_CTX_CANCELLED(query_ctx) \
+    if (query_ctx->is_cancelled()) {            \
+        return nullptr;                         \
+    }                                           \
+    query_ctx->increment_num_fragments();       \
+    if (query_ctx->is_cancelled()) {            \
+        query_ctx->rollback_inc_fragments();    \
+        return nullptr;                         \
+    }
+
 QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
     size_t i = _slot_idx(query_id);
     auto& mutex = _mutexes[i];
@@ -348,7 +359,7 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         // lookup query context in context_map
         auto it = context_map.find(query_id);
         if (it != context_map.end()) {
-            it->second->increment_num_fragments();
+            RETURN_NULL_IF_CTX_CANCELLED(it->second);
             return it->second.get();
         }
     }
@@ -358,13 +369,13 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         auto it = context_map.find(query_id);
         auto sc_it = sc_map.find(query_id);
         if (it != context_map.end()) {
-            it->second->increment_num_fragments();
+            RETURN_NULL_IF_CTX_CANCELLED(it->second);
             return it->second.get();
         } else {
             // lookup query context for the second chance in sc_map
             if (sc_it != sc_map.end()) {
                 auto ctx = std::move(sc_it->second);
-                ctx->increment_num_fragments();
+                RETURN_NULL_IF_CTX_CANCELLED(ctx);
                 sc_map.erase(sc_it);
                 auto* raw_ctx_ptr = ctx.get();
                 context_map.emplace(query_id, std::move(ctx));

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -76,36 +76,25 @@ Status OlapScanContext::prepare(RuntimeState* state) {
 
 void OlapScanContext::close(RuntimeState* state) {
     _chunk_buffer.close();
-    for (const auto& rowsets_per_tablet : _tablet_rowsets) {
-        Rowset::release_readers(rowsets_per_tablet);
-    }
+    _rowset_release_guard.reset();
 }
 
 Status OlapScanContext::capture_tablet_rowsets(const std::vector<TInternalScanRange*>& olap_scan_ranges) {
-    _tablet_rowsets.resize(olap_scan_ranges.size());
+    std::vector<std::vector<RowsetSharedPtr>> tablet_rowsets;
+    tablet_rowsets.resize(olap_scan_ranges.size());
     _tablets.resize(olap_scan_ranges.size());
     for (int i = 0; i < olap_scan_ranges.size(); ++i) {
         auto* scan_range = olap_scan_ranges[i];
 
         ASSIGN_OR_RETURN(TabletSharedPtr tablet, OlapScanNode::get_tablet(scan_range));
+        ASSIGN_OR_RETURN(tablet_rowsets[i], OlapScanNode::capture_tablet_rowsets(tablet, scan_range));
 
-        if (scan_range->__isset.gtid) {
-            std::shared_lock l(tablet->get_header_lock());
-            RETURN_IF_ERROR(tablet->capture_consistent_rowsets(scan_range->gtid, &_tablet_rowsets[i]));
-            Rowset::acquire_readers(_tablet_rowsets[i]);
-        } else {
-            int64_t version = strtoul(scan_range->version.c_str(), nullptr, 10);
-            // Capture row sets of this version tablet.
-            std::shared_lock l(tablet->get_header_lock());
-            RETURN_IF_ERROR(tablet->capture_consistent_rowsets(Version(0, version), &_tablet_rowsets[i]));
-            Rowset::acquire_readers(_tablet_rowsets[i]);
-        }
-
-        VLOG(1) << "capture tablet rowsets: " << tablet->full_name() << ", rowsets: " << _tablet_rowsets[i].size()
+        VLOG(1) << "capture tablet rowsets: " << tablet->full_name() << ", rowsets: " << tablet_rowsets[i].size()
                 << ", version: " << scan_range->version << ", gtid: " << scan_range->gtid;
 
         _tablets[i] = std::move(tablet);
     }
+    _rowset_release_guard = MultiRowsetReleaseGuard(std::move(tablet_rowsets), adopt_acquire_t{});
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -23,6 +23,7 @@
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
 #include "runtime/global_dict/parser.h"
+#include "storage/rowset/rowset.h"
 #include "util/phmap/phmap_fwd_decl.h"
 
 namespace starrocks {
@@ -115,7 +116,9 @@ public:
 
     Status capture_tablet_rowsets(const std::vector<TInternalScanRange*>& olap_scan_ranges);
     const std::vector<TabletSharedPtr>& tablets() const { return _tablets; }
-    const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets() const { return _tablet_rowsets; };
+    const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets() const {
+        return _rowset_release_guard.tablet_rowsets();
+    };
 
     const std::vector<ColumnAccessPathPtr>* column_access_paths() const;
 
@@ -148,7 +151,7 @@ private:
     // of the left table are compacted at building the right hash table. Therefore, reference
     // the row sets into _tablet_rowsets in the preparation phase to avoid the row sets being deleted.
     std::vector<TabletSharedPtr> _tablets;
-    std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
+    MultiRowsetReleaseGuard _rowset_release_guard;
     ConcurrentJitRewriter& _jit_rewriter;
 };
 

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -417,14 +417,56 @@ private:
     KeysType _keys_type;
 };
 
-class RowsetReleaseGuard {
+struct adopt_acquire_t {
+    explicit adopt_acquire_t() = default;
+};
+
+template <class T>
+class TReleaseGuard {
 public:
-    explicit RowsetReleaseGuard(std::shared_ptr<Rowset> rowset) : _rowset(std::move(rowset)) { _rowset->acquire(); }
-    ~RowsetReleaseGuard() { _rowset->release(); }
+    explicit TReleaseGuard(T rowset) : _rowset(std::move(rowset)) { _rowset->acquire(); }
+    explicit TReleaseGuard(T rowset, adopt_acquire_t) : _rowset(std::move(rowset)) {}
+    ~TReleaseGuard() {
+        if (_rowset) {
+            _rowset->release();
+        }
+    }
 
 private:
-    std::shared_ptr<Rowset> _rowset;
+    T _rowset;
 };
+
+template <class T>
+class TReleaseGuard<std::vector<std::vector<T>>> {
+public:
+    TReleaseGuard() = default;
+    explicit TReleaseGuard(std::vector<std::vector<T>>&& rowsets, adopt_acquire_t)
+            : _tablet_rowsets(std::move(rowsets)) {}
+
+    TReleaseGuard& operator=(TReleaseGuard&& other) noexcept {
+        std::swap(_tablet_rowsets, other._tablet_rowsets);
+        return *this;
+    }
+    ~TReleaseGuard() { reset(); }
+
+    void reset() {
+        for (auto& rowset_list : _tablet_rowsets) {
+            Rowset::release_readers(rowset_list);
+        }
+        _tablet_rowsets.clear();
+    }
+    const std::vector<std::vector<T>>& tablet_rowsets() const { return _tablet_rowsets; }
+
+    TReleaseGuard(TReleaseGuard&& other) = delete;
+    TReleaseGuard(const TReleaseGuard& other) = delete;
+    TReleaseGuard& operator=(const TReleaseGuard& other) = delete;
+
+private:
+    std::vector<std::vector<T>> _tablet_rowsets;
+};
+using RowsetReleaseGuard = TReleaseGuard<RowsetSharedPtr>;
+using MultiRowsetReleaseGuard = TReleaseGuard<std::vector<std::vector<RowsetSharedPtr>>>;
+
 using TabletSchemaSPtr = std::shared_ptr<TabletSchema>;
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -438,6 +438,7 @@ public class RuntimeProfile {
         return builder.toString();
     }
 
+    // concurrency safe
     public void addChild(RuntimeProfile child) {
         if (child == null) {
             return;
@@ -446,6 +447,18 @@ public class RuntimeProfile {
         childMap.put(child.name, child);
         Pair<RuntimeProfile, Boolean> pair = Pair.create(child, true);
         childList.add(pair);
+    }
+
+    // concurrency safe
+    public void addChildren(List<RuntimeProfile> children) {
+        if (children.isEmpty()) {
+            return;
+        }
+        final RuntimeProfile child = children.get(0);
+        childMap.put(child.name, child);
+        List<Pair<RuntimeProfile, Boolean>> childList =
+                children.stream().map(c -> new Pair<>(c, true)).collect(Collectors.toList());
+        this.childList.addAll(childList);
     }
 
     public void removeChild(String childName) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/CaptureVersionNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CaptureVersionNode.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TPlanNodeType;
+
+import java.util.ArrayList;
+
+public class CaptureVersionNode extends PlanNode {
+
+    public CaptureVersionNode(PlanNodeId id, ArrayList<TupleId> tupleIds) {
+        super(id, tupleIds, "CAPTURE_VERSION");
+        Preconditions.checkArgument(tupleIds.size() > 0);
+    }
+
+    @Override
+    protected void toThrift(TPlanNode msg) {
+        msg.node_type = TPlanNodeType.CAPTURE_VERSION_NODE;
+
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -227,6 +227,10 @@ public class OlapScanNode extends ScanNode {
         this.withoutColocateRequirement = withoutColocateRequirement;
     }
 
+    public boolean isLocalNativeTable() {
+        return olapTable.isOlapTable();
+    }
+
     public boolean getWithoutColocateRequirement() {
         return this.withoutColocateRequirement;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNodeId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNodeId.java
@@ -21,12 +21,14 @@ import com.starrocks.common.Id;
 import com.starrocks.common.IdGenerator;
 
 public class PlanNodeId extends Id<PlanNodeId> {
+    public static final PlanNodeId DUMMY_PLAN_NODE_ID = new PlanNodeId(-1000);
+
     public PlanNodeId(int id) {
         super(id);
     }
 
     public static IdGenerator<PlanNodeId> createGenerator() {
-        return new IdGenerator<PlanNodeId>() {
+        return new IdGenerator<>() {
             @Override
             public PlanNodeId getNextId() {
                 return new PlanNodeId(nextId++);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -90,6 +90,10 @@ public abstract class ScanNode extends PlanNode {
         return desc.getTable().getName();
     }
 
+    public boolean isLocalNativeTable() {
+        return false;
+    }
+
     /**
      * cast expr to SlotDescriptor type
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -73,6 +73,7 @@ public class CoordinatorPreprocessor {
     private final ConnectContext connectContext;
 
     private final JobSpec jobSpec;
+    private final boolean enablePhasedSchedule;
     private final ExecutionDAG executionDAG;
 
     private final WorkerProvider.Factory workerProviderFactory;
@@ -80,12 +81,13 @@ public class CoordinatorPreprocessor {
 
     private final FragmentAssignmentStrategyFactory fragmentAssignmentStrategyFactory;
 
-    public CoordinatorPreprocessor(ConnectContext context, JobSpec jobSpec) {
+    public CoordinatorPreprocessor(ConnectContext context, JobSpec jobSpec, boolean enablePhasedSchedule) {
         workerProviderFactory = newWorkerProviderFactory();
         this.coordAddress = new TNetworkAddress(LOCAL_IP, Config.rpc_port);
 
         this.connectContext = Preconditions.checkNotNull(context);
         this.jobSpec = jobSpec;
+        this.enablePhasedSchedule = enablePhasedSchedule;
         this.executionDAG = ExecutionDAG.build(jobSpec);
 
         SessionVariable sessionVariable = connectContext.getSessionVariable();
@@ -105,6 +107,7 @@ public class CoordinatorPreprocessor {
 
         this.connectContext = context;
         this.jobSpec = JobSpec.Factory.mockJobSpec(connectContext, fragments, scanNodes);
+        this.enablePhasedSchedule = false;
         this.executionDAG = ExecutionDAG.build(jobSpec);
 
         SessionVariable sessionVariable = connectContext.getSessionVariable();
@@ -251,6 +254,7 @@ public class CoordinatorPreprocessor {
 
         validateExecutionDAG();
 
+        executionDAG.prepareCaptureVersion(enablePhasedSchedule);
         executionDAG.finalizeDAG();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -66,11 +66,14 @@ import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.Deployer;
 import com.starrocks.qe.scheduler.QueryRuntimeProfile;
+import com.starrocks.qe.scheduler.dag.AllAtOnceExecutionSchedule;
 import com.starrocks.qe.scheduler.dag.ExecutionDAG;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.qe.scheduler.dag.ExecutionSchedule;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
 import com.starrocks.qe.scheduler.dag.JobSpec;
+import com.starrocks.qe.scheduler.dag.PhasedExecutionSchedule;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
@@ -154,6 +157,8 @@ public class DefaultCoordinator extends Coordinator {
     private boolean isShortCircuit = false;
     private boolean isBinaryRow = false;
 
+    private ExecutionSchedule schedule;
+
     public static class Factory implements Coordinator.Factory {
 
         @Override
@@ -219,7 +224,8 @@ public class DefaultCoordinator extends Coordinator {
 
         @Override
         public DefaultCoordinator createRefreshDictionaryCacheScheduler(ConnectContext context, TUniqueId queryId,
-                                                                        DescriptorTable descTable, List<PlanFragment> fragments,
+                                                                        DescriptorTable descTable,
+                                                                        List<PlanFragment> fragments,
                                                                         List<ScanNode> scanNodes) {
 
             JobSpec jobSpec = JobSpec.Factory.fromRefreshDictionaryCacheSpec(context, queryId, descTable, fragments,
@@ -260,7 +266,8 @@ public class DefaultCoordinator extends Coordinator {
         FragmentInstanceExecState execState = FragmentInstanceExecState.createFakeExecution(queryId, address);
         executionDAG.addExecution(execState);
 
-        this.queryProfile = new QueryRuntimeProfile(connectContext, jobSpec, 1, false);
+        this.queryProfile = new QueryRuntimeProfile(connectContext, jobSpec, false);
+        queryProfile.initFragmentProfiles(1);
         queryProfile.attachInstances(Collections.singletonList(queryId));
         queryProfile.attachExecutionProfiles(executionDAG.getExecutions());
 
@@ -272,7 +279,8 @@ public class DefaultCoordinator extends Coordinator {
         this.jobSpec = jobSpec;
         this.returnedAllResults = false;
 
-        this.coordinatorPreprocessor = new CoordinatorPreprocessor(context, jobSpec);
+        final boolean enablePhasedScheduler = context.getSessionVariable().enablePhasedScheduler();
+        this.coordinatorPreprocessor = new CoordinatorPreprocessor(context, jobSpec, enablePhasedScheduler);
         this.executionDAG = coordinatorPreprocessor.getExecutionDAG();
 
         List<PlanFragment> fragments = jobSpec.getFragments();
@@ -284,15 +292,22 @@ public class DefaultCoordinator extends Coordinator {
         }
 
         shortCircuitExecutor =
-                ShortCircuitExecutor.create(context, fragments, scanNodes, descTable, isBinaryRow, jobSpec.isNeedReport(),
+                ShortCircuitExecutor.create(context, fragments, scanNodes, descTable, isBinaryRow,
+                        jobSpec.isNeedReport(),
                         jobSpec.getPlanProtocol(), coordinatorPreprocessor.getWorkerProvider());
 
         if (null != shortCircuitExecutor) {
             isShortCircuit = true;
         }
+        if (enablePhasedScheduler) {
+            schedule = new PhasedExecutionSchedule(connectContext);
+        } else {
+            schedule = new AllAtOnceExecutionSchedule();
+        }
 
-        this.queryProfile = new QueryRuntimeProfile(connectContext, jobSpec, executionDAG.getFragmentsInCreatedOrder().size(),
-                isShortCircuit);
+        this.queryProfile =
+                new QueryRuntimeProfile(connectContext, jobSpec,
+                        isShortCircuit);
     }
 
     @Override
@@ -522,6 +537,18 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     @Override
+    public Status scheduleNextTurn(TUniqueId fragmentInstanceId) {
+        try {
+            schedule.tryScheduleNextTurn(fragmentInstanceId);
+        } catch (Exception e) {
+            LOG.warn("schedule fragment:{} next internal error:", DebugUtil.printId(fragmentInstanceId), e);
+            cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, e.getMessage());
+            return Status.internalError(e.getMessage());
+        }
+        return Status.OK;
+    }
+
+    @Override
     public String getSchedulerExplain() {
         return executionDAG.getFragmentsInPreorder().stream()
                 .map(ExecutionFragment::getExplainString)
@@ -529,6 +556,8 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     private void prepareProfile() {
+        this.queryProfile.initFragmentProfiles(executionDAG.getFragmentsInCreatedOrder().size());
+
         ExecutionFragment rootExecFragment = executionDAG.getRootFragment();
         boolean isLoadType = !(rootExecFragment.getPlanFragment().getSink() instanceof ResultSink);
         if (isLoadType) {
@@ -541,7 +570,8 @@ public class DefaultCoordinator extends Coordinator {
                 jobSpec.getQueryOptions().setEnable_profile(true);
             }
             if (jobSpec.isBrokerLoad() && jobSpec.getQueryOptions().getBig_query_profile_threshold() == 0) {
-                jobSpec.getQueryOptions().setBig_query_profile_threshold(Config.default_big_load_profile_threshold_second * 1000);
+                jobSpec.getQueryOptions()
+                        .setBig_query_profile_threshold(Config.default_big_load_profile_threshold_second * 1000);
             }
             // runtime load profile does not need to report too frequently
             if (jobSpec.getQueryOptions().getRuntime_profile_report_interval() < 30) {
@@ -605,11 +635,9 @@ public class DefaultCoordinator extends Coordinator {
         try (Timer ignored = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeployLockInternalTime")) {
             Deployer deployer =
                     new Deployer(connectContext, jobSpec, executionDAG, coordinatorPreprocessor.getCoordAddress(),
-                            this::handleErrorExecution);
-            for (List<ExecutionFragment> concurrentFragments : executionDAG.getFragmentsInTopologicalOrderFromRoot()) {
-                deployer.deployFragments(concurrentFragments, needDeploy);
-            }
-
+                            this::handleErrorExecution, needDeploy);
+            schedule.prepareSchedule(deployer, executionDAG);
+            this.schedule.schedule();
             queryProfile.attachExecutionProfiles(executionDAG.getExecutions());
         } finally {
             unlock();
@@ -877,13 +905,26 @@ public class DefaultCoordinator extends Coordinator {
         if (null != receiver) {
             receiver.cancel();
         }
-        cancelRemoteFragmentsAsync(cancelReason);
+        if (isPhasedSchedule()) {
+            cancelRemoteQueryContext(cancelReason);
+        } else {
+            cancelRemoteFragmentsAsync(cancelReason);
+        }
         if (cancelReason != PPlanFragmentCancelReason.LIMIT_REACH) {
             // count down to zero to notify all objects waiting for this
             if (!connectContext.isProfileEnabled()) {
                 queryProfile.finishAllInstances(Status.OK);
             }
         }
+    }
+
+    private boolean isPhasedSchedule() {
+        return schedule instanceof PhasedExecutionSchedule;
+    }
+
+    // For phased schedule execution, we cancel the query context. (BE will cancel the relevant fragment internally)
+    private void cancelRemoteQueryContext(PPlanFragmentCancelReason cancelReason) {
+        executionDAG.cancelQueryContext(cancelReason);
     }
 
     private void cancelRemoteFragmentsAsync(PPlanFragmentCancelReason cancelReason) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
@@ -26,6 +26,8 @@ import com.starrocks.thrift.TReportAuditStatisticsParams;
 import com.starrocks.thrift.TReportAuditStatisticsResult;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TReportExecStatusResult;
+import com.starrocks.thrift.TReportFragmentFinishParams;
+import com.starrocks.thrift.TReportFragmentFinishResponse;
 import com.starrocks.thrift.TUniqueId;
 
 import java.util.List;
@@ -38,6 +40,7 @@ public interface QeProcessor {
     TReportAuditStatisticsResult reportAuditStatistics(TReportAuditStatisticsParams params, TNetworkAddress beAddr);
 
     TBatchReportExecStatusResult batchReportExecStatus(TBatchReportExecStatusParams params, TNetworkAddress beAddr);
+    TReportFragmentFinishResponse reportFragmentFinish(TReportFragmentFinishParams params);
 
     void registerQuery(TUniqueId queryId, Coordinator coord) throws UserException;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.Config;
+import com.starrocks.common.Status;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.memory.MemoryTrackable;
@@ -49,6 +50,8 @@ import com.starrocks.thrift.TReportAuditStatisticsParams;
 import com.starrocks.thrift.TReportAuditStatisticsResult;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TReportExecStatusResult;
+import com.starrocks.thrift.TReportFragmentFinishParams;
+import com.starrocks.thrift.TReportFragmentFinishResponse;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
@@ -285,6 +288,22 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         }
 
         return resultList;
+    }
+
+    @Override
+    public TReportFragmentFinishResponse reportFragmentFinish(TReportFragmentFinishParams params) {
+        final TReportFragmentFinishResponse result = new TReportFragmentFinishResponse();
+        final QueryInfo info = coordinatorMap.get(params.query_id);
+        if (info == null) {
+            LOG.debug("reportFragmentFinish() failed, query does not exist, fragment_instance_id={}, query_id={},",
+                    DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id));
+            result.setStatus(new TStatus(TStatusCode.OK));
+            return result;
+        }
+        final TUniqueId fragment_instance_id = params.fragment_instance_id;
+        Status status = info.getCoord().scheduleNextTurn(fragment_instance_id);
+        result.setStatus(status.toThrift());
+        return result;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -85,7 +85,6 @@ public class ResultReceiver {
             while (!isDone && !isCancel) {
                 PFetchDataRequest request = new PFetchDataRequest(finstId);
 
-                currentThread = Thread.currentThread();
                 Future<PFetchDataResult> future = BackendServiceClient.getInstance().fetchDataAsync(address, request);
                 PFetchDataResult pResult = null;
                 while (pResult == null) {
@@ -153,10 +152,6 @@ public class ResultReceiver {
             if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);
             }
-        } finally {
-            synchronized (this) {
-                currentThread = null;
-            }
         }
 
         if (isCancel) {
@@ -167,14 +162,5 @@ public class ResultReceiver {
 
     public void cancel() {
         isCancel = true;
-        synchronized (this) {
-            if (currentThread != null) {
-                // TODO(cmy): we cannot interrupt this thread, or we may throw
-                // java.nio.channels.ClosedByInterruptException when we call
-                // MysqlChannel.realNetSend -> SocketChannelImpl.write
-                // And user will lost connection to starrocks
-                // currentThread.interrupt();
-            }
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -111,6 +111,7 @@ import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.privilege.ObjectType;
 import com.starrocks.privilege.PrivilegeException;
 import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.proto.QueryStatisticsItemPB;
 import com.starrocks.qe.QueryState.MysqlStateType;
@@ -737,7 +738,7 @@ public class StmtExecutor {
         } finally {
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
             if (context.getState().isError() && coord != null) {
-                coord.cancel(context.getState().getErrorMessage());
+                coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, context.getState().getErrorMessage());
             }
 
             if (parsedStmt instanceof InsertStmt && !parsedStmt.isExplain()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -105,6 +105,10 @@ public abstract class Coordinator {
      */
     public abstract void startScheduling(boolean needDeploy) throws Exception;
 
+    public Status scheduleNextTurn(TUniqueId fragmentInstanceId) {
+        return Status.OK;
+    }
+
     public void startScheduling() throws Exception {
         startScheduling(true);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -97,7 +97,7 @@ public class QueryRuntimeProfile {
     private boolean profileAlreadyReported = false;
 
     private RuntimeProfile queryProfile;
-    private final List<RuntimeProfile> fragmentProfiles;
+    private List<RuntimeProfile> fragmentProfiles;
 
     // The load channel profile is only present if loading to OlapTables.
     // The hierarchy is LoadChannel -> Channel(BE) -> Index
@@ -140,25 +140,27 @@ public class QueryRuntimeProfile {
 
     public QueryRuntimeProfile(ConnectContext connectContext,
                                JobSpec jobSpec,
-                               int numFragments,
                                boolean isShortCircuit) {
         this.connectContext = connectContext;
         this.jobSpec = jobSpec;
         this.isShortCircuit = isShortCircuit;
 
         this.queryProfile = new RuntimeProfile("Execution");
-        this.fragmentProfiles = new ArrayList<>(numFragments);
-        for (int i = 0; i < numFragments; i++) {
-            RuntimeProfile profile = new RuntimeProfile("Fragment " + i);
-            fragmentProfiles.add(profile);
-            queryProfile.addChild(profile);
-        }
 
         if (jobSpec.hasOlapTableSink()) {
             loadChannelProfile = Optional.of(new RuntimeProfile(LOAD_CHANNEL_PROFILE_NAME));
             queryProfile.addChild(loadChannelProfile.get());
         } else {
             loadChannelProfile = Optional.empty();
+        }
+    }
+
+    public void initFragmentProfiles(int numFragments) {
+        this.fragmentProfiles = new ArrayList<>(numFragments);
+        for (int i = 0; i < numFragments; i++) {
+            RuntimeProfile profile = new RuntimeProfile("Fragment " + i);
+            fragmentProfiles.add(profile);
+            queryProfile.addChild(profile);
         }
     }
 
@@ -219,12 +221,18 @@ public class QueryRuntimeProfile {
     }
 
     public void attachExecutionProfiles(Collection<FragmentInstanceExecState> executions) {
+        Map<Integer, List<RuntimeProfile>> profiles = Maps.newHashMap();
         for (FragmentInstanceExecState execState : executions) {
             if (!execState.computeTimeInProfile(fragmentProfiles.size())) {
                 return;
             }
-            fragmentProfiles.get(execState.getFragmentIndex()).addChild(execState.getProfile());
+            if (execState.getProfile() == null) {
+                continue;
+            }
+            profiles.computeIfAbsent(execState.getFragmentIndex(), k -> Lists.newArrayList());
+            profiles.get(execState.getFragmentIndex()).add(execState.getProfile());
         }
+        profiles.forEach((k, v) -> fragmentProfiles.get(k).addChildren(v));
     }
 
     public void finishInstance(TUniqueId instanceId) {
@@ -588,7 +596,7 @@ public class QueryRuntimeProfile {
                 newQueryProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);
         processTimer.setValue(System.nanoTime() - start);
 
-        Optional<RuntimeProfile> mergedLoadChannelProfile =  mergeLoadChannelProfile();
+        Optional<RuntimeProfile> mergedLoadChannelProfile = mergeLoadChannelProfile();
         mergedLoadChannelProfile.ifPresent(newQueryProfile::addChild);
 
         return newQueryProfile;
@@ -613,10 +621,10 @@ public class QueryRuntimeProfile {
         counter.setValue(channelProfiles.size());
 
         String hosts = channelProfiles.stream()
-                               .map(p -> getChannelHost(p.getName()))
-                               .filter(Optional::isPresent)
-                               .map(Optional::get)
-                               .collect(Collectors.joining(","));
+                .map(p -> getChannelHost(p.getName()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.joining(","));
         mergedProfile.addInfoString("BackendAddresses", hosts);
 
         RuntimeProfile mergedChannelProfile =

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -213,6 +213,7 @@ public class TFragmentInstanceFactory {
         result.params.setFragment_instance_id(instance.getInstanceId());
         result.params.setPer_node_scan_ranges(instance.getNode2ScanRanges());
         result.params.setNode_to_per_driver_seq_scan_ranges(instance.getNode2DriverSeqToScanRanges());
+        result.params.setReport_when_finish(execFragment.isNeedReportFragmentFinish());
 
         if (isEnablePipelineTableSinkDop) {
             result.params.setSender_id(accTabletSinkDop);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.starrocks.common.UserException;
+import com.starrocks.qe.scheduler.Deployer;
+import com.starrocks.qe.scheduler.slot.DeployState;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.thrift.TUniqueId;
+
+import java.util.List;
+
+// all at once execution schedule only schedule once.
+public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
+    private Deployer deployer;
+    private ExecutionDAG dag;
+
+    @Override
+    public void prepareSchedule(Deployer deployer, ExecutionDAG dag) {
+        this.deployer = deployer;
+        this.dag = dag;
+    }
+
+    @Override
+    public void schedule() throws RpcException, UserException {
+        for (List<ExecutionFragment> executionFragments : dag.getFragmentsInTopologicalOrderFromRoot()) {
+            final DeployState deployState = deployer.createFragmentExecStates(executionFragments);
+            deployer.deployFragments(deployState);
+        }
+    }
+
+    public void tryScheduleNextTurn(TUniqueId fragmentInstanceId) {
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/CaptureVersionFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/CaptureVersionFragmentBuilder.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.planner.BlackHoleTableSink;
+import com.starrocks.planner.CaptureVersionNode;
+import com.starrocks.planner.DataPartition;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanFragmentId;
+import com.starrocks.planner.PlanNode;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TScanRangeParams;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CaptureVersionFragmentBuilder {
+    private final List<ExecutionFragment> fragments;
+
+    public CaptureVersionFragmentBuilder(List<ExecutionFragment> fragments) {
+        this.fragments = fragments;
+    }
+
+    public ExecutionFragment build(ExecutionDAG dag) {
+        Map<ComputeNode, List<TScanRangeParams>> workerId2ScanRanges = Maps.newHashMap();
+        int id = 0;
+
+        for (ExecutionFragment fragment : fragments) {
+            final PlanFragmentId fragmentId = fragment.getFragmentId();
+            for (FragmentInstance instance : fragment.getInstances()) {
+                final Set<Integer> localNativeScanNodeIds = instance.getExecFragment().getScanNodes().stream()
+                        .filter(ScanNode::isLocalNativeTable).map(node -> node.getId().asInt()).collect(
+                                Collectors.toSet());
+                final ComputeNode worker = instance.getWorker();
+                final Map<Integer, List<TScanRangeParams>> node2ScanRanges = instance.getNode2ScanRanges();
+                final Map<Integer, Map<Integer, List<TScanRangeParams>>> node2DriverSeqToScanRanges =
+                        instance.getNode2DriverSeqToScanRanges();
+
+                // collect olap per driver scan ranges
+                final Stream<TScanRangeParams> tabletStream = node2DriverSeqToScanRanges.entrySet().stream()
+                        .filter(e -> localNativeScanNodeIds.contains(e.getKey()))
+                        .map(k -> k.getValue().values()).flatMap(Collection::stream).flatMap(Collection::stream);
+
+                // collect olap normal scan ranges
+                final Stream<TScanRangeParams> nodeStream =
+                        node2ScanRanges.entrySet().stream().filter(e -> localNativeScanNodeIds.contains(e.getKey()))
+                                .map(Map.Entry::getValue).flatMap(Collection::stream);
+
+                final List<TScanRangeParams> instanceScanRanges =
+                        Stream.concat(tabletStream, nodeStream).filter(r -> r.scan_range.isSetInternal_scan_range())
+                                .collect(Collectors.toList());
+
+                if (instanceScanRanges.isEmpty()) {
+                    continue;
+                }
+
+                final List<TScanRangeParams> workerIdScanRanges =
+                        workerId2ScanRanges.computeIfAbsent(worker, k -> Lists.newArrayList());
+                workerIdScanRanges.addAll(instanceScanRanges);
+            }
+            id = Math.max(id, fragmentId.asInt());
+        }
+
+        if (!workerId2ScanRanges.isEmpty()) {
+            final PlanFragmentId captureVersionFragmentId = new PlanFragmentId(id + 1);
+            final int fid = captureVersionFragmentId.asInt();
+            // Just get a tuple id.
+            final ArrayList<TupleId> tupleIds = fragments.get(0).getPlanFragment().getPlanRoot().getTupleIds();
+            PlanNode dummyNode = new CaptureVersionNode(PlanNodeId.DUMMY_PLAN_NODE_ID, tupleIds);
+            final PlanFragment captureVersionFragment =
+                    new PlanFragment(captureVersionFragmentId, dummyNode, DataPartition.RANDOM);
+            captureVersionFragment.setSink(new BlackHoleTableSink());
+            final ExecutionFragment fragment = new ExecutionFragment(dag, captureVersionFragment, fragments.size());
+
+            workerId2ScanRanges.forEach((worker, scanRanges) -> {
+                final FragmentInstance instance = new FragmentInstance(worker, fragment);
+                instance.addScanRanges(PlanNodeId.DUMMY_PLAN_NODE_ID.asInt(), scanRanges);
+                fragment.addInstance(instance);
+            });
+
+            return fragment;
+        }
+
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
@@ -86,6 +86,9 @@ public class ExecutionFragment {
     private Boolean cachedIsLocalBucketShuffleJoin = null;
 
     private boolean isRightOrFullBucketShuffle = false;
+    // used for phased schedule
+    private boolean isScheduled = false;
+    private boolean needReportFragmentFinish = false;
 
     public ExecutionFragment(ExecutionDAG executionDAG, PlanFragment planFragment, int fragmentIndex) {
         this.executionDAG = executionDAG;
@@ -439,5 +442,20 @@ public class ExecutionFragment {
         }
 
         return childHasBucketShuffle;
+    }
+
+    public boolean isScheduled() {
+        return isScheduled;
+    }
+
+    public void setIsScheduled(boolean isScheduled) {
+        this.isScheduled = isScheduled;
+    }
+
+    public boolean isNeedReportFragmentFinish() {
+        return needReportFragmentFinish;
+    }
+    public void setNeedReportFragmentFinish(boolean needReportFragmentFinish) {
+        this.needReportFragmentFinish = needReportFragmentFinish;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionSchedule.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.starrocks.common.UserException;
+import com.starrocks.qe.scheduler.Deployer;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.thrift.TUniqueId;
+
+public interface ExecutionSchedule {
+    void prepareSchedule(Deployer deployer, ExecutionDAG dag);
+
+    void schedule() throws RpcException, UserException;
+
+    void tryScheduleNextTurn(TUniqueId fragmentInstanceId) throws RpcException, UserException;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -132,9 +132,15 @@ public class FragmentInstance {
             }
 
             node2ScanRanges.forEach((scanId, scanRanges) -> {
-                ScanNode scanNode = execFragment.getScanNode(new PlanNodeId(scanId));
-                builder.addValue(scanId + ":" + scanNode.getPlanNodeName(),
-                        () -> explainScanRanges(builder, scanRanges, 0));
+                String nodeName;
+                PlanNodeId nodeId = new PlanNodeId(scanId);
+                if (nodeId.equals(PlanNodeId.DUMMY_PLAN_NODE_ID)) {
+                    nodeName = "CAPTURE_ROWSET";
+                } else {
+                    ScanNode scanNode = execFragment.getScanNode(new PlanNodeId(scanId));
+                    nodeName = scanNode.getPlanNodeName();
+                }
+                builder.addValue(scanId + ":" + nodeName, () -> explainScanRanges(builder, scanRanges, 0));
             });
         });
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentSequence.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentSequence.java
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.planner.DataSink;
+import com.starrocks.planner.DataStreamSink;
+import com.starrocks.planner.ExceptNode;
+import com.starrocks.planner.ExchangeNode;
+import com.starrocks.planner.IntersectNode;
+import com.starrocks.planner.MultiCastDataSink;
+import com.starrocks.planner.PlanFragmentId;
+import com.starrocks.planner.PlanNode;
+import com.starrocks.planner.PlanNodeId;
+
+import java.util.List;
+import java.util.Map;
+
+// build a reverse schedule order
+// eg:
+// ┌─────────────────────────────┐
+// │                             │
+// │           Join              │
+// │             │               │
+// │             │               │
+// │        ┌────┴──────┐        │
+// │        │           │        │
+// │        ▼           ▼        │
+// │       Join      Exchange    │
+// │        │           │        │
+// │        │           │        │
+// │   ┌────┴───┐       │        │
+// │   │        │       │        │
+// │   ▼        ▼       │        │
+// │ Exchange  Exchange │        │
+// └───┬────────┬───────┼────────┘
+//     │        │       │
+//     │        │       │
+//     │        │       │
+//     ▼        ▼       ▼
+//     F1       F2      F3
+// the fragment child schedule order should be [F1, F2, F3]
+// In phased schedule we should schedule F3 firstly. When F3 finished, then schedule F2
+public class FragmentSequence {
+
+    private final ExecutionDAG dag;
+    private final List<PlanFragmentId> scheduleOrderList;
+
+    public FragmentSequence(ExecutionDAG dag, List<PlanFragmentId> fragmentIds) {
+        this.dag = dag;
+        this.scheduleOrderList = fragmentIds;
+    }
+
+    public ExecutionFragment getAt(int i) {
+        final PlanFragmentId fragmentId = scheduleOrderList.get(i);
+        return dag.getFragment(fragmentId);
+    }
+
+    public static class Builder {
+        private static void buildExgNodeIdToSourceFragmentId(ExecutionFragment fragment,
+                                                             Map<PlanNodeId, PlanFragmentId> exchangeToSource) {
+            final DataSink sink = fragment.getPlanFragment().getSink();
+            if (sink instanceof DataStreamSink) {
+                exchangeToSource.put(sink.getExchNodeId(), fragment.getFragmentId());
+            } else if (sink instanceof MultiCastDataSink) {
+                for (DataStreamSink dataStreamSink : ((MultiCastDataSink) sink).getDataStreamSinks()) {
+                    exchangeToSource.put(dataStreamSink.getExchNodeId(), fragment.getFragmentId());
+                }
+            }
+            for (int i = 0; i < fragment.childrenSize(); i++) {
+                buildExgNodeIdToSourceFragmentId(fragment.getChild(i), exchangeToSource);
+            }
+        }
+
+        public static Map<PlanFragmentId, FragmentSequence> build(ExecutionDAG dag, ExecutionFragment root) {
+
+            Map<PlanNodeId, PlanFragmentId> exchangeToSource = Maps.newHashMap();
+            buildExgNodeIdToSourceFragmentId(root, exchangeToSource);
+
+            Map<PlanFragmentId, FragmentSequence> result = Maps.newHashMap();
+            buildIfNotExists(dag, root, exchangeToSource, result);
+
+            return result;
+        }
+
+        private static void buildIfNotExists(ExecutionDAG dag, ExecutionFragment node,
+                                             Map<PlanNodeId, PlanFragmentId> exchangeToFragment,
+                                             Map<PlanFragmentId, FragmentSequence> sequenceMap) {
+            if (sequenceMap.containsKey(node.getFragmentId())) {
+                return;
+            }
+
+            final List<PlanFragmentId> childFragments = Lists.newArrayList();
+            build(node.getPlanFragment().getPlanRoot(), childFragments, exchangeToFragment);
+            final FragmentSequence sequence = new FragmentSequence(dag, Lists.reverse(childFragments));
+            sequenceMap.put(node.getFragmentId(), sequence);
+
+            for (int i = 0; i < node.childrenSize(); i++) {
+                buildIfNotExists(dag, node.getChild(i), exchangeToFragment, sequenceMap);
+            }
+        }
+
+        private static void build(PlanNode node, List<PlanFragmentId> list,
+                                  Map<PlanNodeId, PlanFragmentId> exchangeToFragment) {
+
+            if (node instanceof ExceptNode || node instanceof IntersectNode) {
+                for (PlanNode child : node.getChildren()) {
+                    if (child instanceof ExchangeNode) {
+                        list.add(exchangeToFragment.get(child.getId()));
+                        continue;
+                    }
+                    build(child, list, exchangeToFragment);
+                }
+            } else {
+                if (node instanceof ExchangeNode) {
+                    list.add(exchangeToFragment.get(node.getId()));
+                    return;
+                }
+                for (int i = node.getChildren().size() - 1; i >= 0; i--) {
+                    final PlanNode child = node.getChild(i);
+                    if (child instanceof ExchangeNode) {
+                        list.add(exchangeToFragment.get(child.getId()));
+                        continue;
+                    }
+                    build(child, list, exchangeToFragment);
+                }
+
+            }
+
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
@@ -1,0 +1,449 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.UnionFind;
+import com.starrocks.planner.PlanFragmentId;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.scheduler.Deployer;
+import com.starrocks.qe.scheduler.slot.DeployState;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.thrift.TUniqueId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class PhasedExecutionSchedule implements ExecutionSchedule {
+    private static class PackedExecutionFragment {
+        PackedExecutionFragment(ExecutionFragment fragment) {
+            fragments.add(fragment);
+        }
+
+        PackedExecutionFragment(Collection<ExecutionFragment> fragments) {
+            this.fragments.addAll(fragments);
+        }
+
+        private final List<ExecutionFragment> fragments = Lists.newArrayList();
+
+        List<ExecutionFragment> getFragments() {
+            return fragments;
+        }
+    }
+
+    private Deployer deployer;
+    private ExecutionDAG dag;
+
+    public PhasedExecutionSchedule(ConnectContext context) {
+        this.connectContext = context;
+        this.maxScheduleConcurrency = context.getSessionVariable().getPhasedSchedulerMaxConcurrency();
+    }
+
+    private final Stack<PackedExecutionFragment> stack = new Stack<>();
+
+    // Maximum scheduling concurrency.
+    private final int maxScheduleConcurrency;
+    // fragment id -> in-degree > 1 children (cte producer fragments)
+    //       A(E)
+    //       │
+    //       │
+    //       │
+    // ┌─────┼─────┐
+    // │     │     │
+    // ▼     ▼     ▼
+    // B(E)  C     D(E)
+    // │           │
+    // │           │
+    // └─────┬─────┘
+    //       │
+    //       ▼
+    //       E
+    private final Map<PlanFragmentId, Set<PlanFragmentId>> commonChildrens = Maps.newHashMap();
+    private Map<PlanFragmentId, Integer> fragmentInDegrees = Maps.newHashMap();
+    // the same with fragmentInDegrees.
+    private Map<PlanFragmentId, Integer> scheduleFragmentInDegrees = Maps.newHashMap();
+    // Constructing equivalence classes. Having the same child is in an equivalent class.
+    private final UnionFind<PlanFragmentId> mergedUnionFind = new UnionFind<>();
+    // Controls that only one thread can call scheduleNext.
+    private final AtomicInteger inputScheduleTaskNums = new AtomicInteger();
+    private final ConnectContext connectContext;
+    private final Set<PlanFragmentId> waitScheduleFragments = Sets.newHashSet();
+
+    // TODO: coordinate in BE
+    private final Map<PlanFragmentId, AtomicInteger> schedulingFragmentInstances = Maps.newConcurrentMap();
+
+    // fragment schedule queue
+    private final Queue<List<DeployState>> deployStates = Lists.newLinkedList();
+
+    // fragment id -> fragment child schedule order
+    private Map<PlanFragmentId, FragmentSequence> sequenceMap = Maps.newHashMap();
+
+    public void prepareSchedule(Deployer deployer, ExecutionDAG dag) {
+        this.deployer = deployer;
+        this.dag = dag;
+        ExecutionFragment rootFragment = dag.getRootFragment();
+        this.stack.push(new PackedExecutionFragment(rootFragment));
+        // build in-degrees
+        fragmentInDegrees = buildChildInDegrees(rootFragment);
+        scheduleFragmentInDegrees = Maps.newHashMap(fragmentInDegrees);
+        // build common children
+        buildCommonChildren(rootFragment);
+
+        buildMergedSets(rootFragment, Sets.newHashSet());
+
+        sequenceMap = FragmentSequence.Builder.build(dag, rootFragment);
+    }
+
+    private Map<PlanFragmentId, Integer> buildChildInDegrees(ExecutionFragment root) {
+        Queue<ExecutionFragment> queue = Lists.newLinkedList();
+        Map<PlanFragmentId, Integer> inDegrees = Maps.newHashMap();
+        inDegrees.put(root.getFragmentId(), 0);
+        queue.add(root);
+
+        while (!queue.isEmpty()) {
+            final ExecutionFragment fragment = queue.poll();
+            for (int i = 0; i < fragment.childrenSize(); i++) {
+                ExecutionFragment child = fragment.getChild(i);
+                PlanFragmentId cid = fragment.getChild(i).getFragmentId();
+                Integer v = inDegrees.get(cid);
+                if (v != null) {
+                    inDegrees.put(cid, v + 1);
+                } else {
+                    inDegrees.put(cid, 1);
+                    queue.add(child);
+                }
+            }
+        }
+
+        return inDegrees;
+    }
+
+    private Set<PlanFragmentId> buildCommonChildren(ExecutionFragment fragment) {
+        final PlanFragmentId fragmentId = fragment.getFragmentId();
+        final Set<PlanFragmentId> planFragmentIds = commonChildrens.get(fragmentId);
+
+        if (planFragmentIds != null) {
+            return planFragmentIds;
+        }
+
+        final Set<PlanFragmentId> fragmentCommonChild = Sets.newHashSet();
+
+        if (fragmentInDegrees.get(fragmentId) > 1) {
+            fragmentCommonChild.add(fragmentId);
+        }
+
+        for (int i = 0; i < fragment.childrenSize(); i++) {
+            final ExecutionFragment child = fragment.getChild(i);
+            final Set<PlanFragmentId> childCommonChildren = buildCommonChildren(child);
+            fragmentCommonChild.addAll(childCommonChildren);
+        }
+
+        commonChildrens.put(fragmentId, fragmentCommonChild);
+        return fragmentCommonChild;
+    }
+
+    private void buildMergedSets(ExecutionFragment node, Set<PlanFragmentId> accessed) {
+        final PlanFragmentId fragmentId = node.getFragmentId();
+
+        if (accessed.contains(fragmentId)) {
+            return;
+        }
+        accessed.add(fragmentId);
+
+        final Set<PlanFragmentId> planFragmentIds = commonChildrens.get(fragmentId);
+        for (PlanFragmentId planFragmentId : planFragmentIds) {
+            mergedUnionFind.union(fragmentId, planFragmentId);
+        }
+        for (int i = 0; i < node.childrenSize(); i++) {
+            final ExecutionFragment child = node.getChild(i);
+            buildMergedSets(child, accessed);
+        }
+    }
+
+    // build all deploy states
+    private void buildDeployStates() {
+        while (!isFinished()) {
+            final List<DeployState> nextTurnSchedule = getNextTurnSchedule();
+            deployStates.add(nextTurnSchedule);
+        }
+    }
+
+    // schedule next
+    public void schedule() throws RpcException, UserException {
+        buildDeployStates();
+        final int oldTaskCnt = inputScheduleTaskNums.getAndIncrement();
+        if (oldTaskCnt == 0) {
+            int dec = 0;
+            do {
+                doDeploy();
+                dec = inputScheduleTaskNums.getAndDecrement();
+            } while (dec > 1);
+        }
+    }
+
+    private void doDeploy() throws RpcException, UserException {
+        if (deployStates.isEmpty()) {
+            return;
+        }
+        final List<DeployState> deployState = deployStates.poll();
+        Preconditions.checkState(deployState != null);
+        for (DeployState state : deployState) {
+            deployer.deployFragments(state);
+        }
+    }
+
+    public void tryScheduleNextTurn(TUniqueId fragmentInstanceId) throws RpcException, UserException {
+        final FragmentInstance instance = dag.getInstanceByInstanceId(fragmentInstanceId);
+        final PlanFragmentId fragmentId = instance.getFragmentId();
+        final AtomicInteger countDowns = schedulingFragmentInstances.get(fragmentId);
+        if (countDowns.decrementAndGet() != 0) {
+            return;
+        }
+        try (var guard = ConnectContext.ScopeGuard.setIfNotExists(connectContext)) {
+            final int oldTaskCnt = inputScheduleTaskNums.getAndIncrement();
+            if (oldTaskCnt == 0) {
+                int dec = 0;
+                do {
+                    doDeploy();
+                    dec = inputScheduleTaskNums.getAndDecrement();
+                } while (dec > 1);
+            }
+        }
+    }
+
+    // inner data structure (ExecutionDag::executors) should be protected by Coordinator lock
+    private List<DeployState> getNextTurnSchedule() {
+        if (isFinished()) {
+            return Collections.emptyList();
+        }
+        List<List<ExecutionFragment>> scheduleFragments = Lists.newArrayList();
+        int currentScheduleConcurrency = 0;
+        while (currentScheduleConcurrency < maxScheduleConcurrency) {
+            if (isFinished()) {
+                break;
+            }
+            if (scheduleNext(scheduleFragments) && waitScheduleFragments.isEmpty()) {
+                currentScheduleConcurrency++;
+            }
+        }
+
+        // merge and build fragment
+        final List<List<ExecutionFragment>> fragments = buildScheduleOrder(scheduleFragments);
+
+        // build deploy states
+        List<DeployState> deployStates = Lists.newArrayList();
+        for (List<ExecutionFragment> fragment : fragments) {
+            for (ExecutionFragment executionFragment : fragment) {
+                final PlanFragmentId fragmentId = executionFragment.getFragmentId();
+                int instanceNums = executionFragment.getInstances().size();
+                schedulingFragmentInstances.put(fragmentId, new AtomicInteger(instanceNums));
+            }
+            final DeployState deployState = deployer.createFragmentExecStates(fragment);
+            deployStates.add(deployState);
+        }
+        return deployStates;
+    }
+
+    // Get the sequence of fragments for the next dispatch.
+    // 1. Get the top-of-stack fragments and add them to the sequence to be scheduled.
+    // 2. Iterate through each fragment.
+    //   2.1 Iterate over the children of each fragment. lower their in-degree.
+    //   2.2 Stack each child in turn. If any of the fragment's children belong to the same equivalence
+    //   class, then the children are scheduled together. They are stacked together.
+    private boolean scheduleNext(List<List<ExecutionFragment>> scheduleFragments) {
+        List<ExecutionFragment> currentScheduleFragments = Lists.newArrayList();
+
+        PackedExecutionFragment packedExecutionFragment = stack.pop();
+        currentScheduleFragments.addAll(packedExecutionFragment.getFragments());
+
+        Preconditions.checkState(!currentScheduleFragments.isEmpty());
+
+        final Iterator<ExecutionFragment> iterator = currentScheduleFragments.iterator();
+        while (iterator.hasNext()) {
+            final ExecutionFragment fragment = iterator.next();
+            if (fragment.isScheduled()) {
+                iterator.remove();
+                continue;
+            }
+            fragment.setIsScheduled(true);
+
+            // keep the order
+            final Map<Integer, LinkedHashSet<ExecutionFragment>> groups = Maps.newHashMap();
+            final Set<PlanFragmentId> processedFragments = Sets.newHashSet();
+
+            for (int i = fragment.childrenSize() - 1; i >= 0; i--) {
+                final ExecutionFragment child = sequenceMap.get(fragment.getFragmentId()).getAt(i);
+                final PlanFragmentId childFragmentId = child.getFragmentId();
+                final int groupId = mergedUnionFind.getGroupIdOrAdd(childFragmentId);
+                Set<ExecutionFragment> groupFragments = groups.computeIfAbsent(groupId, k -> Sets.newLinkedHashSet());
+                int degree =
+                        scheduleFragmentInDegrees.compute(childFragmentId, (k, v) -> Preconditions.checkNotNull(v) - 1);
+                // we won't schedule the fragment that in-degree neq 0
+                if (degree == 0) {
+                    groupFragments.add(child);
+                } else {
+                    waitScheduleFragments.add(child.getFragmentId());
+                }
+            }
+
+            if (groups.size() != fragment.childrenSize()) {
+                List<PackedExecutionFragment> fragments =  Lists.newArrayList();
+                for (int i = fragment.childrenSize() - 1; i >= 0; i--) {
+                    final ExecutionFragment child = sequenceMap.get(fragment.getFragmentId()).getAt(i);
+                    final PlanFragmentId childFragmentId = child.getFragmentId();
+                    final int groupId = mergedUnionFind.getGroupIdOrAdd(childFragmentId);
+                    final Set<ExecutionFragment> groupFragments = groups.get(groupId);
+                    // The current fragment is in the same group as the prev fragment and
+                    // does not need to be processed.
+                    if (processedFragments.contains(childFragmentId)) {
+                        continue;
+                    }
+
+                    fragments.add(new PackedExecutionFragment(groupFragments));
+
+                    for (ExecutionFragment groupFragment : groupFragments) {
+                        processedFragments.add(groupFragment.getFragmentId());
+                    }
+
+                    // child that index > 0 needs to schedule the next round of fragments.
+                    // eg: each node is a fragment
+                    //           Union
+                    //            │
+                    //            │
+                    //            │
+                    //  ┌─────────┼─────────┐
+                    //  │         │         │
+                    //  ▼         ▼         ▼
+                    // AGG(1)    AGG(2)    AGG(3)
+                    //  │         │         │
+                    //  │         │         │
+                    //  ▼         ▼         ▼
+                    //SCAN(1)   SCAN(2)   SCAN(3)
+                    //
+                    // in this case when AGG2/AGG3 fragment finished we should trigger next schedule
+                    if (i != 0) {
+                        child.setNeedReportFragmentFinish(true);
+                    }
+                }
+                for (int i = fragments.size() - 1; i >= 0; i--) {
+                    stack.push(fragments.get(i));
+                }
+            } else {
+                for (int i = 0; i < fragment.childrenSize(); i++) {
+                    final ExecutionFragment child = sequenceMap.get(fragment.getFragmentId()).getAt(i);
+                    if (!scheduleFragmentInDegrees.get(child.getFragmentId()).equals(0)) {
+                        continue;
+                    }
+                    if (i != 0) {
+                        child.setNeedReportFragmentFinish(true);
+                    }
+                    stack.push(new PackedExecutionFragment(child));
+                }
+            }
+        }
+
+        if (!currentScheduleFragments.isEmpty()) {
+            for (ExecutionFragment currentScheduleFragment : currentScheduleFragments) {
+                waitScheduleFragments.remove(currentScheduleFragment.getFragmentId());
+            }
+            scheduleFragments.add(currentScheduleFragments);
+            for (ExecutionFragment currentScheduleFragment : currentScheduleFragments) {
+                if (currentScheduleFragment.childrenSize() == 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Input: set of N fragments
+    // Output: a fragment scheduling sequence by topological ordering
+    private List<List<ExecutionFragment>> buildScheduleOrder(List<List<ExecutionFragment>> scheduleFragments) {
+        List<List<ExecutionFragment>> groups = Lists.newArrayList();
+        // collect zero in-degree nodes
+        Queue<ExecutionFragment> queue = Lists.newLinkedList();
+
+        final Set<ExecutionFragment> fragments =
+                scheduleFragments.stream().flatMap(Collection::stream).collect(Collectors.toUnmodifiableSet());
+
+        for (ExecutionFragment fragment : fragments) {
+            if (fragmentInDegrees.get(fragment.getFragmentId()).equals(0)) {
+                queue.add(fragment);
+            }
+        }
+
+        int totalFragments = fragments.size();
+
+        final ExecutionFragment captureVersionFragment = dag.getCaptureVersionFragment();
+        if (captureVersionFragment != null && !captureVersionFragment.isScheduled()) {
+            queue.add(captureVersionFragment);
+            totalFragments++;
+        }
+
+        // topological-sort for input fragments
+        int scheduleFragmentNums = 0;
+        while (!queue.isEmpty()) {
+            int groupSize = queue.size();
+            List<ExecutionFragment> group = new ArrayList<>(groupSize);
+            // The next `groupSize` fragments can be delivered concurrently, because zero in-degree indicates that
+            // they don't depend on each other and all the fragments depending on them have been delivered.
+            for (int i = 0; i < groupSize; ++i) {
+                ExecutionFragment fragment = Preconditions.checkNotNull(queue.poll());
+                fragment.setIsScheduled(true);
+                group.add(fragment);
+
+                for (int j = 0; j < fragment.childrenSize(); j++) {
+                    ExecutionFragment child = fragment.getChild(j);
+                    final PlanFragmentId fragmentId = child.getFragmentId();
+                    int degree = fragmentInDegrees.compute(fragmentId, (k, v) -> Preconditions.checkNotNull(v) - 1);
+                    if (degree == 0 && fragments.contains(child)) {
+                        queue.add(child);
+                    }
+                }
+            }
+            groups.add(group);
+            scheduleFragmentNums += group.size();
+        }
+
+        if (scheduleFragmentNums != totalFragments) {
+            throw new StarRocksPlannerException("invalid schedule plan",
+                    ErrorType.INTERNAL_ERROR);
+        }
+
+        return groups;
+    }
+
+    public boolean isFinished() {
+        return stack.isEmpty();
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ScheduleNextTurnRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ScheduleNextTurnRunner.java
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.starrocks.common.UserException;
+import com.starrocks.rpc.RpcException;
+
+import java.util.Collection;
+
+public interface ScheduleNextTurnRunner {
+    Collection<FragmentInstanceExecState> doSchedule() throws RpcException, UserException;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/DeployState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/DeployState.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeployState {
+    // Divide requests of fragments in the current group to three stages.
+    // - stage 1, the request with RF coordinator + descTable.
+    // - stage 2, the first request to a host, which need send descTable.
+    // - stage 3, the non-first requests to a host, which needn't send descTable.
+    private final List<List<FragmentInstanceExecState>> threeStageExecutionsToDeploy =
+            ImmutableList.of(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+
+    public List<List<FragmentInstanceExecState>> getThreeStageExecutionsToDeploy() {
+        return threeStageExecutionsToDeploy;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
@@ -244,7 +244,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
         List<ScanNode> scanNodes = execPlan.getScanNodes();
         TDescriptorTable descTable = execPlan.getDescTbl().toThrift();
         JobSpec jobSpec = JobSpec.Factory.fromMVMaintenanceJobSpec(connectContext, fragments, scanNodes, descTable);
-        this.queryCoordinator = new CoordinatorPreprocessor(connectContext, jobSpec);
+        this.queryCoordinator = new CoordinatorPreprocessor(connectContext, jobSpec, false);
         this.epochCoordinator = new TxnBasedEpochCoordinator(this);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -278,6 +278,8 @@ import com.starrocks.thrift.TReportAuditStatisticsParams;
 import com.starrocks.thrift.TReportAuditStatisticsResult;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TReportExecStatusResult;
+import com.starrocks.thrift.TReportFragmentFinishParams;
+import com.starrocks.thrift.TReportFragmentFinishResponse;
 import com.starrocks.thrift.TReportLakeCompactionRequest;
 import com.starrocks.thrift.TReportLakeCompactionResponse;
 import com.starrocks.thrift.TReportRequest;
@@ -2935,5 +2937,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     public TGetTemporaryTablesInfoResponse getTemporaryTablesInfo(TGetTemporaryTablesInfoRequest request)
             throws TException {
         return InformationSchemaDataSource.generateTemporaryTablesInfoResponse(request);
+    }
+
+    @Override
+    public TReportFragmentFinishResponse reportFragmentFinish(TReportFragmentFinishParams request) throws TException {
+        return QeProcessorImpl.INSTANCE.reportFragmentFinish(request);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3040,6 +3040,7 @@ public class PlanFragmentBuilder {
 
             ScalarOperatorToExpr.FormatterContext formatterContext =
                     new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr());
+            List<PlanFragment> childFragments = Lists.newArrayList();
             for (int i = 0; i < optExpr.getInputs().size(); i++) {
                 List<ColumnRefOperator> childOutput = setOperation.getChildOutputColumns().get(i);
                 ExecGroup setExecGroup = this.currentExecGroup;
@@ -3067,9 +3068,16 @@ public class PlanFragmentBuilder {
                         new ExchangeNode(context.getNextNodeId(), fragment.getPlanRoot(), fragment.getDataPartition());
                 this.currentExecGroup.add(exchangeNode, true);
 
+                childFragments.add(fragment);
                 exchangeNode.setFragment(setOperationFragment);
-                fragment.setDestination(exchangeNode);
                 setOperationNode.addChild(exchangeNode);
+            }
+
+            // keep the fragment child order with execution order
+            // for intersect and except. child(0) is build node.
+            for (int i = setOperationNode.getChildren().size() - 1; i >= 0; i--) {
+                final PlanFragment planFragment = childFragments.get(i);
+                planFragment.setDestination((ExchangeNode) setOperationNode.getChild(i));
             }
 
             // reset column is nullable, for handle union select xx join select xxx...

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfilingExecPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfilingExecPlanTest.java
@@ -73,7 +73,7 @@ public class ProfilingExecPlanTest {
                         "STREAM_AGG", "STREAM_JOIN", "PROJECT", "PAIMON_SCAN", "TABLE_FUNCTION", "MYSQL_SCAN",
                         "EMPTY_SET", "HUDI_SCAN", "HASH_JOIN", "ES_SCAN", "SCHEMA_SCAN", "ASSERT_NUM_ROWS", "SELECT",
                         "STREAM_LOAD_SCAN", "ANALYTIC_EVAL", "ICEBERG_SCAN", "AGGREGATION", "FILE_SCAN", "EXCHANGE",
-                        "META_SCAN", "OLAP_SCAN", "ODPS_SCAN", "ICEBERG_METADATA_SCAN", "KUDU_SCAN");
+                        "META_SCAN", "OLAP_SCAN", "ODPS_SCAN", "ICEBERG_METADATA_SCAN", "KUDU_SCAN", "CAPTURE_VERSION");
 
         Method method = ProfilingExecPlan.class.getDeclaredMethod("normalizeNodeName", Class.class);
         method.setAccessible(true);
@@ -82,7 +82,7 @@ public class ProfilingExecPlanTest {
             if (Modifier.isAbstract(aClass.getModifiers())) {
                 continue;
             }
-            Assert.assertTrue(names.contains((String) method.invoke(null, aClass)));
+            Assert.assertTrue(aClass.toString(), names.contains((String) method.invoke(null, aClass)));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/PhasedScheduleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/PhasedScheduleTest.java
@@ -1,0 +1,161 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.api.client.util.Lists;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.dag.ExecutionDAG;
+import com.starrocks.qe.scheduler.dag.FragmentInstance;
+import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
+import com.starrocks.qe.scheduler.slot.DeployState;
+import com.starrocks.thrift.TUniqueId;
+import mockit.Mock;
+import mockit.MockUp;
+import org.assertj.core.util.Sets;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class PhasedScheduleTest extends SchedulerTestBase {
+    @Test
+    public void testSchedule() throws Exception {
+        connectContext.getSessionVariable().setEnablePhasedScheduler(true);
+        connectContext.getSessionVariable().setPhasedSchedulerMaxConcurrency(1);
+
+        String sql = "select count(1) from lineitem " +
+                "UNION ALL select count(1) from lineitem " +
+                "UNION ALL select count(1) from lineitem";
+
+        Set<FragmentInstanceExecState> dispatched = Sets.newHashSet();
+        // deploy
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+                final List<List<FragmentInstanceExecState>> state =
+                        deployState.getThreeStageExecutionsToDeploy();
+                for (List<FragmentInstanceExecState> execStates : state) {
+                    dispatched.addAll(execStates);
+                }
+            }
+        };
+
+        // firstly schedule
+        final DefaultCoordinator coordinator = startScheduling(sql);
+        final ExecutionDAG executionDAG = coordinator.getExecutionDAG();
+        reportScan(Sets.newHashSet(dispatched), executionDAG, coordinator);
+
+        Set<FragmentInstanceExecState> noDispatched = Sets.newHashSet();
+        for (FragmentInstanceExecState execution : executionDAG.getExecutions()) {
+            if (!dispatched.contains(execution)) {
+                noDispatched.add(execution);
+            }
+        }
+        Assert.assertFalse(noDispatched.isEmpty());
+        reportScan(noDispatched, executionDAG, coordinator);
+
+    }
+
+    @Test
+    public void testPhasedScheduleWithCTE() throws Exception {
+        connectContext.getSessionVariable().setEnablePhasedScheduler(true);
+        connectContext.getSessionVariable().setPhasedSchedulerMaxConcurrency(1);
+
+        String sql =
+                "with a as (select count(*) from lineitem) " +
+                        "select /*+SET_VAR(cbo_cte_reuse_rate=0) */ * from a union all select * from a;";
+
+        // firstly schedule
+        final DefaultCoordinator coordinator = startScheduling(sql);
+        final ExecutionDAG executionDAG = coordinator.getExecutionDAG();
+        final int size = executionDAG.getExecutions().size();
+        Assert.assertEquals(size, 11);
+    }
+
+    @Test
+    public void testScheduleWithParallelReport() throws Exception {
+        connectContext.getSessionVariable().setEnablePhasedScheduler(true);
+        connectContext.getSessionVariable().setPhasedSchedulerMaxConcurrency(1);
+
+        String sql = "select count(1) from lineitem " +
+                "UNION ALL select count(1) from lineitem " +
+                "UNION ALL select count(1) from lineitem";
+
+        Set<FragmentInstanceExecState> dispatched = Sets.newHashSet();
+        // deploy
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+                final List<List<FragmentInstanceExecState>> state =
+                        deployState.getThreeStageExecutionsToDeploy();
+                for (List<FragmentInstanceExecState> execStates : state) {
+                    dispatched.addAll(execStates);
+                }
+            }
+        };
+
+        // firstly schedule
+        final DefaultCoordinator coordinator = startScheduling(sql);
+        final ExecutionDAG executionDAG = coordinator.getExecutionDAG();
+
+        parallelReport(Sets.newHashSet(dispatched), executionDAG, coordinator);
+
+        Set<FragmentInstanceExecState> noDispatched = Sets.newHashSet();
+        for (FragmentInstanceExecState execution : executionDAG.getExecutions()) {
+            if (!dispatched.contains(execution)) {
+                noDispatched.add(execution);
+            }
+        }
+        Assert.assertFalse(noDispatched.isEmpty());
+
+        parallelReport(noDispatched, executionDAG, coordinator);
+
+    }
+
+    private void reportScan(Collection<FragmentInstanceExecState> instances, ExecutionDAG dag, Coordinator coordinator)
+            throws Exception {
+        for (FragmentInstanceExecState execution : instances) {
+            final FragmentInstance instance =
+                    dag.getInstanceByInstanceId(execution.getInstanceId());
+            boolean isleaf = !instance.getExecFragment().getScanNodes().isEmpty();
+            if (isleaf) {
+                coordinator.scheduleNextTurn(execution.getInstanceId());
+            }
+        }
+    }
+
+    private void parallelReport(Collection<FragmentInstanceExecState> instances, ExecutionDAG dag,
+                                Coordinator coordinator) throws Exception {
+        final List<TUniqueId> uniqueIds = Lists.newArrayList();
+        for (FragmentInstanceExecState execution : instances) {
+            final FragmentInstance instance =
+                    dag.getInstanceByInstanceId(execution.getInstanceId());
+            boolean isleaf = !instance.getExecFragment().getScanNodes().isEmpty();
+            if (isleaf) {
+                uniqueIds.add(execution.getInstanceId());
+            }
+        }
+        uniqueIds.stream().parallel().forEach(i -> {
+            try {
+                coordinator.scheduleNextTurn(i);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -69,7 +69,8 @@ public class QueryRuntimeProfileTest {
             }
         };
 
-        QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, 1, false);
+        QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, false);
+        profile.initFragmentProfiles(1);
         TReportExecStatusParams reportExecStatusParams = buildReportStatus();
         profile.updateLoadChannelProfile(reportExecStatusParams);
         Optional<RuntimeProfile> optional = profile.mergeLoadChannelProfile();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -734,6 +734,16 @@ struct TReportExecStatusParams {
   29: optional DataCache.TLoadDataCacheMetrics load_datacache_metrics
 }
 
+struct TReportFragmentFinishParams {
+    1: optional Types.TUniqueId query_id
+    2: optional Types.TUniqueId fragment_instance_id
+    4: optional i32 backend_num
+}
+
+struct TReportFragmentFinishResponse {
+    1: optional Status.TStatus status
+}
+
 struct TAuditStatistics {
     3: optional i64 scan_rows
     4: optional i64 scan_bytes
@@ -1900,5 +1910,7 @@ service FrontendService {
 
     TListSessionsResponse listSessions(1: TListSessionsRequest request)
     TGetTemporaryTablesInfoResponse getTemporaryTablesInfo(1: TGetTemporaryTablesInfoRequest request)
+
+    TReportFragmentFinishResponse reportFragmentFinish(TReportFragmentFinishParams request)
 }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -372,6 +372,8 @@ struct TPlanFragmentExecParams {
   54: optional bool enable_exchange_perf
 
   70: optional i32 pipeline_sink_dop
+
+  73: optional bool report_when_finish;
 }
 
 // Global query parameters assigned by the coordinator.

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -84,6 +84,7 @@ enum TPlanNodeType {
   STREAM_JOIN_NODE,
   STREAM_AGG_NODE,
   LAKE_META_SCAN_NODE,
+  CAPTURE_VERSION_NODE,
 }
 
 // phases of an execution node

--- a/test/sql/test_phased_schedule/R/test_phased_schedule
+++ b/test/sql/test_phased_schedule/R/test_phased_schedule
@@ -1,0 +1,214 @@
+-- name: test_phased_schedule
+set enable_phased_scheduler = true;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `small_table1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `small_table2` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `small_table3` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+create table empty_t like t0;
+-- result:
+-- !result
+create table TMP like t0;
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into t0 values (null,null,null,null);
+-- result:
+-- !result
+insert into small_table1 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  100));
+-- result:
+-- !result
+insert into small_table2 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  2));
+-- result:
+-- !result
+insert into small_table3 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  10));
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+40961
+-- !result
+select count(*) from t1;
+-- result:
+0
+-- !result
+select count(*) from empty_t;
+-- result:
+0
+-- !result
+select count(*) from small_table1;
+-- result:
+100
+-- !result
+set phased_scheduler_max_concurrency = 1;
+-- result:
+-- !result
+insert into TMP select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5;
+-- result:
+-- !result
+select count(*) from TMP;
+-- result:
+12
+-- !result
+truncate table TMP;
+-- result:
+-- !result
+select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5;
+-- result:
+1	1	1	1
+2	2	2	2
+1	1	1	1
+2	2	2	2
+1	1	1	1
+2	2	2	2
+1	1	1	1
+2	2	2	2
+1	1	1	1
+2	2	2	2
+1	1	1	1
+2	2	2	2
+-- !result
+select c0,c1,c2 from small_table2 s1 group by 1,2,3 union all select c0,c1,c2 from small_table2 s2 group by 1,2,3  union all select c0,c1,c2 from small_table2 s3 group by 1,2,3  union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s5 group by 1,2,3;
+-- result:
+2	2	2
+1	1	1
+2	2	2
+1	1	1
+2	2	2
+1	1	1
+2	2	2
+1	1	1
+2	2	2
+1	1	1
+2	2	2
+1	1	1
+-- !result
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0;
+-- result:
+2
+-- !result
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join empty_t s3 on s1.c0 = s3.c0;
+-- result:
+0
+-- !result
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 where s3.c3 = 0;
+-- result:
+0
+-- !result
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 where s3.c1 = 0;
+-- result:
+0
+-- !result
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join [bucket] t0 r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- result:
+40960	40960
+-- !result
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- result:
+40960	40960
+-- !result
+with agged_table as ( select distinct c2 as c0, c3 as c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- result:
+40960	40960
+-- !result
+with agged_table as ( select distinct c0,c1 from (select l.c0, r.c1 from t0 l join t1 r on l.c3=r.c3)t) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- result:
+0	0
+-- !result
+with agged_table as ( select distinct c0,c1 from (select l.c0, r.c1 from t0 l join t1 r on l.c1=r.c1)t) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- result:
+0	0
+-- !result
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 join small_table1 s4 on s1.c0 = s4.c0 join small_table2 s5 on s1.c0 = s5.c0 join small_table3 s6 on s1.c0 = s6.c0 join small_table1 s7 on s1.c0 = s7.c0 join small_table2 s8 on s1.c0 = s8.c0 join small_table3 s9 on s1.c0 = s9.c0 join small_table1 s10 on s1.c0 = s10.c0;
+-- result:
+2
+-- !result
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(*), sum(c0),sum(c1) from (select * from agged_table union all select l.c1, l.c0 from agged_table l join t0 r on l.c0=r.c2) tb;
+-- result:
+81921	1677762560.0	1677762560.0
+-- !result
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(*), sum(c0),sum(c1) from (select l.c1, l.c0 from agged_table l join t0 r on l.c0=r.c2 union all select * from agged_table) tb;
+-- result:
+81921	1677762560.0	1677762560.0
+-- !result

--- a/test/sql/test_phased_schedule/T/test_phased_schedule
+++ b/test/sql/test_phased_schedule/T/test_phased_schedule
@@ -1,0 +1,121 @@
+-- name: test_phased_schedule
+set enable_phased_scheduler = true;
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `small_table1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `small_table2` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `small_table3` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+create table empty_t like t0;
+create table TMP like t0;
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+insert into t0 values (null,null,null,null);
+insert into small_table1 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  100));
+insert into small_table2 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  2));
+insert into small_table3 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  10));
+
+select count(*) from t0;
+select count(*) from t1;
+select count(*) from empty_t;
+select count(*) from small_table1;
+
+-- simple case union all insert into select *
+-- simple case union all select *
+set phased_scheduler_max_concurrency = 1;
+insert into TMP select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5;
+select count(*) from TMP;
+truncate table TMP;
+select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5;
+select c0,c1,c2 from small_table2 s1 group by 1,2,3 union all select c0,c1,c2 from small_table2 s2 group by 1,2,3  union all select c0,c1,c2 from small_table2 s3 group by 1,2,3  union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s5 group by 1,2,3;
+-- join cases
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0;
+-- short-circuit
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join empty_t s3 on s1.c0 = s3.c0;
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 where s3.c3 = 0;
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 where s3.c1 = 0;
+-- simple cte
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join [bucket] t0 r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- cte join cte
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+with agged_table as ( select distinct c2 as c0, c3 as c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- cte has join
+with agged_table as ( select distinct c0,c1 from (select l.c0, r.c1 from t0 l join t1 r on l.c3=r.c3)t) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+with agged_table as ( select distinct c0,c1 from (select l.c0, r.c1 from t0 l join t1 r on l.c1=r.c1)t) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(l.c0), count(l.c1) from t0 l join [colocate] (select l.c0, r.c1 from agged_table l join agged_table r on l.c0=r.c0 and l.c1 = r.c1) r on l.c0=r.c0 and l.c1 = r.c1;
+-- 10 small joins
+select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 join small_table1 s4 on s1.c0 = s4.c0 join small_table2 s5 on s1.c0 = s5.c0 join small_table3 s6 on s1.c0 = s6.c0 join small_table1 s7 on s1.c0 = s7.c0 join small_table2 s8 on s1.c0 = s8.c0 join small_table3 s9 on s1.c0 = s9.c0 join small_table1 s10 on s1.c0 = s10.c0;
+-- union all with cte
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(*), sum(c0),sum(c1) from (select * from agged_table union all select l.c1, l.c0 from agged_table l join t0 r on l.c0=r.c2) tb;
+with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_reuse_rate=-1) */ count(*), sum(c0),sum(c1) from (select l.c1, l.c0 from agged_table l join t0 r on l.c0=r.c2 union all select * from agged_table) tb;


### PR DESCRIPTION
## Why I'm doing:

For particularly complex queries, the tried schedule approach will instantly consume a lot of cpu and memory, resulting in a very easy OOM.
An example is a union all 100 AGG, each AGG needs to consume about 100M memory, then this query at least 10G memory.

These 10 queries are concurrently sent down to the BE will cause the cpu of the BE to be overloaded and the performance will be degraded instead. If we limit N fragments to be sent down at a time, then it will reduce a lot of memory.



## What I'm doing:
To solve above problem. we support a fixed phased scheduler
```
      │     
      │     
      ▼     
      A     
      │     
      │     
┌─────┴────┐
▼     ▼    ▼
D     B    C
```
Tired: schedule A, then schedule B,C,D
phased: schedule A, schedule C, when C finished shedule B...

```
select count(lo_orderkey),count(sp), count(k) from (
    select lo_orderkey, sum(lo_ordtotalprice) sp, 'k1' k from lineorder partition (p1) group by lo_orderkey 
    union all 
    select lo_orderkey, sum(lo_ordtotalprice) sp, 'k2' k from lineorder partition (p1) group by lo_orderkey 
    union all 
    select lo_orderkey, sum(lo_ordtotalprice) sp, 'k3' k from lineorder partition (p1) group by lo_orderkey 
    union all
    select lo_orderkey, sum(lo_ordtotalprice) sp, 'k4' k from lineorder partition (p1) group by lo_orderkey 
) tb;
```
for phased max concurrency = 1
| dop=4            | Memory   | Time cost |      |      |
| ---------------- | -------- | --------- | ---- | ---- |
| single AGG          | 1.690 GB | 2.00      |      |      |
| Tiered schedule: | 6.822 GB | 2.51s     |      |      |
| Phased schedule: | 2.630 GB | 8.54      |      |      |

for 100 concurrency test union all 100 small AGG
```
select count(lo_orderkey),count(sp), count(k) from (
    select lo_orderkey, sum(lo_ordtotalprice) sp, 'k1' k from lineorder tablet (11068) group by lo_orderkey 
    union all
    ......
    select lo_orderkey, sum(lo_ordtotalprice) sp, 'k1' k from lineorder tablet (11068) group by lo_orderkey 
) tb;
```
|                  | Time   |
| ---------------- | ------ |
| Tiered schedule: | 43.442 |
| Phased schedule: | 22.918 |



for 200 concurrency

|                  | Time   |
| ---------------- | ------ |
| Tiered schedule: | OOM    |
| Phased schedule: | 36.402 |



# todo list
support adaptive phased schedule

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
