### PR TITLE
[BugFix]reserve SLICE_MEMEQUAL_OVERFLOW_PADDING for key in hash table

### DIFF
--- a/be/src/bench/CMakeLists.txt
+++ b/be/src/bench/CMakeLists.txt
@@ -29,3 +29,5 @@ ADD_BE_BENCH(${SRC_DIR}/bench/orc_column_reader_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/hash_functions_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/binary_column_copy_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/hyperscan_vec_bench)
+
+ADD_BE_BENCH(${SRC_DIR}/bench/mem_equal_bench)

--- a/be/src/bench/mem_equal_bench.cpp
+++ b/be/src/bench/mem_equal_bench.cpp
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "column/column_hash.h"
+#include "exprs/string_functions.h"
+#include "util/memcmp.h"
+
+namespace starrocks {
+
+static std::string kAlphaNumber =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+
+static size_t ROUND_NUM = 1000;
+
+static size_t PADDED_BYTES = 15;
+
+template <bool padded, bool equal>
+static void do_MemEqual(benchmark::State& state) {
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::uniform_int_distribution<int> beginning_gen(0, 40);
+    std::uniform_int_distribution<int> length_gen(1, 16);
+
+    std::vector<int> beginnings;
+    std::vector<int> lengths;
+
+    for (size_t i = 0; i < ROUND_NUM; i++) {
+        beginnings.emplace_back(beginning_gen(rng));
+        lengths.emplace_back(length_gen(rng));
+    }
+
+    auto sum = std::accumulate(lengths.begin(), lengths.end(), 0);
+    std::vector<char> buffer_0(sum + PADDED_BYTES);
+    std::vector<char> buffer_1(sum + PADDED_BYTES);
+
+    auto acc_begin = 0;
+    for (size_t i = 0; i < ROUND_NUM; i++) {
+        memcpy(buffer_0.data() + acc_begin, kAlphaNumber.data() + beginnings[i], lengths[i]);
+        memcpy(buffer_1.data() + acc_begin, kAlphaNumber.data() + beginnings[i], lengths[i]);
+        if constexpr (!equal) {
+            std::uniform_int_distribution<int> index_gen(0, lengths[i] - 1);
+            auto index = index_gen(rng);
+            buffer_1[acc_begin + index] = 'z';
+        }
+        beginnings[i] = acc_begin;
+        acc_begin += lengths[i];
+    }
+
+    for (auto _ : state) {
+        state.ResumeTiming();
+        bool and_res = true;
+        bool or_res = false;
+        bool res = false;
+        for (size_t i = 0; i < ROUND_NUM; i++) {
+            if constexpr (padded) {
+                res = memequal_padded(buffer_0.data() + beginnings[i], lengths[i], buffer_1.data() + beginnings[i],
+                                lengths[i]);
+            } else {
+                res = memequal(buffer_0.data() + beginnings[i], lengths[i], buffer_1.data() + beginnings[i],
+                         lengths[i]);
+            }
+            and_res &= res;
+            or_res |= res;
+        }
+        state.PauseTiming();
+        if constexpr (equal) {
+            ASSERT_TRUE(and_res);
+        } else {
+            ASSERT_FALSE(or_res);
+        }
+    }
+}
+
+static void process_args(benchmark::internal::Benchmark* b) {
+    b->Iterations(100000);
+}
+
+static void BM_memequal_padded_equal(benchmark::State& state) {
+    do_MemEqual<true, true>(state);
+}
+
+static void BM_memequal_padded_notequal(benchmark::State& state) {
+    do_MemEqual<true, false>(state);
+}
+
+static void BM_memequal_no_padded_equal(benchmark::State& state) {
+    do_MemEqual<false, true>(state);
+}
+
+static void BM_memequal_no_padded_notequal(benchmark::State& state) {
+    do_MemEqual<false, true>(state);
+}
+
+BENCHMARK(BM_memequal_padded_equal)->Apply(process_args);
+BENCHMARK(BM_memequal_padded_notequal)->Apply(process_args);
+BENCHMARK(BM_memequal_no_padded_equal)->Apply(process_args);
+BENCHMARK(BM_memequal_no_padded_notequal)->Apply(process_args);
+
+/*
+-------------------------------------------------------------------------------------------
+Benchmark                                                 Time             CPU   Iterations
+-------------------------------------------------------------------------------------------
+BM_memequal_padded_equal/iterations:100000             1807 ns         1813 ns       100000
+BM_memequal_padded_notequal/iterations:100000          2547 ns         2552 ns       100000
+BM_memequal_no_padded_equal/iterations:100000          8560 ns         8575 ns       100000
+BM_memequal_no_padded_notequal/iterations:100000       8272 ns         8286 ns       100000
+*/
+
+
+/* if we fix the string's length as 8, the result is as below,
+ * it makes sense that memequal_no_padded compare uint64 and
+ * memequal compare __m128i
+-------------------------------------------------------------------------------------------
+Benchmark                                                 Time             CPU   Iterations
+-------------------------------------------------------------------------------------------
+BM_memequal_padded_equal/iterations:100000             2456 ns         2463 ns       100000
+BM_memequal_padded_notequal/iterations:100000          2495 ns         2502 ns       100000
+BM_memequal_no_padded_equal/iterations:100000          2107 ns         2114 ns       100000
+BM_memequal_no_padded_notequal/iterations:100000       2110 ns         2117 ns       100000
+ */
+
+} // namespace starrocks
+
+BENCHMARK_MAIN();

--- a/be/src/bench/mem_equal_bench.cpp
+++ b/be/src/bench/mem_equal_bench.cpp
@@ -76,10 +76,10 @@ static void do_MemEqual(benchmark::State& state) {
         for (size_t i = 0; i < ROUND_NUM; i++) {
             if constexpr (padded) {
                 res = memequal_padded(buffer_0.data() + beginnings[i], lengths[i], buffer_1.data() + beginnings[i],
-                                lengths[i]);
+                                      lengths[i]);
             } else {
                 res = memequal(buffer_0.data() + beginnings[i], lengths[i], buffer_1.data() + beginnings[i],
-                         lengths[i]);
+                               lengths[i]);
             }
             and_res &= res;
             or_res |= res;
@@ -127,7 +127,6 @@ BM_memequal_padded_notequal/iterations:100000          2547 ns         2552 ns  
 BM_memequal_no_padded_equal/iterations:100000          8560 ns         8575 ns       100000
 BM_memequal_no_padded_notequal/iterations:100000       8272 ns         8286 ns       100000
 */
-
 
 /* if we fix the string's length as 8, the result is as below,
  * it makes sense that memequal_no_padded compare uint64 and

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -459,7 +459,7 @@ struct AggHashMapWithOneStringKeyWithNullable
                         DCHECK(not_founds);
                         (*not_founds)[i] = 1;
                     }
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     strings::memcpy_inlined(pos, key.data, key.size);
                     Slice pk{pos, key.size};
                     AggDataPtr pv = allocate_func(pk);
@@ -489,7 +489,7 @@ struct AggHashMapWithOneStringKeyWithNullable
                         DCHECK(not_founds);
                         (*not_founds)[i] = 1;
                     }
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     strings::memcpy_inlined(pos, key.data, key.size);
                     Slice pk{pos, key.size};
                     AggDataPtr pv = allocate_func(pk);
@@ -539,7 +539,7 @@ struct AggHashMapWithOneStringKeyWithNullable
             if constexpr (compute_not_founds) {
                 (*not_founds)[row] = 1;
             }
-            uint8_t* pos = pool->allocate(key.size);
+            uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
             strings::memcpy_inlined(pos, key.data, key.size);
             Slice pk{pos, key.size};
             AggDataPtr pv = allocate_func(pk);
@@ -596,7 +596,7 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
     AggHashMapWithSerializedKey(int chunk_size, Args&&... args)
             : Base(chunk_size, std::forward<Args>(args)...),
               mem_pool(std::make_unique<MemPool>()),
-              buffer(mem_pool->allocate(max_one_row_size * chunk_size)),
+              buffer(mem_pool->allocate(max_one_row_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING)),
               _chunk_size(chunk_size) {}
 
     AggDataPtr get_null_key_data() { return nullptr; }
@@ -653,7 +653,7 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
                         (*not_founds)[i] = 1;
                     }
                     // we must persist the slice before insert
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     strings::memcpy_inlined(pos, key.data, key.size);
                     Slice pk{pos, key.size};
                     AggDataPtr pv = allocate_func(pk);
@@ -697,7 +697,7 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
                         (*not_founds)[i] = 1;
                     }
                     // we must persist the slice before insert
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     strings::memcpy_inlined(pos, key.data, key.size);
                     Slice pk{pos, key.size};
                     AggDataPtr pv = allocate_func(pk);

--- a/be/src/exec/aggregate/agg_hash_set.h
+++ b/be/src/exec/aggregate/agg_hash_set.h
@@ -330,7 +330,7 @@ struct AggHashSetOfOneStringKey : public AggHashSet<HashSet, AggHashSetOfOneStri
                 KeyType key(tmp);
                 this->hash_set.lazy_emplace(key, [&](const auto& ctor) {
                     // we must persist the slice before insert
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     memcpy(pos, key.data, key.size);
                     ctor(pos, key.size, key.hash);
                 });
@@ -355,7 +355,7 @@ struct AggHashSetOfOneStringKey : public AggHashSet<HashSet, AggHashSetOfOneStri
             if constexpr (compute_and_allocate) {
                 this->hash_set.lazy_emplace_with_hash(key, key.hash, [&](const auto& ctor) {
                     // we must persist the slice before insert
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     memcpy(pos, key.data, key.size);
                     ctor(pos, key.size, key.hash);
                 });
@@ -451,7 +451,7 @@ struct AggHashSetOfOneNullableStringKey : public AggHashSet<HashSet, AggHashSetO
             const auto& key = cache[i];
             if constexpr (compute_and_allocate) {
                 this->hash_set.lazy_emplace_with_hash(key, key.hash, [&](const auto& ctor) {
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     memcpy(pos, key.data, key.size);
                     ctor(pos, key.size, key.hash);
                 });
@@ -467,7 +467,7 @@ struct AggHashSetOfOneNullableStringKey : public AggHashSet<HashSet, AggHashSetO
         KeyType key(tmp);
 
         this->hash_set.lazy_emplace(key, [&](const auto& ctor) {
-            uint8_t* pos = pool->allocate(key.size);
+            uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
             memcpy(pos, key.data, key.size);
             ctor(pos, key.size, key.hash);
         });
@@ -501,7 +501,7 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
 
     AggHashSetOfSerializedKey(int32_t chunk_size)
             : _mem_pool(std::make_unique<MemPool>()),
-              _buffer(_mem_pool->allocate(max_one_row_size * chunk_size)),
+              _buffer(_mem_pool->allocate(max_one_row_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING)),
               _chunk_size(chunk_size) {}
 
     // When compute_and_allocate=false:
@@ -544,7 +544,7 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
                 KeyType key(tmp);
                 this->hash_set.lazy_emplace(key, [&](const auto& ctor) {
                     // we must persist the slice before insert
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     memcpy(pos, key.data, key.size);
                     ctor(pos, key.size, key.hash);
                 });
@@ -567,7 +567,7 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
             if constexpr (compute_and_allocate) {
                 this->hash_set.lazy_emplace_with_hash(key, key.hash, [&](const auto& ctor) {
                     // we must persist the slice before insert
-                    uint8_t* pos = pool->allocate(key.size);
+                    uint8_t* pos = pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                     memcpy(pos, key.data, key.size);
                     ctor(pos, key.size, key.hash);
                 });
@@ -632,7 +632,7 @@ struct AggHashSetOfSerializedKeyFixedSize : public AggHashSet<HashSet, AggHashSe
 
     AggHashSetOfSerializedKeyFixedSize(int32_t chunk_size)
             : _mem_pool(std::make_unique<MemPool>()),
-              buffer(_mem_pool->allocate(max_fixed_size * chunk_size)),
+              buffer(_mem_pool->allocate(max_fixed_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING)),
               _chunk_size(chunk_size) {
         memset(buffer, 0x0, max_fixed_size * _chunk_size);
     }

--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -39,7 +39,8 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
     if (UNLIKELY(cur_max_one_row_size > buffer_state->max_one_row_size)) {
         buffer_state->max_one_row_size = cur_max_one_row_size;
         buffer_state->mem_pool.clear();
-        buffer_state->buffer = buffer_state->mem_pool.allocate(buffer_state->max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+        buffer_state->buffer = buffer_state->mem_pool.allocate(buffer_state->max_one_row_size * state->chunk_size() +
+                                                               SLICE_MEMEQUAL_OVERFLOW_PADDING);
     }
 
     _serialize_columns(chunk, exprs, chunk_size, buffer_state);

--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -39,7 +39,7 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
     if (UNLIKELY(cur_max_one_row_size > buffer_state->max_one_row_size)) {
         buffer_state->max_one_row_size = cur_max_one_row_size;
         buffer_state->mem_pool.clear();
-        buffer_state->buffer = buffer_state->mem_pool.allocate(buffer_state->max_one_row_size * state->chunk_size());
+        buffer_state->buffer = buffer_state->mem_pool.allocate(buffer_state->max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING);
     }
 
     _serialize_columns(chunk, exprs, chunk_size, buffer_state);
@@ -47,7 +47,7 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
     for (size_t i = 0; i < chunk_size; ++i) {
         ExceptSliceFlag key(buffer_state->buffer + i * buffer_state->max_one_row_size, buffer_state->slice_sizes[i]);
         _hash_set->lazy_emplace(key, [&](const auto& ctor) {
-            uint8_t* pos = pool->allocate(key.slice.size);
+            uint8_t* pos = pool->allocate_with_reserve(key.slice.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
             memcpy(pos, key.slice.data, key.slice.size);
             ctor(pos, key.slice.size);
         });

--- a/be/src/exec/intersect_hash_set.cpp
+++ b/be/src/exec/intersect_hash_set.cpp
@@ -23,7 +23,7 @@ template <typename HashSet>
 Status IntersectHashSet<HashSet>::init(RuntimeState* state) {
     _hash_set = std::make_unique<HashSet>();
     _mem_pool = std::make_unique<MemPool>();
-    _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
+    _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING);
     RETURN_IF_UNLIKELY_NULL(_buffer, Status::MemoryAllocFailed("alloc mem for intersect hash set failed"));
     return Status::OK();
 }
@@ -38,7 +38,7 @@ void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& c
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
+        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING);
     }
 
     _serialize_columns(chunkPtr, exprs, chunk_size);
@@ -47,7 +47,7 @@ void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& c
         IntersectSliceFlag key(_buffer + i * _max_one_row_size, _slice_sizes[i]);
         _hash_set->lazy_emplace(key, [&](const auto& ctor) {
             // we must persist the slice before insert
-            uint8_t* pos = pool->allocate(key.slice.size);
+            uint8_t* pos = pool->allocate_with_reserve(key.slice.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
             memcpy(pos, key.slice.data, key.slice.size);
             ctor(pos, key.slice.size);
         });
@@ -63,7 +63,7 @@ Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, cons
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
+        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING);
         if (UNLIKELY(_buffer == nullptr)) {
             return Status::InternalError("Mem usage has exceed the limit of BE");
         }

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -41,7 +41,7 @@ struct ArrayAggAggregateState {
                     auto raw_key = column.get_slice(offset + i);
                     KeyType key(raw_key);
                     set.template lazy_emplace(key, [&](const auto& ctor) {
-                        uint8_t* pos = mem_pool->allocate(key.size);
+                        uint8_t* pos = mem_pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                         assert(pos != nullptr);
                         memcpy(pos, key.data, key.size);
                         ctor(pos, key.size, key.hash);

--- a/be/src/exprs/agg/array_union_agg.h
+++ b/be/src/exprs/agg/array_union_agg.h
@@ -41,7 +41,7 @@ struct ArrayUnionAggAggregateState {
                     auto raw_key = column.get_slice(offset + i);
                     KeyType key(raw_key);
                     set.template lazy_emplace(key, [&](const auto& ctor) {
-                        uint8_t* pos = mem_pool->allocate(key.size);
+                        uint8_t* pos = mem_pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                         assert(pos != nullptr);
                         memcpy(pos, key.data, key.size);
                         ctor(pos, key.size, key.hash);

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -116,7 +116,7 @@ struct DistinctAggregateState<LT, SumLT, StringLTGuard<LT>> {
         size_t ret = 0;
         KeyType key(raw_key);
         set.template lazy_emplace(key, [&](const auto& ctor) {
-            uint8_t* pos = mem_pool->allocate(key.size);
+            uint8_t* pos = mem_pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
             assert(pos != nullptr);
             memcpy(pos, key.data, key.size);
             ctor(pos, key.size, key.hash);
@@ -129,7 +129,7 @@ struct DistinctAggregateState<LT, SumLT, StringLTGuard<LT>> {
         size_t ret = 0;
         KeyType key(reinterpret_cast<uint8_t*>(raw_key.data), raw_key.size, hash);
         set.template lazy_emplace_with_hash(key, hash, [&](const auto& ctor) {
-            uint8_t* pos = mem_pool->allocate(key.size);
+            uint8_t* pos = mem_pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
             assert(pos != nullptr);
             memcpy(pos, key.data, key.size);
             ctor(pos, key.size, key.hash);
@@ -171,7 +171,7 @@ struct DistinctAggregateState<LT, SumLT, StringLTGuard<LT>> {
             KeyType key(raw_key);
             // we only memcpy when the key is new
             set.template lazy_emplace(key, [&](const auto& ctor) {
-                uint8_t* pos = mem_pool->allocate(key.size);
+                uint8_t* pos = mem_pool->allocate_with_reserve(key.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
                 assert(pos != nullptr);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);


### PR DESCRIPTION
## Why I'm doing:
after:
<img width="1512" alt="截屏2024-07-10 15 32 55" src="https://github.com/StarRocks/starrocks/assets/28446271/f3b5a3e7-56e4-4362-8fe9-d432ee15afdc">
before:
<img width="1492" alt="截屏2024-07-10 16 10 29" src="https://github.com/StarRocks/starrocks/assets/28446271/427cfb3e-9fc9-481d-8e2b-c4959ca5cfc5">

before this fix, it will try to exhaust the chunk, chunk[0] size is 4096 and allocated_bytes is 4096, 
there is no room for SLICE_PADDING. 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
