### PR TITLE
[BugFix]copy no_cast_column to reuse _result_chunk of jdbcScanner

### DIFF
--- a/be/src/exec/jdbc_scanner.cpp
+++ b/be/src/exec/jdbc_scanner.cpp
@@ -22,6 +22,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exprs/cast_expr.h"
+#include "exprs/clone_expr.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "runtime/types.h"
@@ -418,7 +419,8 @@ Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
             cast_expr = VectorizedCastExprFactory::from_type(intermediate, _slot_descs[i]->type(), column_ref, &_pool,
                                                              true);
         } else {
-            cast_expr = column_ref;
+            // clone to reuse result_chunk
+            cast_expr = CloneExpr::from_child(column_ref, &_pool);
         }
 
         _cast_exprs.push_back(_pool.add(new ExprContext(cast_expr)));

--- a/be/src/exprs/clone_expr.h
+++ b/be/src/exprs/clone_expr.h
@@ -31,5 +31,16 @@ public:
         ASSIGN_OR_RETURN(ColumnPtr column, get_child(0)->evaluate_checked(context, ptr));
         return column->clone_shared();
     }
+
+    static Expr* from_child(Expr* child, ObjectPool* pool) {
+        TExprNode clone_node;
+        clone_node.node_type = TExprNodeType::CLONE_EXPR;
+        clone_node.type = child->type().to_thrift();
+        clone_node.__set_child_type(to_thrift(child->type().type));
+        clone_node.__set_child_type_desc(child->type().to_thrift());
+        Expr* clone_expr = pool->add(new CloneExpr(clone_node));
+        clone_expr->add_child(child);
+        return clone_expr;
+    }
 };
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
for no_cast_column the cast_expr will be column_ref which will return the ptr to result_chunk,
we need copy it to reuse result_chunk.

Fixes #issue
fix https://github.com/StarRocks/StarRocksTest/issues/8025

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
