### PR TITLE
[Enhancement] Delta lake only get the statistics of the columns involved in the query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaDataType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaDataType.java
@@ -35,11 +35,12 @@ import io.delta.kernel.types.TimestampType;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * An Enum representing Delta's {@link DataType} class types.
- *
  */
 public enum DeltaDataType {
     ARRAY(ArrayType.class),
@@ -78,10 +79,31 @@ public enum DeltaDataType {
 
     /**
      * @param deltaDataType A concrete implementation of {@link DataType} class that we would
-     *                        like to map to {@link com.starrocks.catalog.Type} instance.
+     *                      like to map to {@link com.starrocks.catalog.Type} instance.
      * @return mapped instance of {@link DeltaDataType} Enum.
      */
     public static DeltaDataType instanceFrom(Class<? extends DataType> deltaDataType) {
         return LOOKUP_MAP.getOrDefault(deltaDataType, OTHER);
+    }
+
+    private static final Set<DataType> PRIMITIVE_TYPES = new HashSet<>() {
+        {
+            add(BooleanType.BOOLEAN);
+            add(ByteType.BYTE);
+            add(ShortType.SHORT);
+            add(IntegerType.INTEGER);
+            add(LongType.LONG);
+            add(FloatType.FLOAT);
+            add(DoubleType.DOUBLE);
+            add(DateType.DATE);
+            add(TimestampType.TIMESTAMP);
+            add(TimestampNTZType.TIMESTAMP_NTZ);
+            add(BinaryType.BINARY);
+            add(StringType.STRING);
+        }
+    };
+
+    public static boolean isPrimitiveType(DataType type) {
+        return PRIMITIVE_TYPES.contains(type);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -50,7 +50,6 @@ import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
-import io.delta.kernel.types.BasePrimitiveType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import org.apache.logging.log4j.LogManager;
@@ -123,7 +122,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         String tableName = deltaLakeTable.getTableName();
         PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, snapshotId, operator);
 
-        triggerDeltaLakePlanFilesIfNeeded(key, table, operator);
+        triggerDeltaLakePlanFilesIfNeeded(key, table, operator, fieldNames);
 
         List<FileScanTask> scanTasks = splitTasks.get(key);
         if (scanTasks == null) {
@@ -150,7 +149,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
         DeltaUtils.checkTableFeatureSupported(snapshot.getProtocol(), snapshot.getMetadata());
 
-        triggerDeltaLakePlanFilesIfNeeded(key, deltaLakeTable, predicate);
+        triggerDeltaLakePlanFilesIfNeeded(key, deltaLakeTable, predicate, columns);
 
         List<FileScanTask> deltaLakeScanTasks = splitTasks.get(key);
         if (deltaLakeScanTasks == null) {
@@ -169,16 +168,28 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         }
     }
 
-    private void triggerDeltaLakePlanFilesIfNeeded(PredicateSearchKey key, Table table, ScalarOperator operator) {
+    private void triggerDeltaLakePlanFilesIfNeeded(PredicateSearchKey key, Table table,
+                                                   ScalarOperator operator, Map<ColumnRefOperator, Column> columns) {
         if (!scannedTables.contains(key)) {
             try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "DELTA_LAKE.processSplit." + key)) {
-                collectDeltaLakePlanFiles(key, table, operator, ConnectContext.get());
+                List<String> fieldNames = columns.keySet().stream()
+                        .map(ColumnRefOperator::getName).collect(Collectors.toList());
+                collectDeltaLakePlanFiles(key, table, operator, ConnectContext.get(), fieldNames);
+            }
+        }
+    }
+
+    private void triggerDeltaLakePlanFilesIfNeeded(PredicateSearchKey key, Table table,
+                                                   ScalarOperator operator, List<String> fieldNames) {
+        if (!scannedTables.contains(key)) {
+            try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "DELTA_LAKE.processSplit." + key)) {
+                collectDeltaLakePlanFiles(key, table, operator, ConnectContext.get(), fieldNames);
             }
         }
     }
 
     private void collectDeltaLakePlanFiles(PredicateSearchKey key, Table table, ScalarOperator operator,
-                                           ConnectContext connectContext) {
+                                           ConnectContext connectContext, List<String> fieldNames) {
         DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
         Metadata metadata = deltaLakeTable.getDeltaMetadata();
         Engine engine = deltaLakeTable.getDeltaEngine();
@@ -195,14 +206,25 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         ScanBuilderImpl scanBuilder = (ScanBuilderImpl) snapshot.getScanBuilder(engine);
         ScanImpl scan = (ScanImpl) scanBuilder.withFilter(engine, deltaLakePredicate).build();
 
-        Set<String> nonPartitionPrimitiveColumns = schema.fieldNames().stream()
-                .filter(column -> BasePrimitiveType.isPrimitiveType(
-                        schema.get(column).getDataType().toString())
-                        && !partitionColumns.contains(column)).collect(Collectors.toSet());
-        Set<String> partitionPrimitiveColumns = partitionColumns.stream()
-                .filter(column -> BasePrimitiveType.isPrimitiveType(
-                        schema.get(column).getDataType().toString()
-                )).collect(Collectors.toSet());
+        Set<String> nonPartitionPrimitiveColumns;
+        Set<String> partitionPrimitiveColumns;
+        if (fieldNames != null) {
+            nonPartitionPrimitiveColumns = fieldNames.stream()
+                    .filter(column -> DeltaDataType.isPrimitiveType(schema.get(column).getDataType())
+                    && !partitionColumns.contains(column))
+                    .collect(Collectors.toSet());
+            partitionPrimitiveColumns = fieldNames.stream()
+                    .filter(column -> DeltaDataType.isPrimitiveType(schema.get(column).getDataType())
+                    && partitionColumns.contains(column))
+                    .collect(Collectors.toSet());
+        } else {
+            nonPartitionPrimitiveColumns = schema.fieldNames().stream()
+                    .filter(column -> DeltaDataType.isPrimitiveType(schema.get(column).getDataType())
+                            && !partitionColumns.contains(column)).collect(Collectors.toSet());
+            partitionPrimitiveColumns = partitionColumns.stream()
+                    .filter(column -> DeltaDataType.isPrimitiveType(schema.get(column).getDataType()))
+                    .collect(Collectors.toSet());
+        }
 
         List<FileScanTask> files = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -117,13 +117,13 @@ public class DeltaLakeScanNode extends ScanNode {
         return scanRangeLocationsList;
     }
 
-    public void setupScanRangeLocations(DescriptorTable descTbl) throws UserException {
+    public void setupScanRangeLocations(DescriptorTable descTbl, List<String> fieldNames) throws UserException {
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "DeltaLake.getScanFiles")) {
-            setupScanRangeLocationsImpl(descTbl);
+            setupScanRangeLocationsImpl(descTbl, fieldNames);
         }
     }
 
-    public void setupScanRangeLocationsImpl(DescriptorTable descTbl) throws UserException {
+    public void setupScanRangeLocationsImpl(DescriptorTable descTbl, List<String> fieldNames) throws UserException {
         Metadata deltaMetadata = deltaLakeTable.getDeltaMetadata();
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
         DeltaUtils.checkTableFeatureSupported(snapshot.getProtocol(), deltaMetadata);
@@ -136,7 +136,7 @@ public class DeltaLakeScanNode extends ScanNode {
         Map<PartitionKey, Long> partitionKeys = Maps.newHashMap();
 
         List<RemoteFileInfo> splits = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                catalogName, deltaLakeTable, null, snapshotId, predicate, null, -1);
+                catalogName, deltaLakeTable, null, snapshotId, predicate, fieldNames, -1);
         if (splits.isEmpty()) {
             LOG.warn("There is no scan tasks after planFiles on {}.{} and predicate: [{}]", dbName, tableName, predicate);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1212,7 +1212,10 @@ public class PlanFragmentBuilder {
                 }
 
                 deltaLakeScanNode.preProcessDeltaLakePredicate(node.getPredicate());
-                deltaLakeScanNode.setupScanRangeLocations(context.getDescTbl());
+                List<String> fieldNames = node.getColRefToColumnMetaMap().keySet().stream()
+                        .map(ColumnRefOperator::getName)
+                        .collect(Collectors.toList());
+                deltaLakeScanNode.setupScanRangeLocations(context.getDescTbl(), fieldNames);
 
                 HDFSScanNodePredicates scanNodePredicates = deltaLakeScanNode.getScanNodePredicates();
                 prepareCommonExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

No need to collect the statistics which no involved in the query.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
