### PR TITLE
[BugFix] Fix escape character in default value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -587,7 +587,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 sb.append("DEFAULT ").append("(").append(defaultExpr.getExpr()).append(") ");
             }
         } else if (defaultValue != null && !type.isOnlyMetricType()) {
-            sb.append("DEFAULT \"").append(defaultValue).append("\" ");
+            sb.append("DEFAULT \"").append(StringEscapeUtils.escapeJava(defaultValue)).append("\" ");
         } else if (isGeneratedColumn()) {
             String generatedColumnSql;
             if (idToColumn != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -2023,7 +2023,7 @@ public class CreateTableTest {
     public void testDefaultValueHasEscapeStringNonPK() throws Exception {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.useDatabase("test");
-        String sql1 = "CREATE TABLE `news_rt` (\n" +
+        String sql1 = "CREATE TABLE `news_rt_non_pk` (\n" +
                 "  `id` bigint(20) NOT NULL COMMENT \"pkid\",\n" +
                 "  `title` varchar(65533) NOT NULL DEFAULT \"\\\"\" COMMENT \"title\"\n" +
                 ") ENGINE=OLAP \n" +
@@ -2034,8 +2034,8 @@ public class CreateTableTest {
                 "\"replication_num\" = \"1\"\n" +
                 ");";
         starRocksAssert.withTable(sql1);
-        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt;");
-        starRocksAssert.dropTable("news_rt");
+        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt_non_pk;");
+        starRocksAssert.dropTable("news_rt_non_pk");
         starRocksAssert.withTable(createTableSql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -2018,4 +2018,24 @@ public class CreateTableTest {
         starRocksAssert.dropTable("news_rt");
         starRocksAssert.withTable(createTableSql);
     }
+
+    @Test
+    public void testDefaultValueHasEscapeStringNonPK() throws Exception {
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.useDatabase("test");
+        String sql1 = "CREATE TABLE `news_rt` (\n" +
+                "  `id` bigint(20) NOT NULL COMMENT \"pkid\",\n" +
+                "  `title` varchar(65533) NOT NULL DEFAULT \"\\\"\" COMMENT \"title\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`id`)\n" +
+                "COMMENT \"news\"\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(sql1);
+        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt;");
+        starRocksAssert.dropTable("news_rt");
+        starRocksAssert.withTable(createTableSql);
+    }
 }


### PR DESCRIPTION
… table statement contains escape characters

## Why I'm doing:
When the user uses the migration tool, he finds that the following table creation statement fails to migrate.
```
CREATE TABLE news_rt3 (
id bigint(20) NOT NULL COMMENT "pkid",
title varchar(65533) NOT NULL DEFAULT "\"" COMMENT "title"
) ENGINE=OLAP
DUPLICATE KEY(id)
COMMENT "news"
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES (
"replication_num" = "1"
);
```
When you use show create table, the following statements will be displayed.
```
CREATE TABLE `news_rt` (
  `id` bigint(20) NOT NULL COMMENT "pkid",
  `title` varchar(65533) NOT NULL DEFAULT """ COMMENT "title"
) ENGINE=OLAP 
DUPLICATE KEY(`id`)
COMMENT "news"
DISTRIBUTED BY HASH(`id`) BUCKETS 1 
PROPERTIES (
"compression" = "LZ4",
"enable_persistent_index" = "true",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);
```
This statement fails because it is not escaped. Similar problems include escaping \\ and escaping \r.

## What I'm doing:
Add escape when showing create table.

Fixes #47861

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
