### PR TITLE
[Refactor] refactor `RemotePathKey` calling parameters

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -122,7 +122,7 @@ public class FileTable extends Table {
         Configuration configuration = hdfsEnvironment.getConfiguration();
         HiveRemoteFileIO remoteFileIO = new HiveRemoteFileIO(configuration);
         boolean recursive = Boolean.parseBoolean(fileProperties.getOrDefault(JSON_RECURSIVE_DIRECTORIES, "false"));
-        RemotePathKey pathKey = new RemotePathKey(getTableLocation(), recursive, Optional.empty());
+        RemotePathKey pathKey = new RemotePathKey(getTableLocation(), recursive);
         boolean enableWildCards = Boolean.parseBoolean(fileProperties.getOrDefault(JSON_ENABLE_WILDCARDS, "false"));
 
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.conf.Configuration;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class FileTable extends Table {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileLoadingContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileLoadingContext.java
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
+/*
+  When doing concurrent loading remote files, some variables can be shared and reused to save costs.
+  And in this context, we maintain fields can be shared and reused.
+ */
+public class RemoteFileLoadingContext {
+    // ---- concurrent initialization -----
+    public AtomicBoolean init = new AtomicBoolean(false);
+    public ReentrantLock lock = new ReentrantLock();
+
+    // ---- hudi related fields -----
+    public String hudiTableLocation = null;
+    public HoodieTableFileSystemView hudiFsView = null;
+    public HoodieTimeline hudiTimeline = null;
+    public HoodieInstant hudiLastInstant = null;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -45,6 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.starrocks.connector.hive.HiveWriteUtils.checkedDelete;
 import static com.starrocks.connector.hive.HiveWriteUtils.createDirectory;
@@ -74,27 +74,36 @@ public class RemoteFileOperations {
         this.conf = conf;
     }
 
-    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions) {
-        return getRemoteFiles(partitions, Optional.empty(), true);
+    public static class Options {
+        public static Options DEFAULT = new Options();
+        public String hudiTableLocation = null;
+        public boolean useCache = true;
+
+        public static Options toUseHudiTableLocation(String hudiTableLocation) {
+            Options opt = new Options();
+            opt.hudiTableLocation = hudiTableLocation;
+            return opt;
+        }
+
+        public static Options toUseCache(boolean useCache) {
+            Options opt = new Options();
+            opt.useCache = useCache;
+            return opt;
+        }
     }
 
-    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, boolean useCache) {
-        return getRemoteFiles(partitions, Optional.empty(), useCache);
-    }
+    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, Options options) {
+        RemoteFileLoadingContext loadingContext = new RemoteFileLoadingContext();
+        loadingContext.hudiTableLocation = options.hudiTableLocation;
 
-    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, Optional<String> hudiTableLocation) {
-        return getRemoteFiles(partitions, hudiTableLocation, true);
-    }
-
-    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, Optional<String> hudiTableLocation, boolean useCache) {
         Map<RemotePathKey, Partition> pathKeyToPartition = Maps.newHashMap();
         for (Partition partition : partitions) {
-            RemotePathKey key = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
+            RemotePathKey key = RemotePathKey.of(partition.getFullPath(), isRecursive);
             pathKeyToPartition.put(key, partition);
         }
 
         int cacheMissSize = partitions.size();
-        if (enableCatalogLevelCache && useCache) {
+        if (enableCatalogLevelCache && options.useCache) {
             cacheMissSize = cacheMissSize - remoteFileIO.getPresentRemoteFiles(
                     Lists.newArrayList(pathKeyToPartition.keySet())).size();
         }
@@ -103,15 +112,13 @@ public class RemoteFileOperations {
         List<Future<Map<RemotePathKey, List<RemoteFileDesc>>>> futures = Lists.newArrayList();
         List<Map<RemotePathKey, List<RemoteFileDesc>>> result = Lists.newArrayList();
 
-        RemotePathKey.HudiContext hudiContext = new RemotePathKey.HudiContext();
-
         Tracers.count(Tracers.Module.EXTERNAL, HMS_PARTITIONS_REMOTE_FILES, cacheMissSize);
         try (Timer ignored = Tracers.watchScope(Tracers.Module.EXTERNAL, HMS_PARTITIONS_REMOTE_FILES)) {
             for (Partition partition : partitions) {
-                RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
-                pathKey.setHudiContext(hudiContext);
+                RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive);
+                pathKey.setLoadingContext(loadingContext);
                 Future<Map<RemotePathKey, List<RemoteFileDesc>>> future = pullRemoteFileExecutor.submit(() ->
-                        remoteFileIO.getRemoteFiles(pathKey, useCache));
+                        remoteFileIO.getRemoteFiles(pathKey, options.useCache));
                 futures.add(future);
             }
 
@@ -132,27 +139,24 @@ public class RemoteFileOperations {
     }
 
     public List<RemoteFileInfo> getPresentFilesInCache(Collection<Partition> partitions) {
-        return getPresentFilesInCache(partitions, Optional.empty());
-    }
-
-    public List<RemoteFileInfo> getPresentFilesInCache(Collection<Partition> partitions, Optional<String> hudiTableLocation) {
         Map<RemotePathKey, Partition> pathKeyToPartition = partitions.stream()
-                .collect(Collectors.toMap(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation),
+                .collect(Collectors.toMap(
+                        partition -> RemotePathKey.of(partition.getFullPath(), isRecursive),
                         Function.identity()));
 
         List<RemotePathKey> paths = partitions.stream()
-                .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation))
+                .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive))
                 .collect(Collectors.toList());
 
         Map<RemotePathKey, List<RemoteFileDesc>> presentFiles = remoteFileIO.getPresentRemoteFiles(paths);
         return fillFileInfo(presentFiles, pathKeyToPartition);
     }
 
-    public List<RemoteFileInfo> getRemoteFileInfoForStats(List<Partition> partitions, Optional<String> hudiTableLocation) {
+    public List<RemoteFileInfo> getRemoteFileInfoForStats(List<Partition> partitions, Options options) {
         if (enableCatalogLevelCache) {
-            return getPresentFilesInCache(partitions, hudiTableLocation);
+            return getPresentFilesInCache(partitions);
         } else {
-            return getRemoteFiles(partitions, hudiTableLocation);
+            return getRemoteFiles(partitions, options);
         }
     }
 
@@ -319,7 +323,7 @@ public class RemoteFileOperations {
             RemoteFileInfo.Builder builder = RemoteFileInfo.builder()
                     .setFormat(partition.getInputFormat())
                     .setFullPath(partition.getFullPath())
-                    .setFiles(List.of(fileDesc).stream()
+                    .setFiles(Stream.of(fileDesc)
                             .map(desc -> desc.setTextFileFormatDesc(partition.getTextFileFormatDesc()))
                             .map(desc -> desc.setSplittable(partition.isSplittable()))
                             .collect(Collectors.toList()));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -93,8 +93,8 @@ public class RemoteFileOperations {
     }
 
     public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, Options options) {
-        RemoteFileLoadingContext loadingContext = new RemoteFileLoadingContext();
-        loadingContext.hudiTableLocation = options.hudiTableLocation;
+        RemoteFileScanContext scanContext = new RemoteFileScanContext();
+        scanContext.hudiTableLocation = options.hudiTableLocation;
 
         Map<RemotePathKey, Partition> pathKeyToPartition = Maps.newHashMap();
         for (Partition partition : partitions) {
@@ -116,7 +116,7 @@ public class RemoteFileOperations {
         try (Timer ignored = Tracers.watchScope(Tracers.Module.EXTERNAL, HMS_PARTITIONS_REMOTE_FILES)) {
             for (Partition partition : partitions) {
                 RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive);
-                pathKey.setLoadingContext(loadingContext);
+                pathKey.setScanContext(scanContext);
                 Future<Map<RemotePathKey, List<RemoteFileDesc>>> future = pullRemoteFileExecutor.submit(() ->
                         remoteFileIO.getRemoteFiles(pathKey, options.useCache));
                 futures.add(future);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.ReentrantLock;
   When doing concurrent loading remote files, some variables can be shared and reused to save costs.
   And in this context, we maintain fields can be shared and reused.
  */
-public class RemoteFileLoadingContext {
+public class RemoteFileScanContext {
     // ---- concurrent initialization -----
     public AtomicBoolean init = new AtomicBoolean(false);
     public ReentrantLock lock = new ReentrantLock();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 public class RemotePathKey {
     private final String path;
     private final boolean isRecursive;
-    private RemoteFileLoadingContext loadingContext;
+    private RemoteFileScanContext scanContext;
 
     public static RemotePathKey of(String path, boolean isRecursive) {
         return new RemotePathKey(path, isRecursive);
@@ -72,16 +72,16 @@ public class RemotePathKey {
     }
 
     public void drop() {
-        if (loadingContext != null) {
-            loadingContext = null;
+        if (scanContext != null) {
+            scanContext = null;
         }
     }
 
-    public void setLoadingContext(RemoteFileLoadingContext ctx) {
-        loadingContext = ctx;
+    public void setScanContext(RemoteFileScanContext ctx) {
+        scanContext = ctx;
     }
 
-    public RemoteFileLoadingContext getLoadingContext() {
-        return loadingContext;
+    public RemoteFileScanContext getScanContext() {
+        return scanContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -14,46 +14,20 @@
 
 package com.starrocks.connector;
 
-import org.apache.hudi.common.table.timeline.HoodieInstant;
-import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
-
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class RemotePathKey {
     private final String path;
     private final boolean isRecursive;
-
-    // The table location must exist in HudiTable
-    private final Optional<String> hudiTableLocation;
-
-    public static class HudiContext {
-        // ---- concurrent initialization -----
-        public AtomicBoolean init = new AtomicBoolean(false);
-        public ReentrantLock lock = new ReentrantLock();
-        // ---- actual fields -----
-        public HoodieTableFileSystemView fsView = null;
-        public HoodieTimeline timeline = null;
-        public HoodieInstant lastInstant = null;
-    }
-
-    private HudiContext hudiContext;
+    private RemoteFileLoadingContext loadingContext;
 
     public static RemotePathKey of(String path, boolean isRecursive) {
-        return new RemotePathKey(path, isRecursive, Optional.empty());
+        return new RemotePathKey(path, isRecursive);
     }
 
-    public static RemotePathKey of(String path, boolean isRecursive, Optional<String> hudiTableLocation) {
-        return new RemotePathKey(path, isRecursive, hudiTableLocation);
-    }
-
-    public RemotePathKey(String path, boolean isRecursive, Optional<String> hudiTableLocation) {
+    public RemotePathKey(String path, boolean isRecursive) {
         this.path = path;
         this.isRecursive = isRecursive;
-        this.hudiTableLocation = hudiTableLocation;
     }
 
     public boolean approximateMatchPath(String basePath, boolean isRecursive) {
@@ -70,10 +44,6 @@ public class RemotePathKey {
         return isRecursive;
     }
 
-    public Optional<String> getHudiTableLocation() {
-        return hudiTableLocation;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -84,13 +54,12 @@ public class RemotePathKey {
         }
         RemotePathKey pathKey = (RemotePathKey) o;
         return isRecursive == pathKey.isRecursive &&
-                Objects.equals(path, pathKey.path) &&
-                Objects.equals(hudiTableLocation, pathKey.hudiTableLocation);
+                Objects.equals(path, pathKey.path);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, isRecursive, hudiTableLocation);
+        return Objects.hash(path, isRecursive);
     }
 
     @Override
@@ -98,24 +67,21 @@ public class RemotePathKey {
         final StringBuilder sb = new StringBuilder("RemotePathKey{");
         sb.append("path='").append(path).append('\'');
         sb.append(", isRecursive=").append(isRecursive);
-        if (hudiTableLocation.isPresent()) {
-            sb.append(", hudiTableLocation=").append(hudiTableLocation);
-        }
         sb.append('}');
         return sb.toString();
     }
 
     public void drop() {
-        if (hudiContext != null) {
-            hudiContext = null;
+        if (loadingContext != null) {
+            loadingContext = null;
         }
     }
 
-    public void setHudiContext(HudiContext ctx) {
-        hudiContext = ctx;
+    public void setLoadingContext(RemoteFileLoadingContext ctx) {
+        loadingContext = ctx;
     }
 
-    public HudiContext getHudiContext() {
-        return hudiContext;
+    public RemoteFileLoadingContext getLoadingContext() {
+        return loadingContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCacheUpdateProcessor.java
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -29,6 +29,7 @@ import com.starrocks.connector.CacheUpdateProcessor;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.RemoteFileIO;
+import com.starrocks.connector.RemoteFileLoadingContext;
 import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
@@ -160,7 +161,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
             for (Map.Entry<HivePartitionName, Partition> partitionEntry : partitions.entrySet()) {
                 Optional<String> partitionName = partitionEntry.getKey().getPartitionNames();
                 partitionName.ifPresent(s -> toCheckUpdatedPartitionInfoMap.put(new BasePartitionInfo(dbName, tblName, s),
-                                partitionEntry.getValue()));
+                        partitionEntry.getValue()));
             }
         }
 
@@ -211,11 +212,15 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
 
         if (remoteFileIO.isPresent()) {
             Map<String, Partition> partitions = metastore.getPartitionsByNames(hiveDbName, hiveTableName, hivePartitionNames);
-            Optional<String> hudiBasePath = table.isHiveTable() ? Optional.empty() : Optional.of(hmsTable.getTableLocation());
             List<RemotePathKey> remotePathKeys = partitions.values().stream()
-                    .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiBasePath))
+                    .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive))
                     .collect(Collectors.toList());
-            remotePathKeys.forEach(path -> remoteFileIO.get().updateRemoteFiles(path));
+            RemoteFileLoadingContext loadingContext = new RemoteFileLoadingContext();
+            loadingContext.hudiTableLocation = hmsTable.getTableLocation();
+            remotePathKeys.forEach(path -> {
+                path.setLoadingContext(loadingContext);
+                remoteFileIO.get().updateRemoteFiles(path);
+            });
         }
     }
 
@@ -271,9 +276,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
             }
             List<RemotePathKey> updateKeys = Lists.newArrayList();
             List<RemotePathKey> invalidateKeys = Lists.newArrayList();
-            RemotePathKey.HudiContext hudiContext = new RemotePathKey.HudiContext();
             presentPathKey.forEach(pathKey -> {
-                pathKey.setHudiContext(hudiContext);
                 String pathWithSlash = pathKey.getPath().endsWith("/") ? pathKey.getPath() : pathKey.getPath() + "/";
                 if (operator == Operator.UPDATE && existPaths.contains(pathWithSlash)) {
                     updateKeys.add(pathKey);
@@ -281,7 +284,6 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
                     invalidateKeys.add(pathKey);
                 }
             });
-
             refreshRemoteFilesImpl(tableLocation, updateKeys, invalidateKeys, executor);
         }
     }
@@ -289,11 +291,20 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
     private void refreshRemoteFilesImpl(String tableLocation, List<RemotePathKey> updateKeys,
                                         List<RemotePathKey> invalidateKeys,
                                         ExecutorService refreshExecutor) {
+        Preconditions.checkArgument(remoteFileIO.isPresent());
+        RemoteFileLoadingContext loadingContext = new RemoteFileLoadingContext();
+        loadingContext.hudiTableLocation = tableLocation;
         List<Future<?>> futures = Lists.newArrayList();
-        updateKeys.forEach(pathKey -> futures.add(refreshExecutor.submit(() ->
-                remoteFileIO.get().updateRemoteFiles(pathKey))));
-        invalidateKeys.forEach(pathKey -> futures.add(refreshExecutor.submit(() ->
-                remoteFileIO.get().invalidatePartition(pathKey))));
+        updateKeys.forEach(pathKey -> {
+            pathKey.setLoadingContext(loadingContext);
+            futures.add(refreshExecutor.submit(() ->
+                    remoteFileIO.get().updateRemoteFiles(pathKey)));
+        });
+        invalidateKeys.forEach(pathKey -> {
+            pathKey.setLoadingContext(loadingContext);
+            futures.add(refreshExecutor.submit(() ->
+                    remoteFileIO.get().invalidatePartition(pathKey)));
+        });
 
         for (Future<?> future : futures) {
             try {
@@ -419,5 +430,5 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
             return Objects.hashCode(dbName, tableName, partitionName);
         }
     }
-    
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -240,7 +240,7 @@ public class HiveMetadata implements ConnectorMetadata {
             useRemoteFileCache = ((HiveTable) table).isUseMetadataCache();
         }
 
-        return fileOps.getRemoteFiles(partitions.build(), useRemoteFileCache);
+        return fileOps.getRemoteFiles(partitions.build(), RemoteFileOperations.Options.toUseCache(useRemoteFileCache));
     }
 
     @Override
@@ -252,7 +252,7 @@ public class HiveMetadata implements ConnectorMetadata {
         if (table instanceof HiveTable) {
             useRemoteFileCache = ((HiveTable) table).isUseMetadataCache();
         }
-        return fileOps.getRemoteFiles(partitions.build(), useRemoteFileCache);
+        return fileOps.getRemoteFiles(partitions.build(), RemoteFileOperations.Options.toUseCache(useRemoteFileCache));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStatisticsProvider.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.google.common.base.Preconditions;
@@ -45,7 +44,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
@@ -148,8 +146,8 @@ public class HiveStatisticsProvider {
                 Lists.newArrayList(hmsOps.getPartition(hmsTbl.getDbName(), hmsTbl.getTableName(), Lists.newArrayList())) :
                 Lists.newArrayList(hmsOps.getPartitionByPartitionKeys(table, partitionKeys).values());
 
-        Optional<String> hudiBasePath = table.isHiveTable() ? Optional.empty() : Optional.of(hmsTbl.getTableLocation());
-        List<RemoteFileInfo> remoteFileInfos = fileOps.getRemoteFileInfoForStats(partitions, hudiBasePath);
+        List<RemoteFileInfo> remoteFileInfos = fileOps.getRemoteFileInfoForStats(partitions,
+                RemoteFileOperations.Options.toUseHudiTableLocation(hmsTbl.getTableLocation()));
 
         long totalBytes = 0;
         for (RemoteFileInfo remoteFileInfo : remoteFileInfos) {
@@ -326,7 +324,7 @@ public class HiveStatisticsProvider {
                 .mapToDouble(x -> x)
                 .max();
 
-        return  ndv.isPresent() ? ndv.getAsDouble() : 1;
+        return ndv.isPresent() ? ndv.getAsDouble() : 1;
     }
 
     private double nullsFraction(Column column, Collection<HivePartitionStats> partitionStatistics) {
@@ -357,7 +355,6 @@ public class HiveStatisticsProvider {
         return (double) totalNullsNums / totalRowNums;
     }
 
-
     private double averageRowSize(Column column, Collection<HivePartitionStats> partitionStatistics, double totalRowNums) {
         if (!column.getType().isStringType()) {
             return column.getType().getTypeSize();
@@ -384,7 +381,7 @@ public class HiveStatisticsProvider {
     }
 
     private double max(List<HiveColumnStats> columnStatistics) {
-        OptionalDouble max =  columnStatistics.stream()
+        OptionalDouble max = columnStatistics.stream()
                 .map(HiveColumnStats::getMax)
                 .filter(value -> value != POSITIVE_INFINITY)
                 .mapToDouble(x -> x)
@@ -393,7 +390,7 @@ public class HiveStatisticsProvider {
     }
 
     private double min(List<HiveColumnStats> columnStatistics) {
-        OptionalDouble min =  columnStatistics.stream()
+        OptionalDouble min = columnStatistics.stream()
                 .map(HiveColumnStats::getMin)
                 .filter(value -> value != NEGATIVE_INFINITY)
                 .mapToDouble(x -> x)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -155,7 +155,8 @@ public class HudiMetadata implements ConnectorMetadata {
             }
         }
 
-        return fileOps.getRemoteFiles(partitions.build(), Optional.of(hmsTbl.getTableLocation()));
+        return fileOps.getRemoteFiles(partitions.build(),
+                RemoteFileOperations.Options.toUseHudiTableLocation(hmsTbl.getTableLocation()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileIO;
+import com.starrocks.connector.RemoteFileLoadingContext;
 import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.hadoop.conf.Configuration;
@@ -42,7 +43,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.table.view.FileSystemViewManager.createInMemoryFileSystemViewWithTimeline;
@@ -51,14 +51,11 @@ public class HudiRemoteFileIO implements RemoteFileIO {
     private static final Logger LOG = LogManager.getLogger(HudiRemoteFileIO.class);
     private final Configuration configuration;
 
-    // table location -> HoodieTableMetaClient
-    private final Map<String, HoodieTableMetaClient> hudiClients = new ConcurrentHashMap<>();
-
     public HudiRemoteFileIO(Configuration configuration) {
         this.configuration = configuration;
     }
 
-    private void createHudiContext(RemotePathKey.HudiContext ctx, String hudiTableLocation) {
+    private void createHudiContext(RemoteFileLoadingContext ctx) {
         if (ctx.init.get()) {
             return;
         }
@@ -70,14 +67,14 @@ public class HudiRemoteFileIO implements RemoteFileIO {
             HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(configuration);
             HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
             HoodieTableMetaClient metaClient =
-                    HoodieTableMetaClient.builder().setConf(configuration).setBasePath(hudiTableLocation).build();
+                    HoodieTableMetaClient.builder().setConf(configuration).setBasePath(ctx.hudiTableLocation).build();
             // metaClient.reloadActiveTimeline();
             HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
             Option<HoodieInstant> lastInstant = timeline.lastInstant();
             if (lastInstant.isPresent()) {
-                ctx.fsView = createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
-                ctx.lastInstant = lastInstant.get();
-                ctx.timeline = timeline;
+                ctx.hudiFsView = createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
+                ctx.hudiLastInstant = lastInstant.get();
+                ctx.hudiTimeline = timeline;
             }
             ctx.init.set(true);
         } finally {
@@ -87,24 +84,25 @@ public class HudiRemoteFileIO implements RemoteFileIO {
 
     @Override
     public Map<RemotePathKey, List<RemoteFileDesc>> getRemoteFiles(RemotePathKey pathKey) {
-        String tableLocation = pathKey.getHudiTableLocation().orElseThrow(() ->
-                new StarRocksConnectorException("Missing hudi table base location on %s", pathKey));
+        RemoteFileLoadingContext loadingContext = pathKey.getLoadingContext();
+        String tableLocation = loadingContext.hudiTableLocation;
+        if (tableLocation == null) {
+            throw new StarRocksConnectorException("Missing hudi table base location on %s", pathKey);
+        }
 
         String partitionPath = pathKey.getPath();
         String partitionName = FSUtils.getRelativePartitionPath(new Path(tableLocation), new Path(partitionPath));
 
         ImmutableMap.Builder<RemotePathKey, List<RemoteFileDesc>> resultPartitions = ImmutableMap.builder();
         List<RemoteFileDesc> fileDescs = Lists.newArrayList();
-
-        RemotePathKey.HudiContext hudiContext = pathKey.getHudiContext();
-        createHudiContext(hudiContext, tableLocation);
-        if (hudiContext.lastInstant == null) {
+        createHudiContext(loadingContext);
+        if (loadingContext.hudiLastInstant == null) {
             return resultPartitions.put(pathKey, fileDescs).build();
         }
 
         try {
-            Iterator<FileSlice> hoodieFileSliceIterator = hudiContext.fsView
-                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, hudiContext.lastInstant.getTimestamp()).iterator();
+            Iterator<FileSlice> hoodieFileSliceIterator = loadingContext.hudiFsView
+                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, loadingContext.hudiLastInstant.getTimestamp()).iterator();
             while (hoodieFileSliceIterator.hasNext()) {
                 FileSlice fileSlice = hoodieFileSliceIterator.next();
                 Optional<HoodieBaseFile> baseFile = fileSlice.getBaseFile().toJavaOptional();
@@ -113,7 +111,7 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                 List<String> logs = fileSlice.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
                 // The file name of HoodieBaseFile contains "instantTime", so we set the `modificationTime` to 0.
                 HudiRemoteFileDesc res = HudiRemoteFileDesc.createHudiRemoteFileDesc(fileName, fileLength,
-                        ImmutableList.of(), ImmutableList.copyOf(logs), hudiContext.lastInstant);
+                        ImmutableList.of(), ImmutableList.copyOf(logs), loadingContext.hudiLastInstant);
                 fileDescs.add(res);
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -72,7 +72,8 @@ public class RemoteFileOperationsTest {
         List<String> partitionNames = Lists.newArrayList("col1=1", "col1=2");
         Map<String, Partition> partitions = metastore.getPartitionsByNames("db1", "table1", partitionNames);
 
-        List<RemoteFileInfo> remoteFileInfos = ops.getRemoteFiles(Lists.newArrayList(partitions.values()));
+        List<RemoteFileInfo> remoteFileInfos =
+                ops.getRemoteFiles(Lists.newArrayList(partitions.values()), RemoteFileOperations.Options.DEFAULT);
         Assert.assertEquals(2, remoteFileInfos.size());
         Assert.assertTrue(remoteFileInfos.get(0).toString().contains("emoteFileInfo{format=ORC, files=["));
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -227,7 +227,7 @@ public class HiveMetadataTest {
 
     @Test
     public void testGetFileWithSubdir() throws StarRocksConnectorException {
-        RemotePathKey pathKey = new RemotePathKey("hdfs://127.0.0.1:10000/hive.db", true, Optional.empty());
+        RemotePathKey pathKey = new RemotePathKey("hdfs://127.0.0.1:10000/hive.db", true);
         Map<RemotePathKey, List<RemoteFileDesc>> files = hiveRemoteFileIO.getRemoteFiles(pathKey);
         List<RemoteFileDesc> remoteFileDescs = files.get(pathKey);
         Assert.assertEquals(1, remoteFileDescs.size());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.google.common.collect.Lists;
@@ -118,7 +117,7 @@ public class HiveStatisticsProviderTest {
         Statistics statistics = statisticsProvider.getTableStatistics(
                 optimizerContext, hiveTable, Lists.newArrayList(partColumnRefOperator, dataColumnRefOperator),
                 Lists.newArrayList(hivePartitionKey1, hivePartitionKey2));
-        Assert.assertEquals(1,  statistics.getOutputRowCount(), 0.001);
+        Assert.assertEquals(1, statistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(0, statistics.getColumnStatistics().size());
 
         cachingHiveMetastore.getPartitionStatistics(hiveTable, Lists.newArrayList("col1=1", "col1=2"));
@@ -187,7 +186,7 @@ public class HiveStatisticsProviderTest {
 
         List<String> partitionNames = Lists.newArrayList("col1=1", "col1=2");
         Map<String, Partition> partitions = metastore.getPartitionsByNames("db1", "table1", partitionNames);
-        fileOps.getRemoteFiles(Lists.newArrayList(partitions.values()));
+        fileOps.getRemoteFiles(Lists.newArrayList(partitions.values()), RemoteFileOperations.Options.DEFAULT);
         PartitionKey hivePartitionKey1 = PartitionUtil.createPartitionKey(
                 Lists.newArrayList("1"), hiveTable.getPartitionColumns());
         PartitionKey hivePartitionKey2 = PartitionUtil.createPartitionKey(
@@ -222,7 +221,6 @@ public class HiveStatisticsProviderTest {
         stats.initialize(columnStatisticsData, 10);
         Assert.assertEquals(0, stats.getMax(), 0.000001);
         Assert.assertEquals(0, stats.getMin(), 0.000001);
-
 
         columnStatisticsData = new ColumnStatisticsData();
         LongColumnStatsData longColumnStatsData = new LongColumnStatsData();


### PR DESCRIPTION
## Why I'm doing:

There are two points:
1. `RemotePathKey` does not need to bind `hudiTableLocation` at all.  This field does not need to be cached.
2. rename `HudiContext` to `LoadingContext`, which is more general
3. `getRemoteFiles` is overloaded in a bad way,  better to extract parameters into a class `Options` 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
