### PR TITLE
[Enhancement] DeltaLake supports reading metadata without stat generated by older versions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -32,32 +32,31 @@ public class ScanFileUtils {
         public long numRecords;
     }
 
-    public static long getFileRows(Row file) {
+    public static long getFileRows(Row file, FileStatus fileStatus, long estimateRowSize) {
         String stats = file.getString(ADD_FILE_STATS_ORDINAL);
-        if (stats == null) {
-            throw new IllegalArgumentException("There is no `stats` entry in the add file row");
+        if (stats != null) {
+            Records records = GsonUtils.GSON.fromJson(stats, Records.class);
+            if (records != null) {
+                return records.numRecords;
+            }
         }
 
-        Records records = GsonUtils.GSON.fromJson(stats, Records.class);
-        if (records == null) {
-            throw new IllegalArgumentException("There is no `records` entry in the stats row");
-        }
-
-        return records.numRecords;
+        return fileStatus.getSize() / estimateRowSize;
     }
 
-    public static DeltaLakeAddFileStatsSerDe getColumnStatistics(Row file) {
+    public static DeltaLakeAddFileStatsSerDe getColumnStatistics(Row file, FileStatus fileStatus,
+                                                                 long estimateRowSize) {
         String stats = file.getString(ADD_FILE_STATS_ORDINAL);
-        if (stats == null) {
-            throw new IllegalArgumentException("There is no `stats` entry in the add file row");
+        if (stats != null) {
+            DeltaLakeAddFileStatsSerDe fileStatsSerDe = GsonUtils.GSON.fromJson(
+                    stats, DeltaLakeAddFileStatsSerDe.class);
+            if (fileStatsSerDe != null) {
+                return fileStatsSerDe;
+            }
         }
 
-        DeltaLakeAddFileStatsSerDe statistics = GsonUtils.GSON.fromJson(stats, DeltaLakeAddFileStatsSerDe.class);
-        if (statistics == null) {
-            throw new IllegalArgumentException("There is no entry in the stats row");
-        }
-
-        return statistics;
+        long estimateRowCount = fileStatus.getSize() / estimateRowSize;
+        return new DeltaLakeAddFileStatsSerDe(estimateRowCount, null, null, null);
     }
 
     private static Row getAddFileEntry(Row scanFileInfo) {
@@ -67,18 +66,20 @@ public class ScanFileUtils {
         return scanFileInfo.getStruct(ADD_FILE_ORDINAL);
     }
 
-    public static Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> convertFromRowToFileScanTask(boolean needStats, Row file) {
+    public static Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> convertFromRowToFileScanTask(
+            boolean needStats, Row file, long estimizateRowSize) {
         FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(file);
         Map<String, String> partitionValues = InternalScanFileUtils.getPartitionValues(file);
         Row addFileRow = getAddFileEntry(file);
 
         FileScanTask fileScanTask;
         if (needStats) {
-            DeltaLakeAddFileStatsSerDe stats = ScanFileUtils.getColumnStatistics(addFileRow);
+            DeltaLakeAddFileStatsSerDe stats = ScanFileUtils.getColumnStatistics(
+                    addFileRow, fileStatus, estimizateRowSize);
             fileScanTask = new FileScanTask(fileStatus, stats.numRecords, partitionValues);
             return new Pair<>(fileScanTask, stats);
         } else {
-            long records = ScanFileUtils.getFileRows(addFileRow);
+            long records = ScanFileUtils.getFileRows(addFileRow, fileStatus, estimizateRowSize);
             fileScanTask = new FileScanTask(fileStatus, records, partitionValues);
             return new Pair<>(fileScanTask, null);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScanFileUtils.java
@@ -67,7 +67,7 @@ public class ScanFileUtils {
     }
 
     public static Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> convertFromRowToFileScanTask(
-            boolean needStats, Row file, long estimizateRowSize) {
+            boolean needStats, Row file, long estimateRowSize) {
         FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(file);
         Map<String, String> partitionValues = InternalScanFileUtils.getPartitionValues(file);
         Row addFileRow = getAddFileEntry(file);
@@ -75,11 +75,11 @@ public class ScanFileUtils {
         FileScanTask fileScanTask;
         if (needStats) {
             DeltaLakeAddFileStatsSerDe stats = ScanFileUtils.getColumnStatistics(
-                    addFileRow, fileStatus, estimizateRowSize);
+                    addFileRow, fileStatus, estimateRowSize);
             fileScanTask = new FileScanTask(fileStatus, stats.numRecords, partitionValues);
             return new Pair<>(fileScanTask, stats);
         } else {
-            long records = ScanFileUtils.getFileRows(addFileRow, fileStatus, estimizateRowSize);
+            long records = ScanFileUtils.getFileRows(addFileRow, fileStatus, estimateRowSize);
             fileScanTask = new FileScanTask(fileStatus, records, partitionValues);
             return new Pair<>(fileScanTask, null);
         }

--- a/test/sql/test_deltalake/R/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/R/test_deltalake_collect_stats
@@ -126,6 +126,10 @@ function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delt
 -- result:
 None
 -- !result
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
+-- result:
+None
+-- !result
 set enable_delta_lake_column_statistics=true;
 -- result:
 -- !result
@@ -238,6 +242,10 @@ function: assert_explain_costs_contains('select c3 from delta_test_${uuid0}.delt
 None
 -- !result
 function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delta_oss_db.t_p_bool', 'c1-->[0.0, 1.0, 0.25, 1.0, 1.0] UNKNOWN')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
 -- result:
 None
 -- !result

--- a/test/sql/test_deltalake/R/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/R/test_deltalake_collect_stats
@@ -126,7 +126,7 @@ function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delt
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stat', 'cardinality=156')
 -- result:
 None
 -- !result
@@ -245,7 +245,7 @@ function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delt
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stat', 'cardinality=156')
 -- result:
 None
 -- !result

--- a/test/sql/test_deltalake/T/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/T/test_deltalake_collect_stats
@@ -48,6 +48,8 @@ function: assert_explain_costs_contains('select c3 from delta_test_${uuid0}.delt
 
 function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delta_oss_db.t_p_bool', 'c1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
 
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
+
 set enable_delta_lake_column_statistics=true;
 
 function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'cardinality=8')
@@ -85,5 +87,7 @@ function: assert_explain_costs_contains('select c2 from delta_test_${uuid0}.delt
 function: assert_explain_costs_contains('select c3 from delta_test_${uuid0}.delta_oss_db.t_p_time', 'c3-->[1.704168306E9, 1.704686706E9, 0.0, 8.0, 1.0] UNKNOWN')
 
 function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delta_oss_db.t_p_bool', 'c1-->[0.0, 1.0, 0.25, 1.0, 1.0] UNKNOWN')
+
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
 
 drop catalog delta_test_${uuid0}

--- a/test/sql/test_deltalake/T/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/T/test_deltalake_collect_stats
@@ -48,7 +48,7 @@ function: assert_explain_costs_contains('select c3 from delta_test_${uuid0}.delt
 
 function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delta_oss_db.t_p_bool', 'c1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN')
 
-function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stat', 'cardinality=156')
 
 set enable_delta_lake_column_statistics=true;
 
@@ -88,6 +88,6 @@ function: assert_explain_costs_contains('select c3 from delta_test_${uuid0}.delt
 
 function: assert_explain_costs_contains('select c1 from delta_test_${uuid0}.delta_oss_db.t_p_bool', 'c1-->[0.0, 1.0, 0.25, 1.0, 1.0] UNKNOWN')
 
-function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stats', 'cardinality=156')
+function: assert_explain_costs_contains('select * from delta_test_${uuid0}.delta_oss_db.t_without_stat', 'cardinality=156')
 
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The metdata generated by delta lake has no stat.

```
{"commitInfo":{"timestamp":1720172614781,"operation":"WRITE","operationParameters":{"mode":"Append","partitionBy":"[]"},"readVersion":0,"isBlindAppend":true,"operationMetrics":{"numFiles":"4","numOutputBytes":"2440","numOutputRows":"4"}}}
{"add":{"path":"part-00000-8bae0835-6d1e-441a-bb16-72512018f2c3-c000.snappy.parquet","partitionValues":{},"size":623,"modificationTime":1720172614000,"dataChange":true}}
{"add":{"path":"part-00001-0cf492f8-f661-497f-8e1b-696cb807db72-c000.snappy.parquet","partitionValues":{},"size":623,"modificationTime":1720172614000,"dataChange":true}}
{"add":{"path":"part-00002-15c565e6-319a-42a4-a622-a01a71d4398b-c000.snappy.parquet","partitionValues":{},"size":623,"modificationTime":1720172614000,"dataChange":true}}
{"add":{"path":"part-00003-8a267696-b2ea-42d4-aff6-0116dc2f5941-c000.snappy.parquet","partitionValues":{},"size":571,"modificationTime":1720172614000,"dataChange":true}}
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
