### PR TITLE
[BugFix] Fix missing set execution id in user variable var

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -772,6 +772,7 @@ public class StmtExecutor {
         SessionVariable clonedSessionVariable = null;
         Map<String, UserVariable> userVariablesFromHint = Maps.newHashMap();
         UUID queryId = context.getQueryId();
+        final TUniqueId executionId = context.getExecutionId();
         for (HintNode hint : parsedStmt.getAllQueryScopeHints()) {
             if (hint instanceof SetVarHint) {
                 if (clonedSessionVariable == null) {
@@ -793,9 +794,12 @@ public class StmtExecutor {
                     SetStmtAnalyzer.analyzeUserVariable(entry.getValue());
                     if (entry.getValue().getEvaluatedExpression() == null) {
                         try {
-                            context.setQueryId(UUIDUtil.genUUID());
+                            final UUID uuid = UUIDUtil.genUUID();
+                            context.setQueryId(uuid);
+                            context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
                             entry.getValue().deriveUserVariableExpressionResult(context);
                         } finally {
+                            context.setExecutionId(executionId);
                             context.setQueryId(queryId);
                             context.resetReturnRows();
                             context.getState().reset();

--- a/test/sql/test_user_variables/R/test_user_variable
+++ b/test/sql/test_user_variables/R/test_user_variable
@@ -1,0 +1,49 @@
+-- name: test_user_variable
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into t0 values (null,null,null,null);
+-- result:
+-- !result
+set @var = 1;
+-- result:
+-- !result
+select @var;
+-- result:
+1
+-- !result
+set @var = (select count(*) from t0 limit 1);
+-- result:
+-- !result
+select @var;
+-- result:
+40961
+-- !result
+with tx as (select @var2 as x)
+select /*+ SET_USER_VARIABLE(@var2 = (select count(*) from t0 limit 1)) */ * from tx;
+-- result:
+40961
+-- !result
+select @var2;
+-- result:
+None
+-- !result
+with tx as (select @var2 as x)
+select /*+ SET_USER_VARIABLE(@var2 = (select count(*) from (select l.c0 from t0 l join t0 r on l.c0 = r.c0 ) tb)) */ * from tx;
+-- result:
+40960
+-- !result

--- a/test/sql/test_user_variables/T/test_user_variable
+++ b/test/sql/test_user_variables/T/test_user_variable
@@ -1,0 +1,32 @@
+-- name: test_user_variable
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+insert into t0 values (null,null,null,null);
+
+-- basic test
+set @var = 1;
+select @var;
+-- user variable generate from SQL
+set @var = (select count(*) from t0 limit 1);
+select @var;
+
+-- user variable using in hint
+with tx as (select @var2 as x)
+select /*+ SET_USER_VARIABLE(@var2 = (select count(*) from t0 limit 1)) */ * from tx;
+select @var2;
+
+
+with tx as (select @var2 as x)
+select /*+ SET_USER_VARIABLE(@var2 = (select count(*) from (select l.c0 from t0 l join t0 r on l.c0 = r.c0 ) tb)) */ * from tx;


### PR DESCRIPTION
## Why I'm doing:

the query id dispatch to BE is execution id. if miss set it. be will recv two same query id. they will use the same query context.

## What I'm doing:

fix the stack trace:
```
*** SIGABRT (@0x3eb002fe74f) received by PID 3139407 (TID 0x7f5aba7d8640) from PID 3139407; stack trace: ***
    @         0x1c9d9e4a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f5bba7ba520 (unknown)
    @     0x7f5bba80e9fc pthread_kill
    @     0x7f5bba7ba476 raise
    @     0x7f5bba7a07f3 abort
    @          0xbdd85e1 starrocks::failure_function()
    @         0x1c9cd841 google::LogMessage::Fail()
    @         0x1c9cfe9f google::LogMessage::SendToLog()
    @         0x1c9cd380 google::LogMessage::Flush()
    @         0x1c9d050d google::LogMessageFatal::~LogMessageFatal()
    @          0xc4c7d9a starrocks::RowDescriptor::RowDescriptor()
    @          0xddb7dc7 starrocks::ExecNode::ExecNode()
    @          0xe970ce4 starrocks::ProjectNode::ProjectNode()
    @          0xddc12e0 starrocks::ExecNode::create_vectorized_node()
    @          0xddbf290 starrocks::ExecNode::create_tree_helper()
    @          0xddbec1b starrocks::ExecNode::create_tree()
    @          0xf15d286 starrocks::pipeline::FragmentExecutor::_prepare_exec_plan()
    @          0xf167366 starrocks::pipeline::FragmentExecutor::prepare()
    @         0x18731e03 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment_by_pipeline()
    @         0x187317fa starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @         0x1872b3df starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @         0x18751f5e _ZZN9starrocks24PInternalServiceImplBaseINS_16PInternalServiceEE18exec_plan_fragmentEPN6google8protobuf13RpcControllerEPKNS_24PExecPlanFragmentRequestEPNS_23PExecPlanFragmentResultEPNS4_7ClosureEENKUlvE_clEv
    @         0x1876305c _ZSt13__invoke_implIvRZN9starrocks24PInternalServiceImplBaseINS0_16PInternalServiceEE18exec_plan_fragmentEPN6google8protobuf13RpcControllerEPKNS0_24PExecPlanFragmentRequestEPNS0_23PExecPlanFragmentResultEPNS5_7ClosureEEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @         0x1875f639 _ZSt10__invoke_rIvRZN9starrocks24PInternalServiceImplBaseINS0_16PInternalServiceEE18exec_plan_fragmentEPN6google8protobuf13RpcControllerEPKNS0_24PExecPlanFragmentRequestEPNS0_23PExecPlanFragmentResultEPNS5_7ClosureEEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESI_E4typeEOSJ_DpOSK_
    @         0x1875bf0d _ZNSt17_Function_handlerIFvvEZN9starrocks24PInternalServiceImplBaseINS1_16PInternalServiceEE18exec_plan_fragmentEPN6google8protobuf13RpcControllerEPKNS1_24PExecPlanFragmentRequestEPNS1_23PExecPlanFragmentResultEPNS6_7ClosureEEUlvE_E9_M_invokeERKSt9_Any_data
    @          0xbcab5ba std::function<>::operator()()
    @          0xc15c958 starrocks::PriorityThreadPool::work_thread()
    @          0xc1b126d std::__invoke_impl<>()
    @          0xc1b10a5 std::__invoke<>()
    @          0xc1b1039 _ZNKSt12_Mem_fn_baseIMN9starrocks18PriorityThreadPoolEFviELb1EEclIJRPS1_RiEEEDTcl8__invokedtdefpT6_M_pmfspcl7forwardIT_Efp_EEEDpOS9_
    @          0xc1b0fa6 std::__invoke_impl<>()
    @          0xc1b0ee9 _ZSt10__invoke_rIvRSt7_Mem_fnIMN9starrocks18PriorityThreadPoolEFviEEJRPS2_RiEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESB_E4typeEOSC_DpOSD_
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
