### PR TITLE
[Enhancement] support upsert/delete mix transaction rebuild in cloud native pk index

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -122,6 +122,8 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         DelfileWithRowsetId del_file_with_rid;
         del_file_with_rid.set_name(op_write.dels(i));
         del_file_with_rid.set_origin_rowset_id(rowset->id());
+        // For now, op_offset is always max segment's id
+        del_file_with_rid.set_op_offset(std::max(op_write.rowset().segments_size(), 1) - 1);
         rowset->add_del_files()->CopyFrom(del_file_with_rid);
     }
     // if rowset don't contain segment files, still inc next_rowset_id

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -102,7 +102,8 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
             update_index_value(&old_index_value_vers, version, IndexValue(NullIndexValue));
         }
     }
-    _max_rss_rowid = std::max(_max_rss_rowid, ((uint64_t)rowset_id) << 32);
+    // Delete is after upsert, so using UINT32_MAX as it's rowid
+    _max_rss_rowid = std::max(_max_rss_rowid, ((uint64_t)rowset_id) << 32 | (uint64_t)UINT32_MAX);
     *num_found = nfound;
     return Status::OK();
 }
@@ -124,7 +125,8 @@ Status PersistentIndexMemtable::erase_with_filter(size_t n, const Slice* keys, c
             update_index_value(&old_index_value_vers, version, IndexValue(NullIndexValue));
         }
     }
-    _max_rss_rowid = std::max(_max_rss_rowid, ((uint64_t)rowset_id) << 32);
+    // Delete is after upsert, so using UINT32_MAX as it's rowid
+    _max_rss_rowid = std::max(_max_rss_rowid, ((uint64_t)rowset_id) << 32 | (uint64_t)UINT32_MAX);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -219,10 +219,9 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     for (uint32_t segment_id = 0; segment_id < op_write.rowset().segments_size(); segment_id++) {
         new_deletes[rowset_id + segment_id] = {};
     }
-    // Delete is always after upsert now, so use max segment id in this rowset as it's rssid.
-    // E.g. if rowset's id is 10, and there are two segments in this rowset,
-    //      so rssid of these segments is 10 an 11. And we choose 11 as delete's rebuild rssid
-    // TODO : support mix order of upsert and delete in one transaction.
+    // Rssid of delete files is equal to `rowset_id + op_offset`, and delete is always after upsert now,
+    // so we use max segment id as `op_offset`.
+    // TODO : support real order of mix upsert and delete in one transaction.
     const uint32_t del_rebuild_rssid = rowset_id + std::max(op_write.rowset().segments_size(), 1) - 1;
     // 2. Handle segment one by one to save memory usage.
     for (uint32_t segment_id = 0; segment_id < op_write.rowset().segments_size(); segment_id++) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1364,6 +1364,86 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels3) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).del_files_size(), 2);
 }
 
+TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels4) {
+    std::vector<std::pair<ChunkPtr, std::vector<uint32_t>>> chunks;
+    // upsert + delete
+    chunks.push_back(gen_data_and_index(kChunkSize, 0, true, true));
+    chunks.push_back(gen_data_and_index(kChunkSize, 0, false, false));
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    const int64_t old_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    auto old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 1;
+    // publish upsert and delete on one txn
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->write(*(chunks[1].first), chunks[1].second.data(), chunks[1].second.size()));
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    config::write_buffer_size = old_size;
+    config::l0_max_mem_usage = old_val;
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).segments_size(), 5);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).del_files_size(), 1);
+    EXPECT_EQ(0, read_rows(tablet_id, version));
+
+    // compact
+    {
+        auto old_val = config::lake_pk_compaction_min_input_segments;
+        config::lake_pk_compaction_min_input_segments = 1;
+        int64_t txn_id = next_id();
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+        ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+        EXPECT_EQ(100, task_context->progress.value());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        config::lake_pk_compaction_min_input_segments = old_val;
+    }
+    // clear index, and then rebuild
+    EXPECT_TRUE(_update_mgr->try_remove_primary_index_cache(tablet_id));
+    {
+        // re write chunk0
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*(chunks[0].first), chunks[0].second.data(), chunks[0].second.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    EXPECT_EQ(kChunkSize, read_rows(tablet_id, version));
+}
+
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,
                          ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
                                            PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE}));

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -70,6 +70,11 @@ message DelfileWithRowsetId {
     optional string name = 1;
     // origin rowset that generate this del file.
     optional uint32 origin_rowset_id = 2;
+    // If there is a upsert and delete mix transaction, we use
+    // `op_offset` to identify the order of deletes.
+    // E.g. there are <upsert, upsert, upsert, delete> in a transaction,
+    //      so the `op_offset` of this delete is 2.
+    optional uint32 op_offset = 3;
 }
 
 message RowsetMetadataPB {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -70,10 +70,19 @@ message DelfileWithRowsetId {
     optional string name = 1;
     // origin rowset that generate this del file.
     optional uint32 origin_rowset_id = 2;
-    // If there is a upsert and delete mix transaction, we use
-    // `op_offset` to identify the order of deletes.
-    // E.g. there are <upsert, upsert, upsert, delete> in a transaction,
-    //      so the `op_offset` of this delete is 2.
+    // Because of historical reason, DELETE don't have its own segment id, we only use
+    // `rowset_id + segment_id` for UPSERT.
+    // So if there is a UPSERT and DELETE mix transaction, we use
+    // `op_offset` to identify the order of deletes, and rssid of DELETE will be
+    // just same as previous UPSERT. And if the Rowset don't have UPSERT, DELETE's rssid
+    // will be same as rowset_id.
+    //
+    // E.g. there are <UPSERT, UPSERT, UPSERT, DELETE, DELETE> in a transaction,
+    //      so the `op_offset` of this DELETE is 2.
+    //      And rssid of them will be rowset_id + [0, 1, 2, 2, 2].
+    //
+    //      there are <DELETE, DELETE> in a transaction, so the `op_offset` of this DELETE is 0.
+    //      And rssid of them will be rowset_id + [0, 0].
     optional uint32 op_offset = 3;
 }
 


### PR DESCRIPTION
## Why I'm doing:
When we do data ingestion though broker load or stream load, SR support handle mix UPSERT and DELETE operations in one transaction. And when using cloud native pk index, we need to decide the rebuild order of UPSERT and DELETE in this mix transaction.

## What I'm doing:
1. Add `op_offset` to `DelfileWithRowsetId`.
```
E.g.
There are <UPSERT, UPSERT, UPSERT, DELETE> in a mix transaction,
then `op_offset` of this DELETE is 2.
```
Then we use `rowset_id + op_offset` as rssid of this delete files, decide its rebuild order when handle cloud native pk index rebuild.
> Notice, we always put DELETE after UPSERT in cloud native now, will support real order mix transaction later.

2. Using `UINT32_MAX` as DELETE record's Rowid, because when one of UPSERT and DELETE have same `rssid`, DELETE is always ordered after UPSERT.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
