### PR TITLE
[BugFix] Fix NPE due to MvRewriteContext not correctly initialized

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.google.api.client.util.Lists;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -721,7 +722,7 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
             logMVRewrite(mvRewriteContext, "Push down agg query split predicate: {}", queryPredicateSplit);
 
             MvRewriteContext newMvRewriteContext = new MvRewriteContext(mvRewriteContext.getMaterializationContext(),
-                    queryTables, optExpression, queryColumnRefRewriter, queryPredicateSplit, null, rule);
+                    queryTables, optExpression, queryColumnRefRewriter, queryPredicateSplit, Lists.newArrayList(), rule);
             // set aggregate push down context to be used in the final stage
             newMvRewriteContext.setAggregatePushDownContext(ctx);
             AggregatedMaterializedViewRewriter rewriter = new AggregatedMaterializedViewRewriter(newMvRewriteContext);


### PR DESCRIPTION
## Why I'm doing:
At line https://github.com/StarRocks/starrocks/blob/0e43064d309e3583f63ba2ae236ea3de4ba58ba1/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java#L1957 
   `predicates.removeAll(mvRewriteContext.getOnPredicates())` throws NPE when `mvRewriteContext.getOnPredicates()` is null which is the `null` at line  https://github.com/StarRocks/starrocks/blob/0e43064d309e3583f63ba2ae236ea3de4ba58ba1/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java#L724

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
