### PR TITLE
[Feature] support iceberg query with branch/tag/version/timestamp

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -119,7 +119,6 @@ public class IcebergTable extends Table {
         return remoteTableName;
     }
 
-
     @Override
     public String getUUID() {
         if (CatalogMgr.isExternalCatalog(catalogName)) {
@@ -369,6 +368,11 @@ public class IcebergTable extends Table {
 
     @Override
     public boolean supportPreCollectMetadata() {
+        return true;
+    }
+
+    @Override
+    public boolean supportTimeTravel() {
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -372,7 +372,7 @@ public class IcebergTable extends Table {
     }
 
     @Override
-    public boolean supportTimeTravel() {
+    public boolean isTemporal() {
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MysqlTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MysqlTable.java
@@ -235,4 +235,9 @@ public class MysqlTable extends Table {
     public boolean supportInsert() {
         return true;
     }
+
+    @Override
+    public boolean supportTimeTravel() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MysqlTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MysqlTable.java
@@ -237,7 +237,7 @@ public class MysqlTable extends Table {
     }
 
     @Override
-    public boolean supportTimeTravel() {
+    public boolean isTemporal() {
         return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -206,6 +207,8 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     @SerializedName(value = "mvs")
     protected Set<MvId> relatedMaterializedViews;
 
+    protected Optional<Long> snapshotId = Optional.empty();
+
     // unique constraints for mv rewrite
     // a table may have multi unique constraints
     protected List<UniqueConstraint> uniqueConstraints;
@@ -264,6 +267,14 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Optional<Long> getSnapshotId() {
+        return snapshotId;
+    }
+
+    public void setSnapshotId(Optional<Long> snapshotId) {
+        this.snapshotId = snapshotId;
     }
 
     public String getTableIdentifier() {
@@ -737,6 +748,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     }
 
     public boolean supportPreCollectMetadata() {
+        return false;
+    }
+
+    public boolean supportTimeTravel() {
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -751,7 +751,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return false;
     }
 
-    public boolean supportTimeTravel() {
+    public boolean isTemporal() {
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -60,7 +60,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -207,8 +206,6 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     @SerializedName(value = "mvs")
     protected Set<MvId> relatedMaterializedViews;
 
-    protected Optional<Long> snapshotId = Optional.empty();
-
     // unique constraints for mv rewrite
     // a table may have multi unique constraints
     protected List<UniqueConstraint> uniqueConstraints;
@@ -267,14 +264,6 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public Optional<Long> getSnapshotId() {
-        return snapshotId;
-    }
-
-    public void setSnapshotId(Optional<Long> snapshotId) {
-        this.snapshotId = snapshotId;
     }
 
     public String getTableIdentifier() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -137,10 +137,12 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public TableVersionRange getTableVersionRange(Table table) {
-        // TODO: refactor this in time travel patch
+    public TableVersionRange getTableVersionRange(Table table,
+                                                  Optional<ConnectorTableVersion> startVersion,
+                                                  Optional<ConnectorTableVersion> endVersion) {
+        // TODO: refactor this in next patch
         if (table instanceof IcebergTable) {
-            return normal.getTableVersionRange(table);
+            return normal.getTableVersionRange(table, startVersion, endVersion);
         } else {
             return TableVersionRange.empty();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -124,8 +124,9 @@ public interface ConnectorMetadata {
         return null;
     }
 
-    // TODO: add connector table version params in the next patch
-    default TableVersionRange getTableVersionRange(Table table) {
+    default TableVersionRange getTableVersionRange(Table table,
+                                                   Optional<ConnectorTableVersion> startVersion,
+                                                   Optional<ConnectorTableVersion> endVersion) {
         return TableVersionRange.empty();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableVersion.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+
+public class ConnectorTableVersion {
+    private final PointerType pointerType;
+    private final ConstantOperator constantOp;
+
+    public ConnectorTableVersion(PointerType pointerType, ConstantOperator constantOperator) {
+        this.pointerType = pointerType;
+        this.constantOp = constantOperator;
+    }
+
+    public PointerType getPointerType() {
+        return pointerType;
+    }
+
+    public ConstantOperator getConstantOperator() {
+        return constantOp;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PointerType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PointerType.java
@@ -1,0 +1,26 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+/**
+ * This enum represents the type of pointer used in TableVersion.
+ * TEMPORAL pointers are used in TIMESTAMP based query periods.
+ * VERSION pointers are used in VERSION based query periods.
+ */
+public enum PointerType {
+    TEMPORAL,
+    VERSION,
+    UNKNOWN
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/TableMetaMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/TableMetaMetadata.java
@@ -16,8 +16,11 @@ package com.starrocks.connector.metadata;
 
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.metadata.iceberg.LogicalIcebergMetadataTable;
+
+import java.util.Optional;
 
 
 // TODO(stephen): what's the pretty class name?
@@ -34,6 +37,21 @@ public class TableMetaMetadata implements ConnectorMetadata {
     }
 
     public Table getTable(String dbName, String tblName) {
+        MetadataTableName metadataTableName = MetadataTableName.from(tblName);
+        MetadataTableType tableType = metadataTableName.getTableType();
+        String tableName = metadataTableName.getTableName();
+
+        switch (tableType) {
+            case LOGICAL_ICEBERG_METADATA:
+                return LogicalIcebergMetadataTable.create(catalogName, dbName, tableName);
+            default:
+                throw new StarRocksConnectorException("Unrecognized metadata table type {}", tableType);
+        }
+    }
+
+    // TODO(stephen): use QueryPeriod for compatibility
+    public Table getTable(String dbName, String tblName, Optional<ConnectorTableVersion> startVersion,
+                          Optional<ConnectorTableVersion> endVersion) {
         MetadataTableName metadataTableName = MetadataTableName.from(tblName);
         MetadataTableType tableType = metadataTableName.getTableType();
         String tableName = metadataTableName.getTableName();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/TableMetaMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/TableMetaMetadata.java
@@ -16,12 +16,8 @@ package com.starrocks.connector.metadata;
 
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadata;
-import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.metadata.iceberg.LogicalIcebergMetadataTable;
-
-import java.util.Optional;
-
 
 // TODO(stephen): what's the pretty class name?
 public class TableMetaMetadata implements ConnectorMetadata {
@@ -37,21 +33,6 @@ public class TableMetaMetadata implements ConnectorMetadata {
     }
 
     public Table getTable(String dbName, String tblName) {
-        MetadataTableName metadataTableName = MetadataTableName.from(tblName);
-        MetadataTableType tableType = metadataTableName.getTableType();
-        String tableName = metadataTableName.getTableName();
-
-        switch (tableType) {
-            case LOGICAL_ICEBERG_METADATA:
-                return LogicalIcebergMetadataTable.create(catalogName, dbName, tableName);
-            default:
-                throw new StarRocksConnectorException("Unrecognized metadata table type {}", tableType);
-        }
-    }
-
-    // TODO(stephen): use QueryPeriod for compatibility
-    public Table getTable(String dbName, String tblName, Optional<ConnectorTableVersion> startVersion,
-                          Optional<ConnectorTableVersion> endVersion) {
         MetadataTableName metadataTableName = MetadataTableName.from(tblName);
         MetadataTableType tableType = metadataTableName.getTableType();
         String tableName = metadataTableName.getTableName();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
@@ -102,7 +102,7 @@ public class LogicalIcebergMetadataTable extends MetadataTable {
     }
 
     @Override
-    public boolean supportTimeTravel() {
+    public boolean isTemporal() {
         return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
@@ -100,4 +100,9 @@ public class LogicalIcebergMetadataTable extends MetadataTable {
         tTableDescriptor.setHdfsTable(hdfsTable);
         return tTableDescriptor;
     }
+
+    @Override
+    public boolean supportTimeTravel() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -23,6 +23,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
@@ -121,9 +122,11 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public TableVersionRange getTableVersionRange(Table table) {
+    public TableVersionRange getTableVersionRange(Table table,
+                                                  Optional<ConnectorTableVersion> startVersion,
+                                                  Optional<ConnectorTableVersion> endVersion) {
         ConnectorMetadata metadata = metadataOfTable(table);
-        return metadata.getTableVersionRange(table);
+        return metadata.getTableVersionRange(table, startVersion, endVersion);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -504,19 +504,6 @@ public class MetadataMgr {
         return connectorTable;
     }
 
-    public Table getTable(String catalogName, String dbName, String tblName,
-                          Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion) {
-        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
-        Table connectorTable = connectorMetadata.map(metadata -> metadata.getTable(dbName, tblName, startVersion, endVersion))
-                .orElse(null);
-        if (connectorTable != null) {
-            // Load meta information from ConnectorTblMetaInfoMgr for each external table.
-            connectorTblMetaInfoMgr.setTableInfoForConnectorTable(catalogName, dbName, connectorTable);
-        }
-        return connectorTable;
-    }
-
-
     public Table getTable(Long databaseId, Long tableId) {
         Database database = localMetastore.getDb(databaseId);
         if (database == null) {
@@ -525,9 +512,11 @@ public class MetadataMgr {
         return database.getTable(tableId);
     }
 
-    public TableVersionRange getTableVersionRange(Table table) {
+    public TableVersionRange getTableVersionRange(Table table,
+                                                  Optional<ConnectorTableVersion> startVersion,
+                                                  Optional<ConnectorTableVersion> endVersion) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
-        return connectorMetadata.map(metadata -> metadata.getTableVersionRange(table))
+        return connectorMetadata.map(metadata -> metadata.getTableVersionRange(table, startVersion, endVersion))
                 .orElse(TableVersionRange.empty().empty());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -49,6 +49,7 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
+import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.ConnectorTblMetaInfoMgr;
 import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
@@ -502,6 +503,19 @@ public class MetadataMgr {
         }
         return connectorTable;
     }
+
+    public Table getTable(String catalogName, String dbName, String tblName,
+                          Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        Table connectorTable = connectorMetadata.map(metadata -> metadata.getTable(dbName, tblName, startVersion, endVersion))
+                .orElse(null);
+        if (connectorTable != null) {
+            // Load meta information from ConnectorTblMetaInfoMgr for each external table.
+            connectorTblMetaInfoMgr.setTableInfoForConnectorTable(catalogName, dbName, connectorTable);
+        }
+        return connectorTable;
+    }
+
 
     public Table getTable(Long databaseId, Long tableId) {
         Database database = localMetastore.getDb(databaseId);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -386,8 +386,8 @@ public class QueryAnalyzer {
 
                     r = viewRelation;
                 } else {
-                    if (tableRelation.getQueryPeriodString() != null && !table.supportTimeTravel()) {
-                        throw unsupportedException("Unsupported table type for query period clauses, table type: " +
+                    if (tableRelation.getQueryPeriodString() != null && !table.isTemporal()) {
+                        throw unsupportedException("Unsupported table type for temporal clauses, table type: " +
                                 table.getType());
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1255,15 +1255,17 @@ public class QueryAnalyzer {
                     table = metadataMgr.getTemporaryTable(session.getSessionId(), catalogName, db.getId(), tbName);
                 }
                 if (table == null) {
-                    if (tableRelation.getQueryPeriod() == null) {
-                        table = metadataMgr.getTable(catalogName, dbName, tbName);
-                    } else {
-                        // for time travel
-                        QueryPeriod queryPeriod = tableRelation.getQueryPeriod();
-                        QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
-                        Optional<ConnectorTableVersion> startVersion = resolveQueryPeriod(queryPeriod.getStart(), periodType);
-                        Optional<ConnectorTableVersion> endVersion = resolveQueryPeriod(queryPeriod.getEnd(), periodType);
-                        table = metadataMgr.getTable(catalogName, dbName, tbName, startVersion, endVersion);
+                    try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
+                        if (tableRelation.getQueryPeriod() == null) {
+                            table = metadataMgr.getTable(catalogName, dbName, tbName);
+                        } else {
+                            // for time travel
+                            QueryPeriod queryPeriod = tableRelation.getQueryPeriod();
+                            QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
+                            Optional<ConnectorTableVersion> startVersion = resolveQueryPeriod(queryPeriod.getStart(), periodType);
+                            Optional<ConnectorTableVersion> endVersion = resolveQueryPeriod(queryPeriod.getEnd(), periodType);
+                            table = metadataMgr.getTable(catalogName, dbName, tbName, startVersion, endVersion);
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -57,6 +57,8 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.ConnectorTableVersion;
+import com.starrocks.connector.PointerType;
 import com.starrocks.privilege.SecurityPolicyRewriteRule;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -74,6 +76,7 @@ import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.PivotAggregation;
 import com.starrocks.sql.ast.PivotRelation;
 import com.starrocks.sql.ast.PivotValue;
+import com.starrocks.sql.ast.QueryPeriod;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -90,7 +93,12 @@ import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.TypeManager;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.dump.HiveMetaStoreTableDumpInfo;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -378,12 +386,9 @@ public class QueryAnalyzer {
 
                     r = viewRelation;
                 } else {
-                    if (tableRelation.getTemporalClause() != null) {
-                        if (table.getType() != Table.TableType.MYSQL && table.getType() != Table.TableType.METADATA) {
-                            throw unsupportedException(
-                                    "Unsupported table type for temporal clauses: " + table.getType() +
-                                            "; only external MYSQL tables support temporal clauses");
-                        }
+                    if (tableRelation.getQueryPeriodString() != null && !table.supportTimeTravel()) {
+                        throw unsupportedException("Unsupported table type for query period clauses, table type: " +
+                                table.getType());
                     }
 
                     if (table.isSupported()) {
@@ -1250,8 +1255,15 @@ public class QueryAnalyzer {
                     table = metadataMgr.getTemporaryTable(session.getSessionId(), catalogName, db.getId(), tbName);
                 }
                 if (table == null) {
-                    try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
+                    if (tableRelation.getQueryPeriod() == null) {
                         table = metadataMgr.getTable(catalogName, dbName, tbName);
+                    } else {
+                        // for time travel
+                        QueryPeriod queryPeriod = tableRelation.getQueryPeriod();
+                        QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
+                        Optional<ConnectorTableVersion> startVersion = resolveQueryPeriod(queryPeriod.getStart(), periodType);
+                        Optional<ConnectorTableVersion> endVersion = resolveQueryPeriod(queryPeriod.getEnd(), periodType);
+                        table = metadataMgr.getTable(catalogName, dbName, tbName, startVersion, endVersion);
                     }
                 }
             }
@@ -1289,6 +1301,34 @@ public class QueryAnalyzer {
         } catch (AnalysisException e) {
             throw new SemanticException(e.getMessage());
         }
+    }
+
+    private Optional<ConnectorTableVersion> resolveQueryPeriod(Optional<Expr> version, QueryPeriod.PeriodType type) {
+        if (version.isEmpty()) {
+            return Optional.empty();
+        }
+        ScalarOperator result;
+        try {
+            Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+            ExpressionAnalyzer.analyzeExpression(version.get(), new AnalyzeState(), scope, session);
+            ExpressionMapping expressionMapping = new ExpressionMapping(scope);
+            result = SqlToScalarOperatorTranslator.translate(version.get(), expressionMapping, new ColumnRefFactory());
+        } catch (Exception e) {
+            throw new SemanticException("Failed to resolve query period [type: %s, value: %s]. msg: %s",
+                    type.toString(), version.get().toString(), e.getMessage());
+        }
+
+        if (!(result instanceof ConstantOperator)) {
+            if (version.get() instanceof FunctionCallExpr) {
+                throw new SemanticException("Invalid datetime function: [type: %s, value: %s]. " +
+                        "The function requirement must be inferred in frontend.", type.toString(), version.get().toString());
+            } else {
+                throw new SemanticException("Invalid version value. [type: %s, value: %s]",
+                        type.toString(), version.get().toString());
+            }
+        }
+        PointerType pointerType = type == QueryPeriod.PeriodType.TIMESTAMP ? PointerType.TEMPORAL : PointerType.VERSION;
+        return Optional.of(new ConnectorTableVersion(pointerType, (ConstantOperator) result));
     }
 
     private Table resolveTableFunctionTable(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryPeriod.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryPeriod.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.Optional;
+
+public class QueryPeriod implements ParseNode {
+    private final Optional<Expr> start;
+    private final Optional<Expr> end;
+    private final PeriodType periodType;
+
+    public QueryPeriod(PeriodType periodType, Expr end) {
+        this(periodType, Optional.empty(), Optional.of(end));
+    }
+
+    private QueryPeriod(PeriodType periodType, Optional<Expr> start, Optional<Expr> end) {
+        this.periodType = periodType;
+        this.start = start;
+        this.end = end;
+    }
+
+    public enum PeriodType {
+        TIMESTAMP,
+        VERSION
+    }
+
+    public Optional<Expr> getStart() {
+        return start;
+    }
+
+    public Optional<Expr> getEnd() {
+        return end;
+    }
+
+    public PeriodType getPeriodType() {
+        return periodType;
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
@@ -47,8 +47,11 @@ public class TableRelation extends Relation {
     private final List<Long> tabletIds;
     private final List<Long> replicaIds;
     private final Set<TableHint> tableHints = new HashSet<>();
-    // optional temporal clause for external MySQL tables that support this syntax
-    private String temporalClause;
+    // used for mysql external table
+    private String queryPeriodString;
+
+    // used for time travel
+    private QueryPeriod queryPeriod;
 
     private Expr partitionPredicate;
 
@@ -200,12 +203,20 @@ public class TableRelation extends Relation {
         return name.toString();
     }
 
-    public void setTemporalClause(String temporalClause) {
-        this.temporalClause = temporalClause;
+    public String getQueryPeriodString() {
+        return queryPeriodString;
     }
 
-    public String getTemporalClause() {
-        return this.temporalClause;
+    public void setQueryPeriodString(String queryPeriodString) {
+        this.queryPeriodString = queryPeriodString;
+    }
+
+    public QueryPeriod getQueryPeriod() {
+        return queryPeriod;
+    }
+
+    public void setQueryPeriod(QueryPeriod queryPeriod) {
+        this.queryPeriod = queryPeriod;
     }
 
     public void setGeneratedExprToColumnRef(Map<Expr, SlotRef> generatedExprToColumnRef) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
@@ -38,16 +38,7 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
                                       Map<Column, ColumnRefOperator> columnMetaToColRefMap,
                                       long limit,
                                       ScalarOperator predicate) {
-        super(OperatorType.LOGICAL_ICEBERG_SCAN,
-                table,
-                colRefToColumnMetaMap,
-                columnMetaToColRefMap,
-                limit,
-                predicate, null, TableVersionRange.empty());
-
-        Preconditions.checkState(table instanceof IcebergTable);
-        IcebergTable icebergTable = (IcebergTable) table;
-        partitionColumns.addAll(icebergTable.getPartitionColumns().stream().map(Column::getName).collect(Collectors.toList()));
+        this(table, colRefToColumnMetaMap, columnMetaToColRefMap, limit, predicate, TableVersionRange.empty());
     }
 
     public LogicalIcebergScanOperator(Table table,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -598,8 +598,8 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
             if (metadataTable.getMetadataTableType() == MetadataTableType.LOGICAL_ICEBERG_METADATA) {
                 scanOperator = new LogicalIcebergMetadataScanOperator(node.getTable(), colRefToColumnMetaMapBuilder.build(),
                         columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
-                if (node.getTemporalClause() != null) {
-                    ((LogicalIcebergMetadataScanOperator) scanOperator).setTemporalClause(node.getTemporalClause());
+                if (node.getQueryPeriodString() != null) {
+                    ((LogicalIcebergMetadataScanOperator) scanOperator).setTemporalClause(node.getQueryPeriodString());
                 }
             } else {
                 throw new StarRocksPlannerException("Not support metadata table type: " + metadataTable.getMetadataTableType(),
@@ -619,8 +619,8 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                     new LogicalMysqlScanOperator(node.getTable(), colRefToColumnMetaMapBuilder.build(),
                             columnMetaToColRefMap, Operator.DEFAULT_LIMIT,
                             null, null);
-            if (node.getTemporalClause() != null) {
-                ((LogicalMysqlScanOperator) scanOperator).setTemporalClause(node.getTemporalClause());
+            if (node.getQueryPeriodString() != null) {
+                ((LogicalMysqlScanOperator) scanOperator).setTemporalClause(node.getQueryPeriodString());
             }
         } else if (Table.TableType.ELASTICSEARCH.equals(node.getTable().getType())) {
             scanOperator =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -40,6 +40,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.connector.ConnectorTableVersion;
+import com.starrocks.connector.PointerType;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.elasticsearch.EsTablePartitions;
 import com.starrocks.connector.metadata.MetadataTable;
@@ -47,6 +49,8 @@ import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.FieldId;
 import com.starrocks.sql.analyzer.RelationFields;
@@ -61,6 +65,7 @@ import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.PivotRelation;
+import com.starrocks.sql.ast.QueryPeriod;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -536,8 +541,16 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                     new ExpressionMapping(node.getScope(), outputVariables), columnRefFactory);
         }
 
+        QueryPeriod queryPeriod = node.getQueryPeriod();
+        Optional<ConnectorTableVersion> startVersion = Optional.empty();
+        Optional<ConnectorTableVersion> endVersion = Optional.empty();
+        if (queryPeriod != null) {
+            QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
+            startVersion = resolveQueryPeriod(queryPeriod.getStart(), periodType);
+            endVersion = resolveQueryPeriod(queryPeriod.getEnd(), periodType);
+        }
         TableVersionRange tableVersionRange = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getTableVersionRange(node.getTable());
+                .getTableVersionRange(node.getTable(), startVersion, endVersion);
 
         LogicalScanOperator scanOperator;
         if (node.getTable().isNativeTableOrMaterializedView()) {
@@ -657,6 +670,34 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                         .collect(Collectors.toMap(Function.identity(), Function.identity())));
 
         return new LogicalPlan(scanBuilder.withNewRoot(projectOperator), outputVariables, List.of());
+    }
+
+    private Optional<ConnectorTableVersion> resolveQueryPeriod(Optional<Expr> version, QueryPeriod.PeriodType type) {
+        if (version.isEmpty()) {
+            return Optional.empty();
+        }
+        ScalarOperator result;
+        try {
+            Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+            ExpressionAnalyzer.analyzeExpression(version.get(), new AnalyzeState(), scope, session);
+            ExpressionMapping expressionMapping = new ExpressionMapping(scope);
+            result = SqlToScalarOperatorTranslator.translate(version.get(), expressionMapping, new ColumnRefFactory());
+        } catch (Exception e) {
+            throw new SemanticException("Failed to resolve query period [type: %s, value: %s]. msg: %s",
+                    type.toString(), version.get().toString(), e.getMessage());
+        }
+
+        if (!(result instanceof ConstantOperator)) {
+            if (version.get() instanceof FunctionCallExpr) {
+                throw new SemanticException("Invalid datetime function: [type: %s, value: %s]. " +
+                        "The function requirement must be inferred in frontend.", type.toString(), version.get().toString());
+            } else {
+                throw new SemanticException("Invalid version value. [type: %s, value: %s]",
+                        type.toString(), version.get().toString());
+            }
+        }
+        PointerType pointerType = type == QueryPeriod.PeriodType.TIMESTAMP ? PointerType.TEMPORAL : PointerType.VERSION;
+        return Optional.of(new ConnectorTableVersion(pointerType, (ConstantOperator) result));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1951,13 +1951,18 @@ queryNoWith
     : queryPrimary (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
     ;
 
-temporalClause
+queryPeriod
     : AS OF expression
-    | FOR SYSTEM_TIME AS OF TIMESTAMP string
     | FOR SYSTEM_TIME BETWEEN expression AND expression
     | FOR SYSTEM_TIME FROM expression TO expression
     | FOR SYSTEM_TIME ALL
-    | FOR VERSION AS OF expression
+    | (FOR)? periodType AS OF (TIMESTAMP)? end=expression
+    ;
+
+periodType
+    : SYSTEM_TIME
+    | TIMESTAMP
+    | VERSION
     ;
 
 queryPrimary
@@ -2033,7 +2038,7 @@ relation
     ;
 
 relationPrimary
-    : qualifiedName temporalClause? partitionNames? tabletList? replicaList? (
+    : qualifiedName queryPeriod? partitionNames? tabletList? replicaList? (
         AS? alias=identifier)? bracketHint? (BEFORE ts=string)?                          #tableAtom
     | '(' VALUES rowConstructor (',' rowConstructor)* ')'
         (AS? alias=identifier columnAliases?)?                                          #inlineTable

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1952,8 +1952,7 @@ queryNoWith
     ;
 
 queryPeriod
-    : AS OF expression
-    | FOR? periodType BETWEEN expression AND expression
+    : FOR? periodType BETWEEN expression AND expression
     | FOR? periodType FROM expression TO expression
     | FOR? periodType ALL
     | FOR? periodType AS OF end=expression

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1953,10 +1953,10 @@ queryNoWith
 
 queryPeriod
     : AS OF expression
-    | FOR SYSTEM_TIME BETWEEN expression AND expression
-    | FOR SYSTEM_TIME FROM expression TO expression
-    | FOR SYSTEM_TIME ALL
-    | (FOR)? periodType AS OF (TIMESTAMP)? end=expression
+    | FOR? periodType BETWEEN expression AND expression
+    | FOR? periodType FROM expression TO expression
+    | FOR? periodType ALL
+    | FOR? periodType AS OF end=expression
     ;
 
 periodType

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -99,14 +99,6 @@ class ParserTest {
     @Test
     void sqlParseTemporalQueriesTest() {
         String[] temporalQueries = new String[] {
-                // DoltDB temporal query syntax
-                // https://docs.dolthub.com/sql-reference/version-control/querying-history
-                "SELECT * FROM t AS OF 'kfvpgcf8pkd6blnkvv8e0kle8j6lug7a';",
-                "SELECT * FROM t AS OF 'myBranch';",
-                "SELECT * FROM t AS OF 'HEAD^2';",
-                "SELECT * FROM t AS OF TIMESTAMP('2020-01-01');",
-                "SELECT * from `mydb/ia1ibijq8hq1llr7u85uivsi5lh3310p`.myTable;",
-
                 // MariaDB temporal query syntax
                 // https://mariadb.com/kb/en/system-versioned-tables/
                 "SELECT * FROM t FOR SYSTEM_TIME AS OF '2016-10-09 08:07:06';",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -109,7 +109,7 @@ class ParserTest {
 
                 // MariaDB temporal query syntax
                 // https://mariadb.com/kb/en/system-versioned-tables/
-                "SELECT * FROM t FOR SYSTEM_TIME AS OF TIMESTAMP '2016-10-09 08:07:06';",
+                "SELECT * FROM t FOR SYSTEM_TIME AS OF '2016-10-09 08:07:06';",
                 "SELECT * FROM t FOR SYSTEM_TIME BETWEEN (NOW() - INTERVAL 1 YEAR) AND NOW();",
                 "SELECT * FROM t FOR SYSTEM_TIME FROM '2016-01-01 00:00:00' TO '2017-01-01 00:00:00';",
                 "SELECT * FROM t FOR SYSTEM_TIME ALL;",

--- a/test/sql/test_iceberg/R/test_timetravel
+++ b/test/sql/test_iceberg/R/test_timetravel
@@ -43,7 +43,7 @@ select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} tim
 3
 4
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} for system_time as of timestamp date_add(now(), INTERVAL 2 DAY) order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} for system_time as of date_add(now(), INTERVAL 2 DAY) order by k1;
 -- result:
 1
 2

--- a/test/sql/test_iceberg/R/test_timetravel
+++ b/test/sql/test_iceberg/R/test_timetravel
@@ -1,0 +1,68 @@
+-- name: test_timetravel
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (k1 int);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 1; 
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 2; 
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create branch test_branch;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 3;
+-- result:
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create tag test_tag;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 4;
+-- result:
+-- !result
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "test_branch" order by k1;
+-- result:
+1
+2
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "test_tag" order by k1;
+-- result:
+1
+2
+3
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} timestamp as of "2099-01-01 01:01:01" order by k1;
+-- result:
+1
+2
+3
+4
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} for system_time as of timestamp date_add(now(), INTERVAL 2 DAY) order by k1;
+-- result:
+1
+2
+3
+4
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+-- result:
+1
+2
+3
+4
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_timetravel
+++ b/test/sql/test_iceberg/T/test_timetravel
@@ -17,7 +17,7 @@ refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${u
 select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "test_branch" order by k1;
 select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "test_tag" order by k1;
 select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} timestamp as of "2099-01-01 01:01:01" order by k1;
-select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} for system_time as of timestamp date_add(now(), INTERVAL 2 DAY) order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} for system_time as of date_add(now(), INTERVAL 2 DAY) order by k1;
 select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
 
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;

--- a/test/sql/test_iceberg/T/test_timetravel
+++ b/test/sql/test_iceberg/T/test_timetravel
@@ -1,0 +1,25 @@
+-- name: test_timetravel
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (k1 int);
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 1; 
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 2; 
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create branch test_branch;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 3;
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} create tag test_tag;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 4;
+
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "test_branch" order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} version as of "test_tag" order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} timestamp as of "2099-01-01 01:01:01" order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} for system_time as of timestamp date_add(now(), INTERVAL 2 DAY) order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
syntax:
```
queryPeriod
    : AS OF expression
    | FOR? periodType BETWEEN expression AND expression
    | FOR? periodType FROM expression TO expression
    | FOR? periodType ALL
    | FOR? periodType AS OF end=expression
    ;

periodType
    : SYSTEM_TIME
    | TIMESTAMP
    | VERSION
    ;
```
```
select * from table version as of 123456678    -- with snapshotId
select * from table version as of "branch"        -- with branch
select * from table version as of "tag"              -- with tag
select * from table timestamp as of "2023-01-01 12:34:45"   -- The latest snapshot before that time
select * from table timestamp as of "2023-01-01"                   -- The latest snapshot before that time
select * from table timestamp as of now()   -- with date function
select * from table for system_time as of current_date(); -- with date function
```

In common, any version information corresponds to a snapshot id, so for iceberg, we parse all version information like branch/tag/timestamp as snasphotId then use it.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/47846

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
