### PR TITLE
[Enhancement] Use basic table in show statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
@@ -16,8 +16,10 @@ package com.starrocks.sql.ast;
 
 import com.google.common.collect.Lists;
 import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.catalog.BasicTable;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -60,8 +62,9 @@ public class ShowAnalyzeJobStmt extends ShowStmt {
 
             if (!analyzeJob.isAnalyzeAllTable()) {
                 String tableName = analyzeJob.getTableName();
-                Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                        .getTable(context, analyzeJob.getCatalogName(), dbName, tableName);
+                BasicTable table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                        .getBasicTable(context, analyzeJob.getCatalogName(), dbName, tableName,
+                                Config.enable_external_catalog_information_schema_tables_access_full_metadata);
 
                 if (table == null) {
                     throw new MetaNotFoundException("No found table: " + tableName);
@@ -78,13 +81,22 @@ public class ShowAnalyzeJobStmt extends ShowStmt {
                     return null;
                 }
 
-                if (null != columns && !columns.isEmpty()
-                        && (columns.size() != table.getBaseSchema().size())) {
-                    String str = String.join(",", columns);
-                    if (str.length() > 100) {
-                        row.set(4, str.substring(0, 100) + "...");
-                    } else {
-                        row.set(4, str);
+                if (null != columns && !columns.isEmpty()) {
+                    // Internal-catalog path returns a real Table; preserve the
+                    // legacy "ALL" rendering when the explicit column list
+                    // equals the full schema. External catalogs only get a
+                    // BasicTable stub here (no schema, no network IO), so we
+                    // always render the captured column names.
+                    long fullSchemaSize = (table instanceof Table)
+                            ? ((Table) table).getBaseSchema().size()
+                            : -1L;
+                    if (columns.size() != fullSchemaSize) {
+                        String str = String.join(",", columns);
+                        if (str.length() > 100) {
+                            row.set(4, str.substring(0, 100) + "...");
+                        } else {
+                            row.set(4, str);
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
@@ -16,7 +16,9 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.BasicTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -54,11 +56,12 @@ public class ShowAnalyzeStatusStmt extends ShowStmt {
         row.set(1, analyzeStatus.getCatalogName() + "." + analyzeStatus.getDbName());
         row.set(2, analyzeStatus.getTableName());
 
-        Table table;
+        BasicTable table;
         // In new privilege framework(RBAC), user needs any action on the table to show analysis status for it.
         try {
-            table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                    context, analyzeStatus.getCatalogName(), analyzeStatus.getDbName(), analyzeStatus.getTableName());
+            table = GlobalStateMgr.getCurrentState().getMetadataMgr().getBasicTable(
+                    context, analyzeStatus.getCatalogName(), analyzeStatus.getDbName(), analyzeStatus.getTableName(),
+                    Config.enable_external_catalog_information_schema_tables_access_full_metadata);
             if (table == null) {
                 throw new SemanticException("Table %s is not found", analyzeStatus.getTableName());
             }
@@ -68,10 +71,19 @@ public class ShowAnalyzeStatusStmt extends ShowStmt {
             return null;
         }
 
-        long totalCollectColumnsSize = StatisticUtils.getCollectibleColumns(table).size();
-        if (null != columns && !columns.isEmpty() && (columns.size() != totalCollectColumnsSize)) {
-            String str = String.join(",", columns);
-            row.set(3, str);
+        if (null != columns && !columns.isEmpty()) {
+            // Internal-catalog path returns a real Table, so we can match the
+            // legacy "ALL" rendering when the explicit column list equals the
+            // full collectible set. External catalogs only get a BasicTable
+            // stub here (no schema, no network IO), so we always render the
+            // captured column names.
+            long totalCollectColumnsSize = (table instanceof Table)
+                    ? StatisticUtils.getCollectibleColumns((Table) table).size()
+                    : -1L;
+            if (columns.size() != totalCollectColumnsSize) {
+                String str = String.join(",", columns);
+                row.set(3, str);
+            }
         }
 
         row.set(4, analyzeStatus.getType().name());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -304,10 +305,61 @@ public class AnalyzeStmtTest {
                         "{}, Test Failed]",
                 ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), analyzeStatus).toString());
 
-        AnalyzeStatus extenalAnalyzeStatus = new ExternalAnalyzeStatus(-1, "hive0", "partitioned_db",
-                "tx", "tx:xxxx", Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
-                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.MIN);
-        Assertions.assertNull(ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), extenalAnalyzeStatus));
+        // SHOW ANALYZE STATUS now resolves external tables via MetadataMgr.getBasicTable(...,
+        // fetchExternalMetadata). The config flag picks the lightweight (no network IO) path or
+        // the legacy full-metadata path, which differ in two externally visible ways.
+        boolean savedFetchFullMetadata = Config.enable_external_catalog_information_schema_tables_access_full_metadata;
+        try {
+            // Case 1: a table that was dropped in the source catalog.
+            AnalyzeStatus deletedExternalStatus = new ExternalAnalyzeStatus(-1, "hive0", "partitioned_db",
+                    "tx", "tx:xxxx", Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
+                    StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.of(2020, 1, 1, 1, 1));
+            deletedExternalStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
+
+            // Lightweight path (default): the BasicTable stub is non-null without touching the
+            // connector, so the row for a dropped external table is now rendered instead of being
+            // silently filtered out.
+            Config.enable_external_catalog_information_schema_tables_access_full_metadata = false;
+            List<String> deletedRow =
+                    ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), deletedExternalStatus);
+            Assertions.assertNotNull(deletedRow);
+            Assertions.assertEquals("hive0.partitioned_db", deletedRow.get(1));
+            Assertions.assertEquals("tx", deletedRow.get(2));
+            Assertions.assertEquals("SUCCESS", deletedRow.get(6));
+
+            // Full-metadata path: getTable cannot resolve the dropped table, so the legacy
+            // fail-soft null (row filtered out) is preserved.
+            Config.enable_external_catalog_information_schema_tables_access_full_metadata = true;
+            Assertions.assertNull(
+                    ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), deletedExternalStatus));
+
+            // Case 2: an explicit column list equal to the table's full collectible set.
+            Table ordersTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getTable(getConnectContext(), "hive0", "partitioned_db", "orders");
+            List<String> allColumns = StatisticUtils.getCollectibleColumns(ordersTable);
+            AnalyzeStatus fullColumnsStatus = new ExternalAnalyzeStatus(-1, "hive0", "partitioned_db",
+                    "orders", "orders:xxxx", allColumns, StatsConstants.AnalyzeType.FULL,
+                    StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.of(2020, 1, 1, 1, 1));
+            fullColumnsStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
+
+            // Lightweight path: no schema is available, so the explicit column list is rendered
+            // verbatim instead of collapsing to "ALL".
+            Config.enable_external_catalog_information_schema_tables_access_full_metadata = false;
+            List<String> namedColumnsRow =
+                    ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), fullColumnsStatus);
+            Assertions.assertNotNull(namedColumnsRow);
+            Assertions.assertEquals(String.join(",", allColumns), namedColumnsRow.get(3));
+
+            // Full-metadata path: the real table schema is available, so a complete column list
+            // still collapses to "ALL" (legacy rendering).
+            Config.enable_external_catalog_information_schema_tables_access_full_metadata = true;
+            List<String> allColumnsRow =
+                    ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), fullColumnsStatus);
+            Assertions.assertNotNull(allColumnsRow);
+            Assertions.assertEquals("ALL", allColumnsRow.get(3));
+        } finally {
+            Config.enable_external_catalog_information_schema_tables_access_full_metadata = savedFetchFullMetadata;
+        }
 
         sql = "show histogram meta where updateTime = '2020-01-01 01:01:00'";
         ShowHistogramStatsMetaStmt showHistogramStatsMetaStmt = (ShowHistogramStatsMetaStmt) analyzeSuccess(sql);


### PR DESCRIPTION
## Why I'm doing:

`SHOW ANALYZE JOB` and `SHOW ANALYZE STATUS` are extremely slow on environments with external catalog analyze jobs.

`ShowAnalyzeJobStmt` and `ShowAnalyzeStatusStmt` call `metadataMgr.getTable()` once per output row for the privilege check and to render the table name. For analyze entries on external catalogs (Iceberg, Hive, Hudi, JDBC, ...) `getTable()` triggers a full metadata fetch per row — one network round trip for every line in the result.

This is the same N+1 problem that #70197 fixed for `information_schema.tables_config` via `metadataMgr.getBasicTable()`. The downstream `Authorizer.checkAnyActionOnTableLikeObject` already accepts the `BasicTable` interface directly — no cast needed.

## What I'm doing:

Switch both call sites to `metadataMgr.getBasicTable(...)`, which is the lightweight variant designed to avoid network interaction with external services (see `BasicTable` javadoc).

Honour the existing config flag `enable_external_catalog_information_schema_tables_access_full_metadata` introduced in #70197 so operators keep a single switch for opting in to full external metadata fetches across all `information_schema` / `SHOW` paths.

For the internal catalog `getBasicTable(...)` still returns a full `Table`, so the legacy `Columns` rendering (collapse to `"ALL"` when the explicit column list equals the full schema) is preserved via an `instanceof Table` cast. For external catalogs no schema is available without network IO, so the captured column names are always rendered.

## Behavior change (external catalogs only)

This PR intentionally changes two visible behaviors for external-catalog rows in `SHOW ANALYZE JOB` / `SHOW ANALYZE STATUS`:

1. Rows for tables that have been **deleted in the source catalog** (Hive/Iceberg) are no longer silently filtered out. The old code relied on `getTable()` returning `null` for missing external tables, throwing `SemanticException`, and the catch returning `null`. The new lightweight path cannot detect deletion without doing the very network IO this PR avoids, so such rows are now rendered with whatever name/columns were captured at analyze time.
2. When the user explicitly listed **all** columns in `ANALYZE TABLE ... (c1,...,cn)` on an external catalog, the `Columns` field used to collapse to `"ALL"`; it now always renders the captured names. Same root cause — we don't have the schema on the lightweight path.

Internal-catalog behavior is unchanged.

Fixes #47295
Related: #70197

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
