### PR TITLE
[BugFix] Fix the bug of LocalPartitionTopnSinkOperator set finishing without check is_cancelled

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -60,7 +60,7 @@ Status LocalPartitionTopnContext::prepare(RuntimeState* state) {
 }
 
 Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk) {
-    auto st = _chunks_partitioner->offer<true>(
+    RETURN_IF_ERROR(_chunks_partitioner->offer<true>(
             chunk,
             [this, state](size_t partition_idx) {
                 _chunks_sorters.emplace_back(std::make_shared<ChunksSorterTopn>(
@@ -69,11 +69,11 @@ Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* st
             },
             [this, state](size_t partition_idx, const ChunkPtr& chunk) {
                 (void)_chunks_sorters[partition_idx]->update(state, chunk);
-            });
+            }));
     if (_chunks_partitioner->is_passthrough()) {
         RETURN_IF_ERROR(transfer_all_chunks_from_partitioner_to_sorters(state));
     }
-    return st;
+    return Status::OK();
 }
 
 void LocalPartitionTopnContext::sink_complete() {

--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
@@ -39,13 +39,17 @@ Status LocalPartitionTopnSinkOperator::push_chunk(RuntimeState* state, const Chu
 
 Status LocalPartitionTopnSinkOperator::set_finishing(RuntimeState* state) {
     ONCE_DETECT(_set_finishing_once);
-    RETURN_IF_ERROR(_partition_topn_ctx->transfer_all_chunks_from_partitioner_to_sorters(state));
-    _partition_topn_ctx->sink_complete();
-    _unique_metrics->add_info_string("IsPassThrough", _partition_topn_ctx->is_passthrough() ? "Yes" : "No");
-    auto* partition_num_counter = ADD_COUNTER(_unique_metrics, "PartitionNum", TUnit::UNIT);
-    COUNTER_SET(partition_num_counter, static_cast<int64_t>(_partition_topn_ctx->num_partitions()));
-    _is_finished = true;
-    return Status::OK();
+    DeferOp defer([&]() {
+        _partition_topn_ctx->sink_complete();
+        _unique_metrics->add_info_string("IsPassThrough", _partition_topn_ctx->is_passthrough() ? "Yes" : "No");
+        auto* partition_num_counter = ADD_COUNTER(_unique_metrics, "PartitionNum", TUnit::UNIT);
+        COUNTER_SET(partition_num_counter, static_cast<int64_t>(_partition_topn_ctx->num_partitions()));
+        _is_finished = true;
+    });
+    if (state->is_cancelled()) {
+        return Status::OK();
+    }
+    return _partition_topn_ctx->transfer_all_chunks_from_partitioner_to_sorters(state);
 }
 
 OperatorPtr LocalPartitionTopnSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
*** Aborted at 1718873562 (unix time) try "date -d @1718873562" if you are using GNU date ***
PC: @          0x32370a3 starrocks::ColumnCompare::do_visit()
*** SIGSEGV (@0x0) received by PID 27779 (TID 0x7f95b7fa8640) from PID 0; stack trace: ***
    @          0x5ee6742 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f9656d6b7fb os::Linux::chained_handler()
    @     0x7f9656d7035c JVM_handle_linux_signal
    @     0x7f9656d62e78 signalHandler()
    @     0x7f9656054df0 (unknown)
    @          0x32370a3 starrocks::ColumnCompare::do_visit()
    @          0x3237246 starrocks::ColumnVisitorAdapter<>::visit()
    @          0x2facfcc starrocks::ColumnFactory<>::accept()
    @          0x3230642 starrocks::compare_column()
    @          0x3230757 starrocks::compare_columns()
    @          0x31983c8 starrocks::get_compare_results_colwise()
    @          0x3198658 starrocks::DataSegment::get_filter_array()
    @          0x31dde6b starrocks::ChunksSorterTopn::_filter_and_sort_data()
    @          0x31dfb2a starrocks::ChunksSorterTopn::_sort_chunks()
    @          0x31dff3b starrocks::ChunksSorterTopn::update()
    @          0x339e8b1 (unknown)
    @          0x33b431b starrocks::pipeline::LocalPartitionTopnContext::transfer_all_chunks_from_partitioner_to_sorters()
    @          0x3395025 starrocks::pipeline::LocalPartitionTopnSinkOperator::set_finishing()
    @          0x33d688b starrocks::pipeline::PipelineDriver::_mark_operator_finishing()
    @          0x33d6999 starrocks::pipeline::PipelineDriver::_mark_operator_finished()
    @          0x33d6ffb starrocks::pipeline::PipelineDriver::_mark_operator_cancelled()
    @          0x33d762a starrocks::pipeline::PipelineDriver::cancel_operators()
    @          0x33ca506 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x2a28a1a starrocks::ThreadPool::dispatch_thread()
    @          0x2a2348a starrocks::Thread::supervise_thread()
    @     0x7f965609f802 start_thread
    @     0x7f965603f450 __clone3
    @                0x0 (unknown)
```

When canceled, the chunk in `_partition_topn_ctx` maybe is incomplete. At this time, `transfer_all_chunks_from_partitioner_to_sorters` is also forced to be executed, which may trigger a crash.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
