### PR TITLE
[BugFix] Change the default datacache disk path to avoid directory creation failure due to permission issues.

### DIFF
--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -89,4 +89,6 @@ Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vect
 Status parse_conf_datacache_disk_spaces(const std::string& config_disk_path, const std::string& config_disk_size,
                                         bool ignore_broken_disk, std::vector<DirSpace>* disk_spaces);
 
+void clean_residual_datacache(const std::string& disk_path);
+
 } // namespace starrocks

--- a/be/src/block_cache/disk_space_monitor.cpp
+++ b/be/src/block_cache/disk_space_monitor.cpp
@@ -50,6 +50,9 @@ void DiskSpaceMonitor::start() {
     if (!_stopped.load(std::memory_order_acquire)) {
         return;
     }
+    if (_dir_spaces.empty()) {
+        return;
+    }
     _stopped.store(false, std::memory_order_release);
     _adjust_datacache_thread = std::thread([this] { _adjust_datacache_callback(); });
     Thread::set_thread_name(_adjust_datacache_thread, "adjust_datacache");


### PR DESCRIPTION
## Why I'm doing:
Now we create a default `datacache` directory, which has the same parent directory with the `storage_root_path` directory, to store datacache disk data if users do not configure the custom cache paths.
However, sometimes the users that start the starrocks_be process have no permission to create the datacache directory under the parent path, which will result in the inability to enable datacache by default due to directory creation failure. 

## What I'm doing:
Change the the default datacache disk path under the `storage_root_path` to avoid directory creation failure due to permission issues, because the  `storage_root_path` always be created manually.
Also, we clean the old residual datacache files in the old directories to free disk spaces.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
