### PR TITLE
[Enhancement] Remove jindo sdk from broker

### DIFF
--- a/fs_brokers/apache_hdfs_broker/build.sh
+++ b/fs_brokers/apache_hdfs_broker/build.sh
@@ -41,8 +41,6 @@ rm -rf ${BROKER_OUTPUT}
 install -d ${BROKER_OUTPUT}/bin ${BROKER_OUTPUT}/conf \
            ${BROKER_OUTPUT}/lib/
 
-cp -r ${STARROCKS_THIRDPARTY}/installed/jindosdk/*.jar ${BROKER_OUTPUT}/lib/
-
 cp -r -p ${BROKER_HOME}/bin/*.sh ${BROKER_OUTPUT}/bin/
 cp -r -p ${BROKER_HOME}/conf/*.conf ${BROKER_OUTPUT}/conf/
 cp -r -p ${BROKER_HOME}/conf/*.xml ${BROKER_OUTPUT}/conf/

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -344,13 +344,6 @@ under the License.
                 <version>${hadoop.version}</version>
             </dependency>
 
-            <!-- https://mvnrepository.com/artifact/com.qcloud.cos/hadoop-cos -->
-            <dependency>
-                <groupId>com</groupId>
-                <artifactId>hadoop-cos</artifactId>
-                <version>1.0.0</version>
-            </dependency>
-
             <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aliyun -->
             <dependency>
                 <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
## Why I'm doing:
jindo sdk was removed from FE in pr https://github.com/StarRocks/starrocks/pull/46297

## What I'm doing:
1. hadoop-aliyun is already in `broker-core/pom.xml`, remove jindo sdk from broker
2. remove useless hadoop-cos dependency description in `pom.xml`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
