### PR TITLE
[BugFix] Fix HudiPartitionTraits get table name error for hudi resource table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
@@ -40,6 +40,11 @@ public class HudiPartitionTraits extends DefaultTraits {
     }
 
     @Override
+    public String getTableName() {
+        return ((HiveMetaStoreTable) table).getTableName();
+    }
+
+    @Override
     public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                 MaterializedView.AsyncRefreshContext context) {
         // TODO: implement

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.paimon.Partition;
 import com.starrocks.connector.partitiontraits.DefaultTraits;
@@ -98,5 +99,15 @@ public class ConnectorPartitionTraitsTest {
                 HiveTable.HiveTableType.MANAGED_TABLE);
         ConnectorPartitionTraits connectorPartitionTraits = ConnectorPartitionTraits.build(hiveTable);
         Assert.assertEquals(connectorPartitionTraits.getTableName(), "hiveTable");
+    }
+
+    @Test
+    public void testHudiResourceTableName() {
+        HudiTable hudiTable = new HudiTable(0, "name", "hdui_catalog", "hudiDb",
+                "hudiTable",  "resource_name", "",
+                Lists.newArrayList(), Lists.newArrayList(), Lists.newArrayList(), 0,
+                Maps.newHashMap(), HudiTable.HudiTableType.COW);
+        ConnectorPartitionTraits connectorPartitionTraits = ConnectorPartitionTraits.build(hudiTable);
+        Assert.assertEquals(connectorPartitionTraits.getTableName(), "hudiTable");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
HudiPartitionTraits use name as its table name, we need use ((HiveMetaStoreTable) table).getTableName()  as table name for hudi resource table
## What I'm doing:

Fixes #issue
Fixes https://github.com/StarRocks/StarRocksTest/issues/8014
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
