### PR TITLE
[BugFix] Fix logical tablet internal parallel SIGFPE (backport #47974)

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -575,7 +575,7 @@ Status LogicalSplitMorselQueue::_init_tablet() {
     }
 
     _largest_rowset = _find_largest_rowset(_tablet_rowsets[_tablet_idx]);
-    if (_largest_rowset == nullptr || _largest_rowset->num_rows() == 0) {
+    if (_largest_rowset == nullptr || _largest_rowset->num_rows() == 0 || _tablets[_tablet_idx]->num_rows() == 0) {
         return Status::OK();
     }
 
@@ -584,8 +584,10 @@ Status LogicalSplitMorselQueue::_init_tablet() {
 
     _short_key_schema = std::make_shared<vectorized::Schema>(
             ChunkHelper::get_short_key_schema_with_format_v2(_tablets[_tablet_idx]->tablet_schema()));
-    _sample_splitted_scan_blocks =
-            _splitted_scan_rows * _segment_group->num_blocks() / _tablets[_tablet_idx]->num_rows();
+    const auto tablet_num_rows =
+            std::max<int64_t>({1, static_cast<int64_t>(_tablets[_tablet_idx]->num_rows()),
+                               static_cast<int64_t>(_largest_rowset->num_rows()), _segment_group->num_rows()});
+    _sample_splitted_scan_blocks = _splitted_scan_rows * _segment_group->num_blocks() / tablet_num_rows;
     _sample_splitted_scan_blocks = std::max<int64_t>(_sample_splitted_scan_blocks, 1);
 
     if (_tablet_seek_ranges.empty()) {

--- a/be/src/storage/rowset/segment_group.cpp
+++ b/be/src/storage/rowset/segment_group.cpp
@@ -90,4 +90,9 @@ void ShortKeyIndexDecoderGroup::_find_position(ssize_t ordinal, ssize_t* decoder
 SegmentGroup::SegmentGroup(std::vector<SegmentSharedPtr>&& segments)
         : _segments(std::move(segments)), _decoder_group(_segments) {}
 
+uint32_t SegmentGroup::num_rows() const {
+    return std::accumulate(_segments.cbegin(), _segments.cend(), 0,
+                           [](uint32_t acc, const auto& segment) { return acc + segment->num_rows(); });
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_group.h
+++ b/be/src/storage/rowset/segment_group.h
@@ -125,6 +125,8 @@ public:
         return _segments[0]->num_short_keys();
     }
 
+    uint32_t num_rows() const;
+
 private:
     std::vector<SegmentSharedPtr> _segments;
     ShortKeyIndexDecoderGroup _decoder_group;

--- a/test/sql/test_tablet_internal_parallel/R/test_logical_split
+++ b/test/sql/test_tablet_internal_parallel/R/test_logical_split
@@ -1,0 +1,86 @@
+-- name: test_logical_split_empty_after_delete
+set enable_tablet_internal_parallel = true;
+-- result:
+-- !result
+set tablet_internal_parallel_mode = 'force_split';
+-- result:
+-- !result
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c_int_1_seq bigint SUM NULL
+) ENGINE=OLAP
+AGGREGATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "colocate_with" = "tablet_internal_group2"
+);
+-- result:
+-- !result
+CREATE TABLE t2 (
+  k1 bigint NULL,
+  c_int_1_seq bigint SUM NULL
+) ENGINE=OLAP
+AGGREGATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "colocate_with" = "tablet_internal_group2"
+);
+-- result:
+-- !result
+insert into t1 select 1, 1;
+-- result:
+-- !result
+insert into t2 select 1, 1;
+-- result:
+-- !result
+delete from t2 where k1 = 1;
+-- result:
+-- !result
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+-- result:
+-- !result
+insert into t2 select 1, 1;
+-- result:
+-- !result
+delete from t2 where k1 = 1;
+-- result:
+-- !result
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+-- result:
+-- !result
+insert into t2 select 1, 1;
+-- result:
+-- !result
+delete from t2 where k1 = 1;
+-- result:
+-- !result
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+-- result:
+-- !result
+insert into t2 select 1, 1;
+-- result:
+-- !result
+delete from t2 where k1 = 1;
+-- result:
+-- !result
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+-- result:
+-- !result
+insert into t2 select 1, 1;
+-- result:
+-- !result
+delete from t2 where k1 = 1;
+-- result:
+-- !result
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+-- result:
+-- !result
+insert into t2 select 1, 1;
+-- result:
+-- !result
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+-- result:
+1
+-- !result

--- a/test/sql/test_tablet_internal_parallel/T/test_logical_split
+++ b/test/sql/test_tablet_internal_parallel/T/test_logical_split
@@ -1,0 +1,55 @@
+-- name: test_logical_split_empty_after_delete
+
+set enable_tablet_internal_parallel = true;
+set tablet_internal_parallel_mode = 'force_split';
+
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c_int_1_seq bigint SUM NULL
+) ENGINE=OLAP
+AGGREGATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "colocate_with" = "tablet_internal_group2"
+);
+
+
+CREATE TABLE t2 (
+  k1 bigint NULL,
+  c_int_1_seq bigint SUM NULL
+) ENGINE=OLAP
+AGGREGATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "colocate_with" = "tablet_internal_group2"
+);
+
+insert into t1 select 1, 1;
+
+-- Execute insert, delete, and query multiple times.
+
+insert into t2 select 1, 1;
+delete from t2 where k1 = 1;
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+
+insert into t2 select 1, 1;
+delete from t2 where k1 = 1;
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+
+insert into t2 select 1, 1;
+delete from t2 where k1 = 1;
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+
+insert into t2 select 1, 1;
+delete from t2 where k1 = 1;
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+
+insert into t2 select 1, 1;
+delete from t2 where k1 = 1;
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;
+
+-- Execute insert and query.
+insert into t2 select 1, 1;
+select t2.c_int_1_seq from t2 join [colocate] (select sleep(2) as x from t1)t on t2.k1 = t.x;


### PR DESCRIPTION
CP from #47974.

## Why I'm doing:

BE crashed.
```
*** Aborted at 1720421674 (unix time) try "date -d @1720421674" if you are using GNU date ***
PC: @          0x41dd343 starrocks::pipeline::LogicalSplitMorselQueue::_init_tablet()
*** SIGFPE (@0x41dd343) received by PID 23700 (TID 0x7f49546b6700) from PID 69063491; stack trace: ***
    @          0x9b5ca32 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f49e1bb2630 (unknown)
    @          0x41dd343 starrocks::pipeline::LogicalSplitMorselQueue::_init_tablet()
    @          0x41dd94f starrocks::pipeline::LogicalSplitMorselQueue::try_get()
    @          0x41eb2a5 starrocks::pipeline::ScanOperator::_pickup_morsel()
    @          0x41ead1e starrocks::pipeline::ScanOperator::_try_to_trigger_next_scan()
    @          0x41eafdc starrocks::pipeline::ScanOperator::pull_chunk()
    @          0x4271815 starrocks::pipeline::PipelineDriver::process()
    @          0x4261e9d starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x37a4c3c starrocks::ThreadPool::dispatch_thread()
    @          0x379e90a starrocks::Thread::supervise_thread()
    @     0x7f49e1baaea5 start_thread
    @     0x7f49e0d95b0d __clone
    @                0x0 (unknown)
```

## What I'm doing:

As for logical tablet internal parallel, we only check whether `_largest_rowset` is empty, but use `_tablets[_tablet_idx]->num_rows()` as a divisor.

However, the number of rows of tablet may less than that of `_largest_rowset`, if there are some delete rowsets after `_largest_rowset`. 

For example, assume that we insert one row and then delete it, there will be two row-sets: 
- `rs#1` contains one row, 
- and `rs#2` contains nothing but a delete predicate.

And `tablet->num_rows()` will be also zero.

```cpp
    _largest_rowset = _find_largest_rowset(_tablet_rowsets[_tablet_idx]);
    if (_largest_rowset == nullptr || _largest_rowset->num_rows() == 0) {
        return Status::OK();
    }

    _sample_splitted_scan_blocks =
            _splitted_scan_rows * _segment_group->num_blocks() / _tablets[_tablet_idx]->num_rows();
    _sample_splitted_scan_blocks = std::max<int64_t>(_sample_splitted_scan_blocks, 1);
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
<hr>This is an automatic backport of pull request #47974 done by [Mergify](https://mergify.com).
## Why I'm doing:

BE crashed.
```
*** Aborted at 1720421674 (unix time) try "date -d @1720421674" if you are using GNU date ***
PC: @          0x41dd343 starrocks::pipeline::LogicalSplitMorselQueue::_init_tablet()
*** SIGFPE (@0x41dd343) received by PID 23700 (TID 0x7f49546b6700) from PID 69063491; stack trace: ***
    @          0x9b5ca32 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f49e1bb2630 (unknown)
    @          0x41dd343 starrocks::pipeline::LogicalSplitMorselQueue::_init_tablet()
    @          0x41dd94f starrocks::pipeline::LogicalSplitMorselQueue::try_get()
    @          0x41eb2a5 starrocks::pipeline::ScanOperator::_pickup_morsel()
    @          0x41ead1e starrocks::pipeline::ScanOperator::_try_to_trigger_next_scan()
    @          0x41eafdc starrocks::pipeline::ScanOperator::pull_chunk()
    @          0x4271815 starrocks::pipeline::PipelineDriver::process()
    @          0x4261e9d starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x37a4c3c starrocks::ThreadPool::dispatch_thread()
    @          0x379e90a starrocks::Thread::supervise_thread()
    @     0x7f49e1baaea5 start_thread
    @     0x7f49e0d95b0d __clone
    @                0x0 (unknown)
```

## What I'm doing:

As for logical tablet internal parallel, we only check whether `_largest_rowset` is empty, but use `_tablets[_tablet_idx]->num_rows()` as a divisor.

However, the number of rows of tablet may less than that of `_largest_rowset`, if there are some delete rowsets after `_largest_rowset`. 

For example, assume that we insert one row and then delete it, there will be two row-sets: 
- `rs#1` contains one row, 
- and `rs#2` contains nothing but a delete predicate.

And `tablet->num_rows()` will be also zero.

```cpp
    _largest_rowset = _find_largest_rowset(_tablet_rowsets[_tablet_idx]);
    if (_largest_rowset == nullptr || _largest_rowset->num_rows() == 0) {
        return Status::OK();
    }

    _sample_splitted_scan_blocks =
            _splitted_scan_rows * _segment_group->num_blocks() / _tablets[_tablet_idx]->num_rows();
    _sample_splitted_scan_blocks = std::max<int64_t>(_sample_splitted_scan_blocks, 1);
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


