### PR TITLE
[BugFix] Fix HivePartitionTraits get table name error for hive resource table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HivePartitionTraits.java
@@ -42,6 +42,11 @@ public class HivePartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public String getTableName() {
+        return ((HiveMetaStoreTable) table).getTableName();
+    }
+
+    @Override
     public PartitionKey createEmptyKey() {
         return new HivePartitionKey();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -15,6 +15,9 @@
 package com.starrocks.connector;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.paimon.Partition;
 import com.starrocks.connector.partitiontraits.DefaultTraits;
@@ -85,5 +88,15 @@ public class ConnectorPartitionTraitsTest {
             Assert.assertEquals(supportedTableTypes.contains(tableType),
                     ConnectorPartitionTraits.isSupportPCTRefresh(tableType));
         }
+    }
+
+    @Test
+    public void testHiveResourceTableName() {
+        HiveTable hiveTable = new HiveTable(0, "name", Lists.newArrayList(), "resource_name", "hive_catalog",
+                "hiveDb", "hiveTable", "location", "", 0,
+                Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap(), Maps.newHashMap(), null,
+                HiveTable.HiveTableType.MANAGED_TABLE);
+        ConnectorPartitionTraits connectorPartitionTraits = ConnectorPartitionTraits.build(hiveTable);
+        Assert.assertEquals(connectorPartitionTraits.getTableName(), "hiveTable");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
HivePartitionTraits  use name as its table name, we need use `((HiveMetaStoreTable) table).getTableName() ` as table name for hive resource table 

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8014

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
