### PR TITLE
[BugFix] fix wrong result type of TemporaryTableMgr.getAllTemporaryTables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableMgr.java
@@ -153,15 +153,15 @@ public class TemporaryTableMgr {
         return tables.listTables(databaseId);
     }
 
-    // get all temporary tables under specific databases, return a Table<databaseId, sessionId, tableId>
-    public Table<Long, UUID, Long> getAllTemporaryTables(Set<Long> requiredDatabaseIds) {
-        Table<Long, UUID, Long> result = HashBasedTable.create();
+    // get all temporary tables under specific databases, return a Table<databaseId, tableId, sessionId>
+    public Table<Long, Long, UUID> getAllTemporaryTables(Set<Long> requiredDatabaseIds) {
+        Table<Long, Long, UUID> result = HashBasedTable.create();
         tablesMap.forEach((sessionId, tables) -> {
             // db id -> table name -> table id
             Table<Long, String, Long> allTables = tables.getAllTables();
             for (Table.Cell<Long, String, Long> cell : allTables.cellSet()) {
                 if (requiredDatabaseIds.contains(cell.getRowKey())) {
-                    result.put(cell.getRowKey(), sessionId, cell.getValue());
+                    result.put(cell.getRowKey(), cell.getValue(), sessionId);
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -512,19 +512,19 @@ public class InformationSchemaDataSource {
             }
         }
 
-        com.google.common.collect.Table<Long, UUID, Long> allTables = temporaryTableMgr.getAllTemporaryTables(requiredDbIds);
+        com.google.common.collect.Table<Long, Long, UUID> allTables = temporaryTableMgr.getAllTemporaryTables(requiredDbIds);
 
         List<TTableInfo> tableInfos = new ArrayList<>();
         for (Long databaseId : allTables.rowKeySet()) {
             Database db = metadataMgr.getDb(databaseId);
             if (db != null) {
-                Map<UUID, Long> tableMap = allTables.row(databaseId);
+                Map<Long, UUID> tableMap = allTables.row(databaseId);
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    for (Map.Entry<UUID, Long> entry : tableMap.entrySet()) {
-                        UUID sessionId = entry.getKey();
-                        Long tableId = entry.getValue();
+                    for (Map.Entry<Long, UUID> entry : tableMap.entrySet()) {
+                        UUID sessionId = entry.getValue();
+                        Long tableId = entry.getKey();
                         Table table = db.getTable(tableId);
                         if (table != null) {
                             TTableInfo info = new TTableInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/server/TemporaryTableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/TemporaryTableMgrTest.java
@@ -37,6 +37,7 @@ public class TemporaryTableMgrTest {
         temporaryTableMgr.addTemporaryTable(sessionId1, 1L, "table1", 1L);
         temporaryTableMgr.addTemporaryTable(sessionId1, 2L, "table2", 2L);
         temporaryTableMgr.addTemporaryTable(sessionId2, 1L, "table1", 3L);
+        temporaryTableMgr.addTemporaryTable(sessionId2, 1L, "table2", 4L);
 
         Assert.assertTrue(temporaryTableMgr.tableExists(sessionId1, 1L, "table1"));
         long tableId = temporaryTableMgr.getTable(sessionId1, 1L, "table1");
@@ -61,13 +62,14 @@ public class TemporaryTableMgrTest {
 
         {
             Set<Long> dbIds = new HashSet<>(Arrays.asList(1L));
-            Table<Long, UUID, Long> actual = temporaryTableMgr.getAllTemporaryTables(dbIds);
+            Table<Long, Long, UUID> actual = temporaryTableMgr.getAllTemporaryTables(dbIds);
 
-            Assert.assertEquals(actual.size(), 2);
+            Assert.assertEquals(actual.size(), 3);
             Assert.assertTrue(actual.containsRow(1L));
-            Assert.assertTrue(actual.row(1L).size() == 2);
-            Assert.assertTrue(actual.row(1L).get(sessionId1) == 1L);
-            Assert.assertTrue(actual.row(1L).get(sessionId2) == 3L);
+            Assert.assertTrue(actual.row(1L).size() == 3);
+            Assert.assertTrue(actual.row(1L).get(1L) == sessionId1);
+            Assert.assertTrue(actual.row(1L).get(3L) == sessionId2);
+            Assert.assertTrue(actual.row(1L).get(4L) == sessionId2);
         }
 
         Assert.assertEquals(temporaryTableMgr.listSessions().size(), 2);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #48012

`TemporaryTableManager. getAllTemporaryTables` is used to get information about all temporary tables under some specific db IDs. 
The returned results are organized in the form of `Table<database id, session id, table id>`, while the guava table uniquely identifies a cell with rowKey and columnKey. Obviously, if a session creates multiple temporary tables under the same db, the returned results are incorrect.
The solution is simple, change the returned type to `Table<database id, table Id, session id>`


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
