### PR TITLE
[BugFix] do flush before error check in BinaryOutputArchive

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -5258,4 +5258,8 @@ void PersistentIndex::_calc_memory_usage() {
     _memory_usage.store(memory_usage);
 }
 
+void PersistentIndex::test_force_dump() {
+    _dump_snapshot = true;
+}
+
 } // namespace starrocks

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2020,6 +2020,12 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
                 LOG(WARNING) << err_msg;
                 return Status::InternalError(err_msg);
             }
+            if (!ar_out.close()) {
+                std::string err_msg =
+                        strings::Substitute("failed to dump snapshot to file $0, because of close", file_name);
+                LOG(WARNING) << err_msg;
+                return Status::InternalError(err_msg);
+            }
         }
         // dump snapshot success, set _index_file to new snapshot file
         WritableFileOptions wblock_opts;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -813,6 +813,8 @@ public:
 
     void test_calc_memory_usage() { return _calc_memory_usage(); }
 
+    void test_force_dump();
+
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,
                                       const EditVersionWithMerge& min_l2_version);

--- a/be/src/util/phmap/phmap_dump.h
+++ b/be/src/util/phmap/phmap_dump.h
@@ -266,6 +266,11 @@ public:
         return !ofs_.fail();
     }
 
+    bool close() {
+        ofs_.close();
+        return !ofs_.fail();
+    }
+
 private:
     std::ofstream ofs_;
 };

--- a/be/src/util/phmap/phmap_dump.h
+++ b/be/src/util/phmap/phmap_dump.h
@@ -41,6 +41,7 @@
 #include <type_traits>
 
 #include "phmap.h"
+#include "testutil/sync_point.h"
 namespace phmap {
 
 namespace type_traits_internal {
@@ -247,12 +248,18 @@ public:
     BinaryOutputArchive(const char* file_path) { ofs_.open(file_path, std::ios_base::binary); }
 
     bool dump(const char* p, size_t sz) {
+        bool ret = true;
+        TEST_SYNC_POINT_CALLBACK("BinaryOutputArchive::dump::1", &ret);
+        if (!ret) return ret;
         ofs_.write(p, sz);
         return ofs_.good();
     }
 
     template <typename V>
     typename std::enable_if<type_traits_internal::IsTriviallyCopyable<V>::value, bool>::type dump(const V& v) {
+        bool ret = true;
+        TEST_SYNC_POINT_CALLBACK("BinaryOutputArchive::dump::2", &ret);
+        if (!ret) return ret;
         ofs_.write(reinterpret_cast<const char*>(&v), sizeof(V));
         return ofs_.good();
     }

--- a/be/src/util/phmap/phmap_dump.h
+++ b/be/src/util/phmap/phmap_dump.h
@@ -252,7 +252,8 @@ public:
         TEST_SYNC_POINT_CALLBACK("BinaryOutputArchive::dump::1", &ret);
         if (!ret) return ret;
         ofs_.write(p, sz);
-        return ofs_.good();
+        ofs_.flush(); // do flush, so we can check if it success at next line.
+        return !ofs_.fail();
     }
 
     template <typename V>
@@ -261,7 +262,8 @@ public:
         TEST_SYNC_POINT_CALLBACK("BinaryOutputArchive::dump::2", &ret);
         if (!ret) return ret;
         ofs_.write(reinterpret_cast<const char*>(&v), sizeof(V));
-        return ofs_.good();
+        ofs_.flush(); // do flush, so we can check if it success at next line.
+        return !ofs_.fail();
     }
 
 private:

--- a/be/src/util/phmap/phmap_dump.h
+++ b/be/src/util/phmap/phmap_dump.h
@@ -252,7 +252,6 @@ public:
         TEST_SYNC_POINT_CALLBACK("BinaryOutputArchive::dump::1", &ret);
         if (!ret) return ret;
         ofs_.write(p, sz);
-        ofs_.flush(); // do flush, so we can check if it success at next line.
         return !ofs_.fail();
     }
 
@@ -262,11 +261,12 @@ public:
         TEST_SYNC_POINT_CALLBACK("BinaryOutputArchive::dump::2", &ret);
         if (!ret) return ret;
         ofs_.write(reinterpret_cast<const char*>(&v), sizeof(V));
-        ofs_.flush(); // do flush, so we can check if it success at next line.
         return !ofs_.fail();
     }
 
     bool close() {
+        ofs_.flush(); // do flush, so we can check if it success at next line.
+        if (ofs_.fail()) return false;
         ofs_.close();
         return !ofs_.fail();
     }

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -149,6 +149,64 @@ TEST_P(PersistentIndexTest, test_fixlen_mutable_index) {
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
+TEST_P(PersistentIndexTest, test_dump_snapshot_fail) {
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_dump_snapshot_fail";
+    const std::string kIndexFile = "./PersistentIndexTest_test_dump_snapshot_fail/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    using Key = uint64_t;
+    PersistentIndexMetaPB index_meta;
+    const int N = 100;
+    vector<Key> keys;
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    keys.reserve(N);
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+        values.emplace_back(i * 2);
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    EditVersion version(0, 0);
+    index_meta.set_key_size(sizeof(Key));
+    index_meta.set_size(0);
+    version.to_pb(index_meta.mutable_version());
+    MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+    l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_5);
+    IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+    version.to_pb(snapshot_meta->mutable_version());
+
+    std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
+    PersistentIndex index(kPersistentIndexDir);
+    ASSERT_OK(index.load(index_meta));
+    {
+        SyncPoint::GetInstance()->SetCallBack("BinaryOutputArchive::dump::1", [](void* arg) { *(bool*)arg = false; });
+        SyncPoint::GetInstance()->SetCallBack("BinaryOutputArchive::dump::2", [](void* arg) { *(bool*)arg = false; });
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearCallBack("BinaryOutputArchive::dump::1");
+            SyncPoint::GetInstance()->ClearCallBack("BinaryOutputArchive::dump::2");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        index.test_force_dump();
+        ASSERT_OK(index.prepare(EditVersion(1, 0), N));
+        ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
+        ASSERT_FALSE(index.commit(&index_meta).ok());
+        ASSERT_OK(index.on_commited());
+        ASSERT_TRUE(index_meta.l0_meta().wals().empty());
+    }
+
+    ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
+}
+
 TEST_P(PersistentIndexTest, test_small_varlen_mutable_index) {
     using Key = std::string;
     const int N = 1000;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
We add check in PR  #48045 to `BinaryOutputArchive`, however, there are several shortcomings:
1. `!fail()` is better than using `good()`, because it won't check error like `eof`.
2.  Explicit `flush()` should be called before state checking
3. Add UT to make sure #48045 is working well.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
