### PR TITLE
[Enhancement] Limit the number of partitions initially opened by expression partition ingestion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2063,6 +2063,12 @@ public class Config extends ConfigBase {
     public static long max_automatic_partition_number = 4096;
 
     /**
+     * Used to limit num of partition for load open partition number
+     */
+    @ConfField(mutable = true)
+    public static long max_load_initial_open_partition_number = 32;
+
+    /**
      * enable automatic bucket for random distribution table
      */
     @ConfField(mutable = true)


### PR DESCRIPTION
## Why I'm doing:
Currently, when we ingest data, unless a partition is specified, information for all partitions is sent, causing the storage side to open delta writers for all partitions. When there are many partitions, this can consume a large amount of unnecessary memory, even though only a few partitions typically have data written to them. 

## What I'm doing:
This optimization controls the number of partitions sent, allowing the storage side to initially open fewer delta writers. Subsequently, using a mechanism similar to expression partitioning, it dynamically opens the required partitions based on the data during runtime. This approach can significantly reduce memory consumption.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
