### PR TITLE
[Enhancement] add spilling capability for multi_cast_local_exchange operator

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1050,6 +1050,7 @@ CONF_Int64(spill_max_log_block_container_bytes, "10737418240"); // 10GB
 CONF_mDouble(spill_max_dir_bytes_ratio, "0.8"); // 80%
 // min bytes size of spill read buffer. if the buffer size is less than this value, we will disable buffer read
 CONF_Int64(spill_read_buffer_min_bytes, "1048576");
+CONF_mInt64(mem_limited_chunk_queue_block_size, "8388608");
 
 CONF_Int32(internal_service_query_rpc_thread_num, "-1");
 

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -174,6 +174,8 @@ set(EXEC_FILES
     pipeline/exchange/local_exchange_sink_operator.cpp
     pipeline/exchange/local_exchange_source_operator.cpp
     pipeline/exchange/multi_cast_local_exchange.cpp
+    pipeline/exchange/mem_limited_chunk_queue.cpp
+    pipeline/exchange/spillable_multi_cast_local_exchange.cpp
     pipeline/exchange/multi_cast_local_exchange_sink_operator.cpp
     pipeline/exchange/multi_cast_local_exchange_source_operator.cpp
     pipeline/exchange/sink_buffer.cpp

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -1,0 +1,529 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/exchange/mem_limited_chunk_queue.h"
+
+#include <algorithm>
+
+#include "common/logging.h"
+#include "exec/pipeline/exchange/multi_cast_local_exchange.h"
+#include "exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h"
+#include "exec/spill/block_manager.h"
+#include "exec/spill/data_stream.h"
+#include "exec/spill/dir_manager.h"
+#include "exec/spill/executor.h"
+#include "exec/spill/mem_table.h"
+#include "exec/spill/options.h"
+#include "fmt/format.h"
+#include "fs/fs.h"
+#include "serde/column_array_serde.h"
+#include "serde/protobuf_serde.h"
+#include "testutil/sync_point.h"
+#include "util/defer_op.h"
+#include "util/raw_container.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::pipeline {
+
+MemLimitedChunkQueue::MemLimitedChunkQueue(RuntimeState* state, int32_t consumer_number, Options opts)
+        : _state(state),
+          _consumer_number(consumer_number),
+          _opened_source_opcount(consumer_number),
+          _consumer_progress(consumer_number),
+          _opts(std::move(opts)) {
+    Block* block = new Block();
+    _head = block;
+    _tail = block;
+    _next_flush_block = block;
+    // push a dummy Cell
+    Cell dummy;
+    dummy.used_count = consumer_number;
+    _tail->cells.emplace_back(dummy);
+
+    for (int32_t i = 0; i < consumer_number; i++) {
+        // init as dummy cell
+        _consumer_progress[i] = std::make_unique<Iterator>(_head, 0);
+        _opened_source_opcount[i] = 0;
+    }
+
+    _iterator.block = _head;
+    _iterator.index = 0;
+}
+
+MemLimitedChunkQueue::~MemLimitedChunkQueue() {
+    while (_head) {
+        Block* next = _head->next;
+        delete _head;
+        _head = next;
+    }
+}
+
+Status MemLimitedChunkQueue::init_metrics(RuntimeProfile* parent) {
+    _peak_memory_bytes_counter = parent->AddHighWaterMarkCounter(
+            "ExchangerPeakMemoryUsage", TUnit::BYTES,
+            RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
+    _peak_memory_rows_counter = parent->AddHighWaterMarkCounter(
+            "ExchangerPeakBufferRowSize", TUnit::UNIT,
+            RuntimeProfile::Counter::create_strategy(TUnit::UNIT, TCounterMergeType::SKIP_FIRST_MERGE));
+
+    _flush_io_timer = ADD_TIMER(parent, "FlushIOTime");
+    _flush_io_count = ADD_COUNTER(parent, "FlushIOCount", TUnit::UNIT);
+    _flush_io_bytes = ADD_COUNTER(parent, "FlushIOBytes", TUnit::BYTES);
+    _read_io_timer = ADD_TIMER(parent, "ReadIOTime");
+    _read_io_count = ADD_COUNTER(parent, "ReadIOCount", TUnit::UNIT);
+    _read_io_bytes = ADD_COUNTER(parent, "ReadIOBytes", TUnit::BYTES);
+    return Status::OK();
+}
+
+Status MemLimitedChunkQueue::push(const ChunkPtr& chunk) {
+    RETURN_IF_ERROR(get_io_task_status());
+    std::unique_lock l(_mutex);
+    if (UNLIKELY(_chunk_builder == nullptr)) {
+        _chunk_builder = chunk->clone_empty();
+    }
+    int32_t closed_source_number = _consumer_number - _opened_source_number;
+
+    DCHECK(_tail != nullptr) << "tail won't be null";
+    DCHECK(_tail->next == nullptr) << "tail should be the last block";
+
+    // create a new block
+    if (_tail->memory_usage >= _opts.block_size) {
+        Block* block = new Block();
+        block->next = nullptr;
+        _tail->next = block;
+        _tail = block;
+    }
+
+    _total_accumulated_rows += chunk->num_rows();
+    _total_accumulated_bytes += chunk->memory_usage();
+
+    Cell cell;
+    cell.chunk = chunk;
+    cell.used_count = closed_source_number;
+    cell.accumulated_rows = _total_accumulated_rows;
+    cell.accumulated_bytes = _total_accumulated_bytes;
+    _tail->cells.emplace_back(cell);
+    _tail->memory_usage += chunk->memory_usage();
+
+    size_t in_memory_rows = _total_accumulated_rows - _flushed_accumulated_rows + _current_load_rows;
+    size_t in_memory_bytes = _total_accumulated_bytes - _flushed_accumulated_bytes + _current_load_bytes;
+
+#ifndef BE_TEST
+    _peak_memory_rows_counter->set(in_memory_rows);
+    _peak_memory_bytes_counter->set(in_memory_bytes);
+#endif
+    return Status::OK();
+}
+
+bool MemLimitedChunkQueue::can_push() {
+    std::shared_lock l(_mutex);
+    size_t unconsumed_bytes = _total_accumulated_bytes - _fastest_accumulated_bytes;
+    // if the fastest consumer still has a lot of data to consume, it will no longer accept new input.
+    if (unconsumed_bytes >= _opts.max_unconsumed_bytes) {
+        return false;
+    }
+
+    size_t in_memory_bytes = _total_accumulated_bytes - _flushed_accumulated_bytes;
+    if (in_memory_bytes >= _opts.memory_limit && _next_flush_block->next != nullptr) {
+        if (bool expected = false; _has_flush_io_task.compare_exchange_strong(expected, true)) {
+            TEST_SYNC_POINT("MemLimitedChunkQueue::can_push::before_submit_flush_task");
+            auto status = submit_flush_task();
+            if (!status.ok()) {
+                update_io_task_status(status);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return true;
+}
+
+StatusOr<ChunkPtr> MemLimitedChunkQueue::pop(int32_t consumer_index) {
+    DCHECK(consumer_index <= _consumer_number);
+    RETURN_IF_ERROR(get_io_task_status());
+    std::unique_lock l(_mutex);
+
+    DCHECK(_consumer_progress[consumer_index] != nullptr);
+    auto iter = _consumer_progress[consumer_index].get();
+    if (!iter->has_next()) {
+        if (_opened_sink_number == 0) {
+            return Status::EndOfFile("no more data");
+        }
+        return Status::InternalError("unreachable path");
+    }
+    iter->move_to_next();
+    DCHECK(iter->get_block()->in_mem);
+    Cell* cell = iter->get_cell();
+    DCHECK(cell->chunk != nullptr);
+
+    cell->used_count += 1;
+    VLOG_ROW << fmt::format(
+            "[MemLimitedChunkQueue] pop chunk for consumer[{}] from block[{}], accumulated_rows[{}], "
+            "accumulated_bytes[{}], used_count[{}]",
+            consumer_index, (void*)(iter->get_block()), cell->accumulated_rows, cell->accumulated_bytes,
+            cell->used_count);
+    auto result = cell->chunk;
+
+    _update_progress(iter);
+    return result;
+}
+
+void MemLimitedChunkQueue::evict_loaded_block() {
+    if (_loaded_blocks.size() < _consumer_number) {
+        return;
+    }
+    Block* block = _loaded_blocks.front();
+    _loaded_blocks.pop();
+    _current_load_rows -= block->flush_rows;
+    _current_load_bytes -= block->flush_bytes;
+    for (auto& cell : block->cells) {
+        if (cell.chunk != nullptr) {
+            cell.chunk.reset();
+        }
+    }
+    block->in_mem = false;
+    VLOG_ROW << fmt::format("[MemLimitedChunkQueue] evict block [{}]", (void*)block);
+}
+
+bool MemLimitedChunkQueue::can_pop(int32_t consumer_index) {
+    DCHECK(consumer_index < _consumer_number);
+    std::shared_lock l(_mutex);
+    DCHECK(_consumer_progress[consumer_index] != nullptr);
+
+    auto iter = _consumer_progress[consumer_index].get();
+    if (iter->has_next()) {
+        auto next_iter = iter->next();
+        if (next_iter.block->in_mem) {
+            return true;
+        }
+        TEST_SYNC_POINT_CALLBACK("MemLimitedChunkQueue::can_pop::before_submit_load_task", next_iter.block);
+        if (bool expected = false; next_iter.block->has_load_task.compare_exchange_strong(expected, true)) {
+            VLOG_ROW << fmt::format("[MemLimitedChunkQueue] submit load task for block [{}]", (void*)next_iter.block);
+            auto status = submit_load_task(next_iter.block);
+            if (!status.ok()) {
+                update_io_task_status(status);
+                return true;
+            }
+        }
+        return false;
+    } else if (_opened_sink_number == 0) {
+        return true;
+    }
+
+    return false;
+}
+
+void MemLimitedChunkQueue::open_consumer(int32_t consumer_index) {
+    std::unique_lock l(_mutex);
+    if (_opened_source_opcount[consumer_index] == 0) {
+        _opened_source_number++;
+    }
+    _opened_source_opcount[consumer_index]++;
+}
+
+void MemLimitedChunkQueue::close_consumer(int32_t consumer_index) {
+    std::unique_lock l(_mutex);
+    _opened_source_opcount[consumer_index] -= 1;
+    if (_opened_source_opcount[consumer_index] == 0) {
+        _opened_source_number--;
+        _close_consumer(consumer_index);
+    }
+}
+
+void MemLimitedChunkQueue::open_producer() {
+    std::unique_lock l(_mutex);
+    _opened_sink_number++;
+}
+
+void MemLimitedChunkQueue::close_producer() {
+    std::unique_lock l(_mutex);
+    _opened_sink_number--;
+}
+
+void MemLimitedChunkQueue::_update_progress(Iterator* iter) {
+    if (iter != nullptr) {
+        Cell* cell = iter->get_cell();
+        _fastest_accumulated_rows = std::max(_fastest_accumulated_rows, cell->accumulated_rows);
+        _fastest_accumulated_bytes = std::max(_fastest_accumulated_bytes, cell->accumulated_bytes);
+    } else {
+        // nullptr means one consumer is closed, should update
+        _fastest_accumulated_rows = 0;
+        _fastest_accumulated_bytes = 0;
+        for (int32_t i = 0; i < _consumer_number; i++) {
+            auto iter = _consumer_progress[i].get();
+            if (iter == nullptr) {
+                continue;
+            }
+            if (!iter->has_next()) {
+                // all data is consumed
+                _fastest_accumulated_rows = _total_accumulated_rows;
+                _fastest_accumulated_bytes = _total_accumulated_bytes;
+                break;
+            }
+            Cell* cell = iter->get_cell();
+            _fastest_accumulated_rows = std::max(_fastest_accumulated_rows, cell->accumulated_rows);
+            _fastest_accumulated_bytes = std::max(_fastest_accumulated_bytes, cell->accumulated_bytes);
+        }
+    }
+
+    while (_iterator.valid()) {
+        Cell* cell = _iterator.get_cell();
+        if (cell->used_count != _consumer_number) {
+            break;
+        }
+        _head_accumulated_rows = cell->accumulated_rows;
+        _head_accumulated_bytes = cell->accumulated_bytes;
+        // advance flushed position
+        _flushed_accumulated_rows = std::max(_flushed_accumulated_rows, _head_accumulated_rows);
+        _flushed_accumulated_bytes = std::max(_flushed_accumulated_bytes, _head_accumulated_bytes);
+        VLOG_ROW << fmt::format("release chunk, current head_accumulated_rows[{}], head_accumulated_bytes[{}]",
+                                _head_accumulated_rows, _head_accumulated_bytes);
+        cell->chunk.reset();
+        if (_iterator.has_next()) {
+            _iterator.move_to_next();
+        } else {
+            break;
+        }
+    }
+}
+
+void MemLimitedChunkQueue::_close_consumer(int32_t consumer_index) {
+    DCHECK(_consumer_progress[consumer_index] != nullptr);
+    auto iter = _consumer_progress[consumer_index].get();
+    if (iter->has_next()) {
+        do {
+            iter->move_to_next();
+            Cell* cell = iter->get_cell();
+            cell->used_count += 1;
+        } while (iter->has_next());
+    }
+    _consumer_progress[consumer_index].reset();
+    _update_progress();
+}
+
+Status MemLimitedChunkQueue::flush() {
+    Block* block = nullptr;
+    std::vector<ChunkPtr> chunks;
+    {
+        std::unique_lock l(_mutex);
+
+        // 1. find block to flush
+        while (_next_flush_block) {
+            // don't flush the last block
+            if (_next_flush_block->next == nullptr) {
+                break;
+            }
+            if (_next_flush_block->block) {
+                // already flushed, should skip it
+                _next_flush_block = _next_flush_block->next;
+            } else {
+                // check if need flush
+                chunks.clear();
+                std::for_each(_next_flush_block->cells.begin(), _next_flush_block->cells.end(),
+                              [&chunks, this](Cell& cell) {
+                                  if (cell.chunk == nullptr || cell.used_count == _consumer_number) {
+                                      return;
+                                  }
+                                  cell.flushed = true;
+                                  chunks.emplace_back(cell.chunk);
+                              });
+                if (!chunks.empty()) {
+                    break;
+                }
+                _next_flush_block = _next_flush_block->next;
+            }
+        }
+        block = _next_flush_block;
+        DCHECK(block != nullptr) << "block can't be null";
+        if (block->next == nullptr) {
+            return Status::OK();
+        }
+        if (block->block != nullptr) {
+            return Status::OK();
+        }
+    }
+
+    DCHECK(!chunks.empty());
+
+    size_t max_serialize_size = 0;
+    size_t flushed_rows = 0, flushed_bytes = 0;
+    for (auto& chunk : chunks) {
+        for (const auto& column : chunk->columns()) {
+            max_serialize_size += serde::ColumnArraySerde::max_serialized_size(*column, _opts.encode_level);
+        }
+        flushed_rows += chunk->num_rows();
+        flushed_bytes += chunk->memory_usage();
+    }
+    std::shared_ptr<spill::Block> spill_block;
+
+    TEST_SYNC_POINT_CALLBACK("MemLimitedChunkQueue::after_calculate_max_serialize_size", &max_serialize_size);
+    raw::RawString serialize_buffer;
+    serialize_buffer.resize(max_serialize_size);
+    uint8_t* buf = reinterpret_cast<uint8_t*>(serialize_buffer.data());
+    uint8_t* begin = buf;
+    // 2. serialize data
+    for (auto& chunk : chunks) {
+        for (const auto& column : chunk->columns()) {
+            buf = serde::ColumnArraySerde::serialize(*column, buf, false, _opts.encode_level);
+            RETURN_IF(buf == nullptr, Status::InternalError("serialize data error"));
+        }
+    }
+    size_t content_length = buf - begin;
+    // 3. acquire block
+    spill::AcquireBlockOptions options;
+    options.block_size = content_length;
+    options.direct_io = false;
+    options.query_id = _state->query_id();
+    options.fragment_instance_id = _state->fragment_instance_id();
+    options.name = "mcast_local_exchange";
+    options.plan_node_id = _opts.plan_node_id;
+    ASSIGN_OR_RETURN(spill_block, _opts.block_manager->acquire_block(options));
+
+    // 4. flush serialized data
+    std::vector<Slice> data;
+    data.emplace_back(serialize_buffer.data(), content_length);
+    {
+        SCOPED_TIMER(_flush_io_timer);
+        RETURN_IF_ERROR(spill_block->append(data));
+        RETURN_IF_ERROR(spill_block->flush());
+        COUNTER_UPDATE(_flush_io_count, 1);
+        COUNTER_UPDATE(_flush_io_bytes, content_length);
+    }
+
+    {
+        std::unique_lock l(_mutex);
+        block->block = spill_block;
+        block->in_mem = false;
+        // 5. clear flushed data in memory
+        for (auto& cell : block->cells) {
+            if (cell.flushed) {
+                cell.chunk.reset();
+                block->flush_chunks++;
+            }
+        }
+        block->flush_rows = flushed_rows;
+        block->flush_bytes = flushed_bytes;
+        _flushed_accumulated_rows = block->cells.back().accumulated_rows;
+        _flushed_accumulated_bytes = block->cells.back().accumulated_bytes;
+        _next_flush_block = block->next;
+        VLOG_ROW << fmt::format("flush block [{}], rows[{}], bytes[{}]", (void*)block, _flushed_accumulated_rows,
+                                _flushed_accumulated_bytes);
+        TEST_SYNC_POINT_CALLBACK("MemLimitedChunkQueue::after_flush_block", block);
+    }
+    return Status::OK();
+}
+
+Status MemLimitedChunkQueue::submit_flush_task() {
+    auto flush_task = [this, guard = RESOURCE_TLS_MEMTRACER_GUARD(_state)](auto& yield_ctx) {
+        TEST_SYNC_POINT("MemLimitedChunkQueue::before_execute_flush_task");
+        RETURN_IF(!guard.scoped_begin(), (void)0);
+        DEFER_GUARD_END(guard);
+        auto defer = DeferOp([&]() {
+            _has_flush_io_task = false;
+            TEST_SYNC_POINT("MemLimitedChunkQueue::after_execute_flush_task");
+        });
+
+        auto status = flush();
+        if (!status.ok()) {
+            update_io_task_status(status);
+            return;
+        }
+    };
+
+    auto io_task = workgroup::ScanTask(_state->fragment_ctx()->workgroup().get(), std::move(flush_task));
+    RETURN_IF_ERROR(spill::IOTaskExecutor::submit(std::move(io_task)));
+    return Status::OK();
+}
+
+// reload block from disk
+Status MemLimitedChunkQueue::load(Block* block) {
+    std::shared_ptr<spill::BlockReader> block_reader;
+    raw::RawString buffer;
+    size_t block_len;
+    size_t flush_chunks;
+    // 1. read serialize data
+    {
+        std::shared_lock l(_mutex);
+        DCHECK(!block->in_mem) << "block should not be in memory, " << (void*)(block);
+        DCHECK(block->block != nullptr) << "block must have spill block";
+
+        spill::BlockReaderOptions options;
+        options.enable_buffer_read = true;
+        options.read_io_timer = _read_io_timer;
+        options.read_io_count = _read_io_count;
+        options.read_io_bytes = _read_io_bytes;
+        block_reader = block->block->get_reader(options);
+        block_len = block->block->size();
+        flush_chunks = block->flush_chunks;
+    }
+    buffer.resize(block_len);
+    RETURN_IF_ERROR(block_reader->read_fully(buffer.data(), block_len));
+
+    // 2. deserialize data
+    uint8_t* buf = reinterpret_cast<uint8_t*>(buffer.data());
+    const uint8_t* read_cursor = buf;
+    std::vector<ChunkPtr> chunks(flush_chunks);
+    for (auto& chunk : chunks) {
+        chunk = _chunk_builder->clone_empty();
+        for (auto& column : chunk->columns()) {
+            read_cursor = serde::ColumnArraySerde::deserialize(read_cursor, column.get(), false, _opts.encode_level);
+            RETURN_IF(read_cursor == nullptr, Status::InternalError("deserialize failed"));
+        }
+    }
+    {
+        std::unique_lock l(_mutex);
+        for (size_t i = 0, j = 0; i < chunks.size() && j < block->cells.size(); j++) {
+            if (block->cells[j].flushed) {
+                block->cells[j].chunk = chunks[i++];
+            }
+        }
+        block->in_mem = true;
+        block->has_load_task = false;
+        evict_loaded_block();
+        _loaded_blocks.push(block);
+        _current_load_rows += block->flush_rows;
+        _current_load_bytes += block->flush_bytes;
+        VLOG_ROW << fmt::format("load block done, block[{}], current load rows[{}], current load bytes[{}]",
+                                (void*)block, _current_load_rows, _current_load_bytes);
+    }
+
+    return Status::OK();
+}
+
+Status MemLimitedChunkQueue::submit_load_task(Block* block) {
+    auto load_task = [this, block, guard = RESOURCE_TLS_MEMTRACER_GUARD(_state)](auto& yield_ctx) {
+        TEST_SYNC_POINT_CALLBACK("MemLimitedChunkQueue::before_execute_load_task", block);
+        RETURN_IF(!guard.scoped_begin(), (void)0);
+        DEFER_GUARD_END(guard);
+        auto status = load(block);
+        if (!status.ok()) {
+            update_io_task_status(status);
+        }
+    };
+    auto io_task = workgroup::ScanTask(_state->fragment_ctx()->workgroup().get(), std::move(load_task));
+    RETURN_IF_ERROR(spill::IOTaskExecutor::submit(std::move(io_task)));
+    return Status::OK();
+}
+
+const size_t memory_limit_per_producer = 1L * 1024 * 1024;
+
+void MemLimitedChunkQueue::enter_release_memory_mode() {
+    std::unique_lock l(_mutex);
+    size_t new_memory_limit = memory_limit_per_producer * _opened_sink_number;
+    VLOG_ROW << fmt::format("change memory limit from [{}] to [{}]", _opts.memory_limit, new_memory_limit);
+    _opts.memory_limit = new_memory_limit;
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
@@ -183,10 +183,6 @@ private:
         return status == nullptr ? Status::OK() : *status;
     }
 
-#ifdef BE_TEST
-public:
-#endif
-
     RuntimeState* _state = nullptr;
     std::shared_mutex _mutex;
     // an empty chunk, only keep meta

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
@@ -1,0 +1,218 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <queue>
+
+#include "exec/pipeline/exchange/multi_cast_local_exchange.h"
+#include "serde/encode_context.h"
+
+namespace starrocks::pipeline {
+
+class MemLimitedChunkQueue {
+private:
+    struct Cell {
+        ChunkPtr chunk;
+        size_t accumulated_rows = 0;
+        size_t accumulated_bytes = 0;
+        int32_t used_count = 0;
+        bool flushed = false;
+    };
+
+    struct Block {
+        std::vector<Cell> cells;
+        bool in_mem = true;
+        std::atomic_bool has_load_task = false;
+        size_t memory_usage = 0;
+        Block* next = nullptr;
+        // spillable block, only used when spill happens
+        spill::BlockPtr block;
+        size_t flush_chunks = 0;
+        size_t flush_rows = 0;
+        size_t flush_bytes = 0;
+    };
+
+    struct Iterator {
+        Iterator() = default;
+        Iterator(Block* blk, size_t idx) : block(blk), index(idx) {}
+        Block* block = nullptr;
+        size_t index = 0;
+
+        bool valid() const { return block != nullptr && index < block->cells.size(); }
+
+        bool has_next() const {
+            if (block == nullptr) {
+                return false;
+            }
+            if (index + 1 == block->cells.size()) {
+                // current block is end, should check next
+                if (block->next != nullptr && !block->next->cells.empty()) {
+                    return true;
+                }
+                return false;
+            }
+            // still has un-consumed data in current block
+            return true;
+        }
+
+        // return an copy of next cell
+        Iterator next() const {
+            DCHECK(has_next());
+            Iterator iter(block, index);
+            iter.move_to_next();
+            return iter;
+        }
+        void move_to_next() {
+            DCHECK(has_next());
+            index++;
+            DCHECK_LE(index, block->cells.size());
+            if (index == block->cells.size()) {
+                block = block->next;
+                index = 0;
+            }
+        }
+
+        Cell* get_cell() {
+            DCHECK(block != nullptr);
+            DCHECK(index < block->cells.size()) << ", invalid index: " << index << ", size: " << block->cells.size();
+            return &(block->cells[index]);
+        }
+
+        Block* get_block() { return block; }
+    };
+    static const size_t kDefaultBlockSize = 8L * 1024 * 1024;
+    static const size_t kDefaultMaxUnconsumedBytes = 16L * 1024 * 1024;
+    static const size_t kDefaultMemoryLimit = 16L * 1024 * 1024;
+
+public:
+    struct Options {
+        int32_t plan_node_id = 0;
+        // memory block size
+        size_t block_size = kDefaultBlockSize;
+        size_t memory_limit = kDefaultMemoryLimit;
+        size_t max_unconsumed_bytes = kDefaultMaxUnconsumedBytes;
+        int encode_level = 7;
+        CompressionTypePB compress_type = CompressionTypePB::LZ4;
+        spill::BlockManager* block_manager = nullptr;
+        workgroup::WorkGroupPtr wg;
+    };
+
+    MemLimitedChunkQueue(RuntimeState* state, int32_t consumer_number, Options opts);
+    ~MemLimitedChunkQueue();
+
+    Status init_metrics(RuntimeProfile* parent);
+
+    Status push(const ChunkPtr& chunk);
+    bool can_push();
+
+    StatusOr<ChunkPtr> pop(int32_t consumer_index);
+    bool can_pop(int32_t consumer_index);
+
+    void open_consumer(int32_t consumer_index);
+
+    void close_consumer(int32_t consumer_index);
+
+    void open_producer();
+
+    void close_producer();
+
+    void enter_release_memory_mode();
+
+private:
+    void _update_progress(Iterator* iter = nullptr);
+
+    void _close_consumer(int32_t consumer_index);
+
+    Status flush();
+    // trigger flush task
+    Status submit_flush_task();
+    // reload block from disk
+    Status load(Block* block);
+    Status submit_load_task(Block* block);
+
+    void evict_loaded_block();
+
+    inline void update_io_task_status(const Status& status) {
+        if (status.ok() || _io_task_status.load() != nullptr) {
+            return;
+        }
+        std::shared_ptr<Status> old_status;
+        auto new_status = std::make_shared<Status>(status);
+        _io_task_status.compare_exchange_strong(old_status, new_status);
+    }
+    Status get_io_task_status() const {
+        auto status = _io_task_status.load();
+        return status == nullptr ? Status::OK() : *status;
+    }
+
+#ifdef BE_TEST
+public:
+#endif
+
+    RuntimeState* _state = nullptr;
+    std::shared_mutex _mutex;
+    // an empty chunk, only keep meta
+    ChunkPtr _chunk_builder;
+    Block* _head = nullptr;
+    Block* _tail = nullptr;
+    Block* _next_flush_block = nullptr;
+    // an iterator point to head;
+    Iterator _iterator;
+
+    int32_t _consumer_number;
+    int32_t _opened_source_number = 0;
+    int32_t _opened_sink_number = 0;
+    std::vector<int32_t> _opened_source_opcount;
+    // record consume progress
+    std::vector<std::unique_ptr<Iterator>> _consumer_progress;
+
+    // all
+    size_t _total_accumulated_rows = 0;
+    size_t _total_accumulated_bytes = 0;
+    // head
+    size_t _head_accumulated_rows = 0;
+    size_t _head_accumulated_bytes = 0;
+
+    // not flushed
+    size_t _flushed_accumulated_rows = 0;
+    size_t _flushed_accumulated_bytes = 0;
+
+    // consumer
+    size_t _fastest_accumulated_rows = 0;
+    size_t _fastest_accumulated_bytes = 0;
+
+    size_t _current_load_rows = 0;
+    size_t _current_load_bytes = 0;
+
+    Options _opts;
+
+    std::atomic<std::shared_ptr<Status>> _io_task_status;
+
+    std::atomic_bool _has_flush_io_task = false;
+    std::queue<Block*> _loaded_blocks;
+
+    RuntimeProfile::HighWaterMarkCounter* _peak_memory_bytes_counter = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* _peak_memory_rows_counter = nullptr;
+
+    RuntimeProfile::Counter* _flush_io_timer = nullptr;
+    RuntimeProfile::Counter* _flush_io_count = nullptr;
+    RuntimeProfile::Counter* _flush_io_bytes = nullptr;
+    // io stats of load task
+    RuntimeProfile::Counter* _read_io_timer = nullptr;
+    RuntimeProfile::Counter* _read_io_count = nullptr;
+    RuntimeProfile::Counter* _read_io_bytes = nullptr;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
@@ -35,6 +35,10 @@ private:
         std::vector<Cell> cells;
         bool in_mem = true;
         std::atomic_bool has_load_task = false;
+        // The number of requests pending to be read.
+        // there may be a flush task between can_pop and pop,
+        // we should prevent the block that is about to be read from being flushed.
+        std::atomic_int pending_read_requests = 0;
         size_t memory_usage = 0;
         Block* next = nullptr;
         // spillable block, only used when spill happens

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
@@ -126,10 +126,7 @@ StatusOr<ChunkPtr> InMemoryMultiCastLocalExchanger::pull_chunk(RuntimeState* sta
     DCHECK(_progress[mcast_consumer_index] != nullptr);
     Cell* cell = _progress[mcast_consumer_index];
     if (cell->next == nullptr) {
-        if (_opened_sink_number == 0) {
-            LOG(INFO) << "eof, index:" << mcast_consumer_index;
-            return Status::EndOfFile("mcast_local_exchanger eof");
-        }
+        if (_opened_sink_number == 0) return Status::EndOfFile("mcast_local_exchanger eof");
         return Status::InternalError("unreachable in multicast local exchanger");
     }
     cell = cell->next;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
@@ -56,6 +56,7 @@ bool InMemoryMultiCastLocalExchanger::can_push_chunk() const {
     std::unique_lock l(_mutex);
     // if for the fastest consumer, the exchanger still has enough chunk to be consumed.
     // the exchanger does not need any input.
+
     if ((_current_accumulated_row_size - _fast_accumulated_row_size) >
         _runtime_state->chunk_size() * kBufferedRowSizeScaleFactor) {
         return false;
@@ -125,7 +126,10 @@ StatusOr<ChunkPtr> InMemoryMultiCastLocalExchanger::pull_chunk(RuntimeState* sta
     DCHECK(_progress[mcast_consumer_index] != nullptr);
     Cell* cell = _progress[mcast_consumer_index];
     if (cell->next == nullptr) {
-        if (_opened_sink_number == 0) return Status::EndOfFile("mcast_local_exchanger eof");
+        if (_opened_sink_number == 0) {
+            LOG(INFO) << "eof, index:" << mcast_consumer_index;
+            return Status::EndOfFile("mcast_local_exchanger eof");
+        }
         return Status::InternalError("unreachable in multicast local exchanger");
     }
     cell = cell->next;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
@@ -95,7 +95,6 @@ private:
     };
     void _update_progress(Cell* fast = nullptr);
     void _closer_consumer(int32_t mcast_consumer_index);
-    RuntimeState* _runtime_state;
     mutable std::mutex _mutex;
     size_t _consumer_number;
     size_t _current_accumulated_row_size = 0;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
@@ -95,6 +95,7 @@ private:
     };
     void _update_progress(Cell* fast = nullptr);
     void _closer_consumer(int32_t mcast_consumer_index);
+    RuntimeState* _runtime_state;
     mutable std::mutex _mutex;
     size_t _consumer_number;
     size_t _current_accumulated_row_size = 0;
@@ -132,7 +133,6 @@ public:
     void enter_release_memory_mode() override;
 
 private:
-    RuntimeState* _runtime_state = nullptr;
     std::shared_ptr<MemLimitedChunkQueue> _queue;
 };
 

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
@@ -113,4 +113,28 @@ private:
     RuntimeProfile::HighWaterMarkCounter* _peak_buffer_row_size_counter = nullptr;
 };
 
+class MemLimitedChunkQueue;
+
+class SpillableMultiCastLocalExchanger : public MultiCastLocalExchanger {
+public:
+    SpillableMultiCastLocalExchanger(RuntimeState* runtime_state, size_t consumer_number, int32_t plan_node_id);
+    ~SpillableMultiCastLocalExchanger() override = default;
+
+    Status init_metrics(RuntimeProfile* profile) override;
+    bool can_pull_chunk(int32_t mcast_consumer_index) const override;
+    bool can_push_chunk() const override;
+    Status push_chunk(const ChunkPtr& chunk, int32_t sink_driver_sequence) override;
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state, int32_t mcast_consumer_index) override;
+    void open_source_operator(int32_t mcast_consumer_index) override;
+    void close_source_operator(int32_t mcast_consumer_index) override;
+    void open_sink_operator() override;
+    void close_sink_operator() override;
+    bool releaseable() const override { return true; }
+    void enter_release_memory_mode() override;
+
+private:
+    RuntimeState* _runtime_state = nullptr;
+    std::shared_ptr<MemLimitedChunkQueue> _queue;
+};
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
@@ -38,8 +38,7 @@
 namespace starrocks::pipeline {
 
 SpillableMultiCastLocalExchanger::SpillableMultiCastLocalExchanger(RuntimeState* runtime_state, size_t consumer_number,
-                                                                   int32_t plan_node_id)
-        : _runtime_state(runtime_state) {
+                                                                   int32_t plan_node_id) {
     DCHECK(runtime_state->enable_spill() && runtime_state->enable_multi_cast_local_exchange_spill());
     MemLimitedChunkQueue::Options opts;
     if (runtime_state->spill_mode() == TSpillMode::FORCE) {

--- a/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
@@ -41,6 +41,7 @@ SpillableMultiCastLocalExchanger::SpillableMultiCastLocalExchanger(RuntimeState*
                                                                    int32_t plan_node_id) {
     DCHECK(runtime_state->enable_spill() && runtime_state->enable_multi_cast_local_exchange_spill());
     MemLimitedChunkQueue::Options opts;
+    opts.block_size = config::mem_limited_chunk_queue_block_size;
     if (runtime_state->spill_mode() == TSpillMode::FORCE) {
         opts.memory_limit = 16L * 1024 * 1024;
     } else {

--- a/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+
+#include <memory>
+
+#include "common/compiler_util.h"
+#include "common/status.h"
+#include "exec/pipeline/exchange/mem_limited_chunk_queue.h"
+#include "exec/pipeline/exchange/multi_cast_local_exchange.h"
+#include "exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h"
+#include "exec/spill/block_manager.h"
+#include "exec/spill/data_stream.h"
+#include "exec/spill/dir_manager.h"
+#include "exec/spill/executor.h"
+#include "exec/spill/mem_table.h"
+#include "exec/spill/options.h"
+#include "fmt/format.h"
+#include "fs/fs.h"
+#include "serde/column_array_serde.h"
+#include "serde/protobuf_serde.h"
+#include "util/defer_op.h"
+#include "util/raw_container.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::pipeline {
+
+SpillableMultiCastLocalExchanger::SpillableMultiCastLocalExchanger(RuntimeState* runtime_state, size_t consumer_number,
+                                                                   int32_t plan_node_id)
+        : _runtime_state(runtime_state) {
+    DCHECK(runtime_state->enable_spill() && runtime_state->enable_multi_cast_local_exchange_spill());
+    MemLimitedChunkQueue::Options opts;
+    if (runtime_state->spill_mode() == TSpillMode::FORCE) {
+        opts.memory_limit = 16L * 1024 * 1024;
+    } else {
+        opts.memory_limit = std::numeric_limits<size_t>::max();
+    }
+    opts.plan_node_id = plan_node_id;
+    opts.block_manager = runtime_state->query_ctx()->spill_manager()->block_manager();
+    opts.encode_level = runtime_state->spill_encode_level();
+
+    _queue = std::make_shared<MemLimitedChunkQueue>(runtime_state, consumer_number, opts);
+}
+
+Status SpillableMultiCastLocalExchanger::init_metrics(RuntimeProfile* profile) {
+    return _queue->init_metrics(profile);
+}
+
+bool SpillableMultiCastLocalExchanger::can_pull_chunk(int32_t mcast_consumer_index) const {
+    return _queue->can_pop(mcast_consumer_index);
+}
+
+bool SpillableMultiCastLocalExchanger::can_push_chunk() const {
+    return _queue->can_push();
+}
+
+Status SpillableMultiCastLocalExchanger::push_chunk(const ChunkPtr& chunk, int32_t sink_driver_sequence) {
+    return _queue->push(chunk);
+}
+
+StatusOr<ChunkPtr> SpillableMultiCastLocalExchanger::pull_chunk(RuntimeState* state, int32_t mcast_consumer_index) {
+    return _queue->pop(mcast_consumer_index);
+}
+
+void SpillableMultiCastLocalExchanger::open_source_operator(int32_t mcast_consumer_index) {
+    _queue->open_consumer(mcast_consumer_index);
+}
+
+void SpillableMultiCastLocalExchanger::close_source_operator(int32_t mcast_consumer_index) {
+    _queue->close_consumer(mcast_consumer_index);
+}
+
+void SpillableMultiCastLocalExchanger::open_sink_operator() {
+    _queue->open_producer();
+}
+
+void SpillableMultiCastLocalExchanger::close_sink_operator() {
+    _queue->close_producer();
+}
+
+void SpillableMultiCastLocalExchanger::enter_release_memory_mode() {
+    _queue->enter_release_memory_mode();
+}
+} // namespace starrocks::pipeline

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -363,6 +363,9 @@ public:
     }
     bool enable_sort_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::SORT); }
     bool enable_nl_join_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::NL_JOIN); }
+    bool enable_multi_cast_local_exchange_spill() const {
+        return spillable_operator_mask() & (1LL << TSpillableOperatorType::MULTI_CAST_LOCAL_EXCHANGE);
+    }
 
     int32_t spill_mem_table_size() const {
         return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_mem_table_size);

--- a/be/src/util/bit_mask.h
+++ b/be/src/util/bit_mask.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+namespace starrocks {
+
+class BitMask {
+public:
+    BitMask(size_t size) : _bits((size + 7 / 8), 0) {}
+    ~BitMask() = default;
+
+    void set_bit(size_t pos) { _bits[pos >> 3] |= (1 << (pos & 7)); }
+    void clear_bit(size_t pos) { _bits[pos >> 3] &= ~(1 << (pos & 7)); }
+
+    bool is_bit_set(size_t pos) { return (_bits[pos >> 3] & (1 << (pos & 7))) != 0; }
+
+    bool all_bits_zero() const {
+        for (uint8_t byte : _bits) {
+            if (byte != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+private:
+    std::vector<uint8_t> _bits;
+};
+} // namespace starrocks

--- a/be/src/util/bit_mask.h
+++ b/be/src/util/bit_mask.h
@@ -12,17 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
-#include <vector>
+#include <cstring>
 
 namespace starrocks {
 
 class BitMask {
 public:
-    BitMask(size_t size) : _bits((size + 7 / 8), 0) {}
-    ~BitMask() = default;
+    BitMask(size_t size) {
+        _size = (size + 7) / 8;
+        _bits = new uint8_t[_size];
+        memset(_bits, 0, _size);
+    }
+    ~BitMask() {
+        if (_bits) {
+            delete[] _bits;
+        }
+    }
 
     void set_bit(size_t pos) { _bits[pos >> 3] |= (1 << (pos & 7)); }
     void clear_bit(size_t pos) { _bits[pos >> 3] &= ~(1 << (pos & 7)); }
@@ -30,8 +37,8 @@ public:
     bool is_bit_set(size_t pos) { return (_bits[pos >> 3] & (1 << (pos & 7))) != 0; }
 
     bool all_bits_zero() const {
-        for (uint8_t byte : _bits) {
-            if (byte != 0) {
+        for (size_t i = 0; i < _size; i++) {
+            if (_bits[i] != 0) {
                 return false;
             }
         }
@@ -39,6 +46,7 @@ public:
     }
 
 private:
-    std::vector<uint8_t> _bits;
+    size_t _size;
+    uint8_t* _bits;
 };
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -386,6 +386,7 @@ set(EXEC_FILES
         ./util/aes_util_test.cpp
         ./util/await_test.cpp
         ./util/bitmap_test.cpp
+        ./util/bit_mask_test.cpp
         ./util/bit_stream_utils_test.cpp
         ./util/bit_util_test.cpp
         ./util/block_compression_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -51,7 +51,7 @@ set(EXEC_FILES
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
-        ./exec/pipeline/exchanger_test.cpp
+        ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp
         ./exec/schema_columns_scanner_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -51,6 +51,7 @@ set(EXEC_FILES
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
+        ./exec/pipeline/exchanger_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp
         ./exec/schema_columns_scanner_test.cpp

--- a/be/test/exec/pipeline/exchanger_test.cpp
+++ b/be/test/exec/pipeline/exchanger_test.cpp
@@ -1,0 +1,511 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// @TODO test exchanger
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "exec/pipeline/exchange/mem_limited_chunk_queue.h"
+#include "exec/pipeline/exchange/multi_cast_local_exchange.h"
+#include "exec/pipeline/pipeline_fwd.h"
+#include "exec/pipeline/query_context.h"
+#include "exec/pipeline/stream_epoch_manager.h"
+#include "exec/workgroup/work_group.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+#include "testutil/sync_point.h"
+#include "types/logical_type.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::pipeline {
+
+class MemLimitedChunkQueueTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        ASSERT_OK(GlobalEnv::GetInstance()->init());
+        TUniqueId dummy_query_id = generate_uuid();
+        auto path = config::storage_root_path + "/spill_test_data/" + print_id(dummy_query_id);
+        auto fs = FileSystem::Default();
+        ASSERT_OK(fs->create_dir_recursive(path));
+        LOG(INFO) << "path: " << path;
+
+        dummy_wg = std::make_shared<workgroup::WorkGroup>("default_wg", workgroup::WorkGroup::DEFAULT_WG_ID,
+                                                          workgroup::WorkGroup::DEFAULT_VERSION, 4, 100.0, 0, 1.0,
+                                                          workgroup::WorkGroupType::WG_DEFAULT);
+        dummy_wg->init();
+
+        dummy_dir_mgr = std::make_unique<spill::DirManager>();
+        ASSERT_OK(dummy_dir_mgr->init(path));
+
+        dummy_block_mgr = std::make_unique<spill::LogBlockManager>(dummy_query_id, dummy_dir_mgr.get());
+
+        dummy_fragment_ctx.set_workgroup(dummy_wg);
+        dummy_query_ctx = std::make_shared<QueryContext>();
+
+        dummy_runtime_state.set_fragment_ctx(&dummy_fragment_ctx);
+        dummy_runtime_state.set_query_ctx(dummy_query_ctx.get());
+    }
+    void TearDown() override {}
+
+protected:
+    std::shared_ptr<QueryContext> dummy_query_ctx;
+    FragmentContext dummy_fragment_ctx;
+    RuntimeState dummy_runtime_state;
+    RuntimeProfile dummy_runtime_profile{"dummy"};
+    workgroup::WorkGroupPtr dummy_wg;
+
+    std::unique_ptr<spill::DirManager> dummy_dir_mgr;
+    std::unique_ptr<spill::LogBlockManager> dummy_block_mgr;
+};
+
+class AutoIncChunkBuilder {
+public:
+    AutoIncChunkBuilder(size_t chunk_size = 4096) : _chunk_size(chunk_size) {}
+
+    ChunkPtr get_next() {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_BIGINT), false);
+        for (size_t i = 0; i < _chunk_size; i++) {
+            col->append_datum(Datum(_next_value++));
+        }
+        chunk->append_column(std::move(col), 0);
+        return chunk;
+    }
+    size_t _next_value = 0;
+    size_t _chunk_size;
+};
+
+void wait_flush_task_done(MemLimitedChunkQueue& queue) {
+    while (queue._has_flush_io_task) {
+        usleep(1000);
+    }
+}
+
+TEST_F(MemLimitedChunkQueueTest, test_iterator) {
+    MemLimitedChunkQueue::Options options;
+    options.block_size = 1024 * 128;
+    options.memory_limit = INT64_MAX; // disable spill
+    options.block_manager = dummy_block_mgr.get();
+    // @TODO test different block size
+    MemLimitedChunkQueue queue(&dummy_runtime_state, 1, options);
+    ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+
+    // 32k per chunk,
+    AutoIncChunkBuilder builder;
+
+    for (size_t i = 0; i < 100; i++) {
+        auto chunk = builder.get_next();
+        ASSERT_OK(queue.push(chunk, nullptr));
+    }
+    MemLimitedChunkQueue::Iterator iter = MemLimitedChunkQueue::Iterator(queue._head, 0);
+
+    size_t acc_rows = 0, acc_bytes = 0;
+    for (size_t i = 0; i < 100; i++) {
+        ASSERT_TRUE(iter.valid());
+        MemLimitedChunkQueue::Cell* cell = iter.get_cell();
+        if (i == 0) {
+            // dummy cell
+            ASSERT_TRUE(cell->chunk == nullptr);
+            ASSERT_EQ(cell->accumulated_rows, 0);
+            ASSERT_EQ(cell->accumulated_bytes, 0);
+        } else {
+            ASSERT_EQ(cell->chunk->num_rows(), 4096);
+            acc_rows += cell->chunk->num_rows();
+            acc_bytes += cell->chunk->memory_usage();
+            ASSERT_EQ(cell->accumulated_rows, acc_rows);
+            ASSERT_EQ(cell->accumulated_bytes, acc_bytes);
+        }
+        iter.move_to_next();
+    }
+    ASSERT_FALSE(iter.has_next());
+}
+
+TEST_F(MemLimitedChunkQueueTest, test_push_pop_without_spill) {
+    MemLimitedChunkQueue::Options options;
+    options.block_size = 1024 * 128;
+    options.memory_limit = INT64_MAX; // disable spill
+    options.block_manager = dummy_block_mgr.get();
+    int32_t consumer_number = 3;
+    MemLimitedChunkQueue queue(&dummy_runtime_state, consumer_number, options);
+    ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+    // set opened consumer number
+    for (int32_t i = 0; i < consumer_number; i++) {
+        queue.open_consumer(i);
+    }
+    // 32k per chunk,
+    AutoIncChunkBuilder builder;
+
+    for (size_t i = 0; i < 100; i++) {
+        auto chunk = builder.get_next();
+        ASSERT_OK(queue.push(chunk, nullptr));
+    }
+
+    size_t expected_head_acc_rows = 0;
+    size_t expected_head_acc_bytes = 0;
+    for (size_t i = 0; i < 100; i++) {
+        for (int32_t consumer_idx = 0; consumer_idx < consumer_number; consumer_idx++) {
+            ASSIGN_OR_ABORT(auto chunk, queue.pop(consumer_idx));
+            ASSERT_EQ(chunk->num_rows(), 4096);
+            if (consumer_idx < consumer_number - 1) {
+                ASSERT_EQ(queue._head_accumulated_rows, expected_head_acc_rows);
+                ASSERT_EQ(queue._head_accumulated_bytes, expected_head_acc_bytes);
+            }
+            LOG(INFO) << "consumer " << consumer_idx << ": " << chunk->debug_row(0) << ", " << chunk->debug_row(4095);
+        }
+        expected_head_acc_rows += 4096;
+        expected_head_acc_bytes += 4096 * 8;
+
+        ASSERT_EQ(queue._head_accumulated_rows, expected_head_acc_rows);
+        ASSERT_EQ(queue._head_accumulated_bytes, expected_head_acc_bytes);
+    }
+}
+
+TEST_F(MemLimitedChunkQueueTest, test_back_pressure) {
+    MemLimitedChunkQueue::Options options;
+    options.block_size = 1024 * 128;
+    options.memory_limit = 1024 * 256;
+    options.max_unconsumed_bytes = 1024 * 64;
+    options.block_manager = dummy_block_mgr.get();
+    // @TODO test different block size
+    int32_t consumer_number = 1;
+    MemLimitedChunkQueue queue(&dummy_runtime_state, consumer_number, options);
+    ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+    // set opened consumer number
+    for (int32_t i = 0; i < consumer_number; i++) {
+        queue.open_consumer(i);
+    }
+    // 32k per chunk,
+    AutoIncChunkBuilder builder;
+    ASSERT_TRUE(queue.can_push());
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    ASSERT_TRUE(queue.can_push());
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    // unconsumed bytes is 16k, can't push before consume
+    ASSERT_FALSE(queue.can_push());
+
+    // consume
+    ASSERT_TRUE(queue.can_pop(0));
+    ASSERT_OK(queue.pop(0));
+    ASSERT_TRUE(queue.can_push());
+}
+
+TEST_F(MemLimitedChunkQueueTest, test_push_with_flush) {
+    MemLimitedChunkQueue::Options options;
+    options.block_size = 1024 * 64;
+    options.memory_limit = 1024 * 64;
+    options.max_unconsumed_bytes = INT64_MAX;
+    options.block_manager = dummy_block_mgr.get();
+    // @TODO test different block size
+    int32_t consumer_number = 3;
+    MemLimitedChunkQueue queue(&dummy_runtime_state, consumer_number, options);
+    ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+    // set opened consumer number
+    for (int32_t i = 0; i < consumer_number; i++) {
+        queue.open_consumer(i);
+    }
+    // 32k per chunk,
+    AutoIncChunkBuilder builder;
+
+    // push some chunks, trigger spill, submit spill
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+
+    // only one block, cannot trigger flush
+    ASSERT_TRUE(queue.can_push());
+
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    // after push the third chunk, there are 2 blocks and the 1st should be flushed
+    int32_t submitted_flush_tasks = 0, finished_flush_task = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::before_execute_flush_task", [&](void* arg) {
+        LOG(INFO) << "before execute flush task";
+        ASSERT_EQ(queue._has_flush_io_task, true);
+        submitted_flush_tasks++;
+    });
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_execute_flush_task", [&](void* arg) {
+        LOG(INFO) << "after execute flush task";
+        ASSERT_EQ(queue._has_flush_io_task, false);
+        finished_flush_task++;
+    });
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    ASSERT_FALSE(queue.can_push());
+    // wait flush task finished
+    wait_flush_task_done(queue);
+    ASSERT_EQ(submitted_flush_tasks, 1);
+    ASSERT_EQ(finished_flush_task, 1);
+
+    ASSERT_TRUE(queue.can_push());
+
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    ASSERT_TRUE(queue.can_push());
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    ASSERT_FALSE(queue.can_push());
+    wait_flush_task_done(queue);
+    ASSERT_EQ(submitted_flush_tasks, 2);
+    ASSERT_EQ(finished_flush_task, 2);
+}
+
+TEST_F(MemLimitedChunkQueueTest, test_flush_with_pop) {
+    // push -> submit flush task-> (consume some data) -> execute flush task but no data to flush
+    MemLimitedChunkQueue::Options options;
+    options.block_size = 1024 * 64;
+    options.memory_limit = 1024 * 64;
+    options.max_unconsumed_bytes = INT64_MAX;
+    options.block_manager = dummy_block_mgr.get();
+    int32_t consumer_number = 1;
+    MemLimitedChunkQueue queue(&dummy_runtime_state, consumer_number, options);
+    ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+    // set opened consumer number
+    for (int32_t i = 0; i < consumer_number; i++) {
+        queue.open_consumer(i);
+    }
+    // 32k per chunk,
+    AutoIncChunkBuilder builder;
+
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+
+    // only one block, cannot trigger flush
+    ASSERT_TRUE(queue.can_push());
+
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+
+    int32_t submitted_flush_tasks = 0, finished_flush_task = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::before_execute_flush_task", [&](void* arg) {
+        LOG(INFO) << "before execute flush task";
+        ASSERT_EQ(queue._has_flush_io_task, true);
+        submitted_flush_tasks++;
+        // before execute flush task, consumer consume some data
+        ASSERT_OK(queue.pop(0));
+        ASSERT_OK(queue.pop(0));
+    });
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_calculate_max_serialize_size", [&](void* arg) {
+        size_t max_serialize_size = *((size_t*)arg);
+        ASSERT_EQ(max_serialize_size, 0);
+    });
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_flush_block", [&](void* arg) {
+        MemLimitedChunkQueue::Block* block = (MemLimitedChunkQueue::Block*)arg;
+        ASSERT_TRUE(block->block == nullptr);
+    });
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_execute_flush_task", [&](void* arg) {
+        LOG(INFO) << "after execute flush task";
+        ASSERT_EQ(queue._has_flush_io_task, false);
+        finished_flush_task++;
+    });
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    ASSERT_FALSE(queue.can_push());
+    wait_flush_task_done(queue);
+
+    ASSERT_EQ(submitted_flush_tasks, 1);
+    ASSERT_EQ(finished_flush_task, 1);
+
+    ASSERT_TRUE(queue.can_push());
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+    ASSERT_TRUE(queue.can_push());
+    ASSERT_OK(queue.push(builder.get_next(), nullptr));
+
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::before_execute_flush_task", [&](void* arg) {
+        LOG(INFO) << "before execute flush task";
+        ASSERT_EQ(queue._has_flush_io_task, true);
+        submitted_flush_tasks++;
+        // before execute flush task, consumer consume some data
+        ASSERT_OK(queue.pop(0));
+    });
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_calculate_max_serialize_size", [&](void* arg) {
+        size_t max_serialize_size = *((size_t*)arg);
+        // only one chunk should be flushed
+        ASSERT_EQ(max_serialize_size, 34844);
+    });
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_flush_block", [&](void* arg) {
+        MemLimitedChunkQueue::Block* block = (MemLimitedChunkQueue::Block*)arg;
+        ASSERT_TRUE(block->block != nullptr);
+    });
+    SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_execute_flush_task", [&](void* arg) {
+        LOG(INFO) << "after execute flush task";
+        ASSERT_EQ(queue._has_flush_io_task, false);
+        finished_flush_task++;
+    });
+    ASSERT_FALSE(queue.can_push());
+    wait_flush_task_done(queue);
+    ASSERT_EQ(submitted_flush_tasks, 2);
+    ASSERT_EQ(finished_flush_task, 2);
+}
+
+TEST_F(MemLimitedChunkQueueTest, test_load) {
+    // 3 consumers, consume progress is different, flush task, some data not in memory, load
+
+    // case 1
+    {
+        // 1 consumer, some block not in memory, trigger load task
+        MemLimitedChunkQueue::Options options;
+        options.block_size = 1024 * 64;
+        options.memory_limit = 1024 * 64;
+        options.max_unconsumed_bytes = INT64_MAX;
+        options.block_manager = dummy_block_mgr.get();
+        int32_t consumer_number = 1;
+        MemLimitedChunkQueue queue(&dummy_runtime_state, consumer_number, options);
+        ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+        // set opened consumer number
+        for (int32_t i = 0; i < consumer_number; i++) {
+            queue.open_consumer(i);
+        }
+        queue.open_producer();
+        // 32k per chunk,
+        AutoIncChunkBuilder builder;
+
+        ASSERT_TRUE(queue.can_push());
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        ASSERT_TRUE(queue.can_push());
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        ASSERT_TRUE(queue.can_push());
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        ASSERT_FALSE(queue.can_push());
+        wait_flush_task_done(queue);
+        int32_t submitted_load_tasks = 0;
+        SyncPoint::GetInstance()->EnableProcessing();
+        SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::before_execute_load_task", [&](void* arg) {
+            // MemLimitedChunkQueue::Block* block = (MemLimitedChunkQueue::Block*)arg;
+            submitted_load_tasks++;
+        });
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearAllCallBacks();
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        // consume to load
+        // 1st block is flushed, should trigger a load task
+        ASSERT_FALSE(queue.can_pop(0));
+        // wait until can pop
+        while (!queue.can_pop(0)) {
+            bthread_usleep(1000);
+        }
+        ASSERT_OK(queue.pop(0));
+        ASSERT_TRUE(queue.can_pop(0));
+        ASSERT_OK(queue.pop(0));
+        ASSERT_TRUE(queue.can_pop(0));
+        ASSERT_OK(queue.pop(0));
+
+        //all data consumed
+        ASSERT_FALSE(queue.can_pop(0));
+        ASSERT_EQ(submitted_load_tasks, 1);
+    }
+
+    // case 2
+    // multi consumers, some block not in memory, trigger load task, some consumer read the same block,
+    {
+        MemLimitedChunkQueue::Options options;
+        options.block_size = 1024 * 64;
+        options.memory_limit = 1024 * 64;
+        options.max_unconsumed_bytes = INT64_MAX;
+        options.block_manager = dummy_block_mgr.get();
+        int32_t consumer_number = 2;
+        MemLimitedChunkQueue queue(&dummy_runtime_state, consumer_number, options);
+        ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+        // set opened consumer number
+        for (int32_t i = 0; i < consumer_number; i++) {
+            queue.open_consumer(i);
+        }
+        queue.open_producer();
+        // 32k per chunk,
+        AutoIncChunkBuilder builder;
+
+        // push 3 chunks, consumer 0 consume 1 chunk, consumer 2 do nothing
+        ASSERT_TRUE(queue.can_push());
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        ASSERT_TRUE(queue.can_push());
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        ASSERT_TRUE(queue.can_push());
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+
+        ASSERT_TRUE(queue.can_pop(0));
+        ASSERT_OK(queue.pop(0));
+
+        // trigger flush
+        ASSERT_FALSE(queue.can_push());
+        // wait flush done
+        wait_flush_task_done(queue);
+        int32_t submitted_load_tasks = 0;
+        SyncPoint::GetInstance()->EnableProcessing();
+        SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::before_execute_load_task",
+                                              [&](void* arg) { submitted_load_tasks++; });
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearAllCallBacks();
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        // consumer 1 consume
+        ASSERT_FALSE(queue.can_pop(1));
+        SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::can_pop::before_submit_load_task", [&](void* arg) {
+            MemLimitedChunkQueue::Block* block = (MemLimitedChunkQueue::Block*)arg;
+            ASSERT_TRUE(block->has_load_task);
+        });
+        ASSERT_FALSE(queue.can_pop(0));
+        while (!queue.can_pop(1)) {
+            bthread_usleep(1000);
+        }
+        // these 2 consumers consume the same block, so consumer 0 can pop too, only 1 load task is triggered
+        ASSERT_TRUE(queue.can_pop(0));
+        ASSERT_EQ(submitted_load_tasks, 1);
+    }
+
+    {
+        // case 3, multi consumer, the fast is very fast, loaded block should evcit
+        MemLimitedChunkQueue::Options options;
+        options.block_size = 1024 * 32;
+        options.memory_limit = 1024 * 32;
+        options.max_unconsumed_bytes = INT64_MAX;
+        options.block_manager = dummy_block_mgr.get();
+        int32_t consumer_number = 2;
+        MemLimitedChunkQueue queue(&dummy_runtime_state, consumer_number, options);
+        ASSERT_OK(queue.init_metrics(&dummy_runtime_profile));
+        // set opened consumer number
+        for (int32_t i = 0; i < consumer_number; i++) {
+            queue.open_consumer(i);
+        }
+        queue.open_producer();
+        // 32k per chunk,
+        AutoIncChunkBuilder builder;
+
+        // force push and wait spill
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        ASSERT_TRUE(queue.can_push());
+        ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        for (int i = 0; i < 10; i++) {
+            ASSERT_FALSE(queue.can_push());
+            wait_flush_task_done(queue);
+            ASSERT_OK(queue.push(builder.get_next(), nullptr));
+        }
+        for (int i = 0; i < 10; i++) {
+            while (!queue.can_pop(0)) {
+                bthread_usleep(1000);
+            }
+            ASSERT_OK(queue.pop(0));
+        }
+        for (int i = 0; i < 10; i++) {
+            while (!queue.can_pop(1)) {
+                bthread_usleep(1000);
+            }
+            ASSERT_OK(queue.pop(1));
+        }
+    }
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/mem_limited_chunk_queue_test.cpp
+++ b/be/test/exec/pipeline/mem_limited_chunk_queue_test.cpp
@@ -536,7 +536,7 @@ TEST_F(MemLimitedChunkQueueTest, test_concurrent_load_flush) {
         SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::flush::after_find_block_to_flush", [&](void* arg) {
             MemLimitedChunkQueue::Block* block = (MemLimitedChunkQueue::Block*)arg;
             // this block is about to be read, won't be flushed
-            ASSERT_GT(block->pending_read_requests, 0);
+            ASSERT_TRUE(block->has_pending_reader());
         });
         int32_t flushed_blocks = 0;
         SyncPoint::GetInstance()->SetCallBack("MemLimitedChunkQueue::after_flush_block",

--- a/be/test/util/bit_mask_test.cpp
+++ b/be/test/util/bit_mask_test.cpp
@@ -1,0 +1,33 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/bit_mask.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(BitMask, Basic) {
+    BitMask bit_mask(10);
+    for (int i = 0; i < 10; i++) {
+        bit_mask.set_bit(i);
+        ASSERT_TRUE(bit_mask.is_bit_set(i));
+    }
+    for (int i = 0; i < 10; i++) {
+        ASSERT_FALSE(bit_mask.all_bits_zero());
+        bit_mask.clear_bit(i);
+        ASSERT_FALSE(bit_mask.is_bit_set(i));
+    }
+    ASSERT_TRUE(bit_mask.all_bits_zero());
+}
+} // namespace starrocks

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -113,6 +113,7 @@ enum TSpillableOperatorType {
   AGG_DISTINCT = 2;
   SORT = 3;
   NL_JOIN = 4;
+  MULTI_CAST_LOCAL_EXCHANGE = 5;
 }
 
 enum TTabletInternalParallelMode {

--- a/test/sql/test_spill/R/test_spill_mcast_local_exchange
+++ b/test/sql/test_spill/R/test_spill_mcast_local_exchange
@@ -1,0 +1,38 @@
+-- name: test_spill_mcast_local_exchange
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode='force';
+-- result:
+-- !result
+set spillable_operator_mask = 32;
+-- result:
+-- !result
+set pipeline_dop=2;
+-- result:
+-- !result
+CREATE TABLE t (
+    k1 BIGINT,
+    k2 BIGINT,
+    K3 BIGINT,
+    k4 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY RANDOM PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t select generate_series % 10, generate_series, 10000000 - generate_series, hex(generate_series) from TABLE(generate_series(1, 10000000));
+-- result:
+-- !result
+select k1, count(distinct k2), count(distinct k3), count(distinct k4) from t group by k1 order by k1;
+-- result:
+0	1000000	1000000	1000000
+1	1000000	1000000	1000000
+2	1000000	1000000	1000000
+3	1000000	1000000	1000000
+4	1000000	1000000	1000000
+5	1000000	1000000	1000000
+6	1000000	1000000	1000000
+7	1000000	1000000	1000000
+8	1000000	1000000	1000000
+9	1000000	1000000	1000000
+-- !result

--- a/test/sql/test_spill/T/test_spill_mcast_local_exchange
+++ b/test/sql/test_spill/T/test_spill_mcast_local_exchange
@@ -1,0 +1,15 @@
+-- name: test_spill_mcast_local_exchange
+set enable_spill=true;
+set spill_mode='force';
+set spillable_operator_mask = 32;
+set pipeline_dop=2;
+
+CREATE TABLE t (
+    k1 BIGINT,
+    k2 BIGINT,
+    K3 BIGINT,
+    k4 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY RANDOM PROPERTIES('replication_num'='1');
+insert into t select generate_series % 10, generate_series, 10000000 - generate_series, hex(generate_series) from TABLE(generate_series(1, 10000000));
+select k1, count(distinct k2), count(distinct k3), count(distinct k4) from t group by k1 order by k1;


### PR DESCRIPTION
## Why I'm doing:
When CTEs in a query are reused, the same data is sent to multiple downstream through the MultiCastLocalExchange operator. In the current implementation, all unconsumed data is cached in memory, depending on the gap between the fastest and slowest consumers, resulting in uncontrollable memory usage.

In this scenario, we cannot control memory by restricting the producer's writes, as there may be dependencies between downstream CTEs, such as when the hash join build side and probe side appear simultaneously, the probe side needs to wait for the build side to complete. If restrictions are imposed on the write side, it will cause queries to be stuck forever due to mutual waiting.


## What I'm doing:

In this PR, I introduced a new implementation of `MultiCastLocalExchanger` called `SpillableMultiCastLocalExchanger` that can control the memory usage of operators by spilling data to disk.

`SpillableMultiCastLocalExchanger` is implemented based on `MemLimitedChunkQueue`.

`MemLimitedChunkQueue` is an MPMC queue that accepts multiple producers writing data from different threads and supports multiple consumers consuming the same data, similar to a message queue like Kafka. It controls memory usage by spilling data to disk, while also considering the efficiency of spilling io. as we know, too many small io can seriously affect performance.
`MemLimitedChunkQueue` organizes data internally in the form of a block linked list. The nodes in a linked list are called `Block`, which contain multiple `Cell`s, each Cell contains a Chunk.

Every time chunk is pushed, a Cell is created and added to the Block at the end of the linked list. When the size of the Block exceeds a certain limit, a new Block is generated and added to the end of the linked list.

Block is the smallest unit handling by spill io task. when writing, if the data in memory exceeds a certain size, a flush io task will be submitted to flush the oldest block to the disk.

when consumers consume data and find that the block they want to read is not in memory, they will submit a load io task to load the corresponding block back into memory.

Through this approach, we can ensure that both producers and consumers can function properly while controlling memory usage.

## Test
I constructed a query based on the tpch 100g dataset for testing.
```sql
set pipeline_dop=8;
select l_shipdate,count(distinct l_orderkey),count(distinct l_linenumber),count(distinct l_partkey),count(distinct l_suppkey),count(distinct l_quantity),count(distinct l_extendedprice),count(distinct l_discount),count(distinct l_tax),count(distinct l_returnflag),count(distinct l_linestatus) from lineitem group by l_shipdate;
```

baseline doesn't change other session variables.
for testing, only enable force spill on multi_cast_local_exchange operator.
```sql
set enable_spill=true;
set spill_mode='force';
set spillable_operator_mask=32;
```

here is some metrics from query profile

MULTI_CAST_LOCAL_EXCHANG_SINK
baseline
```
          UniqueMetrics:
             - ExchangerPeakBufferRowSize: 551.312M (551311886)
             - ExchangerPeakMemoryUsage: 31.848 GB
```
with spillable_multi_cast_local_exchange
```
          UniqueMetrics:
             - ExchangerPeakBufferRowSize: 3.473M (3473408)
             - ExchangerPeakMemoryUsage: 205.394 MB
             - FlushIOBytes: 16.275 GB
             - FlushIOCount: 4.079K (4079)
             - FlushIOTime: 18s58ms
             - ReadIOBytes: 16.036 GB
             - ReadIOCount: 3.982K (3982)
             - ReadIOTime: 10s871ms
```
QueryPeakMemoryUsage and QueryTime
baseline: 78.354 GB, 48s952ms
with spillable_multi_cast_local_exchange:67.408 GB, 1m27s

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
