### PR TITLE
[BugFix] check if BinaryOutputArchive write success

### DIFF
--- a/be/src/util/phmap/phmap_dump.h
+++ b/be/src/util/phmap/phmap_dump.h
@@ -248,13 +248,13 @@ public:
 
     bool dump(const char* p, size_t sz) {
         ofs_.write(p, sz);
-        return true;
+        return ofs_.good();
     }
 
     template <typename V>
     typename std::enable_if<type_traits_internal::IsTriviallyCopyable<V>::value, bool>::type dump(const V& v) {
         ofs_.write(reinterpret_cast<const char*>(&v), sizeof(V));
-        return true;
+        return ofs_.good();
     }
 
 private:


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
`Persistent Index` use `BinaryOutputArchive` to generate `l0` snapshot, and if `BinaryOutputArchive` write fail and return true, it will lead to `l0` lost data and cause PK table issue like:
```
load primary index failed: Already exist: FixedMutableIndex<16> insert found duplicate key 800000003B9ACF8D80000000411AB34E, new(rssid=11649 rowid=0), old(rssid=11645 rowid=0)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
