### PR TITLE
[Enhancement][FlatJson] support multi-layer flat json

### DIFF
--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -15,6 +15,7 @@
 #include "column/column_access_path.h"
 
 #include <cstddef>
+#include <utility>
 #include <vector>
 
 #include "column/column.h"
@@ -23,8 +24,10 @@
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
+#include "gen_cpp/PlanNodes_types.h"
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
 #include "types/logical_type.h"
@@ -66,19 +69,10 @@ Status ColumnAccessPath::init(const std::string& parent_path, const TColumnAcces
 
     for (const auto& child : column_path.children) {
         ColumnAccessPathPtr child_path = std::make_unique<ColumnAccessPath>();
-        RETURN_IF_ERROR(child_path->init(_absolute_path + "/", child, state, pool));
+        RETURN_IF_ERROR(child_path->init(_absolute_path + ".", child, state, pool));
         _children.emplace_back(std::move(child_path));
     }
 
-    return Status::OK();
-}
-
-Status ColumnAccessPath::init(TAccessPathType::type type, const std::string& path, uint32_t index) {
-    _type = type;
-    _path = path;
-    _column_index = index;
-    _absolute_path = path;
-    _value_type = TypeDescriptor(LogicalType::TYPE_JSON);
     return Status::OK();
 }
 
@@ -175,6 +169,16 @@ size_t ColumnAccessPath::leaf_size() const {
     return size;
 }
 
+void ColumnAccessPath::get_all_leafs(std::vector<ColumnAccessPath*>* result) {
+    if (_children.empty()) {
+        result->emplace_back(this);
+        return;
+    }
+    for (const auto& child : _children) {
+        child->get_all_leafs(result);
+    }
+}
+
 const std::string ColumnAccessPath::to_string() const {
     std::stringstream ss;
     ss << _path << "(" << _type << ")";
@@ -184,15 +188,58 @@ const std::string ColumnAccessPath::to_string() const {
 StatusOr<std::unique_ptr<ColumnAccessPath>> ColumnAccessPath::create(const TColumnAccessPath& column_path,
                                                                      RuntimeState* state, ObjectPool* pool) {
     auto path = std::make_unique<ColumnAccessPath>();
-    RETURN_IF_ERROR(path->init("/", column_path, state, pool));
+    RETURN_IF_ERROR(path->init("", column_path, state, pool));
     return path;
 }
 
 StatusOr<std::unique_ptr<ColumnAccessPath>> ColumnAccessPath::create(const TAccessPathType::type& type,
                                                                      const std::string& path, uint32_t index) {
     auto p = std::make_unique<ColumnAccessPath>();
-    RETURN_IF_ERROR(p->init(type, path, index));
-    return p;
+    p->_type = type;
+    p->_path = path;
+    p->_column_index = index;
+    p->_absolute_path = path;
+    p->_value_type = TypeDescriptor(LogicalType::TYPE_JSON);
+    p->_children.clear();
+    return std::move(p);
+}
+
+ColumnAccessPath* insert_json_path_impl(const std::string& path, ColumnAccessPath* root) {
+    if (path.empty()) {
+        return root;
+    }
+
+    size_t pos = 0;
+    if (path.starts_with("\"")) {
+        pos = path.find('\"', 1);
+        DCHECK(pos != std::string::npos);
+    }
+    pos = path.find('.', pos);
+    std::string key;
+    std::string next;
+    if (pos == std::string::npos) {
+        key = path;
+    } else {
+        key = path.substr(0, pos);
+        next = path.substr(pos + 1);
+    }
+
+    auto child = root->get_child(key);
+    if (child == nullptr) {
+        auto n = ColumnAccessPath::create(TAccessPathType::FIELD, key, 0);
+        DCHECK(n.ok());
+        root->children().emplace_back(std::move(n.value()));
+        child = root->children().back().get();
+    }
+    return insert_json_path_impl(next, child);
+}
+
+void ColumnAccessPath::insert_json_path(ColumnAccessPath* root, LogicalType type, const std::string& path) {
+    auto leaf = insert_json_path_impl(path, root);
+    leaf->_type = TAccessPathType::type::FIELD;
+    leaf->_column_index = 0;
+    leaf->_absolute_path = path;
+    leaf->_value_type = TypeDescriptor(type);
 }
 
 } // namespace starrocks

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -18,9 +18,11 @@
 #include <string>
 #include <vector>
 
+#include "column/column.h"
 #include "common/status.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/types.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -41,15 +43,14 @@ public:
     static StatusOr<std::unique_ptr<ColumnAccessPath>> create(const TColumnAccessPath& column_path, RuntimeState* state,
                                                               ObjectPool* pool);
 
-    // for test
-    static StatusOr<std::unique_ptr<ColumnAccessPath>> create(const TAccessPathType::type& type,
-                                                              const std::string& path, uint32_t index);
-
     Status init(const std::string& parent_path, const TColumnAccessPath& column_path, RuntimeState* state,
                 ObjectPool* pool);
 
     // for test
-    Status init(TAccessPathType::type type, const std::string& path, uint32_t index);
+    static StatusOr<std::unique_ptr<ColumnAccessPath>> create(const TAccessPathType::type& type,
+                                                              const std::string& path, uint32_t index);
+    static void insert_json_path(ColumnAccessPath* root, LogicalType type, const std::string& path);
+    // end test
 
     const std::string& path() const { return _path; }
 
@@ -85,6 +86,8 @@ public:
     const std::string to_string() const;
 
     size_t leaf_size() const;
+
+    void get_all_leafs(std::vector<ColumnAccessPath*>* result);
 
 private:
     // path type, to mark the path is KEY/OFFSET/FIELD/ALL/INDEX

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -384,11 +384,14 @@ void JsonColumn::check_or_die() const {
     DCHECK(_flat_column_types.size() == _flat_columns.size());
     if (!_flat_columns.empty()) {
         size_t rows = _flat_columns[0]->size();
-        for (size_t i = 0; i < _flat_columns.size(); i++) {
+        for (size_t i = 0; i < _flat_columns.size() - 1; i++) {
             DCHECK(_flat_columns[i]->is_nullable());
             DCHECK(_flat_columns[i]->size() == rows);
             _flat_columns[i]->check_or_die();
         }
+        DCHECK(has_remain() ? _flat_columns.back()->is_json() : _flat_columns.back()->is_nullable());
+        DCHECK(_flat_columns.back()->size() == rows);
+        _flat_columns.back()->check_or_die();
     }
 }
 

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -185,11 +185,25 @@ void JsonColumn::set_flat_columns(const std::vector<std::string>& paths, const s
                                   const Columns& flat_columns) {
     DCHECK_EQ(paths.size(), types.size());
     DCHECK(paths.size() == flat_columns.size() || paths.size() + 1 == flat_columns.size()); // may remain column
-    _flat_column_paths.insert(_flat_column_paths.cbegin(), paths.cbegin(), paths.cend());
-    _flat_column_types.insert(_flat_column_types.cbegin(), types.cbegin(), types.cend());
-    _flat_columns.insert(_flat_columns.cbegin(), flat_columns.cbegin(), flat_columns.cend());
-    for (size_t i = 0; i < _flat_column_paths.size(); i++) {
-        _path_to_index[_flat_column_paths[i]] = i;
+
+    if (is_flat_json()) {
+        DCHECK_EQ(_flat_columns.size(), flat_columns.size());
+        DCHECK_EQ(_flat_column_paths.size(), paths.size());
+        DCHECK_EQ(_flat_column_types.size(), types.size());
+        DCHECK_EQ(_path_to_index.size(), paths.size());
+        for (size_t i = 0; i < _flat_column_paths.size(); i++) {
+            DCHECK_EQ(_flat_column_paths[i], paths[i]);
+            DCHECK_EQ(_flat_column_types[i], types[i]);
+            DCHECK_EQ(i, _path_to_index[paths[i]]);
+        }
+        _flat_columns = flat_columns;
+    } else {
+        _flat_column_paths = paths;
+        _flat_column_types = types;
+        _flat_columns = flat_columns;
+        for (size_t i = 0; i < _flat_column_paths.size(); i++) {
+            _path_to_index[_flat_column_paths[i]] = i;
+        }
     }
 }
 

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -196,7 +196,13 @@ void JsonColumn::set_flat_columns(const std::vector<std::string>& paths, const s
             DCHECK_EQ(_flat_column_types[i], types[i]);
             DCHECK_EQ(i, _path_to_index[paths[i]]);
         }
-        _flat_columns = flat_columns;
+        if (flat_columns.size() != 0) {
+            for (size_t i = 0; i < _flat_columns.size(); i++) {
+                _flat_columns[i]->append(*flat_columns[i], 0, flat_columns[i]->size());
+            }
+        } else {
+            _flat_columns = flat_columns;
+        }
     } else {
         _flat_column_paths = paths;
         _flat_column_types = types;
@@ -303,10 +309,14 @@ void JsonColumn::append_default(size_t count) {
 
 void JsonColumn::resize(size_t n) {
     if (is_flat_json()) {
+        DCHECK_EQ(0, BaseClass::size());
         for (auto& col : _flat_columns) {
             col->resize(n);
         }
     } else {
+        for (auto& col : _flat_columns) {
+            DCHECK_EQ(0, col->size());
+        }
         BaseClass::resize(n);
     }
 }

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -83,6 +83,8 @@ public:
 
     void append_value_multiple_times(const void* value, size_t count) override;
 
+    void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
+
     void append_default() override;
 
     void append_default(size_t count) override;

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -113,9 +113,15 @@ public:
 
     Columns& get_flat_fields() { return _flat_columns; };
 
+    const Columns& get_flat_fields() const { return _flat_columns; };
+
     ColumnPtr& get_flat_field(int index);
 
     const ColumnPtr& get_flat_field(int index) const;
+
+    ColumnPtr& get_remain();
+
+    const ColumnPtr& get_remain() const;
 
     const std::vector<std::string>& flat_column_paths() const { return _flat_column_paths; }
 
@@ -123,17 +129,18 @@ public:
 
     bool has_flat_column(const std::string& path) const;
 
-    void init_flat_columns(const std::vector<std::string>& paths);
+    bool has_remain() const { return _flat_columns.size() == (_flat_column_paths.size() + 1); }
 
-    void init_flat_columns(const std::vector<std::string>& paths, const std::vector<LogicalType>& types);
+    void set_flat_columns(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
+                          const Columns& flat_columns);
 
     std::string debug_flat_paths() const;
 
 private:
-    // flat-columns
+    // flat-columns[sub_columns, remain_column]
     Columns _flat_columns;
 
-    // flat-column paths
+    // flat-column paths, doesn't contains remain column
     std::vector<std::string> _flat_column_paths;
     std::vector<LogicalType> _flat_column_types;
     std::unordered_map<std::string, int> _path_to_index;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1320,16 +1320,13 @@ CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
 CONF_mBool(enable_json_flat, "true");
 
 // extract flat json column when row_num * null_factor < null_row_num
-CONF_mDouble(json_flat_null_factor, "0.3");
+CONF_mDouble(json_flat_null_factor, "0.4");
 
 // extract flat json column when row_num * sparsity_factor < hit_row_num
 CONF_mDouble(json_flat_sparsity_factor, "0.9");
 
-// only flatten json when the number of sub-field in the JSON exceeds the limit
-CONF_mInt32(json_flat_internal_column_min_limit, "5");
-
 // the maximum number of extracted JSON sub-field
-CONF_mInt32(json_flat_column_max, "20");
+CONF_mInt32(json_flat_column_max, "100");
 
 // Allowable intervals for continuous generation of pk dumps
 // Disable when pk_dump_interval_seconds <= 0

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -397,7 +397,7 @@ void TabletScanner::update_counter() {
         COUNTER_UPDATE(c2, _reader->stats().rows_del_filtered);
     }
     if (_reader->stats().flat_json_hits.size() > 0) {
-        auto path_profile = _parent->_scan_profile->create_child("AccessPathHits");
+        auto path_profile = _parent->_scan_profile->create_child("FlatJsonHits");
 
         for (auto& [k, v] : _reader->stats().flat_json_hits) {
             RuntimeProfile::Counter* path_counter = ADD_COUNTER(path_profile, k, TUnit::UNIT);
@@ -405,11 +405,34 @@ void TabletScanner::update_counter() {
         }
     }
     if (_reader->stats().dynamic_json_hits.size() > 0) {
-        auto path_profile = _parent->_scan_profile->create_child("AccessPathUnhits");
+        auto path_profile = _parent->_scan_profile->create_child("FlatJsonUnhits");
         for (auto& [k, v] : _reader->stats().dynamic_json_hits) {
             RuntimeProfile::Counter* path_counter = ADD_COUNTER(path_profile, k, TUnit::UNIT);
             COUNTER_SET(path_counter, v);
         }
+    }
+    if (_reader->stats().merge_json_hits.size() > 0) {
+        auto path_profile = _parent->_scan_profile->create_child("MergeJsonUnhits");
+        for (auto& [k, v] : _reader->stats().merge_json_hits) {
+            RuntimeProfile::Counter* path_counter = ADD_COUNTER(path_profile, k, TUnit::UNIT);
+            COUNTER_SET(path_counter, v);
+        }
+    }
+    if (_reader->stats().json_init_ns > 0) {
+        RuntimeProfile::Counter* c = ADD_TIMER(_parent->_scan_profile, "FlatJsonInit");
+        COUNTER_UPDATE(c, _reader->stats().json_init_ns);
+    }
+    if (_reader->stats().json_cast_ns > 0) {
+        RuntimeProfile::Counter* c = ADD_TIMER(_parent->_scan_profile, "FlatJsonCast");
+        COUNTER_UPDATE(c, _reader->stats().json_cast_ns);
+    }
+    if (_reader->stats().json_merge_ns > 0) {
+        RuntimeProfile::Counter* c = ADD_TIMER(_parent->_scan_profile, "FlatJsonMerge");
+        COUNTER_UPDATE(c, _reader->stats().json_merge_ns);
+    }
+    if (_reader->stats().json_flatten_ns > 0) {
+        RuntimeProfile::Counter* c = ADD_TIMER(_parent->_scan_profile, "FlatJsonFlatten");
+        COUNTER_UPDATE(c, _reader->stats().json_flatten_ns);
     }
     _has_update_counter = true;
 }

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -77,8 +77,7 @@ struct CastFn {
     struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> { \
         static ColumnPtr cast_fn(ColumnPtr& column) {          \
             return column->clone();                            \
-        }                                                      \
-    };
+        }
 
 #define UNARY_FN_CAST(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                        \
     template <bool AllowThrowException>                                                                      \

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -72,10 +72,12 @@ struct CastFn {
 };
 
 // All cast implements
-#define SELF_CAST(FROM_TYPE)                                                    \
-    template <bool AllowThrowException>                                         \
-    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> {                  \
-        static ColumnPtr cast_fn(ColumnPtr& column) { return column->clone(); } \
+#define SELF_CAST(FROM_TYPE)                                   \
+    template <bool AllowThrowException>                        \
+    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> { \
+        static ColumnPtr cast_fn(ColumnPtr& column) {          \
+            return column->clone();                            \
+        }                                                      \
     };
 
 #define UNARY_FN_CAST(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                        \
@@ -201,7 +203,6 @@ static ColumnPtr cast_to_json_fn(ColumnPtr& column) {
         }
     }
     return builder.build(column->is_constant());
-    return {};
 }
 
 template <LogicalType FromType, LogicalType ToType, bool AllowThrowException>

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -71,13 +71,13 @@ struct CastFn {
     static ColumnPtr cast_fn(ColumnPtr& column);
 };
 
+// clang-format off
 // All cast implements
-#define SELF_CAST(FROM_TYPE)                                   \
-    template <bool AllowThrowException>                        \
-    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> { \
-        static ColumnPtr cast_fn(ColumnPtr& column) {          \
-            return column->clone();                            \
-        }
+#define SELF_CAST(FROM_TYPE)                                                    \
+    template <bool AllowThrowException>                                         \
+    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> {                  \
+        static ColumnPtr cast_fn(ColumnPtr& column) { return column->clone(); } \
+    };
 
 #define UNARY_FN_CAST(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                        \
     template <bool AllowThrowException>                                                                      \
@@ -122,6 +122,7 @@ struct CastFn {
             return CUSTOMIZE_IMPL<FROM_TYPE, TO_TYPE, AllowThrowException>(column); \
         }                                                                           \
     };
+// clang-format on
 
 DEFINE_UNARY_FN_WITH_IMPL(TimeCheck, value) {
     return ((uint64_t)value % 100 > 59 || (uint64_t)value % 10000 > 5959);

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -588,7 +588,7 @@ StatusOr<ColumnPtr> JsonFunctions::_flat_json_query_impl(FunctionContext* contex
             chunk.append_column(flat_column, 0);
             return state->cast_expr->evaluate_checked(nullptr, &chunk);
         }
-        return flat_column->clone();
+        return std::move(flat_column->clone());
     }
 }
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(Storage STATIC
     rowset/bitshuffle_page.cpp
     rowset/bitshuffle_wrapper.cpp
     rowset/column_iterator.cpp
+    rowset/json_column_compactor.cpp
     rowset/json_column_iterator.cpp
     rowset/json_column_writer.cpp
     rowset/cast_column_iterator.cpp

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -69,6 +69,7 @@ Status CompactionUtils::construct_output_rowset_writer(Tablet* tablet, uint32_t 
     context.writer_type =
             (algorithm == VERTICAL_COMPACTION ? RowsetWriterType::kVertical : RowsetWriterType::kHorizontal);
     context.gtid = gtid;
+    context.is_compaction = true;
     Status st = RowsetFactory::create_rowset_writer(context, output_rowset_writer);
     if (!st.ok()) {
         std::stringstream ss;

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -229,7 +229,7 @@ Status DeltaWriterImpl::build_schema_and_writer() {
                                                                         _txn_id, nullptr, false /** no compaction**/);
         } else {
             _tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_manager, _tablet_id, _write_schema,
-                                                                             _txn_id);
+                                                                             _txn_id, false);
         }
         RETURN_IF_ERROR(_tablet_writer->open());
         _mem_table_sink = std::make_unique<TabletWriterSink>(_tablet_writer.get());

--- a/be/src/storage/lake/general_tablet_writer.h
+++ b/be/src/storage/lake/general_tablet_writer.h
@@ -34,7 +34,7 @@ class HorizontalGeneralTabletWriter : public TabletWriter {
 public:
     explicit HorizontalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                            std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                           ThreadPool* flush_pool = nullptr);
+                                           bool is_compaction, ThreadPool* flush_pool = nullptr);
 
     ~HorizontalGeneralTabletWriter() override;
 
@@ -84,7 +84,8 @@ class VerticalGeneralTabletWriter : public TabletWriter {
 public:
     explicit VerticalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                          std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                         uint32_t max_rows_per_segment, ThreadPool* flush_pool = nullptr);
+                                         uint32_t max_rows_per_segment, bool is_compaction,
+                                         ThreadPool* flush_pool = nullptr);
 
     ~VerticalGeneralTabletWriter() override;
 

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -32,7 +32,7 @@ namespace starrocks::lake {
 HorizontalPkTabletWriter::HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                                    std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                                    ThreadPool* flush_pool, bool is_compaction)
-        : HorizontalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, flush_pool),
+        : HorizontalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, is_compaction, flush_pool),
           _rowset_txn_meta(std::make_unique<RowsetTxnMetaPB>()) {
     if (is_compaction) {
         auto rows_mapper_filename = lake_rows_mapper_filename(tablet_id, txn_id);
@@ -111,7 +111,7 @@ VerticalPkTabletWriter::VerticalPkTabletWriter(TabletManager* tablet_mgr, int64_
                                                uint32_t max_rows_per_segment, ThreadPool* flush_pool,
                                                bool is_compaction)
         : VerticalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, max_rows_per_segment,
-                                      flush_pool) {
+                                      is_compaction, flush_pool) {
     if (is_compaction) {
         auto rows_mapper_filename = lake_rows_mapper_filename(tablet_id, txn_id);
         if (rows_mapper_filename.ok()) {

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -85,11 +85,12 @@ StatusOr<std::unique_ptr<TabletWriter>> Tablet::new_writer(WriterType type, int6
         }
     } else {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalGeneralTabletWriter>(_mgr, _id, tablet_schema, txn_id, flush_pool);
+            return std::make_unique<HorizontalGeneralTabletWriter>(_mgr, _id, tablet_schema, txn_id, is_compaction,
+                                                                   flush_pool);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalGeneralTabletWriter>(_mgr, _id, tablet_schema, txn_id, max_rows_per_segment,
-                                                                 flush_pool);
+                                                                 is_compaction, flush_pool);
         }
     }
 }

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -41,12 +41,13 @@ enum WriterType : int { kHorizontal = 0, kVertical = 1 };
 class TabletWriter {
 public:
     explicit TabletWriter(TabletManager* tablet_mgr, int64_t tablet_id, std::shared_ptr<const TabletSchema> schema,
-                          int64_t txn_id, ThreadPool* flush_pool = nullptr)
+                          int64_t txn_id, bool is_compaction, ThreadPool* flush_pool = nullptr)
             : _tablet_mgr(tablet_mgr),
               _tablet_id(tablet_id),
               _schema(std::move(schema)),
               _txn_id(txn_id),
-              _flush_pool(flush_pool) {}
+              _flush_pool(flush_pool),
+              _is_compaction(is_compaction) {}
 
     virtual ~TabletWriter() = default;
 
@@ -141,6 +142,8 @@ protected:
     uint32_t _seg_id = 0;
     bool _finished = false;
     OlapWriterStatistics _stats;
+
+    bool _is_compaction = false;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -56,11 +56,11 @@ StatusOr<std::unique_ptr<TabletWriter>> VersionedTablet::new_writer_with_schema(
     } else {
         if (type == kHorizontal) {
             return std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                                   flush_pool);
+                                                                   is_compaction, flush_pool);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                                 max_rows_per_segment, flush_pool);
+                                                                 max_rows_per_segment, is_compaction, flush_pool);
         }
     }
 }

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -302,7 +302,11 @@ struct OlapReaderStatistics {
     // ------ for json type, to count flat column ------
     // key: json absolute path, value: count
     int64_t json_flatten_ns = 0;
+    int64_t json_cast_ns = 0;
+    int64_t json_merge_ns = 0;
+    int64_t json_init_ns = 0;
     std::unordered_map<std::string, int64_t> flat_json_hits;
+    std::unordered_map<std::string, int64_t> merge_json_hits;
     std::unordered_map<std::string, int64_t> dynamic_json_hits;
 };
 

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -45,6 +45,7 @@
 #include "column/datum_convert.h"
 #include "common/compiler_util.h"
 #include "common/logging.h"
+#include "common/statusor.h"
 #include "runtime/types.h"
 #include "storage/column_predicate.h"
 #include "storage/index/index_descriptor.h"
@@ -131,6 +132,8 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
         // TODO(mofei) store format_version in ColumnReader
         const JsonMetaPB& json_meta = meta->json_meta();
         CHECK_EQ(kJsonMetaDefaultFormatVersion, json_meta.format_version()) << "Only format_version=1 is supported";
+        _is_flat_json = json_meta.is_flat();
+        _has_remain = json_meta.has_remain();
     }
     if (is_scalar_field_type(delegate_type(_column_type))) {
         RETURN_IF_ERROR(EncodingInfo::get(delegate_type(_column_type), meta->encoding(), &_encoding_info));
@@ -677,51 +680,100 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator(ColumnAcces
                                                                      const TabletColumn* column) {
     if (_column_type == LogicalType::TYPE_JSON) {
         auto json_iter = std::make_unique<ScalarColumnIterator>(this);
-        if (path == nullptr || path->children().empty()) {
-            return json_iter;
-        }
 
-        std::vector<std::unique_ptr<ColumnIterator>> flat_iters;
-        // short name path, e.g. 'a'
-        std::vector<std::string> flat_paths;
+        // access sub columns
+        std::vector<ColumnAccessPath*> access_paths;
+        std::vector<std::string> target_paths;
         std::vector<LogicalType> target_types;
-        std::vector<LogicalType> source_types;
-        {
-            for (auto& p : path->children()) {
-                if (UNLIKELY(!p->children().empty())) {
-                    // @todo: support later
-                    return Status::InvalidArgument("doesn't support multi-layer json access path: " +
-                                                   p->absolute_path());
-                }
-                flat_paths.emplace_back(p->path());
+        if (path != nullptr && !path->children().empty()) {
+            path->get_all_leafs(&access_paths);
+            for (auto& p : access_paths) {
+                target_paths.emplace_back(p->absolute_path()); // use absolute path, not relative path
                 target_types.emplace_back(p->value_type().type);
             }
         }
 
-        int start = is_nullable() ? 1 : 0;
-        for (auto& p : flat_paths) {
-            for (size_t i = start; i < _sub_readers->size(); i++) {
+        if (!_is_flat_json) {
+            if (path == nullptr || path->children().empty()) {
+                return json_iter;
+            }
+            // dynamic flattern
+            // we must dynamic flat json, because we don't know other segment wasn't the paths
+            return create_json_dynamic_flat_iterator(std::move(json_iter), target_paths, target_types);
+        }
+
+        std::vector<std::string> source_paths;
+        std::vector<LogicalType> source_types;
+        std::unique_ptr<ColumnIterator> null_iter;
+        std::vector<std::unique_ptr<ColumnIterator>> all_iters;
+        size_t start = is_nullable() ? 1 : 0;
+        size_t end = _has_remain ? _sub_readers->size() - 1 : _sub_readers->size();
+        if (is_nullable()) {
+            ASSIGN_OR_RETURN(null_iter, (*_sub_readers)[0]->new_iterator());
+        }
+
+        if (path == nullptr || path->children().empty()) {
+            DCHECK(_is_flat_json);
+            for (size_t i = start; i < end; i++) {
                 const auto& rd = (*_sub_readers)[i];
-                if (rd->name() == p) {
+                std::string name = rd->name();
+                ASSIGN_OR_RETURN(auto iter, rd->new_iterator());
+                source_paths.emplace_back(name);
+                source_types.emplace_back(rd->column_type());
+                all_iters.emplace_back(std::move(iter));
+            }
+
+            if (_has_remain) {
+                const auto& rd = (*_sub_readers)[end];
+                ASSIGN_OR_RETURN(auto iter, rd->new_iterator());
+                all_iters.emplace_back(std::move(iter));
+            }
+            // access whole json
+            return create_json_merge_iterator(std::move(null_iter), std::move(all_iters), source_paths, source_types);
+        }
+
+        bool need_remain = false;
+        for (size_t k = 0; k < target_paths.size(); k++) {
+            auto& target = target_paths[k];
+            size_t i = start;
+            for (; i < end; i++) {
+                const auto& rd = (*_sub_readers)[i];
+                std::string name = rd->name();
+                // target: b.b2.b3
+                // source: b.b2
+                if (target == name || target.starts_with(name + ".")) {
                     ASSIGN_OR_RETURN(auto iter, rd->new_iterator());
-                    flat_iters.emplace_back(std::move(iter));
+                    source_paths.emplace_back(name);
                     source_types.emplace_back(rd->column_type());
+                    all_iters.emplace_back(std::move(iter));
                     break;
+                } else if (name.starts_with(target + ".")) {
+                    // target: b.b2
+                    // source: b.b2.b3
+                    if (target_types[k] != TYPE_JSON && !is_string_type(target_types[k])) {
+                        // don't need column and remain
+                        break;
+                    }
+                    need_remain = true;
+                    ASSIGN_OR_RETURN(auto iter, rd->new_iterator());
+                    source_paths.emplace_back(name);
+                    source_types.emplace_back(rd->column_type());
+                    all_iters.emplace_back(std::move(iter));
                 }
             }
+            need_remain |= (i == end);
         }
 
-        if (flat_iters.size() != flat_paths.size()) {
-            // we must dynamic flat json, because we don't know other segment wasn't the paths
-            return create_json_dynamic_flat_iterator(std::move(json_iter), flat_paths, target_types, path);
+        if (_has_remain && need_remain) {
+            const auto& rd = (*_sub_readers)[end];
+            ASSIGN_OR_RETURN(auto iter, rd->new_iterator());
+            all_iters.emplace_back(std::move(iter));
         }
 
-        std::unique_ptr<ColumnIterator> null_iterator;
-        if (is_nullable()) {
-            ASSIGN_OR_RETURN(null_iterator, (*_sub_readers)[0]->new_iterator());
-        }
-        return create_json_flat_iterator(this, std::move(null_iterator), std::move(flat_iters), flat_paths,
-                                         target_types, source_types, path);
+        DCHECK(!source_paths.empty());
+        DCHECK(!all_iters.empty());
+        return create_json_flat_iterator(this, std::move(null_iter), std::move(all_iters), target_paths, target_types,
+                                         source_paths, source_types);
     } else if (is_scalar_field_type(delegate_type(_column_type))) {
         return std::make_unique<ScalarColumnIterator>(this);
     } else if (_column_type == LogicalType::TYPE_ARRAY) {

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -733,7 +733,8 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator(ColumnAcces
                 all_iters.emplace_back(std::move(iter));
             }
             // access whole json
-            return create_json_merge_iterator(std::move(null_iter), std::move(all_iters), source_paths, source_types);
+            return create_json_merge_iterator(this, std::move(null_iter), std::move(all_iters), source_paths,
+                                              source_types);
         }
 
         bool need_remain = false;

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -194,6 +194,8 @@ public:
 
     const std::vector<std::unique_ptr<ColumnReader>>* sub_readers() const { return _sub_readers.get(); }
 
+    bool has_remain_json() const { return _has_remain; }
+
 private:
     const std::string& file_name() const { return _segment->file_name(); }
     template <bool is_original_bf>
@@ -294,6 +296,8 @@ private:
 
     // only for json flat column
     std::string _name;
+    bool _is_flat_json = false;
+    bool _has_remain = false;
 
     // only used for inverted index load
     OnceFlag _inverted_index_load_once;

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -85,6 +85,7 @@ struct ColumnWriterOptions {
     GlobalDictMap* global_dict = nullptr;
 
     bool need_flat = false;
+    bool is_compaction = false;
 
     std::string field_name;
 };

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -1,0 +1,185 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/json_column_compactor.h"
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "column/column.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "gen_cpp/segment.pb.h"
+#include "gutil/casts.h"
+#include "storage/rowset/column_writer.h"
+#include "types/constexpr.h"
+#include "util/json_flattener.h"
+
+namespace starrocks {
+Status FlatJsonColumnCompactor::append(const Column& column) {
+    // compection will reuse column, must copy in there.
+    auto clone = column.clone_empty();
+    clone->append(column);
+    _json_datas.emplace_back(std::move(clone));
+
+    _estimate_size += column.byte_size();
+    return Status::OK();
+}
+
+Status FlatJsonColumnCompactor::_compact_columns(std::vector<ColumnPtr>& json_datas) {
+    // all json datas must full json
+    JsonPathDeriver deriver;
+    std::vector<const Column*> vc;
+    for (const auto& js : json_datas) {
+        vc.emplace_back(js.get());
+    }
+    deriver.derived(vc);
+
+    _flat_paths = deriver.flat_paths();
+    _flat_types = deriver.flat_types();
+    _has_remain = deriver.has_remain_json();
+
+    if (_flat_paths.empty()) {
+        // write json directly
+        _is_flat = false;
+        _json_meta->mutable_json_meta()->set_has_remain(false);
+        _json_meta->mutable_json_meta()->set_is_flat(false);
+
+        for (auto& col : json_datas) {
+            JsonColumn* json_col;
+            if (col->is_nullable()) {
+                auto nullable_column = down_cast<const NullableColumn*>(col.get());
+                json_col = down_cast<JsonColumn*>(nullable_column->data_column().get());
+            } else {
+                json_col = down_cast<JsonColumn*>(col.get());
+            }
+
+            if (!json_col->is_flat_json()) {
+                RETURN_IF_ERROR(_json_writer->append(*col));
+            } else {
+                JsonMerger merger(json_col->flat_column_paths(), json_col->flat_column_types(), json_col->has_remain());
+                auto j = merger.merge(json_col->get_flat_fields());
+                RETURN_IF_ERROR(_json_writer->append(*j));
+            }
+        }
+        return Status::OK();
+    }
+
+    _is_flat = true;
+    RETURN_IF_ERROR(_init_flat_writers());
+
+    JsonFlattener flattener(deriver);
+    HyperJsonTransformer transformer(deriver);
+
+    for (auto& col : json_datas) {
+        JsonColumn* json_col;
+        if (col->is_nullable()) {
+            auto nullable_column = down_cast<NullableColumn*>(col.get());
+            json_col = down_cast<JsonColumn*>(nullable_column->data_column().get());
+        } else {
+            json_col = down_cast<JsonColumn*>(col.get());
+        }
+
+        if (!json_col->is_flat_json()) {
+            flattener.flatten(json_col);
+            _flat_columns = flattener.mutable_result();
+        } else {
+            transformer.init_compaction_task(json_col);
+            RETURN_IF_ERROR(transformer.trans(json_col->get_flat_fields()));
+            _flat_columns = transformer.mutable_result();
+            transformer.reset();
+        }
+
+        // recode null column in 1st
+        if (_json_meta->is_nullable()) {
+            auto nulls = NullColumn::create();
+            uint8_t IS_NULL = 1;
+            uint8_t NOT_NULL = 0;
+            if (col->only_null()) {
+                nulls->append_value_multiple_times(&IS_NULL, col->size());
+            } else if (col->is_nullable()) {
+                auto* nullable_column = down_cast<NullableColumn*>(col.get());
+                auto* nl = down_cast<NullColumn*>(nullable_column->null_column().get());
+                nulls->append(*nl, 0, nl->size());
+            } else {
+                nulls->append_value_multiple_times(&NOT_NULL, col->size());
+            }
+
+            _flat_columns.insert(_flat_columns.begin(), nulls);
+        }
+
+        RETURN_IF_ERROR(_write_flat_column());
+        _flat_columns.clear();
+        col->resize_uninitialized(0); // release after write
+    }
+
+    _json_datas.clear(); // release after write
+    return Status::OK();
+}
+
+Status FlatJsonColumnCompactor::finish() {
+    for (const auto& js : _json_datas) {
+        DCHECK_GT(js->size(), 0);
+    }
+    RETURN_IF_ERROR(_compact_columns(_json_datas));
+    for (auto& iter : _flat_writers) {
+        RETURN_IF_ERROR(iter->finish());
+    }
+    return _json_writer->finish();
+}
+
+uint64_t FlatJsonColumnCompactor::estimate_buffer_size() {
+    return _estimate_size;
+}
+
+Status JsonColumnCompactor::append(const Column& column) {
+    const JsonColumn* json_col;
+    NullColumnPtr nulls = nullptr;
+    if (column.is_nullable()) {
+        auto nullable_column = down_cast<const NullableColumn&>(column);
+        nulls = nullable_column.null_column();
+        json_col = down_cast<const JsonColumn*>(nullable_column.data_column().get());
+    } else {
+        json_col = down_cast<const JsonColumn*>(&column);
+    }
+
+    if (!json_col->is_flat_json()) {
+        return _json_writer->append(column);
+    }
+
+    JsonMerger merger(json_col->flat_column_paths(), json_col->flat_column_types(), json_col->has_remain());
+    auto p = merger.merge(json_col->get_flat_fields());
+
+    if (column.is_nullable()) {
+        auto n = NullableColumn::create(p, nulls);
+        return _json_writer->append(*n);
+    } else {
+        return _json_writer->append(*p);
+    }
+}
+
+Status JsonColumnCompactor::finish() {
+    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+    _json_meta->mutable_json_meta()->set_has_remain(false);
+    _json_meta->mutable_json_meta()->set_is_flat(false);
+    return _json_writer->finish();
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -34,7 +34,7 @@
 
 namespace starrocks {
 Status FlatJsonColumnCompactor::append(const Column& column) {
-    // compection will reuse column, must copy in there.
+    // compaction will reuse column, must copy in there.
     _json_datas.emplace_back(column.clone());
 
     _estimate_size += column.byte_size();

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -35,9 +35,7 @@
 namespace starrocks {
 Status FlatJsonColumnCompactor::append(const Column& column) {
     // compection will reuse column, must copy in there.
-    auto clone = column.clone_empty();
-    clone->append(column);
-    _json_datas.emplace_back(std::move(clone));
+    _json_datas.emplace_back(column.clone());
 
     _estimate_size += column.byte_size();
     return Status::OK();

--- a/be/src/storage/rowset/json_column_compactor.h
+++ b/be/src/storage/rowset/json_column_compactor.h
@@ -22,7 +22,7 @@
 namespace starrocks {
 class FlatJsonColumnCompactor final : public FlatJsonColumnWriter {
 public:
-    FlatJsonColumnCompactor(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
+    FlatJsonColumnCompactor(const ColumnWriterOptions& opts, TypeInfoPtr type_info, WritableFile* wfile,
                             std::unique_ptr<ScalarColumnWriter> json_writer)
             : FlatJsonColumnWriter(opts, type_info, wfile, std::move(json_writer)) {}
 
@@ -41,13 +41,11 @@ private:
 
 class JsonColumnCompactor final : public ColumnWriter {
 public:
-    JsonColumnCompactor(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
+    JsonColumnCompactor(const ColumnWriterOptions& opts, TypeInfoPtr type_info, WritableFile* wfile,
                         std::unique_ptr<ScalarColumnWriter> json_writer)
-            : ColumnWriter(std::move(type_info), opts.meta->length(), opts.meta->is_nullable()),
+            : ColumnWriter(type_info, opts.meta->length(), opts.meta->is_nullable()),
               _json_meta(opts.meta),
               _json_writer(std::move(json_writer)) {}
-
-    JsonColumnCompactor(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile);
 
     ~JsonColumnCompactor() override = default;
 

--- a/be/src/storage/rowset/json_column_compactor.h
+++ b/be/src/storage/rowset/json_column_compactor.h
@@ -24,7 +24,7 @@ class FlatJsonColumnCompactor final : public FlatJsonColumnWriter {
 public:
     FlatJsonColumnCompactor(const ColumnWriterOptions& opts, TypeInfoPtr type_info, WritableFile* wfile,
                             std::unique_ptr<ScalarColumnWriter> json_writer)
-            : FlatJsonColumnWriter(opts, type_info, wfile, std::move(json_writer)) {}
+            : FlatJsonColumnWriter(opts, std::move(type_info), wfile, std::move(json_writer)) {}
 
     Status append(const Column& column) override;
     uint64_t estimate_buffer_size() override;

--- a/be/src/storage/rowset/json_column_compactor.h
+++ b/be/src/storage/rowset/json_column_compactor.h
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+
+#include "storage/rowset/column_writer.h"
+#include "storage/rowset/json_column_writer.h"
+
+namespace starrocks {
+class FlatJsonColumnCompactor final : public FlatJsonColumnWriter {
+public:
+    FlatJsonColumnCompactor(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
+                            std::unique_ptr<ScalarColumnWriter> json_writer)
+            : FlatJsonColumnWriter(opts, type_info, wfile, std::move(json_writer)) {}
+
+    Status append(const Column& column) override;
+    uint64_t estimate_buffer_size() override;
+
+    Status finish() override;
+
+private:
+    Status _compact_columns(std::vector<ColumnPtr>& json_datas);
+
+private:
+    std::vector<ColumnPtr> _json_datas;
+    size_t _estimate_size = 0;
+};
+
+class JsonColumnCompactor final : public ColumnWriter {
+public:
+    JsonColumnCompactor(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
+                        std::unique_ptr<ScalarColumnWriter> json_writer)
+            : ColumnWriter(std::move(type_info), opts.meta->length(), opts.meta->is_nullable()),
+              _json_meta(opts.meta),
+              _json_writer(std::move(json_writer)) {}
+
+    JsonColumnCompactor(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile);
+
+    ~JsonColumnCompactor() override = default;
+
+    Status init() override { return _json_writer->init(); }
+
+    Status append(const Column& column) override;
+
+    Status finish_current_page() override { return _json_writer->finish_current_page(); }
+
+    uint64_t estimate_buffer_size() override { return _json_writer->estimate_buffer_size(); }
+
+    Status finish() override;
+
+    Status write_data() override { return _json_writer->write_data(); }
+    Status write_ordinal_index() override { return _json_writer->write_ordinal_index(); }
+    Status write_zone_map() override { return _json_writer->write_zone_map(); }
+    Status write_bitmap_index() override { return _json_writer->write_bitmap_index(); }
+    Status write_bloom_filter_index() override { return _json_writer->write_bloom_filter_index(); }
+    ordinal_t get_next_rowid() const override { return _json_writer->get_next_rowid(); }
+    uint64_t total_mem_footprint() const override { return _json_writer->total_mem_footprint(); }
+
+private:
+    void _flat_column(std::vector<ColumnPtr>& json_datas);
+
+private:
+    ColumnMetaPB* _json_meta;
+    std::unique_ptr<ScalarColumnWriter> _json_writer;
+};
+} // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -479,10 +479,11 @@ Status JsonMergeIterator::_merge(JsonColumn* dst, FUNC func) {
     if (_is_merge) {
         SCOPED_RAW_TIMER(&_opts.stats->json_merge_ns);
         auto json = _merger->merge(all_columns);
-        dst->swap_column(*json);
+        dst->append(*json, 0, json->size());
     } else {
         dst->set_flat_columns(_src_paths, _src_types, all_columns);
     }
+    dst->check_or_die();
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -15,6 +15,7 @@
 #include "storage/rowset/json_column_iterator.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -46,19 +47,26 @@ namespace starrocks {
 
 class JsonFlatColumnIterator final : public ColumnIterator {
 public:
-    JsonFlatColumnIterator(ColumnReader* _reader, std::unique_ptr<ColumnIterator>& null_iter,
-                           std::vector<std::unique_ptr<ColumnIterator>>& field_iters,
-                           std::vector<std::string>& flat_paths, std::vector<LogicalType> target_types,
-                           std::vector<LogicalType> source_types, ColumnAccessPath* path)
-            : _reader(_reader),
+    JsonFlatColumnIterator(ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+                           std::vector<std::unique_ptr<ColumnIterator>> field_iters,
+                           const std::vector<std::string>& target_paths, const std::vector<LogicalType>& target_types,
+                           const std::vector<std::string>& source_paths, const std::vector<LogicalType>& source_types)
+            : _reader(reader),
               _null_iter(std::move(null_iter)),
               _flat_iters(std::move(field_iters)),
-              _flat_paths(std::move(flat_paths)),
+              _target_paths(std::move(target_paths)),
               _target_types(std::move(target_types)),
-              _source_types(std::move(source_types)),
-              _path(path) {}
+              _source_paths(std::move(source_paths)),
+              _source_types(std::move(source_types)){};
 
-    ~JsonFlatColumnIterator() override = default;
+    ~JsonFlatColumnIterator() override {
+        if (transformer != nullptr) {
+            auto [c, m, f] = transformer->cost_ms();
+            _opts.stats->json_cast_ns += c;
+            _opts.stats->json_merge_ns += m;
+            _opts.stats->json_flatten_ns += f;
+        }
+    }
 
     Status init(const ColumnIteratorOptions& opts) override;
 
@@ -82,22 +90,22 @@ public:
 
 private:
     template <typename FUNC>
-    Status _read_and_cast(JsonColumn* json_column, FUNC fn);
+    Status _read(JsonColumn* json_column, FUNC fn);
 
 private:
     ColumnReader* _reader;
 
     std::unique_ptr<ColumnIterator> _null_iter;
     std::vector<std::unique_ptr<ColumnIterator>> _flat_iters;
-    std::vector<std::string> _flat_paths;
+    std::vector<std::string> _target_paths;
     std::vector<LogicalType> _target_types;
+    std::vector<std::string> _source_paths;
     std::vector<LogicalType> _source_types;
-    // to avoid create column with find type
-    std::vector<ColumnPtr> _source_columns;
-    ColumnAccessPath* _path;
 
-    ObjectPool _pool;
-    std::vector<Expr*> _cast_exprs;
+    std::vector<ColumnPtr> _source_column_modules;
+    // to avoid create column with find type
+
+    std::unique_ptr<HyperJsonTransformer> transformer;
 };
 
 Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
@@ -110,66 +118,56 @@ Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
         RETURN_IF_ERROR(iter->init(opts));
     }
 
-    // update stats
-    DCHECK(_path != nullptr);
-    auto abs_path = _path->absolute_path();
-    if (opts.stats->flat_json_hits.count(abs_path) == 0) {
-        opts.stats->flat_json_hits[abs_path] = 1;
-    } else {
-        opts.stats->flat_json_hits[abs_path] = opts.stats->flat_json_hits[abs_path] + 1;
+    bool has_remain = _source_paths.size() != _flat_iters.size();
+    transformer = std::make_unique<HyperJsonTransformer>(_target_paths, _target_types, false);
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
+        transformer->init_read_task(_source_paths, _source_types, has_remain);
+
+        for (int i = 0; i < _source_paths.size(); i++) {
+            auto column = ColumnHelper::create_column(TypeDescriptor(_source_types[i]), true);
+            _source_column_modules.emplace_back(column);
+        }
     }
 
-    DCHECK(_target_types.size() == _source_types.size());
+    DCHECK_EQ(_source_column_modules.size(), _source_paths.size());
+    if (has_remain) {
+        _source_column_modules.emplace_back(JsonColumn::create());
+    }
 
-    for (int i = 0; i < _target_types.size(); i++) {
-        if (_target_types[i] == _source_types[i]) {
-            _cast_exprs.push_back(nullptr);
-            _source_columns.push_back(nullptr);
-            continue;
+    // update stats
+    {
+        auto cp = transformer->cast_paths();
+        for (int i = 0; i < cp.size(); i++) {
+            opts.stats->flat_json_hits[cp[i]] += 1;
         }
-
-        TypeDescriptor source_type(_source_types[i]);
-        TypeDescriptor target_type(_target_types[i]);
-
-        SlotDescriptor source_slot(i, "mock_solt", source_type);
-        ColumnRef* col_ref = _pool.add(new ColumnRef(&source_slot));
-
-        auto cast_expr = VectorizedCastExprFactory::from_type(source_type, target_type, col_ref, &_pool);
-        _cast_exprs.push_back(cast_expr);
-        _source_columns.push_back(ColumnHelper::create_column(TypeDescriptor(_source_types[i]), true));
+        auto mp = transformer->merge_paths();
+        for (int i = 0; i < mp.size(); i++) {
+            opts.stats->merge_json_hits[mp[i]] += 1;
+        }
+        auto fp = transformer->flat_paths();
+        for (int i = 0; i < fp.size(); i++) {
+            opts.stats->dynamic_json_hits[fp[i]] += 1;
+        }
     }
 
     return Status::OK();
 }
 
 template <typename FUNC>
-Status JsonFlatColumnIterator::_read_and_cast(JsonColumn* json_column, FUNC read_fn) {
-    json_column->init_flat_columns(_flat_paths, _target_types);
-    Chunk chunk;
+Status JsonFlatColumnIterator::_read(JsonColumn* json_column, FUNC read_fn) {
+    std::vector<ColumnPtr> columns;
+    for (int i = 0; i < _source_column_modules.size(); i++) {
+        columns.emplace_back(_source_column_modules[i]->clone_empty());
+    }
 
     for (int i = 0; i < _flat_iters.size(); i++) {
-        if (_cast_exprs[i] != nullptr) {
-            ColumnPtr source = _source_columns[i]->clone_empty();
-            RETURN_IF_ERROR(read_fn(i, source.get()));
-
-            chunk.append_column(source, i);
-            ASSIGN_OR_RETURN(auto res, _cast_exprs[i]->evaluate_checked(nullptr, &chunk));
-            auto target = json_column->get_flat_field(i);
-            target->set_delete_state(source->delete_state());
-            if (res->only_null()) {
-                target->append_nulls(source->size());
-            } else if (res->is_constant()) {
-                auto data = down_cast<ConstColumn*>(res.get())->data_column();
-                target->append_value_multiple_times(*data, 0, source->size());
-            } else {
-                target->append(*res, 0, source->size());
-            }
-            DCHECK_EQ(json_column->size(), target->size());
-        } else {
-            auto* flat_column = json_column->get_flat_field(i).get();
-            RETURN_IF_ERROR(read_fn(i, flat_column));
-        }
+        RETURN_IF_ERROR(read_fn(_flat_iters[i].get(), columns[i].get()));
     }
+
+    RETURN_IF_ERROR(transformer->trans(columns));
+    auto result = transformer->mutable_result();
+    json_column->set_flat_columns(_target_paths, _target_types, result);
     return Status::OK();
 }
 
@@ -192,8 +190,8 @@ Status JsonFlatColumnIterator::next_batch(size_t* n, Column* dst) {
     }
 
     // 2. Read flat column
-    auto read = [&](int index, Column* column) { return _flat_iters[index]->next_batch(n, column); };
-    return _read_and_cast(json_column, read);
+    auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(n, column); };
+    return _read(json_column, read);
 }
 
 Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
@@ -216,8 +214,8 @@ Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* ds
     }
 
     // 2. Read flat column
-    auto read = [&](int index, Column* column) { return _flat_iters[index]->next_batch(range, column); };
-    return _read_and_cast(json_column, read);
+    auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(range, column); };
+    return _read(json_column, read);
 }
 
 Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
@@ -235,11 +233,9 @@ Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size
     }
 
     // 2. Read flat column
-    auto read = [&](int index, Column* column) {
-        return _flat_iters[index]->fetch_values_by_rowid(rowids, size, column);
-    };
+    auto read = [&](ColumnIterator* iter, Column* column) { return iter->fetch_values_by_rowid(rowids, size, column); };
 
-    return _read_and_cast(json_column, read);
+    return _read(json_column, read);
 }
 
 Status JsonFlatColumnIterator::seek_to_first() {
@@ -271,12 +267,11 @@ Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<cons
 
 class JsonDynamicFlatIterator final : public ColumnIterator {
 public:
-    JsonDynamicFlatIterator(std::unique_ptr<ScalarColumnIterator>& json_iter, std::vector<std::string> flat_paths,
-                            std::vector<LogicalType> target_types, ColumnAccessPath* path)
+    JsonDynamicFlatIterator(std::unique_ptr<ScalarColumnIterator>& json_iter, std::vector<std::string> target_paths,
+                            std::vector<LogicalType> target_types)
             : _json_iter(std::move(json_iter)),
-              _flat_paths(std::move(flat_paths)),
-              _target_types(std::move(target_types)),
-              _path(path){};
+              _target_paths(std::move(target_paths)),
+              _target_types(std::move(target_types)){};
 
     ~JsonDynamicFlatIterator() override = default;
 
@@ -306,24 +301,20 @@ private:
 
 private:
     std::unique_ptr<ScalarColumnIterator> _json_iter;
-    std::vector<std::string> _flat_paths;
+    std::vector<std::string> _target_paths;
     std::vector<LogicalType> _target_types;
-    ColumnAccessPath* _path;
 
-    JsonFlattener _flattener;
+    std::unique_ptr<JsonFlattener> _flattener;
 };
 
 Status JsonDynamicFlatIterator::init(const ColumnIteratorOptions& opts) {
     RETURN_IF_ERROR(ColumnIterator::init(opts));
-    DCHECK(_path != nullptr);
-    auto abs_path = _path->absolute_path();
-    if (opts.stats->dynamic_json_hits.count(abs_path) == 0) {
-        opts.stats->dynamic_json_hits[abs_path] = 1;
-    } else {
-        opts.stats->dynamic_json_hits[abs_path] = opts.stats->dynamic_json_hits[abs_path] + 1;
+    for (auto& p : _target_paths) {
+        opts.stats->dynamic_json_hits[p] += 1;
     }
 
-    _flattener = JsonFlattener(_flat_paths, _target_types);
+    SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
+    _flattener = std::make_unique<JsonFlattener>(_target_paths, _target_types, false);
     return _json_iter->init(opts);
 }
 
@@ -350,8 +341,9 @@ Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
     }
 
     // 2. flat
-    json_data->init_flat_columns(_flat_paths, _target_types);
-    _flattener.flatten(input, &(json_data->get_flat_fields()));
+    _flattener->flatten(input);
+    auto result = _flattener->mutable_result();
+    json_data->set_flat_columns(_target_paths, _target_types, result);
     return Status::OK();
 }
 
@@ -390,18 +382,236 @@ Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<con
     return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation);
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
-        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
-        std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& full_paths,
-        std::vector<LogicalType>& target_types, std::vector<LogicalType>& source_types, ColumnAccessPath* path) {
-    return std::make_unique<JsonFlatColumnIterator>(reader, null_iter, field_iters, full_paths, target_types,
-                                                    source_types, path);
+class JsonMergeIterator final : public ColumnIterator {
+public:
+    JsonMergeIterator(std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iter,
+                      const std::vector<std::string>& src_paths, const std::vector<LogicalType>& src_types,
+                      bool is_merge)
+            : _null_iter(std::move(null_iter)),
+              _all_iter(std::move(all_iter)),
+              _src_paths(std::move(src_paths)),
+              _src_types(std::move(src_types)),
+              _is_merge(is_merge){};
+
+    ~JsonMergeIterator() override = default;
+
+    [[nodiscard]] Status init(const ColumnIteratorOptions& opts) override;
+
+    [[nodiscard]] Status next_batch(size_t* n, Column* dst) override;
+
+    [[nodiscard]] Status next_batch(const SparseRange<>& range, Column* dst) override;
+
+    [[nodiscard]] Status seek_to_first() override;
+
+    [[nodiscard]] Status seek_to_ordinal(ordinal_t ord) override;
+
+    ordinal_t get_current_ordinal() const override { return _all_iter[0]->get_current_ordinal(); }
+
+    ordinal_t num_rows() const override { return _all_iter[0]->num_rows(); }
+
+    /// for vectorized engine
+    [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                                    const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                                    CompoundNodeType pred_relation) override;
+
+    [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
+
+private:
+    template <typename FUNC>
+    Status _merge(JsonColumn* dst, FUNC func);
+
+private:
+    ColumnReader* _reader;
+
+    std::unique_ptr<ColumnIterator> _null_iter;
+    std::vector<std::unique_ptr<ColumnIterator>> _all_iter;
+    std::vector<std::string> _src_paths;
+    std::vector<LogicalType> _src_types;
+    std::vector<ColumnPtr> _src_column_modules;
+
+    std::unique_ptr<JsonMerger> _merger;
+    bool _is_merge;
+};
+
+Status JsonMergeIterator::init(const ColumnIteratorOptions& opts) {
+    RETURN_IF_ERROR(ColumnIterator::init(opts));
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->init(opts));
+    }
+
+    for (auto& iter : _all_iter) {
+        RETURN_IF_ERROR(iter->init(opts));
+    }
+
+    if (_is_merge) {
+        for (auto& p : _src_paths) {
+            opts.stats->merge_json_hits[p] += 1;
+        }
+
+        SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
+        _merger = std::make_unique<JsonMerger>(_src_paths, _src_types, _all_iter.size() != _src_paths.size());
+    }
+
+    DCHECK(_all_iter.size() == _src_paths.size() || _all_iter.size() == _src_paths.size() + 1);
+    for (int i = 0; i < _src_paths.size(); i++) {
+        auto column = ColumnHelper::create_column(TypeDescriptor(_src_types[i]), true);
+        _src_column_modules.emplace_back(column);
+    }
+
+    if (_all_iter.size() != _src_paths.size()) {
+        // remain
+        _src_column_modules.emplace_back(JsonColumn::create());
+    }
+
+    return Status::OK();
+}
+
+template <typename FUNC>
+Status JsonMergeIterator::_merge(JsonColumn* dst, FUNC func) {
+    std::vector<ColumnPtr> all_columns;
+    for (size_t i = 0; i < _all_iter.size(); i++) {
+        auto iter = _all_iter[i].get();
+        auto c = _src_column_modules[i]->clone_empty();
+        RETURN_IF_ERROR(func(iter, c.get()));
+        all_columns.emplace_back(std::move(c));
+    }
+
+    if (_is_merge) {
+        SCOPED_RAW_TIMER(&_opts.stats->json_merge_ns);
+        auto json = _merger->merge(all_columns);
+        dst->swap_column(*json);
+    } else {
+        dst->set_flat_columns(_src_paths, _src_types, all_columns);
+    }
+    return Status::OK();
+}
+
+Status JsonMergeIterator::next_batch(size_t* n, Column* dst) {
+    JsonColumn* json_column = nullptr;
+    NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+    } else {
+        json_column = down_cast<JsonColumn*>(dst);
+    }
+
+    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+
+    // 1. Read null column
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->next_batch(n, null_column));
+        down_cast<NullableColumn*>(dst)->update_has_null();
+    }
+
+    auto func = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(n, column); };
+    return _merge(json_column, func);
+}
+
+Status JsonMergeIterator::next_batch(const SparseRange<>& range, Column* dst) {
+    JsonColumn* json_column = nullptr;
+    NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+    } else {
+        json_column = down_cast<JsonColumn*>(dst);
+    }
+
+    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+
+    // 1. Read null column
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
+        down_cast<NullableColumn*>(dst)->update_has_null();
+    }
+
+    auto func = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(range, column); };
+    return _merge(json_column, func);
+}
+
+Status JsonMergeIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* dst) {
+    JsonColumn* json_column = nullptr;
+    NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+    } else {
+        json_column = down_cast<JsonColumn*>(dst);
+    }
+
+    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+
+    // 1. Read null column
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->fetch_values_by_rowid(rowids, size, null_column));
+        down_cast<NullableColumn*>(dst)->update_has_null();
+    }
+
+    auto func = [&](ColumnIterator* iter, Column* column) { return iter->fetch_values_by_rowid(rowids, size, column); };
+    return _merge(json_column, func);
+}
+
+Status JsonMergeIterator::seek_to_first() {
+    for (auto& iter : _all_iter) {
+        RETURN_IF_ERROR(iter->seek_to_first());
+    }
+
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->seek_to_first());
+    }
+    return Status::OK();
+}
+
+Status JsonMergeIterator::seek_to_ordinal(ordinal_t ord) {
+    for (auto& iter : _all_iter) {
+        RETURN_IF_ERROR(iter->seek_to_ordinal(ord));
+    }
+
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->seek_to_ordinal(ord));
+    }
+    return Status::OK();
+}
+
+Status JsonMergeIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                                     const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                                     CompoundNodeType pred_relation) {
+    row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
+    return Status::OK();
+}
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(ColumnReader* reader,
+                                                                    std::unique_ptr<ColumnIterator> null_iter,
+                                                                    std::vector<std::unique_ptr<ColumnIterator>> iters,
+                                                                    const std::vector<std::string>& target_paths,
+                                                                    const std::vector<LogicalType>& target_types,
+                                                                    const std::vector<std::string>& source_paths,
+                                                                    const std::vector<LogicalType>& source_types) {
+    return std::make_unique<JsonFlatColumnIterator>(reader, std::move(null_iter), std::move(iters), target_paths,
+                                                    target_types, source_paths, source_types);
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
-        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths,
-        std::vector<LogicalType>& target_types, ColumnAccessPath* path) {
-    return std::make_unique<JsonDynamicFlatIterator>(json_iter, flat_paths, target_types, path);
+        std::unique_ptr<ScalarColumnIterator> json_iter, const std::vector<std::string>& target_paths,
+        const std::vector<LogicalType>& target_types) {
+    return std::make_unique<JsonDynamicFlatIterator>(json_iter, target_paths, target_types);
 }
 
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
+        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
+        const std::vector<std::string>& merge_paths, const std::vector<LogicalType>& merge_types) {
+    return std::make_unique<JsonMergeIterator>(std::move(null_iter), std::move(all_iters), merge_paths, merge_types,
+                                               true);
+}
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_direct_iterator(
+        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
+        const std::vector<std::string>& merge_paths, const std::vector<LogicalType>& merge_types) {
+    return std::make_unique<JsonMergeIterator>(std::move(null_iter), std::move(all_iters), merge_paths, merge_types,
+                                               false);
+}
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -384,10 +384,11 @@ Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<con
 
 class JsonMergeIterator final : public ColumnIterator {
 public:
-    JsonMergeIterator(std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iter,
-                      const std::vector<std::string>& src_paths, const std::vector<LogicalType>& src_types,
-                      bool is_merge)
-            : _null_iter(std::move(null_iter)),
+    JsonMergeIterator(ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+                      std::vector<std::unique_ptr<ColumnIterator>> all_iter, const std::vector<std::string>& src_paths,
+                      const std::vector<LogicalType>& src_types, bool is_merge)
+            : _reader(reader),
+              _null_iter(std::move(null_iter)),
               _all_iter(std::move(all_iter)),
               _src_paths(std::move(src_paths)),
               _src_types(std::move(src_types)),
@@ -603,16 +604,18 @@ StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
-        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
-        const std::vector<std::string>& merge_paths, const std::vector<LogicalType>& merge_types) {
-    return std::make_unique<JsonMergeIterator>(std::move(null_iter), std::move(all_iters), merge_paths, merge_types,
-                                               true);
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& merge_paths,
+        const std::vector<LogicalType>& merge_types) {
+    return std::make_unique<JsonMergeIterator>(reader, std::move(null_iter), std::move(all_iters), merge_paths,
+                                               merge_types, true);
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_direct_iterator(
-        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
-        const std::vector<std::string>& merge_paths, const std::vector<LogicalType>& merge_types) {
-    return std::make_unique<JsonMergeIterator>(std::move(null_iter), std::move(all_iters), merge_paths, merge_types,
-                                               false);
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& merge_paths,
+        const std::vector<LogicalType>& merge_types) {
+    return std::make_unique<JsonMergeIterator>(reader, std::move(null_iter), std::move(all_iters), merge_paths,
+                                               merge_types, false);
 }
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.h
+++ b/be/src/storage/rowset/json_column_iterator.h
@@ -22,12 +22,24 @@
 
 namespace starrocks {
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
-        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
-        std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& full_paths,
-        std::vector<LogicalType>& target_types, std::vector<LogicalType>& source_types, ColumnAccessPath* path);
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(ColumnReader* reader,
+                                                                    std::unique_ptr<ColumnIterator> null_iter,
+                                                                    std::vector<std::unique_ptr<ColumnIterator>> iters,
+                                                                    const std::vector<std::string>& target_paths,
+                                                                    const std::vector<LogicalType>& target_types,
+                                                                    const std::vector<std::string>& source_paths,
+                                                                    const std::vector<LogicalType>& source_types);
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
-        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths,
-        std::vector<LogicalType>& target_types, ColumnAccessPath* path);
+        std::unique_ptr<ScalarColumnIterator> json_iter, const std::vector<std::string>& target_paths,
+        const std::vector<LogicalType>& target_types);
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
+        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
+        const std::vector<std::string>& merge_paths, const std::vector<LogicalType>& merge_types);
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_direct_iterator(
+        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
+        const std::vector<std::string>& all_paths, const std::vector<LogicalType>& all_types);
+
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.h
+++ b/be/src/storage/rowset/json_column_iterator.h
@@ -35,11 +35,13 @@ StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
         const std::vector<LogicalType>& target_types);
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
-        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
-        const std::vector<std::string>& merge_paths, const std::vector<LogicalType>& merge_types);
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& merge_paths,
+        const std::vector<LogicalType>& merge_types);
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_direct_iterator(
-        std::unique_ptr<ColumnIterator> null_iter, std::vector<std::unique_ptr<ColumnIterator>> all_iters,
-        const std::vector<std::string>& all_paths, const std::vector<LogicalType>& all_types);
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& all_paths,
+        const std::vector<LogicalType>& all_types);
 
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -48,7 +48,7 @@ namespace starrocks {
 
 FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, TypeInfoPtr type_info, WritableFile* wfile,
                                            std::unique_ptr<ScalarColumnWriter> json_writer)
-        : ColumnWriter(type_info, opts.meta->length(), opts.meta->is_nullable()),
+        : ColumnWriter(std::move(type_info), opts.meta->length(), opts.meta->is_nullable()),
           _json_meta(opts.meta),
           _wfile(wfile),
           _json_writer(std::move(json_writer)) {}
@@ -272,9 +272,9 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWr
     // compaction
     if (opts.is_compaction) {
         if (opts.need_flat) {
-            return std::make_unique<FlatJsonColumnCompactor>(opts, type_info, wfile, std::move(json_writer));
+            return std::make_unique<FlatJsonColumnCompactor>(opts, std::move(type_info), wfile, std::move(json_writer));
         } else {
-            return std::make_unique<JsonColumnCompactor>(opts, type_info, wfile, std::move(json_writer));
+            return std::make_unique<JsonColumnCompactor>(opts, std::move(type_info), wfile, std::move(json_writer));
         }
     }
 
@@ -282,7 +282,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWr
     if (!opts.need_flat) {
         return std::move(json_writer);
     } else {
-        return std::make_unique<FlatJsonColumnWriter>(opts, type_info, wfile, std::move(json_writer));
+        return std::make_unique<FlatJsonColumnWriter>(opts, std::move(type_info), wfile, std::move(json_writer));
     }
 }
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "column/column.h"
 #include "column/column_helper.h"
@@ -36,250 +37,249 @@
 #include "gutil/casts.h"
 #include "runtime/types.h"
 #include "storage/rowset/column_writer.h"
+#include "storage/rowset/common.h"
+#include "storage/rowset/json_column_compactor.h"
+#include "types/constexpr.h"
 #include "types/logical_type.h"
 #include "util/json_flattener.h"
 #include "velocypack/vpack.h"
 
 namespace starrocks {
 
-class FlatJsonColumnWriter final : public ColumnWriter {
-public:
-    FlatJsonColumnWriter(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
-                         std::unique_ptr<ScalarColumnWriter> json_writer);
-
-    ~FlatJsonColumnWriter() override = default;
-
-    Status init() override { return _json_column_writer->init(); };
-
-    Status append(const Column& column) override;
-
-    Status finish_current_page() override;
-
-    uint64_t estimate_buffer_size() override;
-
-    Status finish() override;
-
-    Status write_data() override;
-    Status write_ordinal_index() override;
-    Status write_zone_map() override;
-    Status write_bitmap_index() override;
-    Status write_bloom_filter_index() override;
-    ordinal_t get_next_rowid() const override { return _json_column_writer->get_next_rowid(); }
-
-    bool is_global_dict_valid() override { return _json_column_writer->is_global_dict_valid(); }
-
-    uint64_t total_mem_footprint() const override { return _json_column_writer->total_mem_footprint(); }
-
-private:
-    void _flat_column(std::vector<ColumnPtr>& json_datas);
-
-private:
-    std::unique_ptr<ScalarColumnWriter> _json_column_writer;
-    ColumnMetaPB* _json_meta;
-    WritableFile* _wfile;
-
-    std::vector<ColumnPtr> _json_datas;
-
-    std::vector<std::unique_ptr<ColumnWriter>> _flat_writers;
-    std::vector<std::string> _flat_paths;
-    std::vector<LogicalType> _flat_types;
-    std::vector<ColumnPtr> _flat_columns;
-};
-
 FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info,
                                            WritableFile* wfile, std::unique_ptr<ScalarColumnWriter> json_writer)
-        : ColumnWriter(std::move(type_info), opts.meta->length(), opts.meta->is_nullable()),
-          _json_column_writer(std::move(json_writer)),
+        : ColumnWriter(type_info, opts.meta->length(), opts.meta->is_nullable()),
           _json_meta(opts.meta),
-          _wfile(wfile) {}
+          _wfile(wfile),
+          _json_writer(std::move(json_writer)) {}
 
-Status FlatJsonColumnWriter::append(const Column& column) {
-    RETURN_IF_ERROR(_json_column_writer->append(column));
-    // write process/compection will reuse column, must copy in there.
-    // @Todo: avoid memory copy
-    auto clone = column.clone_empty();
-    clone->append(column);
-    _json_datas.emplace_back(std::move(clone));
-    return Status::OK();
+Status FlatJsonColumnWriter::init() {
+    return _json_writer->init();
 }
 
-void FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
-    JsonFlattener flattener;
-    flattener.derived_paths(json_datas);
+Status FlatJsonColumnWriter::append(const Column& column) {
+    DCHECK(_flat_paths.empty());
+    DCHECK(_flat_types.empty());
+    DCHECK(_flat_writers.empty());
 
-    _flat_paths = flattener.get_flat_paths();
-    _flat_types = flattener.get_flat_types();
+    auto st = _flat_column(&column);
+    if (st.ok()) {
+        _is_flat = true;
+        RETURN_IF_ERROR(_init_flat_writers());
+        return _write_flat_column();
+    } else {
+        _is_flat = false;
+        return _json_writer->append(column);
+    }
+}
+
+Status FlatJsonColumnWriter::_flat_column(const Column* json_data) {
+    // all json datas must full json
+    JsonPathDeriver deriver;
+    deriver.derived({json_data});
+
+    _flat_paths = deriver.flat_paths();
+    _flat_types = deriver.flat_types();
+    _has_remain = deriver.has_remain_json();
 
     if (_flat_paths.empty()) {
-        return;
+        return Status::InternalError("doesn't have flat column.");
     }
 
-    // extract flat column
-    for (size_t i = 0; i < _flat_paths.size(); i++) {
-        _flat_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(_flat_types[i]), true));
-    }
-
-    for (auto& col : json_datas) {
-        flattener.flatten(col.get(), &_flat_columns);
-    }
+    JsonFlattener flattener(deriver);
+    flattener.flatten(json_data);
+    _flat_columns = flattener.mutable_result();
 
     // recode null column in 1st
     if (_json_meta->is_nullable()) {
         auto nulls = NullColumn::create();
         uint8_t IS_NULL = 1;
         uint8_t NOT_NULL = 0;
-        for (auto& col : json_datas) {
-            if (col->only_null()) {
-                nulls->append_value_multiple_times(&IS_NULL, col->size());
-            } else if (col->is_nullable()) {
-                auto* nullable_column = down_cast<NullableColumn*>(col.get());
-                auto* nl = down_cast<NullColumn*>(nullable_column->null_column().get());
-                nulls->append(*nl, 0, nl->size());
-            } else {
-                nulls->append_value_multiple_times(&NOT_NULL, col->size());
-            }
+        if (json_data->only_null()) {
+            nulls->append_value_multiple_times(&IS_NULL, json_data->size());
+        } else if (json_data->is_nullable()) {
+            auto* nullable_column = down_cast<const NullableColumn*>(json_data);
+            auto* nl = down_cast<NullColumn*>(nullable_column->null_column().get());
+            nulls->append(*nl, 0, nl->size());
+        } else {
+            nulls->append_value_multiple_times(&NOT_NULL, json_data->size());
         }
 
         _flat_columns.insert(_flat_columns.begin(), nulls);
+    }
+    return Status::OK();
+}
+
+Status FlatJsonColumnWriter::_init_flat_writers() {
+    // update json meta
+    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+    _json_meta->mutable_json_meta()->set_has_remain(_has_remain);
+    _json_meta->mutable_json_meta()->set_is_flat(true);
+
+    // recode null column in 1st
+    if (_json_meta->is_nullable()) {
         _flat_paths.insert(_flat_paths.begin(), "nulls");
         _flat_types.insert(_flat_types.begin(), LogicalType::TYPE_TINYINT);
     }
+
+    if (_has_remain) {
+        _flat_paths.emplace_back("remain");
+        _flat_types.emplace_back(LogicalType::TYPE_JSON);
+    }
+
+    for (size_t i = 0; i < _flat_columns.size(); i++) {
+        ColumnWriterOptions opts;
+        opts.meta = _json_meta->add_children_columns();
+        opts.meta->set_column_id(i);
+        opts.meta->set_unique_id(i);
+        opts.meta->set_type(_flat_types[i]);
+        if (_flat_types[i] == TYPE_VARCHAR) {
+            opts.meta->set_length(config::olap_string_max_length);
+        } else {
+            DCHECK_NE(_flat_types[i], TYPE_CHAR);
+            // set length for non-string type (e.g. int, double, date, etc.
+            opts.meta->set_length(get_type_info(_flat_types[i])->size());
+        }
+        if ((_json_meta->is_nullable() && i == 0) || (i == _flat_columns.size() - 1 && _has_remain)) {
+            opts.meta->set_is_nullable(false);
+        } else {
+            opts.meta->set_is_nullable(true);
+        }
+        opts.meta->set_encoding(DEFAULT_ENCODING);
+        opts.meta->set_compression(_json_meta->compression());
+
+        if (_flat_types[i] == LogicalType::TYPE_JSON) {
+            opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+            opts.meta->mutable_json_meta()->set_is_flat(false);
+        }
+
+        opts.meta->set_name(_flat_paths[i]);
+        opts.need_flat = false;
+
+        TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, _flat_types[i], true);
+        ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));
+        _flat_writers.emplace_back(std::move(fw));
+
+        RETURN_IF_ERROR(_flat_writers[i]->init());
+    }
+    return Status::OK();
+}
+
+Status FlatJsonColumnWriter::_write_flat_column() {
+    DCHECK(!_flat_columns.empty());
+    DCHECK(_flat_columns.size() == _flat_writers.size());
+    // flat datas
+    for (size_t i = 0; i < _flat_columns.size(); i++) {
+        RETURN_IF_ERROR(_flat_writers[i]->append(*_flat_columns[i]));
+    }
+
+    return Status::OK();
 }
 
 Status FlatJsonColumnWriter::finish() {
-    for (const auto& js : _json_datas) {
-        DCHECK_GT(js->size(), 0);
-    }
-    _flat_column(_json_datas);
-    _json_datas.clear(); // release column data
-
-    if (!_flat_columns.empty()) {
-        // nulls
-        if (_json_meta->is_nullable()) {
-            ColumnWriterOptions opts;
-            opts.meta = _json_meta->add_children_columns();
-            opts.meta->set_column_id(0);
-            opts.meta->set_unique_id(0);
-            opts.meta->set_type(LogicalType::TYPE_TINYINT);
-            opts.meta->set_length(get_type_info(LogicalType::TYPE_TINYINT)->size());
-            opts.meta->set_is_nullable(false);
-            opts.meta->set_name("nulls");
-            opts.meta->set_encoding(DEFAULT_ENCODING);
-            opts.meta->set_compression(_json_meta->compression());
-
-            TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, LogicalType::TYPE_TINYINT, true);
-            ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));
-            _flat_writers.emplace_back(std::move(fw));
-
-            RETURN_IF_ERROR(_flat_writers[0]->init());
-            RETURN_IF_ERROR(_flat_writers[0]->append(*_flat_columns[0]));
-            RETURN_IF_ERROR(_flat_writers[0]->finish());
-
-            VLOG(8) << "flush flat json nulls";
-        }
-
-        int start = _json_meta->is_nullable() ? 1 : 0;
-        // flat datas
-        for (size_t i = start; i < _flat_columns.size(); i++) {
-            ColumnWriterOptions opts;
-            opts.meta = _json_meta->add_children_columns();
-            opts.meta->set_column_id(i);
-            opts.meta->set_unique_id(i);
-            opts.meta->set_type(_flat_types[i]);
-            if (_flat_types[i] == TYPE_VARCHAR) {
-                opts.meta->set_length(config::olap_string_max_length);
-            } else {
-                DCHECK_NE(_flat_types[i], TYPE_CHAR);
-                // set length for non-string type (e.g. int, double, date, etc.
-                opts.meta->set_length(get_type_info(_flat_types[i])->size());
-            }
-            opts.meta->set_is_nullable(true);
-            opts.meta->set_encoding(DEFAULT_ENCODING);
-            opts.meta->set_compression(_json_meta->compression());
-
-            if (_flat_types[i] == LogicalType::TYPE_JSON) {
-                opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
-            }
-
-            if (_flat_paths[i].find('.') != std::string::npos) {
-                // add escape
-                opts.meta->set_name(fmt::format("\"{}\"", _flat_paths[i]));
-            } else {
-                opts.meta->set_name(_flat_paths[i]);
-            }
-
-            opts.need_flat = false;
-
-            TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, _flat_types[i], true);
-            ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));
-            _flat_writers.emplace_back(std::move(fw));
-
-            RETURN_IF_ERROR(_flat_writers[i]->init());
-            RETURN_IF_ERROR(_flat_writers[i]->append(*_flat_columns[i]));
-            RETURN_IF_ERROR(_flat_writers[i]->finish());
-
-            VLOG(8) << "flush flat json: " << _flat_paths[i];
-        }
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
+    // flat datas
+    for (size_t i = 0; i < _flat_columns.size(); i++) {
+        RETURN_IF_ERROR(_flat_writers[i]->finish());
+        VLOG(8) << "flush flat json: " << _flat_paths[i];
     }
 
-    return _json_column_writer->finish();
+    _flat_columns.clear();
+    return _json_writer->finish();
+}
+
+ordinal_t FlatJsonColumnWriter::get_next_rowid() const {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
+    if (!_is_flat) {
+        return _json_writer->get_next_rowid();
+    }
+    return _flat_writers[0]->get_next_rowid();
 }
 
 uint64_t FlatJsonColumnWriter::estimate_buffer_size() {
-    uint64_t size = _json_column_writer->estimate_buffer_size();
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
+    uint64_t size = 0;
     for (auto& w : _flat_writers) {
         size += w->estimate_buffer_size();
     }
+    size += _json_writer->estimate_buffer_size();
+    return size;
+}
+
+uint64_t FlatJsonColumnWriter::total_mem_footprint() const {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
+    uint64_t size = 0;
+    for (auto& w : _flat_writers) {
+        size += w->total_mem_footprint();
+    }
+    size += _json_writer->total_mem_footprint();
     return size;
 }
 
 Status FlatJsonColumnWriter::write_data() {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
     for (auto& w : _flat_writers) {
         RETURN_IF_ERROR(w->write_data());
     }
-    return _json_column_writer->write_data();
+    return _json_writer->write_data();
 }
 
 Status FlatJsonColumnWriter::write_ordinal_index() {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
     for (auto& w : _flat_writers) {
         RETURN_IF_ERROR(w->write_ordinal_index());
     }
-    return _json_column_writer->write_ordinal_index();
+    return _json_writer->write_ordinal_index();
 }
 Status FlatJsonColumnWriter::write_zone_map() {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
     for (auto& w : _flat_writers) {
         RETURN_IF_ERROR(w->write_zone_map());
     }
-    return _json_column_writer->write_zone_map();
+    return _json_writer->write_zone_map();
 }
 
 Status FlatJsonColumnWriter::write_bitmap_index() {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
     for (auto& w : _flat_writers) {
         RETURN_IF_ERROR(w->write_bitmap_index());
     }
-    return _json_column_writer->write_bitmap_index();
+    return _json_writer->write_bitmap_index();
 }
 
 Status FlatJsonColumnWriter::write_bloom_filter_index() {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
     for (auto& w : _flat_writers) {
         RETURN_IF_ERROR(w->write_bloom_filter_index());
     }
-    return _json_column_writer->write_bloom_filter_index();
+    return _json_writer->write_bloom_filter_index();
 }
 
 Status FlatJsonColumnWriter::finish_current_page() {
+    DCHECK(_is_flat ? !_flat_writers.empty() : _flat_writers.empty());
     for (auto& w : _flat_writers) {
         RETURN_IF_ERROR(w->finish_current_page());
     }
-    return _json_column_writer->finish_current_page();
+    return _json_writer->finish_current_page();
 }
 
 StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWriterOptions& opts,
                                                                   const TypeInfoPtr& type_info, WritableFile* wfile,
                                                                   std::unique_ptr<ScalarColumnWriter> json_writer) {
+    // compaction
+    if (opts.is_compaction) {
+        if (opts.need_flat) {
+            return std::make_unique<FlatJsonColumnCompactor>(opts, type_info, wfile, std::move(json_writer));
+        } else {
+            return std::make_unique<JsonColumnCompactor>(opts, type_info, wfile, std::move(json_writer));
+        }
+    }
+
+    // load
     if (!opts.need_flat) {
         return std::move(json_writer);
+    } else {
+        return std::make_unique<FlatJsonColumnWriter>(opts, type_info, wfile, std::move(json_writer));
     }
-    return std::make_unique<FlatJsonColumnWriter>(opts, type_info, wfile, std::move(json_writer));
 }
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -46,8 +46,8 @@
 
 namespace starrocks {
 
-FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info,
-                                           WritableFile* wfile, std::unique_ptr<ScalarColumnWriter> json_writer)
+FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, TypeInfoPtr type_info, WritableFile* wfile,
+                                           std::unique_ptr<ScalarColumnWriter> json_writer)
         : ColumnWriter(type_info, opts.meta->length(), opts.meta->is_nullable()),
           _json_meta(opts.meta),
           _wfile(wfile),
@@ -267,7 +267,7 @@ Status FlatJsonColumnWriter::finish_current_page() {
 }
 
 StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWriterOptions& opts,
-                                                                  const TypeInfoPtr& type_info, WritableFile* wfile,
+                                                                  TypeInfoPtr type_info, WritableFile* wfile,
                                                                   std::unique_ptr<ScalarColumnWriter> json_writer) {
     // compaction
     if (opts.is_compaction) {

--- a/be/src/storage/rowset/json_column_writer.h
+++ b/be/src/storage/rowset/json_column_writer.h
@@ -19,12 +19,12 @@
 namespace starrocks {
 
 StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWriterOptions& opts,
-                                                                  const TypeInfoPtr& type_info, WritableFile* wfile,
+                                                                  TypeInfoPtr type_info, WritableFile* wfile,
                                                                   std::unique_ptr<ScalarColumnWriter> json_writer);
 
 class FlatJsonColumnWriter : public ColumnWriter {
 public:
-    FlatJsonColumnWriter(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
+    FlatJsonColumnWriter(const ColumnWriterOptions& opts, TypeInfoPtr type_info, WritableFile* wfile,
                          std::unique_ptr<ScalarColumnWriter> json_writer);
 
     ~FlatJsonColumnWriter() override = default;

--- a/be/src/storage/rowset/json_column_writer.h
+++ b/be/src/storage/rowset/json_column_writer.h
@@ -21,4 +21,51 @@ namespace starrocks {
 StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWriterOptions& opts,
                                                                   const TypeInfoPtr& type_info, WritableFile* wfile,
                                                                   std::unique_ptr<ScalarColumnWriter> json_writer);
-}
+
+class FlatJsonColumnWriter : public ColumnWriter {
+public:
+    FlatJsonColumnWriter(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
+                         std::unique_ptr<ScalarColumnWriter> json_writer);
+
+    ~FlatJsonColumnWriter() override = default;
+
+    Status init() override;
+
+    Status append(const Column& column) override;
+
+    Status finish_current_page() override;
+
+    uint64_t estimate_buffer_size() override;
+
+    Status finish() override;
+
+    Status write_data() override;
+    Status write_ordinal_index() override;
+    Status write_zone_map() override;
+    Status write_bitmap_index() override;
+    Status write_bloom_filter_index() override;
+    ordinal_t get_next_rowid() const override;
+
+    uint64_t total_mem_footprint() const override;
+
+protected:
+    Status _init_flat_writers();
+    Status _write_flat_column();
+
+private:
+    Status _flat_column(const Column* json_data);
+
+protected:
+    ColumnMetaPB* _json_meta;
+    WritableFile* _wfile;
+    std::unique_ptr<ScalarColumnWriter> _json_writer;
+
+    std::vector<std::unique_ptr<ColumnWriter>> _flat_writers;
+    std::vector<std::string> _flat_paths;
+    std::vector<LogicalType> _flat_types;
+    std::vector<ColumnPtr> _flat_columns;
+
+    bool _has_remain;
+    bool _is_flat = false;
+};
+} // namespace starrocks

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -122,6 +122,7 @@ Status RowsetWriter::init() {
 
     _writer_options.global_dicts = _context.global_dicts != nullptr ? _context.global_dicts : nullptr;
     _writer_options.referenced_column_ids = _context.referenced_column_ids;
+    _writer_options.is_compaction = _context.is_compaction;
 
     if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
         (_context.is_partial_update || !_context.merge_condition.empty() || _context.miss_auto_increment_column)) {

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -95,6 +95,8 @@ public:
     int64_t gtid = 0;
     // Is pk compaction output writer
     bool is_pk_compaction = false;
+    // is compaction job
+    bool is_compaction = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -94,6 +94,7 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, co
     if (column.type() == TYPE_JSON) {
         JsonMetaPB* json_meta = meta->mutable_json_meta();
         json_meta->set_format_version(kJsonMetaDefaultFormatVersion);
+        json_meta->set_is_flat(false);
     }
 
     for (uint32_t i = 0; i < column.subcolumn_count(); ++i) {
@@ -199,6 +200,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         }
 
         opts.need_flat = config::enable_json_flat;
+        opts.is_compaction = _opts.is_compaction;
         ASSIGN_OR_RETURN(auto writer, ColumnWriter::create(opts, &column, _wfile.get()));
         RETURN_IF_ERROR(writer->init());
         _column_writers.push_back(std::move(writer));

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -95,6 +95,7 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, co
         JsonMetaPB* json_meta = meta->mutable_json_meta();
         json_meta->set_format_version(kJsonMetaDefaultFormatVersion);
         json_meta->set_is_flat(false);
+        json_meta->set_has_remain(false);
     }
 
     for (uint32_t i = 0; i < column.subcolumn_count(); ++i) {

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -77,6 +77,7 @@ struct SegmentWriterOptions {
     std::vector<int32_t> referenced_column_ids;
     SegmentFileMark segment_file_mark;
     std::string encryption_meta;
+    bool is_compaction = false;
 };
 
 // SegmentWriter is responsible for writing data into single segment by all or partital columns.

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1932,6 +1932,7 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo) {
     context.writer_type =
             (algorithm == VERTICAL_COMPACTION ? RowsetWriterType::kVertical : RowsetWriterType::kHorizontal);
     context.is_pk_compaction = true;
+    context.is_compaction = true;
     std::unique_ptr<RowsetWriter> rowset_writer;
     Status st = RowsetFactory::create_rowset_writer(context, &rowset_writer);
     if (!st.ok()) {

--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -311,6 +311,10 @@ bool JsonValue::is_null_or_none() const {
     return is_null() || is_none();
 }
 
+bool JsonValue::is_invalid() const {
+    return binary_.empty();
+}
+
 std::ostream& operator<<(std::ostream& os, const JsonValue& json) {
     return os << json.to_string_uncheck();
 }

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -127,6 +127,7 @@ public:
     bool is_null() const;
     bool is_none() const;
     bool is_null_or_none() const;
+    bool is_invalid() const;
 
     ////////////////// util  //////////////////////
     StatusOr<std::string> to_string() const;

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -20,10 +20,15 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <limits>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
@@ -33,15 +38,25 @@
 #include "column/vectorized_fwd.h"
 #include "common/compiler_util.h"
 #include "common/status.h"
+#include "common/statusor.h"
+#include "exprs/cast_expr.h"
+#include "exprs/column_ref.h"
+#include "exprs/expr_context.h"
 #include "gutil/casts.h"
+#include "runtime/types.h"
 #include "types/logical_type.h"
 #include "util/json.h"
 #include "util/json_converter.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
+namespace flat_json {
+using JsonFlatExtractFunc = void (*)(const vpack::Slice* json, NullableColumn* result);
+using JsonFlatMergeFunc = void (*)(vpack::Builder* builder, const std::string& name, const Column* src, size_t idx);
+
 template <LogicalType TYPE>
-void append_to_number(const vpack::Slice* json, NullableColumn* result) {
+void extract_number(const vpack::Slice* json, NullableColumn* result) {
     try {
         if (LIKELY(json->isNumber() || json->isString())) {
             auto st = get_number_from_vpjson<TYPE>(*json);
@@ -64,7 +79,7 @@ void append_to_number(const vpack::Slice* json, NullableColumn* result) {
     }
 }
 
-void append_to_string(const vpack::Slice* json, NullableColumn* result) {
+void extract_string(const vpack::Slice* json, NullableColumn* result) {
     try {
         if (json->isNone() || json->isNull()) {
             result->append_nulls(1);
@@ -85,7 +100,7 @@ void append_to_string(const vpack::Slice* json, NullableColumn* result) {
     }
 }
 
-void append_to_json(const vpack::Slice* json, NullableColumn* result) {
+void extract_json(const vpack::Slice* json, NullableColumn* result) {
     if (json->isNone()) {
         result->append_nulls(1);
     } else {
@@ -94,14 +109,43 @@ void append_to_json(const vpack::Slice* json, NullableColumn* result) {
     }
 }
 
-using JsonFlatAppendFunc = void (*)(const vpack::Slice* json, NullableColumn* result);
+template <LogicalType TYPE>
+void merge_number(vpack::Builder* builder, const std::string& name, const Column* src, size_t idx) {
+    DCHECK(src->is_nullable());
+    auto* nullable_column = down_cast<const NullableColumn*>(src);
+    auto* col = down_cast<const RunTimeColumnType<TYPE>*>(nullable_column->data_column().get());
+
+    if constexpr (TYPE == LogicalType::TYPE_LARGEINT) {
+        // the value is from json, must be uint64_t
+        builder->add(name, vpack::Value((uint64_t)col->get_data()[idx]));
+    } else {
+        builder->add(name, vpack::Value(col->get_data()[idx]));
+    }
+}
+
+void merge_string(vpack::Builder* builder, const std::string& name, const Column* src, size_t idx) {
+    DCHECK(src->is_nullable());
+    auto* nullable_column = down_cast<const NullableColumn*>(src);
+    auto* col = down_cast<const BinaryColumn*>(nullable_column->data_column().get());
+    builder->add(name, vpack::Value(col->get_slice(idx)));
+}
+
+void merge_json(vpack::Builder* builder, const std::string& name, const Column* src, size_t idx) {
+    DCHECK(src->is_nullable());
+    auto* nullable_column = down_cast<const NullableColumn*>(src);
+    auto* col = down_cast<const JsonColumn*>(nullable_column->data_column().get());
+    builder->add(name, vpack::Value(col->get_object(idx)->get_slice()));
+}
+
+using JsonFlatExtractFunc = void (*)(const vpack::Slice* json, NullableColumn* result);
+using JsonFlatMergeFunc = void (*)(vpack::Builder* builder, const std::string& name, const Column* src, size_t idx);
 static const uint8_t JSON_BASE_TYPE_BITS = 0;     // least flat to JSON type
 static const uint8_t JSON_BIGINT_TYPE_BITS = 225; // 011000 10, bigint compatible type
 
 // clang-format off
 // bool will flatting as string, because it's need save string-literal(true/false)
 // int & string compatible type is json, because int cast to string will add double quote, it's different with json
-static const std::unordered_map<vpack::ValueType, uint8_t> JSON_TYPE_BITS{
+static const std::unordered_map<vpack::ValueType, uint8_t> JSON_TYPE_BITS {
         {vpack::ValueType::None, 255},      // 111111 11, 255
         {vpack::ValueType::SmallInt, 241},  // 111100 01, 241
         {vpack::ValueType::Int, 225},       // 111000 01, 225
@@ -121,80 +165,109 @@ static const std::unordered_map<uint8_t, LogicalType> JSON_BITS_TO_LOGICAL_TYPE 
     {JSON_BASE_TYPE_BITS,                                LogicalType::TYPE_JSON},
 };
 
-static const std::unordered_map<uint8_t, JsonFlatAppendFunc> JSON_BITS_FUNC {
-    {JSON_TYPE_BITS.at(vpack::ValueType::None),        &append_to_number<LogicalType::TYPE_TINYINT>},
-    {JSON_TYPE_BITS.at(vpack::ValueType::SmallInt),    &append_to_number<LogicalType::TYPE_BIGINT>},
-    {JSON_TYPE_BITS.at(vpack::ValueType::Int),         &append_to_number<LogicalType::TYPE_BIGINT>},
-    {JSON_TYPE_BITS.at(vpack::ValueType::UInt),        &append_to_number<LogicalType::TYPE_LARGEINT>},
-    {JSON_TYPE_BITS.at(vpack::ValueType::Double),      &append_to_number<LogicalType::TYPE_DOUBLE>},
-    {JSON_TYPE_BITS.at(vpack::ValueType::String),      &append_to_string},
-    {JSON_BASE_TYPE_BITS,                                &append_to_json},
+static const std::unordered_map<LogicalType, uint8_t> LOGICAL_TYPE_TO_JSON_BITS {
+    {LogicalType::TYPE_TINYINT,         JSON_TYPE_BITS.at(vpack::ValueType::None)},
+    {LogicalType::TYPE_BIGINT,          JSON_TYPE_BITS.at(vpack::ValueType::Int)},
+    {LogicalType::TYPE_LARGEINT,        JSON_TYPE_BITS.at(vpack::ValueType::UInt)},
+    {LogicalType::TYPE_DOUBLE,          JSON_TYPE_BITS.at(vpack::ValueType::Double)},
+    {LogicalType::TYPE_VARCHAR,         JSON_TYPE_BITS.at(vpack::ValueType::String)},
+    {LogicalType::TYPE_JSON,            JSON_BASE_TYPE_BITS},
+};
+
+static const std::unordered_map<uint8_t, JsonFlatExtractFunc> JSON_EXTRACT_FUNC {
+    {LogicalType::TYPE_TINYINT,         &extract_number<LogicalType::TYPE_TINYINT>},
+    {LogicalType::TYPE_BIGINT,          &extract_number<LogicalType::TYPE_BIGINT>},
+    {LogicalType::TYPE_LARGEINT,        &extract_number<LogicalType::TYPE_LARGEINT>},
+    {LogicalType::TYPE_DOUBLE,          &extract_number<LogicalType::TYPE_DOUBLE>},
+    {LogicalType::TYPE_VARCHAR,         &extract_string},
+    {LogicalType::TYPE_CHAR,            &extract_string},
+    {LogicalType::TYPE_JSON,            &extract_json},
+};
+
+// should match with extract function
+static const std::unordered_map<LogicalType, JsonFlatMergeFunc> JSON_MERGE_FUNC {
+    {LogicalType::TYPE_TINYINT,       &merge_number<LogicalType::TYPE_TINYINT>},
+    {LogicalType::TYPE_BIGINT,        &merge_number<LogicalType::TYPE_BIGINT>},
+    {LogicalType::TYPE_LARGEINT,      &merge_number<LogicalType::TYPE_LARGEINT>},
+    {LogicalType::TYPE_DOUBLE,        &merge_number<LogicalType::TYPE_DOUBLE>},
+    {LogicalType::TYPE_VARCHAR,       &merge_string},
+    {LogicalType::TYPE_JSON,          &merge_json},
 };
 // clang-format on
 
-uint8_t JsonFlattener::get_compatibility_type(vpack::ValueType type1, uint8_t type2) {
+uint8_t get_compatibility_type(vpack::ValueType type1, uint8_t type2) {
     if (JSON_TYPE_BITS.contains(type1)) {
         return JSON_TYPE_BITS.at(type1) & type2;
     }
     return JSON_BASE_TYPE_BITS;
 }
 
-JsonFlattener::JsonFlattener(std::vector<std::string>& paths) : _flat_paths(paths) {
-    _flat_types.resize(paths.size(), JSON_BASE_TYPE_BITS);
-    for (int i = 0; i < _flat_paths.size(); i++) {
-        _flat_index[_flat_paths[i]] = i;
-    }
-};
+} // namespace flat_json
 
-JsonFlattener::JsonFlattener(std::vector<std::string>& paths, const std::vector<LogicalType>& types)
-        : _flat_paths(paths) {
-    for (const auto& t : types) {
-        for (const auto& [k, v] : JSON_BITS_TO_LOGICAL_TYPE) {
-            if (t == v) {
-                _flat_types.emplace_back(k);
-                break;
-            }
-        }
+std::pair<std::string, std::string> JsonFlatPath::_split_path(const std::string& path) {
+    size_t pos = 0;
+    if (path.starts_with("\"")) {
+        pos = path.find('\"', 1);
+        DCHECK(pos != std::string::npos);
     }
-    DCHECK_EQ(_flat_types.size(), types.size());
-    for (int i = 0; i < _flat_paths.size(); i++) {
-        _flat_index[_flat_paths[i]] = i;
+    pos = path.find('.', pos);
+    std::string key;
+    std::string next;
+    if (pos == std::string::npos) {
+        key = path;
+    } else {
+        key = path.substr(0, pos);
+        next = path.substr(pos + 1);
     }
-};
 
-std::vector<LogicalType> JsonFlattener::get_flat_types() {
-    std::vector<LogicalType> types;
-    for (const auto& t : _flat_types) {
-        types.emplace_back(JSON_BITS_TO_LOGICAL_TYPE.at(t));
-    }
-    return types;
+    return {key, next};
 }
 
-struct FlatColumnDesc {
-    // json compatible type
-    uint8_t type = JsonFlattener::JSON_NULL_TYPE_BITS;
-    // column path hit count, some json may be null or none, so hit use to record the actual value
-    // e.g: {"a": 1, "b": 2}, path "$.c" not exist, so hit is 0
-    uint64_t hits = 0;
-    // how many rows need to be cast to a compatible type
-    uint16_t casts = 0;
+JsonFlatPath* JsonFlatPath::normalize_from_path(const std::string& path, JsonFlatPath* root) {
+    if (path.empty()) {
+        return root;
+    }
+    auto [key, next] = _split_path(path);
+    auto iter = root->children.find(key);
+    JsonFlatPath* child_path = nullptr;
 
-    // for json-uint, json-uint is uint64_t, check the maximum value and downgrade to bigint
-    uint64_t max = 0;
+    if (iter == root->children.end()) {
+        root->children.emplace(key, std::make_unique<JsonFlatPath>());
+        child_path = root->children[key].get();
+    } else {
+        child_path = iter->second.get();
+    }
+    return normalize_from_path(next, child_path);
+}
 
-    // same key may appear many times in json, so we need avoid duplicate compute hits
-    uint64_t last_row = -1;
-    uint64_t multi_times = 0;
-};
-
-void JsonFlattener::derived_paths(std::vector<ColumnPtr>& json_datas) {
-    _flat_paths.clear();
-    _flat_types.clear();
-
-    if (json_datas.empty()) {
+/*
+* to mark new root
+*              root(Ig)
+*           /       |       \
+*        a(Ex)     b(Ig)    c(Ex)
+*        /         /    \      \   
+*      any     b1(Ex) b2(N)     any
+*                    /    \
+*                b3(IN)   b4(IN)
+*/
+void JsonFlatPath::set_root(const std::string& new_root_path, JsonFlatPath* node) {
+    node->op = OP_IGNORE;
+    if (new_root_path.empty()) {
+        node->op = OP_ROOT;
         return;
     }
+    auto [key, next] = _split_path(new_root_path);
 
+    auto iter = node->children.begin();
+    for (; iter != node->children.end(); iter++) {
+        iter->second->op = OP_EXCLUDE;
+        if (iter->first == key) {
+            set_root(next, iter->second.get());
+        }
+    }
+}
+
+bool check_null_factor(const std::vector<const Column*>& json_datas) {
     size_t total_rows = 0;
     size_t null_count = 0;
 
@@ -204,7 +277,7 @@ void JsonFlattener::derived_paths(std::vector<ColumnPtr>& json_datas) {
             null_count += column->size();
             continue;
         } else if (column->is_nullable()) {
-            auto* nullable_column = down_cast<NullableColumn*>(column.get());
+            auto* nullable_column = down_cast<const NullableColumn*>(column);
             null_count += nullable_column->null_count();
         }
     }
@@ -213,104 +286,265 @@ void JsonFlattener::derived_paths(std::vector<ColumnPtr>& json_datas) {
     if (null_count > total_rows * config::json_flat_null_factor) {
         VLOG(8) << "flat json, null_count[" << null_count << "], row[" << total_rows
                 << "], null_factor: " << config::json_flat_null_factor;
-        return;
+        return false;
     }
 
-    size_t rows = 0;
-    // extract common keys, type
-    std::unordered_map<std::string_view, FlatColumnDesc> derived_maps;
-    for (size_t k = 0; k < json_datas.size(); k++) {
-        size_t row_count = json_datas[k]->size();
+    return true;
+}
 
-        ColumnViewer<TYPE_JSON> viewer(json_datas[k]);
-        for (size_t i = 0; i < row_count; ++i) {
-            rows++;
-            if (viewer.is_null(i)) {
-                continue;
-            }
-
-            JsonValue* json = viewer.value(i);
-            auto vslice = json->to_vslice();
-
-            if (vslice.isNull() || vslice.isNone() || vslice.isEmptyObject() || !vslice.isObject()) {
-                continue;
-            }
-
-            vpack::ObjectIterator iter(vslice);
-            for (const auto& it : iter) {
-                std::string_view name = it.key.stringView();
-                derived_maps[name].hits++;
-                uint8_t base_type = derived_maps[name].type;
-                vpack::ValueType json_type = it.value.type();
-                uint8_t compatibility_type = JsonFlattener::get_compatibility_type(json_type, base_type);
-                derived_maps[name].type = compatibility_type;
-                derived_maps[name].casts += (base_type != compatibility_type);
-
-                derived_maps[name].multi_times += (derived_maps[name].last_row == rows);
-                derived_maps[name].last_row = rows;
-
-                if (json_type == vpack::ValueType::UInt) {
-                    derived_maps[name].max = std::max(derived_maps[name].max, it.value.getUIntUnchecked());
-                }
-            }
-        }
-    }
-
-    if (derived_maps.size() <= config::json_flat_internal_column_min_limit) {
-        VLOG(8) << "flat json, internal column too less: " << derived_maps.size()
-                << ", at least: " << config::json_flat_internal_column_min_limit;
-        return;
-    }
-
-    // try downgrade json-uint to bigint
-    int128_t max = RunTimeTypeLimits<TYPE_BIGINT>::max_value();
-    for (auto& [name, desc] : derived_maps) {
-        if (desc.type == JSON_TYPE_BITS.at(vpack::ValueType::UInt) && desc.max <= max) {
-            desc.type = JSON_BIGINT_TYPE_BITS;
-        }
-    }
-
-    // sort by hit, casts
-    std::vector<pair<std::string_view, FlatColumnDesc>> top_hits(derived_maps.begin(), derived_maps.end());
-    std::sort(top_hits.begin(), top_hits.end(),
-              [](const pair<std::string_view, FlatColumnDesc>& a, const pair<std::string_view, FlatColumnDesc>& b) {
-                  // check hits, the higher the hit rate, the higher the priority.
-                  if (a.second.hits != b.second.hits) {
-                      return a.second.hits > b.second.hits;
-                  }
-                  // check type, the scalar type has the highest priority.
-                  if (a.second.type != b.second.type) {
-                      return a.second.type > b.second.type;
-                  }
-                  // check casts, the fewer the types of inference cast, the higher the priority.
-                  if (a.second.casts != b.second.casts) {
-                      return a.second.casts < b.second.casts;
-                  }
-
-                  // sort by name, just for stable order
-                  return a.first < b.first;
-              });
-
-    for (int i = 0; i < top_hits.size() && i < config::json_flat_column_max; i++) {
-        const auto& [name, desc] = top_hits[i];
-        // check sparsity
-        // same key may appear many times in json, so we need avoid duplicate compute hits
-        if (desc.multi_times <= 0 && desc.hits >= total_rows * config::json_flat_sparsity_factor) {
-            _flat_paths.emplace_back(name);
-            _flat_types.emplace_back(desc.type);
-        }
-        VLOG(8) << "flat json[" << name << "], hit[" << desc.hits << "], row[" << total_rows << "]";
-    }
-
-    // init index map
-    for (int i = 0; i < _flat_paths.size(); i++) {
-        _flat_index[_flat_paths[i]] = i;
+JsonPathDeriver::JsonPathDeriver(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
+                                 bool has_remain)
+        : _has_remain(has_remain), _paths(paths), _types(types) {
+    for (size_t i = 0; i < paths.size(); i++) {
+        auto* leaf = JsonFlatPath::normalize_from_path(paths[i], _path_root.get());
+        leaf->type = types[i];
+        leaf->index = i;
     }
 }
 
-void JsonFlattener::flatten(const Column* json_column, std::vector<ColumnPtr>* result) {
-    DCHECK(result->size() == _flat_paths.size());
+void JsonPathDeriver::derived(const std::vector<const Column*>& json_datas) {
+    DCHECK(_paths.empty());
+    DCHECK(_types.empty());
+    DCHECK(_derived_maps.empty());
+    DCHECK(_path_root == nullptr);
 
+    if (json_datas.empty()) {
+        return;
+    }
+
+    if (!check_null_factor(json_datas)) {
+        return;
+    }
+
+    _path_root = std::make_shared<JsonFlatPath>();
+    _total_rows = 0;
+    // init path by flat json
+    _derived_on_flat_json(json_datas);
+
+    // extract common keys, type
+    for (size_t k = 0; k < json_datas.size(); k++) {
+        _derived(json_datas[k], _total_rows);
+        _total_rows += json_datas[k]->size();
+    }
+
+    _finalize();
+}
+
+void JsonPathDeriver::_derived_on_flat_json(const std::vector<const Column*>& json_datas) {
+    // extract flat paths
+    for (size_t k = 0; k < json_datas.size(); k++) {
+        auto col = json_datas[k];
+        const JsonColumn* json_col;
+        size_t hits = 0;
+        if (col->is_nullable()) {
+            auto nullable = down_cast<const NullableColumn*>(col);
+            hits = nullable->null_count();
+            json_col = down_cast<const JsonColumn*>(nullable->data_column().get());
+        } else {
+            hits = col->size();
+            json_col = down_cast<const JsonColumn*>(col);
+        }
+
+        if (!json_col->is_flat_json()) {
+            continue;
+        }
+
+        auto paths = json_col->flat_column_paths();
+        auto types = json_col->flat_column_types();
+
+        for (size_t i = 0; i < paths.size(); i++) {
+            auto leaf = JsonFlatPath::normalize_from_path(paths[i], _path_root.get());
+            _derived_maps[leaf].type &= flat_json::LOGICAL_TYPE_TO_JSON_BITS.at(types[i]);
+            _derived_maps[leaf].hits += hits;
+        }
+    }
+}
+
+void JsonPathDeriver::_derived(const Column* col, size_t mark_row) {
+    size_t row_count = col->size();
+    const JsonColumn* json_col;
+
+    if (col->is_nullable()) {
+        auto nullable = down_cast<const NullableColumn*>(col);
+        json_col = down_cast<const JsonColumn*>(nullable->data_column().get());
+    } else {
+        json_col = down_cast<const JsonColumn*>(col);
+    }
+
+    if (json_col->is_flat_json()) {
+        if (json_col->has_remain()) {
+            json_col = down_cast<const JsonColumn*>(json_col->get_remain().get());
+        } else {
+            return;
+        }
+    }
+
+    for (size_t i = 0; i < row_count; ++i) {
+        if (col->is_null(i)) {
+            continue;
+        }
+
+        JsonValue* json = json_col->get_object(i);
+        auto vslice = json->to_vslice();
+
+        if (vslice.isNull() || vslice.isNone()) {
+            continue;
+        }
+
+        if (vslice.isEmptyObject() || !vslice.isObject()) {
+            _has_remain = true;
+            continue;
+        }
+
+        _visit_json_paths(vslice, _path_root.get(), mark_row + i);
+    }
+}
+
+void JsonPathDeriver::_visit_json_paths(vpack::Slice value, JsonFlatPath* root, size_t mark_row) {
+    vpack::ObjectIterator it(value, false);
+
+    for (; it.valid(); it.next()) {
+        auto current = (*it);
+        // sub-object?
+        auto v = current.value;
+        auto k = current.key.copyString();
+
+        if (!root->children.contains(k)) {
+            root->children.emplace(k, std::make_unique<JsonFlatPath>());
+        }
+        auto child = root->children[k].get();
+        if (v.isObject()) {
+            _visit_json_paths(v, child, mark_row);
+        } else {
+            _derived_maps[child].hits++;
+            uint8_t base_type = _derived_maps[child].type;
+            vpack::ValueType json_type = v.type();
+            uint8_t compatibility_type = flat_json::get_compatibility_type(json_type, base_type);
+            _derived_maps[child].type = compatibility_type;
+            _derived_maps[child].casts += (base_type != compatibility_type);
+
+            _derived_maps[child].multi_times += (_derived_maps[child].last_row == mark_row);
+            _derived_maps[child].last_row = mark_row;
+
+            if (json_type == vpack::ValueType::UInt) {
+                _derived_maps[child].max = std::max(_derived_maps[child].max, v.getUIntUnchecked());
+            }
+        }
+    }
+}
+
+void JsonPathDeriver::_finalize() {
+    // try downgrade json-uint to bigint
+    int128_t max = RunTimeTypeLimits<TYPE_BIGINT>::max_value();
+    for (auto& [name, desc] : _derived_maps) {
+        if (desc.type == flat_json::JSON_TYPE_BITS.at(vpack::ValueType::UInt) && desc.max <= max) {
+            desc.type = flat_json::JSON_BIGINT_TYPE_BITS;
+        }
+    }
+
+    std::vector<JsonFlatPath*> update_stack;
+    std::vector<std::pair<JsonFlatPath*, std::string>> stack;
+    std::vector<std::pair<JsonFlatPath*, std::string>> hit_leaf;
+
+    stack.emplace_back(_path_root.get(), "");
+    while (!stack.empty()) {
+        auto [node, path] = stack.back();
+        stack.pop_back();
+
+        if (node->children.empty()) {
+            // leaf node
+            // check sparsity, same key may appear many times in json, so we need avoid duplicate compute hits
+            auto desc = _derived_maps[node];
+            if (desc.multi_times <= 0 && desc.hits >= _total_rows * config::json_flat_sparsity_factor) {
+                hit_leaf.emplace_back(node, path);
+                node->type = flat_json::JSON_BITS_TO_LOGICAL_TYPE.at(desc.type);
+                node->remain = false; // later update
+            } else {
+                node->remain = true;
+            }
+            _has_remain |= (desc.multi_times > 0 || desc.hits != _total_rows);
+            VLOG(8) << "flat json[" << path << "], hit[" << desc.hits << "], row[" << _total_rows << "]";
+        } else {
+            update_stack.push_back(node);
+            for (auto& [key, child] : node->children) {
+                stack.emplace_back(child.get(), path + "." + key);
+            }
+        }
+    }
+
+    // sort by name, just for stable order
+    size_t limit = config::json_flat_column_max > 0 ? config::json_flat_column_max : std::numeric_limits<size_t>::max();
+    std::sort(hit_leaf.begin(), hit_leaf.end(), [](const auto& a, const auto& b) { return a.second < b.second; });
+    for (auto& [node, path] : hit_leaf) {
+        if (_paths.size() >= limit) {
+            node->remain = true;
+            _has_remain = true;
+            continue;
+        }
+        node->index = _paths.size();
+        _paths.emplace_back(path.substr(1));
+        _types.emplace_back(node->type);
+    }
+
+    // remove & update remain json
+    while (!update_stack.empty()) {
+        auto* node = update_stack.back();
+        update_stack.pop_back();
+
+        auto iter = node->children.begin();
+        while (iter != node->children.end()) {
+            node->remain |= iter->second->remain;
+            if (iter->second->remain && iter->second->children.empty()) {
+                iter = node->children.erase(iter);
+            } else {
+                ++iter;
+            }
+        }
+    }
+}
+
+JsonFlattener::JsonFlattener(JsonPathDeriver& deriver) {
+    DCHECK(deriver.flat_path_root() != nullptr);
+    _dst_root = deriver.flat_path_root();
+    _dst_paths = deriver.flat_paths();
+    _has_remain = deriver.has_remain_json();
+
+    auto paths = deriver.flat_paths();
+    auto types = deriver.flat_types();
+
+    for (size_t i = 0; i < paths.size(); i++) {
+        _flat_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(types[i]), true));
+    }
+
+    if (_has_remain) {
+        _flat_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_JSON), false));
+        _remain = down_cast<JsonColumn*>(_flat_columns.back().get());
+    }
+}
+
+JsonFlattener::JsonFlattener(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
+                             bool has_remain)
+        : _has_remain(has_remain), _dst_paths(paths) {
+    _dst_root = std::make_shared<JsonFlatPath>();
+
+    for (size_t i = 0; i < paths.size(); i++) {
+        auto* leaf = JsonFlatPath::normalize_from_path(paths[i], _dst_root.get());
+        leaf->type = types[i];
+        leaf->index = i;
+
+        _flat_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(types[i]), true));
+    }
+
+    if (_has_remain) {
+        _flat_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_JSON), false));
+        _remain = down_cast<JsonColumn*>(_flat_columns.back().get());
+    }
+}
+
+void JsonFlattener::flatten(const Column* json_column) {
+    for (auto& col : _flat_columns) {
+        DCHECK_EQ(col->size(), 0);
+    }
     // input
     const JsonColumn* json_data = nullptr;
     if (json_column->is_nullable()) {
@@ -321,73 +555,756 @@ void JsonFlattener::flatten(const Column* json_column, std::vector<ColumnPtr>* r
         json_data = down_cast<const JsonColumn*>(json_column);
     }
 
-    std::vector<NullableColumn*> flat_jsons;
-    for (size_t i = 0; i < _flat_paths.size(); i++) {
-        flat_jsons.emplace_back(down_cast<NullableColumn*>((*result)[i].get()));
+    // may not empty rows when compaction
+    size_t base_rows = _flat_columns[0]->size();
+    // output
+    if (_has_remain) {
+        _flatten<true>(json_column, json_data);
+        for (size_t i = 0; i < _flat_columns.size() - 1; i++) {
+            down_cast<NullableColumn*>(_flat_columns[i].get())->update_has_null();
+        }
+    } else {
+        _flatten<false>(json_column, json_data);
+        for (size_t i = 0; i < _flat_columns.size(); i++) {
+            down_cast<NullableColumn*>(_flat_columns[i].get())->update_has_null();
+        }
     }
 
+    for (auto& col : _flat_columns) {
+        DCHECK_EQ(col->size(), json_column->size() + base_rows);
+    }
+}
+
+template <bool REMAIN>
+bool JsonFlattener::_flatten_json(const vpack::Slice& value, const JsonFlatPath* root, vpack::Builder* builder,
+                                  uint32_t* flat_hit) {
+    vpack::ObjectIterator it(value, false);
+    for (; it.valid(); it.next()) {
+        auto current = (*it);
+        // sub-object
+        auto v = current.value;
+        auto k = current.key.copyString();
+
+        auto child = root->children.find(k);
+        if constexpr (REMAIN) {
+            if (child == root->children.end()) {
+                builder->add(k, v);
+                continue;
+            }
+        } else {
+            if (*flat_hit == 0) {
+                return false;
+            }
+            if (child == root->children.end()) {
+                continue;
+            }
+        }
+
+        if (child->second->children.empty()) {
+            // leaf node
+            auto index = child->second->index;
+            DCHECK(_flat_columns.size() > index);
+            DCHECK(_flat_columns[index]->is_nullable());
+            auto* c = down_cast<NullableColumn*>(_flat_columns[index].get());
+            auto func = flat_json::JSON_EXTRACT_FUNC.at(child->second->type);
+            func(&v, c);
+            *flat_hit ^= (1 << index);
+            // not leaf node, should goto deep
+        } else if (v.isObject()) {
+            if constexpr (REMAIN) {
+                builder->add(k, vpack::Value(vpack::ValueType::Object));
+                _flatten_json<REMAIN>(v, child->second.get(), builder, flat_hit);
+                builder->close();
+            } else {
+                if (!_flatten_json<REMAIN>(v, child->second.get(), builder, flat_hit)) {
+                    return false;
+                }
+            }
+        } else {
+            if constexpr (REMAIN) {
+                builder->add(k, v);
+            }
+        }
+    }
+    return true;
+}
+
+template <bool HAS_REMAIN>
+void JsonFlattener::_flatten(const Column* json_column, const JsonColumn* json_data) {
+    DCHECK(!_dst_paths.empty());
     // may not empty rows when compaction
-    size_t base_rows = flat_jsons[0]->size();
+    size_t base_rows = _flat_columns[0]->size();
     // output
-    DCHECK_LE(_flat_paths.size(), std::numeric_limits<int>::max());
+    DCHECK_LE(_dst_paths.size(), std::numeric_limits<int>::max());
     for (size_t row = 0; row < json_column->size(); row++) {
         if (json_column->is_null(row)) {
-            for (size_t k = 0; k < result->size(); k++) {
-                (*result)[k]->append_nulls(1);
+            for (size_t k = 0; k < _flat_columns.size(); k++) { // all is null
+                _flat_columns[k]->append_default(1);
             }
             continue;
         }
 
         auto* obj = json_data->get_object(row);
         auto vslice = obj->to_vslice();
-        if (vslice.isNone() || vslice.isNull() || vslice.isEmptyObject() || !vslice.isObject()) {
-            for (size_t k = 0; k < result->size(); k++) {
-                (*result)[k]->append_nulls(1);
+        if (vslice.isNone() || vslice.isNull()) {
+            for (size_t k = 0; k < _flat_columns.size(); k++) { // all is null
+                _flat_columns[k]->append_default(1);
             }
             continue;
         }
 
+        if (vslice.isEmptyObject() || !vslice.isObject()) {
+            for (size_t k = 0; k < _dst_paths.size(); k++) { // remain push object
+                _flat_columns[k]->append_default(1);
+            }
+            if constexpr (HAS_REMAIN) {
+                _remain->append(obj);
+            }
+            continue;
+        }
         // bitset, all 1,
         // to mark which column exists in json, to fill null if doesn't found in json
-        uint32_t flat_hit = (1 << _flat_paths.size()) - 1;
-        vpack::ObjectIterator iter(vslice);
-        for (const auto& it : iter) {
-            std::string_view path = it.key.stringView();
-            auto iter = _flat_index.find(std::string(path));
-            if (iter != _flat_index.end()) {
-                int index = iter->second;
-                uint8_t type = _flat_types[index];
-                auto func = JSON_BITS_FUNC.at(type);
-                func(&it.value, flat_jsons[index]);
-                // set index to 0
-                flat_hit ^= (1 << index);
-            }
-
-            if (flat_hit == 0) {
-                break;
-            }
+        uint32_t flat_hit = (1 << _dst_paths.size()) - 1;
+        if constexpr (HAS_REMAIN) {
+            vpack::Builder builder;
+            builder.add(vpack::Value(vpack::ValueType::Object));
+            _flatten_json<HAS_REMAIN>(vslice, _dst_root.get(), &builder, &flat_hit);
+            builder.close();
+            _remain->append(JsonValue(builder.slice()));
+        } else {
+            _flatten_json<HAS_REMAIN>(vslice, _dst_root.get(), nullptr, &flat_hit);
         }
 
         if (UNLIKELY(flat_hit > 0)) {
-            for (size_t k = 0; k < _flat_paths.size() && flat_hit > 0; k++) {
+            for (size_t k = 0; k < _dst_paths.size() && flat_hit > 0; k++) {
                 if (flat_hit & (1 << k)) {
-                    flat_jsons[k]->append_nulls(1);
+                    _flat_columns[k]->append_default(1);
                     flat_hit ^= (1 << k);
                 }
             }
         }
 
-        for (auto col : flat_jsons) {
+        for (auto& col : _flat_columns) {
             DCHECK_EQ(col->size(), row + 1 + base_rows);
+        }
+        if constexpr (HAS_REMAIN) {
+            DCHECK_EQ(row + 1 + base_rows, _remain->size());
+        }
+    }
+}
+
+std::vector<ColumnPtr> JsonFlattener::mutable_result() {
+    std::vector<ColumnPtr> res;
+    for (size_t i = 0; i < _flat_columns.size(); i++) {
+        res.emplace_back(_flat_columns[i]);
+        _flat_columns[i] = _flat_columns[i]->clone_empty();
+    }
+    if (_has_remain) {
+        _remain = down_cast<JsonColumn*>(_flat_columns.back().get());
+    }
+    return res;
+}
+
+JsonMerger::JsonMerger(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain)
+        : _has_remain(has_remain) {
+    _src_root = std::make_shared<JsonFlatPath>();
+
+    for (size_t i = 0; i < paths.size(); i++) {
+        auto* leaf = JsonFlatPath::normalize_from_path(paths[i], _src_root.get());
+        leaf->type = types[i];
+        leaf->index = i;
+    }
+}
+
+void dfs_exclude(JsonFlatPath* node) {
+    if (node->children.empty()) {
+        return;
+    }
+    bool all_exclude = true;
+    for (auto& [_, child] : node->children) {
+        dfs_exclude(child.get());
+        all_exclude &= (child->op == JsonFlatPath::OP_EXCLUDE);
+    }
+    node->op = all_exclude ? JsonFlatPath::OP_EXCLUDE : JsonFlatPath::OP_INCLUDE;
+}
+
+void JsonMerger::set_exclude_paths(const std::vector<std::string>& exclude_paths) {
+    for (auto& path : exclude_paths) {
+        auto* leaf = JsonFlatPath::normalize_from_path(path, _src_root.get());
+        leaf->op = JsonFlatPath::OP_EXCLUDE;
+    }
+    dfs_exclude(_src_root.get());
+}
+
+void JsonMerger::set_root_path(const std::string& base_path) {
+    JsonFlatPath::set_root(base_path, _src_root.get());
+}
+
+ColumnPtr JsonMerger::merge(const std::vector<ColumnPtr>& columns) {
+    DCHECK_GE(columns.size(), 1);
+    _result = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+    _json_result = down_cast<JsonColumn*>(down_cast<NullableColumn*>(_result.get())->data_column().get());
+    _null_result = down_cast<NullColumn*>(down_cast<NullableColumn*>(_result.get())->null_column().get());
+
+    for (auto& col : columns) {
+        _src_columns.emplace_back(col.get());
+    }
+
+    size_t rows = columns[0]->size();
+    if (_src_root->op == JsonFlatPath::OP_INCLUDE) {
+        _merge_impl<true>(rows);
+    } else {
+        _merge_impl<false>(rows);
+    }
+
+    if (_output_nullable) {
+        down_cast<NullableColumn*>(_result.get())->update_has_null();
+        return _result;
+    } else {
+        return down_cast<NullableColumn*>(_result.get())->data_column();
+    }
+}
+
+template <bool IN_TREE>
+void JsonMerger::_merge_impl(size_t rows) {
+    if (_has_remain) {
+        auto remain = down_cast<const JsonColumn*>(_src_columns.back());
+        for (size_t i = 0; i < rows; i++) {
+            auto obj = remain->get_object(i);
+            vpack::Builder builder;
+            builder.add(vpack::Value(vpack::ValueType::Object));
+            if (obj->is_invalid()) {
+                _merge_json(_src_root.get(), &builder, i);
+            } else {
+                auto vs = obj->to_vslice();
+                _merge_json_with_remain<IN_TREE>(_src_root.get(), &vs, &builder, i);
+            }
+            builder.close();
+            auto slice = builder.slice();
+            _json_result->append(JsonValue(slice));
+            _null_result->append(slice.isEmptyObject());
+        }
+    } else {
+        for (size_t i = 0; i < rows; i++) {
+            vpack::Builder builder;
+            builder.add(vpack::Value(vpack::ValueType::Object));
+            _merge_json(_src_root.get(), &builder, i);
+            builder.close();
+            _json_result->append(JsonValue(builder.slice()));
+        }
+        int zero = 0;
+        _null_result->append_value_multiple_times(&zero, rows);
+    }
+}
+
+template <bool IN_TREE>
+void JsonMerger::_merge_json_with_remain(const JsonFlatPath* root, const vpack::Slice* remain, vpack::Builder* builder,
+                                         size_t index) {
+    std::string json = remain->toJson();
+    vpack::ObjectIterator it(*remain, false);
+    for (; it.valid(); it.next()) {
+        auto k = it.key().copyString();
+        auto v = it.value();
+
+        auto iter = root->children.find(k);
+        if (iter == root->children.end()) {
+            if constexpr (IN_TREE) {
+                // only remain contains
+                builder->add(k, v);
+            }
+            continue;
+        }
+        if (iter->second->op == JsonFlatPath::OP_EXCLUDE) {
+            continue;
+        }
+        if (v.isObject()) {
+            if (iter->second->op == JsonFlatPath::OP_IGNORE) {
+                _merge_json_with_remain<false>(iter->second.get(), &v, builder, index);
+            } else if (iter->second->op == JsonFlatPath::OP_ROOT) {
+                _merge_json_with_remain<true>(iter->second.get(), &v, builder, index);
+            } else {
+                DCHECK(iter->second->op == JsonFlatPath::OP_INCLUDE);
+                builder->add(k, vpack::Value(vpack::ValueType::Object));
+                _merge_json_with_remain<true>(iter->second.get(), &v, builder, index);
+                builder->close();
+            }
+            continue;
+        }
+        // leaf node
+        DCHECK(iter->second->op == JsonFlatPath::OP_INCLUDE);
+        builder->add(k, v);
+    }
+    for (auto& [child_name, child] : root->children) {
+        if (child->op == JsonFlatPath::OP_EXCLUDE) {
+            continue;
+        }
+        // e.g. flat path: b.b2.b3}
+        // json: {"b": {}}
+        // we can't output: {"b": {}} to {"b": {"b2": {}}}
+        // must direct relation when has REMAIN
+        if (child->children.empty()) {
+            DCHECK(child->op == JsonFlatPath::OP_INCLUDE);
+            auto col = _src_columns[child->index];
+            if (!col->is_null(index)) {
+                DCHECK(flat_json::JSON_MERGE_FUNC.contains(child->type));
+                auto func = flat_json::JSON_MERGE_FUNC.at(child->type);
+                func(builder, child_name, col, index);
+            }
+            continue;
+        }
+    }
+}
+
+void JsonMerger::_merge_json(const JsonFlatPath* root, vpack::Builder* builder, size_t index) {
+    for (auto& [child_name, child] : root->children) {
+        if (child->op == JsonFlatPath::OP_EXCLUDE) {
+            continue;
+        }
+
+        if (child->children.empty()) {
+            DCHECK(child->op == JsonFlatPath::OP_INCLUDE);
+            auto col = _src_columns[child->index];
+            if (!col->is_null(index)) {
+                DCHECK(flat_json::JSON_MERGE_FUNC.contains(child->type));
+                auto func = flat_json::JSON_MERGE_FUNC.at(child->type);
+                func(builder, child_name, col, index);
+            }
+            continue;
+        }
+
+        if (child->op == JsonFlatPath::OP_IGNORE) {
+            // don't add level
+            _merge_json(child.get(), builder, index);
+        } else if (child->op == JsonFlatPath::OP_ROOT) {
+            _merge_json(child.get(), builder, index);
+        } else {
+            builder->add(child_name, vpack::Value(vpack::ValueType::Object));
+            _merge_json(child.get(), builder, index);
+            builder->close();
+        }
+    }
+}
+
+HyperJsonTransformer::HyperJsonTransformer(JsonPathDeriver& deriver)
+        : _dst_remain(deriver.has_remain_json()), _dst_paths(deriver.flat_paths()), _dst_types(deriver.flat_types()) {
+    for (size_t i = 0; i < _dst_paths.size(); i++) {
+        _dst_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(_dst_types[i]), true));
+    }
+
+    if (_dst_remain) {
+        _dst_columns.emplace_back(JsonColumn::create());
+    }
+}
+
+HyperJsonTransformer::HyperJsonTransformer(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
+                                           bool has_remain)
+        : _dst_remain(has_remain), _dst_paths(paths), _dst_types(types) {
+    for (size_t i = 0; i < _dst_paths.size(); i++) {
+        _dst_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(types[i]), true));
+    }
+
+    if (_dst_remain) {
+        _dst_columns.emplace_back(JsonColumn::create());
+    }
+}
+
+void HyperJsonTransformer::init_read_task(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
+                                          bool has_remain) {
+    DCHECK(_src_paths.empty());
+    DCHECK(_src_types.empty());
+    DCHECK(!paths.empty());
+    DCHECK(!types.empty());
+
+    _src_paths.assign(paths.begin(), paths.end());
+    _src_types.assign(types.begin(), types.end());
+    _merge_tasks.clear();
+    _flat_tasks.clear();
+
+    std::vector<int> equals;
+    std::vector<int> merges;
+    std::unordered_set<int> check_dst;
+    DCHECK(!_dst_remain);
+    // equals & merge
+    for (size_t i = 0; i < _dst_paths.size(); i++) {
+        equals.clear();
+        merges.clear();
+        for (size_t j = 0; j < _src_paths.size(); j++) {
+            if (_dst_paths[i] == _src_paths[j]) {
+                equals.emplace_back(j); // equals
+#ifdef NDEBUG
+                break; // must only one
+#endif
+            } else if (_src_paths[j].starts_with(_dst_paths[i] + ".")) {
+                merges.emplace_back(j);
+            }
+        }
+
+        DCHECK(equals.empty() || merges.empty());
+        if (!equals.empty()) {
+            DCHECK_EQ(equals.size(), 1);
+            check_dst.emplace(i);
+            auto& mk = _merge_tasks.emplace_back();
+            mk.is_merge = false;
+            mk.src_index.emplace_back(equals[0]);
+            mk.dst_index = i;
+            if (_dst_types[i] != _src_types[equals[0]]) {
+                mk.need_cast = true;
+                SlotDescriptor source_slot(i, "mock_solt", TypeDescriptor(_src_types[equals[0]]));
+                ColumnRef* col_ref = _pool.add(new ColumnRef(&source_slot));
+                mk.cast_expr = VectorizedCastExprFactory::from_type(TypeDescriptor(_src_types[equals[0]]),
+                                                                    TypeDescriptor(_dst_types[i]), col_ref, &_pool);
+            }
+        } else if (!merges.empty()) {
+            check_dst.emplace(i);
+            if (_dst_types[i] != TYPE_JSON && !is_string_type(_dst_types[i])) {
+                continue;
+            }
+            auto& mk = _merge_tasks.emplace_back();
+            mk.is_merge = true;
+            mk.src_index = merges;
+            mk.dst_index = i;
+            if (_dst_types[i] != TYPE_JSON) {
+                // must be to string, merge result must be string
+                mk.need_cast = true;
+                SlotDescriptor source_slot(i, "mock_solt", TypeDescriptor(TYPE_JSON));
+                ColumnRef* col_ref = _pool.add(new ColumnRef(&source_slot));
+                mk.cast_expr = VectorizedCastExprFactory::from_type(TypeDescriptor(TYPE_JSON),
+                                                                    TypeDescriptor(_dst_types[i]), col_ref, &_pool);
+            }
         }
     }
 
-    for (auto col : flat_jsons) {
-        DCHECK_EQ(col->size(), json_column->size() + base_rows);
+    std::vector<int> flats;
+    for (size_t j = 0; j < _src_paths.size(); j++) {
+        flats.clear();
+        for (size_t i = 0; i < _dst_paths.size(); i++) {
+#ifdef NDEBUG
+            if (!check_dst.contains(i) && _dst_paths[i].starts_with(_src_paths[j] + ".")) {
+#else
+            if (_dst_paths[i].starts_with(_src_paths[j] + ".")) {
+#endif
+                flats.emplace_back(i);
+                DCHECK(!check_dst.contains(i));
+                check_dst.emplace(i);
+            }
+        }
+        if (!flats.empty()) {
+            auto& fk = _flat_tasks.emplace_back();
+            fk.src_index = j;
+            fk.dst_index = flats;
+        }
     }
 
-    for (auto& col : *result) {
-        down_cast<NullableColumn*>(col.get())->update_has_null();
+    if (has_remain && _dst_paths.size() != check_dst.size()) {
+        // must from remain
+        flats.clear();
+        for (size_t i = 0; i < _dst_paths.size(); i++) {
+            if (!check_dst.contains(i)) {
+                flats.emplace_back(i);
+                DCHECK(!check_dst.contains(i));
+                check_dst.emplace(i);
+            }
+        }
+
+        auto& fk = _flat_tasks.emplace_back();
+        fk.src_index = _src_paths.size();
+        fk.dst_index = flats;
+    }
+
+    for (auto& fk : _flat_tasks) {
+        std::vector<std::string> p;
+        std::vector<LogicalType> t;
+        for (auto& index : fk.dst_index) {
+            p.emplace_back(_dst_paths[index]);
+            t.emplace_back(_dst_types[index]);
+        }
+        fk.flattener = std::make_unique<JsonFlattener>(p, t, false);
+    }
+
+    for (auto& mk : _merge_tasks) {
+        if (mk.is_merge) {
+            std::vector<std::string> p;
+            std::vector<LogicalType> t;
+            for (auto& index : mk.src_index) {
+                p.emplace_back(_src_paths[index]);
+                t.emplace_back(_src_types[index]);
+            }
+            if (has_remain) {
+                mk.src_index.emplace_back(paths.size());
+            }
+            mk.merger = std::make_unique<JsonMerger>(p, t, has_remain);
+            mk.merger->set_root_path(_dst_paths[mk.dst_index]);
+            mk.merger->set_output_nullable(true);
+        }
     }
 }
+
+void HyperJsonTransformer::init_compaction_task(JsonColumn* column) {
+    DCHECK(column->is_flat_json());
+    _src_paths.clear();
+    _src_types.clear();
+    _merge_tasks.clear();
+    _flat_tasks.clear();
+
+    _src_paths.assign(column->flat_column_paths().begin(), column->flat_column_paths().end());
+    _src_types.assign(column->flat_column_types().begin(), column->flat_column_types().end());
+
+    std::unordered_set<std::string> _src_set(_src_paths.begin(), _src_paths.end());
+
+    // output remain, must put merge task at first
+    if (_dst_remain) {
+        _merge_tasks.emplace_back();
+        _merge_tasks.back().dst_index = _dst_paths.size();
+        _merge_tasks.back().is_merge = true;
+    }
+
+    for (size_t j = 0; j < _src_paths.size(); j++) {
+        size_t i = 0;
+        for (; i < _dst_paths.size(); i++) {
+            if (_dst_paths[i] == _src_paths[j]) {
+                auto& mk = _merge_tasks.emplace_back();
+                mk.is_merge = false;
+                mk.is_merge = false;
+                mk.src_index.emplace_back(j);
+                mk.dst_index = i;
+                if (_dst_types[i] != _src_types[j]) {
+                    mk.need_cast = true;
+                    SlotDescriptor source_slot(i, "mock_solt", TypeDescriptor(_src_types[j]));
+                    ColumnRef* col_ref = _pool.add(new ColumnRef(&source_slot));
+                    mk.cast_expr = VectorizedCastExprFactory::from_type(TypeDescriptor(_src_types[j]),
+                                                                        TypeDescriptor(_dst_types[i]), col_ref, &_pool);
+                }
+                break;
+            }
+        }
+
+        if (i >= _dst_paths.size() && _dst_remain) {
+            _merge_tasks[0].src_index.emplace_back(j);
+        }
+    }
+
+    std::vector<std::string> all_flat_paths; // for remove from remain
+    if (column->has_remain()) {
+        for (size_t i = 0; i < _dst_paths.size(); i++) {
+            if (_src_set.find(_dst_paths[i]) == _src_set.end()) {
+                // merge to remain
+                if (_flat_tasks.empty()) {
+                    _flat_tasks.emplace_back();
+                    _flat_tasks.back().src_index = _src_paths.size();
+                }
+                _flat_tasks.back().dst_index.emplace_back(i);
+            }
+        }
+
+        for (size_t i = 0; i < _flat_tasks.size(); i++) {
+            auto& fk = _flat_tasks[i];
+            std::vector<std::string> p;
+            std::vector<LogicalType> t;
+            for (auto& index : fk.dst_index) {
+                p.emplace_back(all_flat_paths[index]);
+                p.emplace_back(_dst_paths[index]);
+                t.emplace_back(_dst_types[index]);
+            }
+            fk.flattener = std::make_unique<JsonFlattener>(p, t, false);
+        }
+    }
+
+    if (_dst_remain) {
+        auto& mk = _merge_tasks[0];
+        DCHECK(mk.is_merge);
+        std::vector<std::string> p;
+        std::vector<LogicalType> t;
+
+        for (auto& index : mk.src_index) {
+            p.emplace_back(_src_paths[index]);
+            t.emplace_back(_src_types[index]);
+        }
+        mk.merger = std::make_unique<JsonMerger>(p, t, column->has_remain());
+        mk.merger->set_exclude_paths(all_flat_paths);
+        if (column->has_remain()) {
+            _merge_tasks[0].src_index.emplace_back(_src_paths.size());
+        }
+    }
+
+    for (size_t i = 1; i < _merge_tasks.size(); i++) {
+        DCHECK(!_merge_tasks[i].is_merge);
+    }
+}
+
+Status HyperJsonTransformer::trans(std::vector<ColumnPtr>& columns) {
+    {
+        SCOPED_RAW_TIMER(&_cast_ms);
+        for (auto& task : _merge_tasks) {
+            if (!task.is_merge) {
+                RETURN_IF_ERROR(_equals(task, columns));
+            }
+        }
+    }
+    {
+        SCOPED_RAW_TIMER(&_merge_ms);
+        for (auto& task : _merge_tasks) {
+            if (task.is_merge) {
+                RETURN_IF_ERROR(_merge(task, columns));
+            }
+        }
+    }
+    {
+        SCOPED_RAW_TIMER(&_flat_ms);
+        for (auto& task : _flat_tasks) {
+            _flat(task, columns);
+        }
+    }
+
+    size_t rows = columns[0]->size();
+    for (size_t i = 0; i < _dst_columns.size() - 1; i++) {
+        if (_dst_columns[i]->size() == 0) {
+            _dst_columns[i]->append_default(rows);
+        } else {
+            DCHECK_EQ(rows, _dst_columns[i]->size());
+        }
+    }
+    return Status::OK();
+}
+
+Status HyperJsonTransformer::_equals(const MergeTask& task, std::vector<ColumnPtr>& columns) {
+    DCHECK(task.src_index.size() == 1);
+    if (task.need_cast) {
+        auto col = columns[task.src_index[0]];
+        return _cast(task, col);
+    }
+    _dst_columns[task.dst_index] = columns[task.src_index[0]];
+    return Status::OK();
+}
+
+Status HyperJsonTransformer::_cast(const MergeTask& task, ColumnPtr& col) {
+    DCHECK(task.need_cast);
+    Chunk chunk;
+    chunk.append_column(col, task.dst_index);
+    ASSIGN_OR_RETURN(auto res, task.cast_expr->evaluate_checked(nullptr, &chunk));
+    res->set_delete_state(col->delete_state());
+
+    if (res->only_null()) {
+        auto check = _dst_columns[task.dst_index]->append_nulls(col->size());
+        DCHECK(check);
+    } else if (res->is_constant()) {
+        auto data = down_cast<ConstColumn*>(res.get())->data_column();
+        _dst_columns[task.dst_index]->append_value_multiple_times(*data, 0, col->size());
+    } else {
+        _dst_columns[task.dst_index].swap(res);
+    }
+    return Status::OK();
+}
+
+Status HyperJsonTransformer::_merge(const MergeTask& task, std::vector<ColumnPtr>& columns) {
+    if (task.dst_index == _dst_paths.size()) {
+        DCHECK(_dst_remain);
+        // output to remain
+        if (task.src_index.size() == 1 && task.src_index[0] == _src_paths.size()) {
+            // only use remain
+            _dst_columns[task.dst_index] = columns[task.src_index[0]];
+            return Status::OK();
+        }
+    }
+
+    std::vector<ColumnPtr> cols;
+    for (auto& index : task.src_index) {
+        cols.emplace_back(columns[index]);
+    }
+    auto result = task.merger->merge(cols);
+    if (task.need_cast) {
+        return _cast(task, result);
+    } else {
+        _dst_columns[task.dst_index] = result;
+    }
+    return Status::OK();
+}
+
+void HyperJsonTransformer::_flat(const FlatTask& task, std::vector<ColumnPtr>& columns) {
+    if (task.dst_index.empty()) {
+        return;
+    }
+
+    if (task.src_index != _src_types.size() && _src_types[task.src_index] != LogicalType::TYPE_JSON) {
+        // not json column, don't need to flatten
+        for (size_t i = 0; i < task.dst_index.size(); i++) {
+            auto check = _dst_columns[task.dst_index[i]]->append_nulls(columns[0]->size());
+            DCHECK(check);
+        }
+        return;
+    }
+
+    task.flattener->flatten(columns[task.src_index].get());
+    auto result = task.flattener->mutable_result();
+
+    for (size_t i = 0; i < task.dst_index.size(); i++) {
+        _dst_columns[task.dst_index[i]] = result[i];
+    }
+}
+
+void HyperJsonTransformer::reset() {
+    _src_paths.clear();
+    _src_types.clear();
+    _merge_tasks.clear();
+    _flat_tasks.clear();
+    _pool.clear();
+    for (size_t i = 0; i < _dst_columns.size(); i++) {
+        _dst_columns[i] = _dst_columns[i]->clone_empty();
+    }
+}
+
+std::vector<ColumnPtr> HyperJsonTransformer::mutable_result() {
+    std::vector<ColumnPtr> res;
+    for (size_t i = 0; i < _dst_columns.size(); i++) {
+        res.emplace_back(_dst_columns[i]);
+        _dst_columns[i] = _dst_columns[i]->clone_empty();
+    }
+    return res;
+}
+
+std::vector<std::string> HyperJsonTransformer::cast_paths() const {
+    std::vector<std::string> res;
+    for (auto& task : _merge_tasks) {
+        if (task.is_merge) {
+            continue;
+        }
+        for (auto& index : task.src_index) {
+            if (index == _src_paths.size()) {
+                res.emplace_back("remain");
+            } else {
+                res.emplace_back(_src_paths[index]);
+            }
+        }
+    }
+    return res;
+}
+
+std::vector<std::string> HyperJsonTransformer::merge_paths() const {
+    std::vector<std::string> res;
+    for (auto& task : _merge_tasks) {
+        if (!task.is_merge) {
+            continue;
+        }
+        for (auto& index : task.src_index) {
+            if (index == _src_paths.size()) {
+                res.emplace_back("remain");
+            } else {
+                res.emplace_back(_src_paths[index]);
+            }
+        }
+    }
+    return res;
+}
+
+std::vector<std::string> HyperJsonTransformer::flat_paths() const {
+    std::vector<std::string> res;
+    for (auto& task : _flat_tasks) {
+        if (task.src_index == _src_paths.size()) {
+            res.emplace_back("remain");
+        } else {
+            res.emplace_back(_src_paths[task.src_index]);
+        }
+    }
+    return res;
+}
+
 } // namespace starrocks

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -1158,7 +1158,7 @@ Status HyperJsonTransformer::trans(std::vector<ColumnPtr>& columns) {
     }
 
     size_t rows = columns[0]->size();
-    for (size_t i = 0; i < _dst_columns.size() - 1; i++) {
+    for (size_t i = 0; i < _dst_columns.size(); i++) {
         if (_dst_columns[i]->size() == 0) {
             _dst_columns[i]->append_default(rows);
         } else {

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -898,7 +898,7 @@ HyperJsonTransformer::HyperJsonTransformer(JsonPathDeriver& deriver)
 
 HyperJsonTransformer::HyperJsonTransformer(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
                                            bool has_remain)
-        : _dst_remain(has_remain), _dst_paths(paths), _dst_types(types) {
+        : _dst_remain(has_remain), _dst_paths(std::move(paths)), _dst_types(types) {
     for (size_t i = 0; i < _dst_paths.size(); i++) {
         _dst_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(types[i]), true));
     }

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -143,7 +143,7 @@ private:
 
     template <bool REMAIN>
     bool _flatten_json(const vpack::Slice& value, const JsonFlatPath* root, vpack::Builder* builder,
-                       uint32_t* flat_hit);
+                       uint32_t* hit_count);
 
 private:
     bool _has_remain = false;

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -17,45 +17,264 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <tuple>
+#include <unordered_map>
 #include <vector>
 
+#include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
 #include "common/status.h"
+#include "common/statusor.h"
+#include "exprs/expr.h"
 #include "types/logical_type.h"
 #include "velocypack/vpack.h"
 
 namespace starrocks {
 namespace vpack = arangodb::velocypack;
 
+class JsonFlatPath {
+public:
+    using OP = uint8_t;
+    static const OP OP_INCLUDE = 0;
+    static const OP OP_EXCLUDE = 1; // for compaction remove extract json
+    static const OP OP_IGNORE = 2;  // for merge and read middle json
+    static const OP OP_ROOT = 3;    // to mark new root
+    // for express flat path
+    int index = -1; // flat paths array index, only use for leaf, to find column
+    LogicalType type = LogicalType::TYPE_JSON;
+    bool remain = false;
+    OP op = OP_INCLUDE; // merge flat json use, to mark the path is need
+    std::unordered_map<std::string, std::unique_ptr<JsonFlatPath>> children;
+
+    JsonFlatPath() = default;
+    JsonFlatPath(JsonFlatPath&&) = default;
+    JsonFlatPath(const JsonFlatPath& rhs) = default;
+    ~JsonFlatPath() = default;
+
+    // return the leaf node
+    static JsonFlatPath* normalize_from_path(const std::string& path, JsonFlatPath* root);
+
+    // set new root, other path will set to exclude, the node must include the root path
+    static void set_root(const std::string& new_root_path, JsonFlatPath* node);
+
+private:
+    static std::pair<std::string, std::string> _split_path(const std::string& path);
+};
+
+// to deriver json flanttern path
+class JsonPathDeriver {
+public:
+    JsonPathDeriver() = default;
+    JsonPathDeriver(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain);
+
+    ~JsonPathDeriver() = default;
+
+    // dervie paths
+    void derived(const std::vector<const Column*>& json_datas);
+
+    bool has_remain_json() const { return _has_remain; }
+
+    std::shared_ptr<JsonFlatPath>& flat_path_root() { return _path_root; }
+
+    const std::vector<std::string>& flat_paths() const { return _paths; }
+
+    const std::vector<LogicalType>& flat_types() const { return _types; }
+
+private:
+    void _derived(const Column* json_data, size_t mark_row);
+
+    void _finalize();
+
+    void _derived_on_flat_json(const std::vector<const Column*>& json_datas);
+
+    void _visit_json_paths(vpack::Slice value, JsonFlatPath* root, size_t mark_row);
+
+private:
+    struct JsonFlatDesc {
+        // json compatible type
+        uint8_t type = 255; // JSON_NULL_TYPE_BITS
+        // column path hit count, some json may be null or none, so hit use to record the actual value
+        // e.g: {"a": 1, "b": 2}, path "$.c" not exist, so hit is 0
+        uint64_t hits = 0;
+        // how many rows need to be cast to a compatible type
+        uint16_t casts = 0;
+
+        // for json-uint, json-uint is uint64_t, check the maximum value and downgrade to bigint
+        uint64_t max = 0;
+
+        // same key may appear many times in json, so we need avoid duplicate compute hits
+        uint64_t last_row = -1;
+        uint64_t multi_times = 0;
+    };
+
+    bool _has_remain = false;
+    std::vector<std::string> _paths;
+    std::vector<LogicalType> _types;
+
+    size_t _total_rows;
+    std::unordered_map<JsonFlatPath*, JsonFlatDesc> _derived_maps;
+    std::shared_ptr<JsonFlatPath> _path_root;
+};
+
+// flattern JsonColumn to flat json A,B,C
 class JsonFlattener {
 public:
-    static const uint8_t JSON_NULL_TYPE_BITS = 0xFC | 1; // must be the NULL type
+    JsonFlattener(JsonPathDeriver& deriver);
 
-public:
-    JsonFlattener() = default;
+    JsonFlattener(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain);
 
     ~JsonFlattener() = default;
 
-    JsonFlattener(std::vector<std::string>& paths);
+    // flatten without flat json, input must not flat json
+    void flatten(const Column* json_column);
 
-    JsonFlattener(std::vector<std::string>& paths, const std::vector<LogicalType>& types);
-
-    void flatten(const Column* json_column, std::vector<ColumnPtr>* result);
-
-    void derived_paths(std::vector<ColumnPtr>& json_datas);
-
-    std::vector<std::string>& get_flat_paths() { return _flat_paths; }
-
-    std::vector<LogicalType> get_flat_types();
-
-    static uint8_t get_compatibility_type(vpack::ValueType type1, uint8_t type2);
+    std::vector<ColumnPtr> mutable_result();
 
 private:
-    std::vector<std::string> _flat_paths;
-    std::vector<uint8_t> _flat_types;
-    std::unordered_map<std::string, int> _flat_index;
+    template <bool HAS_REMAIN>
+    void _flatten(const Column* json_column, const JsonColumn* json_data);
+
+    template <bool REMAIN>
+    bool _flatten_json(const vpack::Slice& value, const JsonFlatPath* root, vpack::Builder* builder,
+                       uint32_t* flat_hit);
+
+private:
+    bool _has_remain = false;
+    // note: paths may be less 1 than flat columns
+    std::vector<std::string> _dst_paths;
+
+    std::vector<ColumnPtr> _flat_columns;
+    JsonColumn* _remain;
+    std::shared_ptr<JsonFlatPath> _dst_root;
 };
+
+// merge flat json A,B,C to JsonColumn
+class JsonMerger {
+public:
+    ~JsonMerger() = default;
+
+    JsonMerger(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain = false);
+
+    // for read, only read some leaf node
+    void set_root_path(const std::string& base_path);
+
+    // for read, must return nullable column
+    void set_output_nullable(bool output_nullable) { _output_nullable = output_nullable; }
+
+    // for compaction, set exclude paths, to remove the path
+    void set_exclude_paths(const std::vector<std::string>& exclude_paths);
+
+    // input nullable-json, output none null json
+    ColumnPtr merge(const std::vector<ColumnPtr>& columns);
+
+private:
+    template <bool IN_TREE>
+    void _merge_impl(size_t rows);
+
+    template <bool IN_TREE>
+    void _merge_json_with_remain(const JsonFlatPath* root, const vpack::Slice* remain, vpack::Builder* builder,
+                                 size_t index);
+
+    void _merge_json(const JsonFlatPath* root, vpack::Builder* builder, size_t index);
+
+private:
+    bool _has_remain = false;
+    std::shared_ptr<JsonFlatPath> _src_root;
+    std::vector<const Column*> _src_columns;
+    bool _output_nullable = false;
+
+    ColumnPtr _result;
+    JsonColumn* _json_result;
+    NullColumn* _null_result;
+};
+
+// use for read json column and compaction
+//
+// handle:
+// flatten json (A, B, C, remain) column to flat json column to (A, B, C, D, remain)
+// some flat, some merge, some extract...
+class HyperJsonTransformer {
+public:
+    HyperJsonTransformer(JsonPathDeriver& deriver);
+
+    HyperJsonTransformer(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain);
+
+    ~HyperJsonTransformer() = default;
+
+    // init for read process
+    void init_read_task(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain);
+
+    // init for compaction
+    void init_compaction_task(JsonColumn* column);
+
+    Status trans(std::vector<ColumnPtr>& columns);
+
+    std::vector<ColumnPtr>& result() { return _dst_columns; }
+
+    std::vector<ColumnPtr> mutable_result();
+
+    void reset();
+
+    std::vector<std::string> cast_paths() const;
+
+    std::vector<std::string> merge_paths() const;
+
+    std::vector<std::string> flat_paths() const;
+
+    // cast, merge, flat
+    std::tuple<int64_t, int64_t, int64_t> cost_ms() const { return {_cast_ms, _merge_ms, _flat_ms}; };
+
+private:
+    // equals or merge, dst-src: 1-N/1-1
+    struct MergeTask {
+        // to avoid create column with find type
+        Expr* cast_expr;
+
+        bool is_merge = false;
+        bool need_cast = false;
+
+        int dst_index = -1;
+        std::vector<int> src_index;
+
+        std::unique_ptr<JsonPathDeriver> deriver;
+        std::unique_ptr<JsonMerger> merger;
+    };
+
+    // flat, dst-src: N-1
+    struct FlatTask {
+        std::vector<int> dst_index;
+        int src_index = -1;
+
+        std::unique_ptr<JsonFlattener> flattener;
+    };
+
+    Status _equals(const MergeTask& task, std::vector<ColumnPtr>& columns);
+    Status _cast(const MergeTask& task, ColumnPtr& columns);
+    Status _merge(const MergeTask& task, std::vector<ColumnPtr>& columns);
+    void _flat(const FlatTask& task, std::vector<ColumnPtr>& columns);
+
+private:
+    bool _dst_remain = false;
+    std::vector<std::string> _dst_paths;
+    std::vector<LogicalType> _dst_types;
+    std::vector<ColumnPtr> _dst_columns;
+
+    std::vector<std::string> _src_paths;
+    std::vector<LogicalType> _src_types;
+    std::vector<MergeTask> _merge_tasks;
+    std::vector<FlatTask> _flat_tasks;
+    ObjectPool _pool;
+
+    int64_t _cast_ms = 0;
+    int64_t _flat_ms = 0;
+    int64_t _merge_ms = 0;
+};
+
 } // namespace starrocks

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -195,11 +195,20 @@ private:
     NullColumn* _null_result;
 };
 
-// use for read json column and compaction
+// use read or compaction flat json
 //
-// handle:
-// flatten json (A, B, C, remain) column to flat json column to (A, B, C, D, remain)
-// some flat, some merge, some extract...
+// to handle input flat json, and output different schema flat json
+// e.g:
+// COMPACTION: INPUT (A, B(int), C, F, REMAIN), OUTPUT (A, B(JSON), C, D, E, REMAIN)
+// - D/E need extract from REMAIN
+// - B need cast to JSON type
+// - REMAIN need remove D/E, and merge F into REMAIN
+//
+// READ: STORAGE (A.A1, A.A2, B(int), C(JSON), REMAIN), READ (A, B(string), C.C1, D)
+// - A need merge A.A1, A.A2, and other A.subfiled which from remain
+// - B need cast to string type
+// - C.C1 need extract from C
+// - D need extract from remain
 class HyperJsonTransformer {
 public:
     HyperJsonTransformer(JsonPathDeriver& deriver);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -285,6 +285,7 @@ set(EXEC_FILES
         ./storage/rowset/segment_iterator_test.cpp
         ./storage/rowset/struct_column_rw_test.cpp
         ./storage/rowset/flat_json_column_rw_test.cpp
+        ./storage/rowset/flat_json_column_compact_test.cpp
         ./storage/rowset/zone_map_index_test.cpp
         ./storage/rowset/unique_rowset_id_generator_test.cpp
         ./storage/rowset/default_value_column_iterator_test.cpp
@@ -419,6 +420,7 @@ set(EXEC_FILES
         ./util/filesystem_util_test.cpp
         ./util/frame_of_reference_coding_test.cpp
         ./util/json_util_test.cpp
+        ./util/json_flattener_test.cpp
         ./util/md5_test.cpp
         ./util/monotime_test.cpp
         ./util/mysql_row_buffer_test.cpp

--- a/be/test/exprs/flat_json_functions_test.cpp
+++ b/be/test/exprs/flat_json_functions_test.cpp
@@ -68,14 +68,10 @@ TEST_P(FlatJsonQueryTestFixture2, flat_json_query) {
 
     auto flat_json = JsonColumn::create();
     auto flat_json_ptr = flat_json.get();
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
-    }
-    flat_json_ptr->init_flat_columns(full_paths, param_flat_type);
 
-    JsonFlattener jf(param_flat_path, param_flat_type);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns{flat_json, builder.build(true)};
 
@@ -171,14 +167,15 @@ TEST_P(FlatJsonQueryErrorTestFixture, json_query) {
 
     auto flat_json = JsonColumn::create();
     auto flat_json_ptr = flat_json.get();
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
-    }
-    flat_json_ptr->init_flat_columns(full_paths);
 
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
+    }
+
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns{flat_json, builder.build(true)};
 
@@ -227,14 +224,9 @@ TEST_P(FlatJsonExistsTestFixture2, flat_json_exists_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
-    }
-    flat_json_ptr->init_flat_columns(full_paths, param_flat_type);
-
-    JsonFlattener jf(param_flat_path, param_flat_type);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -312,14 +304,9 @@ TEST_P(FlatJsonLengthTestFixture2, flat_json_length_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
-    }
-    flat_json_ptr->init_flat_columns(full_paths, param_flat_type);
-
-    JsonFlattener jf(param_flat_path, param_flat_type);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -379,16 +366,12 @@ TEST_P(FlatJsonKeysTestFixture2, json_keys) {
 
     auto flat_json = JsonColumn::create();
     auto flat_json_ptr = flat_json.get();
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
-    }
 
     Columns columns{flat_json, builder.build(true)};
-    flat_json_ptr->init_flat_columns(full_paths, param_flat_type);
 
-    JsonFlattener jf(param_flat_path, param_flat_type);
-    jf.flatten(json_column.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_column.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Status st = JsonFunctions::native_json_path_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
     ASSERT_OK(st);
@@ -457,10 +440,9 @@ public:
         auto flat_json = JsonColumn::create();
         auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-        flat_json_ptr->init_flat_columns(flat_path, flat_type);
-
-        JsonFlattener jf(flat_path, flat_type);
-        jf.flatten(ints.get(), &flat_json_ptr->get_flat_fields());
+        JsonFlattener jf(flat_path, flat_type, false);
+        jf.flatten(ints.get());
+        flat_json_ptr->set_flat_columns(flat_path, flat_type, jf.mutable_result());
 
         Columns columns{flat_json, builder.build(true)};
 
@@ -618,13 +600,11 @@ TEST_P(FlatJsonDeriverPaths, flat_json_path_test) {
     ASSERT_TRUE(json2.ok());
     json_column->append(&*json2);
 
-    Columns columns{json_column};
-    JsonFlattener jf;
-    config::json_flat_internal_column_min_limit = 0;
-    jf.derived_paths(columns);
-    config::json_flat_internal_column_min_limit = 5;
-    std::vector<std::string> path = jf.get_flat_paths();
-    std::vector<LogicalType> type = jf.get_flat_types();
+    std::vector<const Column*> columns{json_column.get()};
+    JsonPathDeriver jf;
+    jf.derived(columns);
+    std::vector<std::string> path = jf.flat_paths();
+    std::vector<LogicalType> type = jf.flat_types();
 
     ASSERT_EQ(param_flat_path, path);
     ASSERT_EQ(param_flat_type, type);
@@ -635,15 +615,15 @@ INSTANTIATE_TEST_SUITE_P(FlatJsonPathDeriver, FlatJsonDeriverPaths,
     ::testing::Values(
         std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT}),
         std::make_tuple(R"({ "k1": "v1" })",  R"({ "k1": "v33" })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_VARCHAR}),
-        std::make_tuple(R"({ "k1": {"k2": 1} })",  R"({ "k1": 123 })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_JSON}),
+        std::make_tuple(R"({ "k1": {"k2": 1} })",  R"({ "k1": 123 })", std::vector<std::string> {}, std::vector<LogicalType> {}),
         std::make_tuple(R"({ "k1": "v1" })",  R"({ "k1": 1.123 })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_JSON}),
-        std::make_tuple(R"({ "k1": {"k2": 1} })", R"({ "k1": 1.123 })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_JSON}),
+        std::make_tuple(R"({ "k1": {"k2": 1} })", R"({ "k1": 1.123 })", std::vector<std::string> {}, std::vector<LogicalType> {}),
         std::make_tuple(R"({ "k1": [1,2,3] })", R"({ "k1": "v33" })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_JSON}),
 
         std::make_tuple(R"({ "k1": "v1", "k2": [3,4,5], "k3": 1, "k4": 1.2344 })",  
-                        R"({ "k1": "abc", "k2": [11,123,54], "k3": 23423, "k4": 1.2344 })", 
-                        std::vector<std::string> {"k3", "k4", "k1", "k2"}, 
-                        std::vector<LogicalType> {TYPE_BIGINT, TYPE_DOUBLE, TYPE_VARCHAR, TYPE_JSON}),
+                        R"({ "k1": "abc", "k2": [11,123,54], "k3": 23423, "k4": 1.2344 })",
+                        std::vector<std::string> {"k1", "k2", "k3", "k4"}, 
+                        std::vector<LogicalType> {TYPE_VARCHAR, TYPE_JSON, TYPE_BIGINT, TYPE_DOUBLE}),
         std::make_tuple(R"({ "k1": 1, "k2": "a" })", R"({ "k1": 3, "k2": null })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_JSON}),
         std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT}),
 

--- a/be/test/exprs/json_functions_test.cpp
+++ b/be/test/exprs/json_functions_test.cpp
@@ -20,6 +20,7 @@
 #include <velocypack/vpack.h>
 
 #include <string>
+#include <vector>
 
 #include "butil/time.h"
 #include "column/const_column.h"
@@ -490,14 +491,13 @@ TEST_P(FlatJsonQueryTestFixture, json_query) {
 
     auto flat_json = JsonColumn::create();
     auto flat_json_ptr = flat_json.get();
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns{flat_json, builder.build(true)};
 
@@ -682,14 +682,13 @@ TEST_P(FlatJsonExistsTestFixture, flat_json_exists_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -758,14 +757,13 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_path_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -806,14 +804,13 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_constant_json_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(ConstColumn::create(flat_json, 2));
@@ -852,14 +849,13 @@ TEST_F(JsonFunctionsTest, flat_json_variable_path_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -899,14 +895,13 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_variable_path_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -948,14 +943,13 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_null_path_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -996,14 +990,13 @@ TEST_F(JsonFunctionsTest, flat_json_constant_path_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);
@@ -1306,14 +1299,13 @@ TEST_P(FlatJsonLengthTestFixture, flat_json_length_test) {
     auto flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
-    std::vector<std::string> full_paths;
-    for (const auto& p : param_flat_path) {
-        full_paths.emplace_back(p);
+    std::vector<LogicalType> param_flat_type;
+    for (auto _ : param_flat_path) {
+        param_flat_type.emplace_back(LogicalType::TYPE_JSON);
     }
-    flat_json_ptr->init_flat_columns(full_paths);
-
-    JsonFlattener jf(param_flat_path);
-    jf.flatten(json_col.get(), &flat_json_ptr->get_flat_fields());
+    JsonFlattener jf(param_flat_path, param_flat_type, false);
+    jf.flatten(json_col.get());
+    flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
     columns.push_back(flat_json);

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -1,0 +1,775 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "column/column_access_path.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "common/statusor.h"
+#include "fs/fs_memory.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gutil/casts.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/column_iterator.h"
+#include "storage/rowset/column_reader.h"
+#include "storage/rowset/column_writer.h"
+#include "storage/rowset/json_column_iterator.h"
+#include "storage/rowset/segment.h"
+#include "storage/tablet_schema_helper.h"
+#include "storage/types.h"
+#include "testutil/assert.h"
+#include "types/logical_type.h"
+#include "util/json.h"
+#include "util/json_flattener.h"
+
+namespace starrocks {
+
+// NOLINTNEXTLINE
+static const std::string TEST_DIR = "/flat_json_column_rw_test";
+
+class FlatJsonColumnCompactTest : public testing::Test {
+public:
+    FlatJsonColumnCompactTest() = default;
+
+    ~FlatJsonColumnCompactTest() override = default;
+
+protected:
+    void SetUp() override { _meta.reset(new ColumnMetaPB()); }
+
+    void TearDown() override {}
+
+    std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
+        return std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
+    }
+
+    ColumnPtr normal_json(const std::string& json, bool is_nullable) {
+        auto json_col = JsonColumn::create();
+        if ("NULL" != json) {
+            auto* json_column = down_cast<JsonColumn*>(json_col.get());
+            ASSIGN_OR_ABORT(auto jv, JsonValue::parse(json));
+            json_column->append(&jv);
+        }
+
+        if (is_nullable) {
+            auto null_col = NullColumn::create();
+            null_col->append("NULL" == json);
+            return NullableColumn::create(json_col, null_col);
+        }
+        return json_col;
+    }
+
+    ColumnPtr flat_json(const std::string& json, bool is_nullable) {
+        auto json_col = JsonColumn::create();
+        if ("NULL" != json) {
+            auto flat_col = JsonColumn::create();
+            auto* flat_column = down_cast<JsonColumn*>(flat_col.get());
+            ASSIGN_OR_ABORT(auto jv, JsonValue::parse(json));
+            flat_column->append(&jv);
+
+            JsonPathDeriver deriver;
+            deriver.derived({flat_column});
+            JsonFlattener flattener(deriver);
+            flattener.flatten(flat_column);
+            json_col->set_flat_columns(deriver.flat_paths(), deriver.flat_types(), flattener.mutable_result());
+        }
+
+        if (is_nullable) {
+            auto null_col = NullColumn::create();
+            null_col->append("NULL" == json);
+            return NullableColumn::create(json_col, null_col);
+        }
+        return json_col;
+    }
+
+    void test_json(ColumnWriterOptions& writer_opts, std::vector<ColumnPtr>& jsons, ColumnPtr& read_col) {
+        auto fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_TRUE(fs->create_dir(TEST_DIR).ok());
+
+        TabletColumn json_tablet_column = create_with_default_value<TYPE_JSON>("");
+        TypeInfoPtr type_info = get_type_info(json_tablet_column);
+
+        const std::string fname = TEST_DIR + "/test_flat_json_compact1.data";
+        auto segment = create_dummy_segment(fs, fname);
+
+        // write data
+        {
+            ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(fname));
+
+            writer_opts.meta = _meta.get();
+            writer_opts.meta->set_column_id(0);
+            writer_opts.meta->set_unique_id(0);
+            writer_opts.meta->set_type(TYPE_JSON);
+            writer_opts.meta->set_length(0);
+            writer_opts.meta->set_encoding(DEFAULT_ENCODING);
+            writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
+            writer_opts.meta->set_is_nullable(jsons[0]->is_nullable());
+            writer_opts.need_zone_map = false;
+            writer_opts.is_compaction = true;
+
+            ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &json_tablet_column, wfile.get()));
+            ASSERT_OK(writer->init());
+
+            for (auto& json : jsons) {
+                ASSERT_TRUE(writer->append(*json).ok());
+            }
+
+            ASSERT_TRUE(writer->finish().ok());
+            ASSERT_TRUE(writer->write_data().ok());
+            ASSERT_TRUE(writer->write_ordinal_index().ok());
+
+            // close the file
+            ASSERT_TRUE(wfile->close().ok());
+        }
+        LOG(INFO) << "Finish writing";
+
+        auto res = ColumnReader::create(_meta.get(), segment.get(), nullptr);
+        ASSERT_TRUE(res.ok());
+        auto reader = std::move(res).value();
+
+        {
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(nullptr));
+            ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
+
+            ColumnIteratorOptions iter_opts;
+            OlapReaderStatistics stats;
+            iter_opts.stats = &stats;
+            iter_opts.read_file = read_file.get();
+            ASSERT_TRUE(iter->init(iter_opts).ok());
+
+            // sequence read
+            auto st = iter->seek_to_first();
+            ASSERT_TRUE(st.ok()) << st.to_string();
+
+            size_t rows_read;
+            std::for_each(jsons.begin(), jsons.end(), [&](ColumnPtr& json) { rows_read += json->size(); });
+            st = iter->next_batch(&rows_read, read_col.get());
+            ASSERT_TRUE(st.ok());
+        }
+    }
+
+private:
+    std::shared_ptr<TabletSchema> _dummy_segment_schema;
+    std::shared_ptr<ColumnMetaPB> _meta;
+};
+
+TEST_F(FlatJsonColumnCompactTest, testJsonCompactToJson) {
+    // clang-format off
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", false),
+            normal_json(R"({"a": 2, "b": 22})", false),
+            normal_json(R"({"a": 3, "b": 23})", false),
+            normal_json(R"({"a": 4, "b": 24})", false),
+            normal_json(R"({"a": 5, "b": 25})", false)
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullJsonCompactToJson) {
+    // clang-format off
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", true),
+            normal_json(R"({"a": 2, "b": 22})", true),
+            normal_json(R"({"a": 3, "b": 23})", true),
+            normal_json(R"({"a": 4, "b": 24})", true),
+            normal_json(R"(NULL)", true)
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", false),
+            flat_json(R"({"a": 2, "b": 22})", false),
+            flat_json(R"({"a": 3, "b": 23})", false),
+            flat_json(R"({"a": 4, "b": 24})", false),
+            flat_json(R"({"a": 5, "b": 25})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson2) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", false),
+            flat_json(R"({"a": 2, "b": 22})", false),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", false),
+            flat_json(R"({"a": 4, "b": 24, "c": 34})", false),
+            flat_json(R"({"a": 5, "b": 25, "c": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson3) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "g": {}})", false),
+            flat_json(R"({"a": 2, "b": 22, "k": "abc"})", false),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", false),
+            flat_json(R"({"a": 4, "b": 24, "d": 34})", false),
+            flat_json(R"({"a": 5, "b": 25, "e": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson4) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", false),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", false),
+            flat_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", false),
+            flat_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", false),
+            flat_json(R"({"a": 5, "b": 25, "b1": {"b2": 5, "b3": {"b4": "ab5", "b5": false}}, "e": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactToJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", false),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", false),
+            normal_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", false),
+            normal_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", false),
+            normal_json(R"({"a": 5, "b": 25, "b1": {"b2": 5, "b3": {"b4": "ab5", "b5": false}}, "e": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", true),
+            flat_json(R"({"a": 2, "b": 22})", true),
+            flat_json(R"({"a": 3, "b": 23})", true),
+            flat_json(R"({"a": 4, "b": 24})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson2) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", true),
+            flat_json(R"({"a": 2, "b": 22})", true),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", true),
+            flat_json(R"({"a": 4, "b": 24, "c": 34})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson3) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "g": {}})", true),
+            flat_json(R"({"a": 2, "b": 22, "k": "abc"})", true),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", true),
+            flat_json(R"({"a": 4, "b": 24, "d": 34})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson4) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", true),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", true),
+            flat_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", true),
+            flat_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullHyperJsonCompactToJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", true),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", true),
+            normal_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", true),
+            normal_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", true),
+            normal_json(R"({"a": 5, "b": 25, "b1": {"b2": 5, "b3": {"b4": "ab5", "b5": false}}, "e": 35})", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testJsonCompactToFlatJson) {
+    // clang-format off
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", false),
+            normal_json(R"({"a": 2, "b": 22})", false),
+            normal_json(R"({"a": 3, "b": 23})", false),
+            normal_json(R"({"a": 4, "b": 24})", false),
+            normal_json(R"({"a": 5, "b": 25})", false)
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullJsonCompactToFlatJson) {
+    // clang-format off
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", true),
+            normal_json(R"({"a": 2, "b": 22})", true),
+            normal_json(R"({"a": 3, "b": 23})", true),
+            normal_json(R"({"a": 4, "b": 24})", true),
+            normal_json(R"(NULL)", true)
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", false),
+            flat_json(R"({"a": 2, "b": 22})", false),
+            flat_json(R"({"a": 3, "b": 23})", false),
+            flat_json(R"({"a": 4, "b": 24})", false),
+            flat_json(R"({"a": 5, "b": 25})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson2) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", false),
+            flat_json(R"({"a": 2, "b": 22})", false),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", false),
+            flat_json(R"({"a": 4, "b": 24, "c": 34})", false),
+            flat_json(R"({"a": 5, "b": 25, "c": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson3) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "g": {}})", false),
+            flat_json(R"({"a": 2, "b": 22, "k": "abc"})", false),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", false),
+            flat_json(R"({"a": 4, "b": 24, "d": 34})", false),
+            flat_json(R"({"a": 5, "b": 25, "e": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson4) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", false),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", false),
+            flat_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", false),
+            flat_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", false),
+            flat_json(R"({"a": 5, "b": 25, "b1": {"b2": 5, "b3": {"b4": "ab5", "b5": false}}, "e": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactToFlatJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", false),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", false),
+            normal_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", false),
+            normal_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", false),
+            normal_json(R"({"a": 5, "b": 25, "b1": {"b2": 5, "b3": {"b4": "ab5", "b5": false}}, "e": 35})", false),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", true),
+            flat_json(R"({"a": 2, "b": 22})", true),
+            flat_json(R"({"a": 3, "b": 23})", true),
+            flat_json(R"({"a": 4, "b": 24})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson2) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21})", true),
+            flat_json(R"({"a": 2, "b": 22})", true),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", true),
+            flat_json(R"({"a": 4, "b": 24, "c": 34})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson3) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "g": {}})", true),
+            flat_json(R"({"a": 2, "b": 22, "k": "abc"})", true),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", true),
+            flat_json(R"({"a": 4, "b": 24, "d": 34})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson4) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", true),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", true),
+            flat_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", true),
+            flat_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", true),
+            flat_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testNullHyperJsonCompactToFlatJson) {
+    // clang-format off
+    Columns jsons = {
+            flat_json(R"({"a": 1, "b": 21, "b1": {"b2": 1, "b3": {"b4": "ab1", "b5": [1, 2, 3]}}, "g": {}})", true),
+            flat_json(R"({"a": 2, "b": 22, "b1": {"b2": 2, "b3": {"b4": "ab2", "b5": {}}}, "k": "abc"})", true),
+            normal_json(R"({"a": 3, "b": 23, "b1": {"b2": 3, "b3": {"b4": "ab3", "b5": "a"}}, "c": 33})", true),
+            normal_json(R"({"a": 4, "b": 24, "b1": {"b2": 4, "b3": {"b4": "ab4", "b5": 1}}, "d": 34})", true),
+            normal_json(R"({"a": 5, "b": 25, "b1": {"b2": 5, "b3": {"b4": "ab5", "b5": false}}, "e": 35})", true),
+    };
+    // clang-format on
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+    }
+}
+
+
+} // namespace starrocks

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -192,7 +192,7 @@ TEST_F(FlatJsonColumnCompactTest, testJsonCompactToJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -217,7 +217,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullJsonCompactToJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -242,7 +242,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -267,7 +267,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson2) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -292,7 +292,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson3) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -317,7 +317,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToJson4) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -342,7 +342,7 @@ TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactToJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -367,7 +367,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -392,7 +392,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson2) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -417,7 +417,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson3) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -442,7 +442,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToJson4) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -467,7 +467,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullHyperJsonCompactToJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -492,7 +492,7 @@ TEST_F(FlatJsonColumnCompactTest, testJsonCompactToFlatJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -517,7 +517,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullJsonCompactToFlatJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -542,7 +542,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -567,7 +567,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson2) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -592,7 +592,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson3) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -617,7 +617,7 @@ TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJson4) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -642,7 +642,7 @@ TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactToFlatJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -667,7 +667,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -692,7 +692,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson2) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -717,7 +717,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson3) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -742,7 +742,7 @@ TEST_F(FlatJsonColumnCompactTest, testNullFlatJsonCompactToFlatJson4) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
 
@@ -767,9 +767,8 @@ TEST_F(FlatJsonColumnCompactTest, testNullHyperJsonCompactToFlatJson) {
     EXPECT_EQ(5, read_json->size());
     EXPECT_EQ(0, read_json->get_flat_fields().size());
     for (size_t i = 0; i < jsons.size(); i++) {
-        EXPECT_EQ(jsons[i], read_json->debug_item(i));
+        EXPECT_EQ(jsons[i]->debug_item(0), read_json->debug_item(i));
     }
 }
-
 
 } // namespace starrocks

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -194,8 +194,8 @@ TEST_F(FlatJsonColumnRWTest, testNormalJsonWithPath) {
     json_col->append(&jv5);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -229,8 +229,8 @@ TEST_F(FlatJsonColumnRWTest, testNormalFlatJsonWithPath) {
     json_col->append(&jv5);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -305,8 +305,8 @@ TEST_F(FlatJsonColumnRWTest, testNullNormalFlatJson) {
     ColumnPtr write_nl_col = NullableColumn::create(write_col, null_col);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -339,8 +339,8 @@ TEST_F(FlatJsonColumnRWTest, tesArrayFlatJson) {
     json_col->append(&jv5);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -374,8 +374,8 @@ TEST_F(FlatJsonColumnRWTest, testEmptyFlatObject) {
     json_col->append(&jv5);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -485,8 +485,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson) {
     json_col->append(&jv5);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.c", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -567,8 +567,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson3) {
     }
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
-    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b.b2", 0));
 
     b_path->children().emplace_back(std::move(b2_path));
     root_path->children().emplace_back(std::move(b_path));
@@ -612,23 +612,14 @@ TEST_F(FlatJsonColumnRWTest, testDeepFlatJson) {
         json_col->append(jv);
     }
 
-    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
-    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
-    ASSIGN_OR_ABORT(auto b3_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2.b3", 0));
-    ASSIGN_OR_ABORT(auto b4_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4", 0));
-    ASSIGN_OR_ABORT(auto b5_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4.b5", 0));
-
-    b4_path->children().emplace_back(std::move(b5_path));
-    b2_path->children().emplace_back(std::move(b3_path));
-    b_path->children().emplace_back(std::move(b4_path));
-    b_path->children().emplace_back(std::move(b2_path));
-    root_path->children().emplace_back(std::move(b_path));
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(4, writer_opts.meta->children_columns_size());
     EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
@@ -666,32 +657,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperFlatJson) {
         json_col->append(jv);
     }
 
-    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
-    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
-    ASSIGN_OR_ABORT(auto b3_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2.b3", 0));
-    ASSIGN_OR_ABORT(auto b4_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4", 0));
-    ASSIGN_OR_ABORT(auto b5_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4.b5", 0));
-    ASSIGN_OR_ABORT(auto a_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto ff_path, ColumnAccessPath::create(TAccessPathType::FIELD, "ff", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "ff.f1", 0));
-    ASSIGN_OR_ABORT(auto gg_path, ColumnAccessPath::create(TAccessPathType::FIELD, "gg", 0));
-    ASSIGN_OR_ABORT(auto g1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "gg.g1", 0));
-    b4_path->children().emplace_back(std::move(b5_path));
-    b2_path->children().emplace_back(std::move(b3_path));
-    b_path->children().emplace_back(std::move(b4_path));
-    b_path->children().emplace_back(std::move(b2_path));
-    ff_path->children().emplace_back(std::move(f1_path));
-    gg_path->children().emplace_back(std::move(g1_path));
-    root_path->children().emplace_back(std::move(b_path));
-    root_path->children().emplace_back(std::move(a_path));
-    root_path->children().emplace_back(std::move(ff_path));
-    root_path->children().emplace_back(std::move(gg_path));
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(7, writer_opts.meta->children_columns_size());
     EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
@@ -766,8 +742,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainJson) {
     json_col->append(&jv5);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.c", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -808,8 +784,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainJson2) {
     }
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
-    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b.b2", 0));
 
     b_path->children().emplace_back(std::move(b2_path));
     root_path->children().emplace_back(std::move(b_path));
@@ -848,14 +824,14 @@ TEST_F(FlatJsonColumnRWTest, testDeepJson) {
         json_col->append(jv);
     }
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = false;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(0, writer_opts.meta->children_columns_size());
     EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
@@ -889,17 +865,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperJson) {
         json_col->append(jv);
     }
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = false;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(0, writer_opts.meta->children_columns_size());
     EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
@@ -933,17 +909,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeJson) {
         json_col->append(jv);
     }
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2.b3");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     auto* read_json = down_cast<JsonColumn*>(read_col.get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -973,17 +949,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson) {
         json_col->append(jv);
     }
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b2");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     auto* read_json = down_cast<JsonColumn*>(read_col.get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -1013,17 +989,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson2) {
         json_col->append(jv);
     }
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     auto* read_json = down_cast<JsonColumn*>(read_col.get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -1162,8 +1138,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullFlatJson) {
     ColumnPtr write_col = create_json(jsons, true);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.c", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -1234,8 +1210,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullFlatJson3) {
     ColumnPtr write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
-    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b.b2", 0));
 
     b_path->children().emplace_back(std::move(b2_path));
     root_path->children().emplace_back(std::move(b_path));
@@ -1275,14 +1251,14 @@ TEST_F(FlatJsonColumnRWTest, testDeepNullFlatJson) {
                                      R"(NULL)", R"({"a": 5, "b": {"b1": 26, "b2": {}, "b4": 23}})"};
 
     ColumnPtr write_col = create_json(json, true);
-    ColumnAccessPath root_path;
-    ColumnAccessPath::insert_json_path(&root_path, LogicalType::TYPE_JSON, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root_path, LogicalType::TYPE_JSON, "b.b2.b3");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root_path);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(5, writer_opts.meta->children_columns_size());
     EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
@@ -1315,17 +1291,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperNullFlatJson) {
             R"(NULL)"};
     ColumnPtr write_col = create_json(json, true);
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(8, writer_opts.meta->children_columns_size());
     EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
@@ -1408,8 +1384,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullJson) {
     ColumnPtr write_col = create_json(jsons, true);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.c", 0));
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
@@ -1446,8 +1422,8 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullJson2) {
     ColumnPtr write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
-    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b.b2", 0));
 
     b_path->children().emplace_back(std::move(b2_path));
     root_path->children().emplace_back(std::move(b_path));
@@ -1482,14 +1458,14 @@ TEST_F(FlatJsonColumnRWTest, testDeepNullJson) {
 
     ColumnPtr write_col = create_json(json, true);
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = false;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(0, writer_opts.meta->children_columns_size());
     EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
@@ -1518,17 +1494,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperNullJson) {
 
     auto write_col = create_json(json, true);
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = false;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(0, writer_opts.meta->children_columns_size());
     EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
@@ -1557,17 +1533,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperNullJson2) {
 
     auto write_col = create_json(json, true);
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     EXPECT_EQ(0, writer_opts.meta->children_columns_size());
     EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
@@ -1595,17 +1571,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeNullJson) {
 
     ColumnPtr write_col = create_json(json, true);
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2.b3");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -1628,17 +1604,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeNullJson) {
             R"({"a": 4, "gg": "te4", "ff": 781, "b": {}})", R"(NULL)"};
     ColumnPtr write_col = create_json(json, true);
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b2");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -1661,17 +1637,17 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeNullJson2) {
             R"({"a": 4, "gg": "te4", "ff": 781, "b": {}})", R"(NULL)"};
     ColumnPtr write_col = create_json(json, true);
 
-    ColumnAccessPath root;
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
-    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
-    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
     EXPECT_TRUE(read_json->is_flat_json());

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -14,7 +14,11 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <vector>
+
 #include "column/column_access_path.h"
+#include "column/column_helper.h"
 #include "column/json_column.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
@@ -48,7 +52,7 @@ public:
     ~FlatJsonColumnRWTest() override = default;
 
 protected:
-    void SetUp() override {}
+    void SetUp() override { _meta.reset(new ColumnMetaPB()); }
 
     void TearDown() override {}
 
@@ -56,13 +60,13 @@ protected:
         return std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
     }
 
-    void test_json(const std::string& case_file, ColumnPtr& write_col, ColumnPtr& read_col, ColumnAccessPath* path) {
+    void test_json(ColumnWriterOptions& writer_opts, const std::string& case_file, ColumnPtr& write_col,
+                   ColumnPtr& read_col, ColumnAccessPath* path) {
         auto fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(fs->create_dir(TEST_DIR).ok());
 
         TabletColumn json_tablet_column = create_with_default_value<TYPE_JSON>("");
         TypeInfoPtr type_info = get_type_info(json_tablet_column);
-        ColumnMetaPB meta;
 
         const std::string fname = TEST_DIR + case_file;
         auto segment = create_dummy_segment(fs, fname);
@@ -71,8 +75,7 @@ protected:
         {
             ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(fname));
 
-            ColumnWriterOptions writer_opts;
-            writer_opts.meta = &meta;
+            writer_opts.meta = _meta.get();
             writer_opts.meta->set_column_id(0);
             writer_opts.meta->set_unique_id(0);
             writer_opts.meta->set_type(TYPE_JSON);
@@ -96,7 +99,7 @@ protected:
         }
         LOG(INFO) << "Finish writing";
 
-        auto res = ColumnReader::create(&meta, segment.get(), nullptr);
+        auto res = ColumnReader::create(_meta.get(), segment.get(), nullptr);
         ASSERT_TRUE(res.ok());
         auto reader = std::move(res).value();
 
@@ -120,13 +123,61 @@ protected:
         }
     }
 
+    ColumnPtr create_json(const std::vector<std::string>& jsons, bool is_nullable) {
+        auto json_col = JsonColumn::create();
+        auto null_col = NullColumn::create();
+        auto* json_column = down_cast<JsonColumn*>(json_col.get());
+        for (auto& json : jsons) {
+            if ("NULL" != json) {
+                ASSIGN_OR_ABORT(auto jv, JsonValue::parse(json));
+                json_column->append(&jv);
+            } else {
+                json_column->append_default();
+            }
+            null_col->append("NULL" == json);
+        }
+
+        if (is_nullable) {
+            return NullableColumn::create(json_col, null_col);
+        }
+        return json_col;
+    }
+
 private:
     std::shared_ptr<TabletSchema> _dummy_segment_schema;
+    std::shared_ptr<ColumnMetaPB> _meta;
 };
 
-TEST_F(FlatJsonColumnRWTest, testNormalFlatJson) {
-    config::json_flat_internal_column_min_limit = 1;
+TEST_F(FlatJsonColumnRWTest, testNormalJson) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
 
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse("{\"a\": 1, \"b\": 21}"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw1.data", write_col, read_col, nullptr);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(0, read_json->get_flat_fields().size());
+    EXPECT_EQ("{\"a\": 1, \"b\": 21}", read_json->debug_item(0));
+    EXPECT_EQ("{\"a\": 4, \"b\": 24}", read_json->debug_item(3));
+}
+
+TEST_F(FlatJsonColumnRWTest, testNormalJsonWithPath) {
     ColumnPtr write_col = JsonColumn::create();
     auto* json_col = down_cast<JsonColumn*>(write_col.get());
 
@@ -149,7 +200,44 @@ TEST_F(FlatJsonColumnRWTest, testNormalFlatJson) {
     root_path->children().emplace_back(std::move(f2_path));
 
     ColumnPtr read_col = JsonColumn::create();
-    test_json("/test_flat_json_rw1.data", write_col, read_col, root_path.get());
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw1.data", write_col, read_col, root_path.get());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(2, read_json->get_flat_fields().size());
+    EXPECT_EQ("{a: 1, b: 21}", read_json->debug_item(0));
+    EXPECT_EQ("{a: 4, b: 24}", read_json->debug_item(3));
+}
+
+TEST_F(FlatJsonColumnRWTest, testNormalFlatJsonWithPath) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse("{\"a\": 1, \"b\": 21}"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw1.data", write_col, read_col, root_path.get());
 
     auto* read_json = down_cast<JsonColumn*>(read_col.get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -161,9 +249,37 @@ TEST_F(FlatJsonColumnRWTest, testNormalFlatJson) {
     EXPECT_EQ("3", read_json->get_flat_field("a")->debug_item(2));
 }
 
-TEST_F(FlatJsonColumnRWTest, testNullFlatJson) {
-    config::json_flat_internal_column_min_limit = 1;
+TEST_F(FlatJsonColumnRWTest, testNormalFlatJsonWithoutPath) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
 
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse("{\"a\": 1, \"b\": 21}"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw1.data", write_col, read_col, nullptr);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    ASSERT_EQ(0, read_json->get_flat_fields().size());
+    EXPECT_EQ("{\"a\": 1, \"b\": 21}", read_json->debug_item(0));
+    EXPECT_EQ("{\"a\": 4, \"b\": 24}", read_json->debug_item(3));
+}
+
+TEST_F(FlatJsonColumnRWTest, testNullNormalFlatJson) {
+    config::json_flat_null_factor = 0.4;
     ColumnPtr write_col = JsonColumn::create();
     auto* json_col = down_cast<JsonColumn*>(write_col.get());
 
@@ -195,7 +311,9 @@ TEST_F(FlatJsonColumnRWTest, testNullFlatJson) {
     root_path->children().emplace_back(std::move(f2_path));
 
     ColumnPtr read_col = NullableColumn::create(JsonColumn::create(), NullColumn::create());
-    test_json("/test_flat_json_rw2.data", write_nl_col, read_col, root_path.get());
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_nl_col, read_col, root_path.get());
 
     auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -204,49 +322,11 @@ TEST_F(FlatJsonColumnRWTest, testNullFlatJson) {
     EXPECT_EQ("{a: 5, b: 25}", read_col->debug_item(4));
 }
 
-TEST_F(FlatJsonColumnRWTest, testLimitFlatJson) {
-    config::json_flat_internal_column_min_limit = 5;
-
-    ColumnPtr write_col = JsonColumn::create();
-    auto* json_col = down_cast<JsonColumn*>(write_col.get());
-
-    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse("{\"a\": 1, \"b\": 21}"));
-    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
-    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
-    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
-    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
-
-    json_col->append(&jv1);
-    json_col->append(&jv2);
-    json_col->append(&jv3);
-    json_col->append(&jv4);
-    json_col->append(&jv5);
-
-    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
-    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
-    root_path->children().emplace_back(std::move(f1_path));
-    root_path->children().emplace_back(std::move(f2_path));
-
-    ColumnPtr read_col = JsonColumn::create();
-    test_json("/test_flat_json_rw3.data", write_col, read_col, root_path.get());
-
-    auto* read_json = down_cast<JsonColumn*>(read_col.get());
-    EXPECT_TRUE(read_json->is_flat_json());
-    EXPECT_EQ(5, read_json->size());
-    ASSERT_EQ(2, read_json->get_flat_fields().size());
-    EXPECT_EQ("{a: 1, b: 21}", read_json->debug_item(0));
-    EXPECT_EQ("{a: 4, b: 24}", read_json->debug_item(3));
-    EXPECT_EQ("3", read_json->get_flat_field("a")->debug_item(2));
-}
-
 TEST_F(FlatJsonColumnRWTest, tesArrayFlatJson) {
-    config::json_flat_internal_column_min_limit = 5;
-
     ColumnPtr write_col = JsonColumn::create();
     auto* json_col = down_cast<JsonColumn*>(write_col.get());
 
-    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"( [{"a": 1}, {"b": 21}] )"));
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"([{"a": 1}, {"b": 21}] )"));
     ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
     ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
     ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
@@ -265,7 +345,9 @@ TEST_F(FlatJsonColumnRWTest, tesArrayFlatJson) {
     root_path->children().emplace_back(std::move(f2_path));
 
     ColumnPtr read_col = JsonColumn::create();
-    test_json("/test_flat_json_rw3.data", write_col, read_col, root_path.get());
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw3.data", write_col, read_col, root_path.get());
 
     auto* read_json = down_cast<JsonColumn*>(read_col.get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -275,13 +357,11 @@ TEST_F(FlatJsonColumnRWTest, tesArrayFlatJson) {
     EXPECT_EQ("{a: 4, b: 24}", read_json->debug_item(3));
 }
 
-TEST_F(FlatJsonColumnRWTest, testEmptyObject) {
-    config::json_flat_internal_column_min_limit = 5;
-
+TEST_F(FlatJsonColumnRWTest, testEmptyFlatObject) {
     ColumnPtr write_col = JsonColumn::create();
     auto* json_col = down_cast<JsonColumn*>(write_col.get());
 
-    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"( "" )"));
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"("" )"));
     ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
     ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
     ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
@@ -299,8 +379,11 @@ TEST_F(FlatJsonColumnRWTest, testEmptyObject) {
     root_path->children().emplace_back(std::move(f1_path));
     root_path->children().emplace_back(std::move(f2_path));
 
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+
     ColumnPtr read_col = JsonColumn::create();
-    test_json("/test_flat_json_rw4.data", write_col, read_col, root_path.get());
+    test_json(writer_opts, "/test_flat_json_rw4.data", write_col, read_col, root_path.get());
 
     auto* read_json = down_cast<JsonColumn*>(read_col.get());
     EXPECT_TRUE(read_json->is_flat_json());
@@ -308,6 +391,1302 @@ TEST_F(FlatJsonColumnRWTest, testEmptyObject) {
     ASSERT_EQ(2, read_json->get_flat_fields().size());
     EXPECT_EQ("{a: NULL, b: NULL}", read_json->debug_item(0));
     EXPECT_EQ("{a: 4, b: 24}", read_json->debug_item(3));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeRemainFlatJson) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"({"a": 1, "b": 21, "c": 31})"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse(R"({"a": 2, "b": 22, "d": 32})"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse(R"({"a": 3, "b": 23, "e": [1,2,3]})"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse(R"({"a": 4, "b": 24, "g": {"x": 1}})"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse(R"({"a": 5, "b": 25})"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(3, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(2).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({"a": 1, "b": 21, "c": 31})", read_col->debug_item(0));
+    EXPECT_EQ(R"({"a": 2, "b": 22, "d": 32})", read_col->debug_item(1));
+    EXPECT_EQ(R"({"a": 3, "b": 23, "e": [1, 2, 3]})", read_col->debug_item(2));
+    EXPECT_EQ(R"({"a": 4, "b": 24, "g": {"x": 1}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({"a": 5, "b": 25})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeRemainFlatJson2) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1, 2, 3]}, "d": 32})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1, 2, 3]})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe"}, "b4": {"b7": 2}}, "g": {"x": 1}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf"}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(4, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(3).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+
+    for (size_t i = 0; i < json.size(); i++) {
+        EXPECT_EQ(json[i], read_col->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"({"a": 1, "b": 21, "c": 31})"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse(R"({"a": 2, "b": 22, "d": 32})"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse(R"({"a": 3, "b": 23, "e": [1,2,3]})"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse(R"({"a": 4, "b": 24, "g": {"x": 1}})"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse(R"({"a": 5, "b": 25})"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+
+    EXPECT_EQ(3, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(2).name());
+
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ("{a: 1, c: 31}", read_col->debug_item(0));
+    EXPECT_EQ("{a: 2, c: NULL}", read_col->debug_item(1));
+    EXPECT_EQ("{a: 3, c: NULL}", read_col->debug_item(2));
+    EXPECT_EQ("{a: 4, c: NULL}", read_col->debug_item(3));
+    EXPECT_EQ("{a: 5, c: NULL}", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson2) {
+    config::json_flat_null_factor = 0.4;
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1, 2, 3]}, "d": 32})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1, 2, 3]})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe"}, "b4": {"b7": 2}}, "g": {"x": 1}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf"}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(4, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(3).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    for (size_t i = 0; i < json.size(); i++) {
+        EXPECT_EQ(json[i], read_col->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson3) {
+    config::json_flat_null_factor = 0.4;
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+
+    b_path->children().emplace_back(std::move(b2_path));
+    root_path->children().emplace_back(std::move(b_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(5, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(4).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b2: {"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b2: {"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b2: {"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b2: {"b3": "qwe", "bf": 4, "c1": {"c2": "d", "cg": 4}}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b2: {"b3": "sdf", "bg": 5, "c1": {"c2": "e", "ch": 5}}})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testDeepFlatJson) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1,2,3]}, "d": 32})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1,2,3]})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe"}, "b4": {"b7": 2}}, "g": {"x": 1}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf"}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+    ASSIGN_OR_ABORT(auto b3_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2.b3", 0));
+    ASSIGN_OR_ABORT(auto b4_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4", 0));
+    ASSIGN_OR_ABORT(auto b5_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4.b5", 0));
+
+    b4_path->children().emplace_back(std::move(b5_path));
+    b2_path->children().emplace_back(std::move(b3_path));
+    b_path->children().emplace_back(std::move(b4_path));
+    b_path->children().emplace_back(std::move(b2_path));
+    root_path->children().emplace_back(std::move(b_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(4, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(3).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc"})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg"})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz"})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe"})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "sdf"})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperFlatJson) {
+    config::json_flat_null_factor = 0.4;
+    config::json_flat_sparsity_factor = 0.5;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+    ASSIGN_OR_ABORT(auto b3_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2.b3", 0));
+    ASSIGN_OR_ABORT(auto b4_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4", 0));
+    ASSIGN_OR_ABORT(auto b5_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b4.b5", 0));
+    ASSIGN_OR_ABORT(auto a_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto ff_path, ColumnAccessPath::create(TAccessPathType::FIELD, "ff", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "ff.f1", 0));
+    ASSIGN_OR_ABORT(auto gg_path, ColumnAccessPath::create(TAccessPathType::FIELD, "gg", 0));
+    ASSIGN_OR_ABORT(auto g1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "gg.g1", 0));
+    b4_path->children().emplace_back(std::move(b5_path));
+    b2_path->children().emplace_back(std::move(b3_path));
+    b_path->children().emplace_back(std::move(b4_path));
+    b_path->children().emplace_back(std::move(b2_path));
+    ff_path->children().emplace_back(std::move(f1_path));
+    gg_path->children().emplace_back(std::move(g1_path));
+    root_path->children().emplace_back(std::move(b_path));
+    root_path->children().emplace_back(std::move(a_path));
+    root_path->children().emplace_back(std::move(ff_path));
+    root_path->children().emplace_back(std::move(gg_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(7, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("ff.f1", writer_opts.meta->children_columns(4).name());
+    EXPECT_EQ("gg", writer_opts.meta->children_columns(5).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(6).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc", a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg", a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz", a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe", a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "sdf", a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeRemainJson) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"({"a": 1, "b": 21, "c": 31})"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse(R"({"a": 2, "b": 22, "d": 32})"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse(R"({"a": 3, "b": 23, "e": [1,2,3]})"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse(R"({"a": 4, "b": 24, "g": {"x": 1}})"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse(R"({"a": 5, "b": 25})"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({"a": 1, "b": 21, "c": 31})", read_col->debug_item(0));
+    EXPECT_EQ(R"({"a": 2, "b": 22, "d": 32})", read_col->debug_item(1));
+    EXPECT_EQ(R"({"a": 3, "b": 23, "e": [1, 2, 3]})", read_col->debug_item(2));
+    EXPECT_EQ(R"({"a": 4, "b": 24, "g": {"x": 1}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({"a": 5, "b": 25})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainJson) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"({"a": 1, "b": 21, "c": 31})"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse(R"({"a": 2, "b": 22, "d": 32})"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse(R"({"a": 3, "b": 23, "e": [1,2,3]})"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse(R"({"a": 4, "b": 24, "g": {"x": 1}})"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse(R"({"a": 5, "b": 25})"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ("{a: 1, c: 31}", read_col->debug_item(0));
+    EXPECT_EQ("{a: 2, c: NULL}", read_col->debug_item(1));
+    EXPECT_EQ("{a: 3, c: NULL}", read_col->debug_item(2));
+    EXPECT_EQ("{a: 4, c: NULL}", read_col->debug_item(3));
+    EXPECT_EQ("{a: 5, c: NULL}", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainJson2) {
+    config::json_flat_null_factor = 0.4;
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+
+    b_path->children().emplace_back(std::move(b2_path));
+    root_path->children().emplace_back(std::move(b_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b2: {"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b2: {"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b2: {"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b2: {"b3": "qwe", "bf": 4, "c1": {"c2": "d", "cg": 4}}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b2: {"b3": "sdf", "bg": 5, "c1": {"c2": "e", "ch": 5}}})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testDeepJson) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1,2,3]}, "d": 32})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1,2,3]})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe"}, "b4": {"b7": 2}}, "g": {"x": 1}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf"}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc"})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg"})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz"})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe"})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "sdf"})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperJson) {
+    config::json_flat_null_factor = 0.4;
+    config::json_flat_sparsity_factor = 0.5;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc", a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg", a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz", a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe", a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "sdf", a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeJson) {
+    config::json_flat_null_factor = 0.4;
+    config::json_flat_sparsity_factor = 0.5;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'abc', a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'efg', a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: 'xyz', a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'qwe', a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'sdf', a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson) {
+    config::json_flat_null_factor = 0.4;
+    config::json_flat_sparsity_factor = 0.5;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b2");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '1', ff.f1: 985, gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '2', ff.f1: 984, gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2: NULL, a: '3', ff.f1: 983, gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '4', ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '5', ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson2) {
+    config::json_flat_null_factor = 0.4;
+    config::json_flat_sparsity_factor = 0.5;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}', a: '1', ff.f1: 985, gg.g1: NULL})",
+            read_col->debug_item(0));
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}', a: '2', ff.f1: 984, gg.g1: NULL})",
+            read_col->debug_item(1));
+    EXPECT_EQ(
+            R"({b.b4.b5: 1, b.b2: '{"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}', a: '3', ff.f1: 983, gg.g1: NULL})",
+            read_col->debug_item(2));
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "qwe", "bf": 4, "c1": {"c2": "d", "cg": 4}}', a: '4', ff.f1: NULL, gg.g1: NULL})",
+            read_col->debug_item(3));
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "sdf", "bg": 5, "c1": {"c2": "e", "ch": 5}}', a: '5', ff.f1: NULL, gg.g1: NULL})",
+            read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeRemainNullFlatJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+    // clang-format off
+    std::vector<std::string> jsons = {
+        R"({"a": 1, "b": 21, "c": 31})",
+        R"({"a": 2, "b": 22, "d": 32})",
+        R"({"a": 3, "b": 23, "e": [1,2,3]})",
+        R"({"a": 4, "b": 24, "g": {"x": 1}})",
+        R"(NULL)"
+    };
+    // clang-format on
+    auto write_col = create_json(jsons, true);
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(4, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("nulls", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(3).name());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({"a": 1, "b": 21, "c": 31})", read_col->debug_item(0));
+    EXPECT_EQ(R"({"a": 2, "b": 22, "d": 32})", read_col->debug_item(1));
+    EXPECT_EQ(R"({"a": 3, "b": 23, "e": [1, 2, 3]})", read_col->debug_item(2));
+    EXPECT_EQ(R"({"a": 4, "b": 24, "g": {"x": 1}})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeRemainNullFlatJson1) {
+    config::json_flat_null_factor = 0;
+    config::json_flat_sparsity_factor = 0.4;
+    // clang-format off
+    std::vector<std::string> jsons = {
+        R"({"a": 1, "b": 21, "c": 31})",
+        R"({"a": 2, "b": 22, "d": 32})",
+        R"({"a": 3, "b": 23, "e": [1,2,3]})",
+        R"({})",
+        R"(NULL)"
+    };
+    // clang-format on
+    auto write_col = create_json(jsons, true);
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({"a": 1, "b": 21, "c": 31})", read_col->debug_item(0));
+    EXPECT_EQ(R"({"a": 2, "b": 22, "d": 32})", read_col->debug_item(1));
+    EXPECT_EQ(R"({"a": 3, "b": 23, "e": [1, 2, 3]})", read_col->debug_item(2));
+    EXPECT_EQ(R"({})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeRemainNullFlatJson2) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> jsons = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1, 2, 3]}, "d": 32})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1, 2, 3]})", R"(NULL)",
+            R"({"a": 5, "b": {}})"};
+    auto write_col = create_json(jsons, true);
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(5, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("nulls", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(4).name());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+
+    for (size_t i = 0; i < jsons.size(); i++) {
+        EXPECT_EQ(jsons[i], read_col->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullFlatJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    // clang-format off
+    std::vector<std::string> jsons = {
+        R"({"a": 1, "b": 21, "c": 31})",
+        R"({"a": 2, "b": 22, "d": 32})",
+        R"({"a": 3, "b": 23, "e": [1,2,3]})",
+        R"({"a": 4, "b": 24, "g": {"x": 1}})",
+        R"({})"
+    };
+    // clang-format on
+    ColumnPtr write_col = create_json(jsons, true);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+
+    EXPECT_EQ(4, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("nulls", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(3).name());
+
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ("{a: 1, c: 31}", read_col->debug_item(0));
+    EXPECT_EQ("{a: 2, c: NULL}", read_col->debug_item(1));
+    EXPECT_EQ("{a: 3, c: NULL}", read_col->debug_item(2));
+    EXPECT_EQ("{a: 4, c: NULL}", read_col->debug_item(3));
+    EXPECT_EQ("{a: NULL, c: NULL}", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullFlatJson2) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1, 2, 3]}, "d": 32})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1, 2, 3]})", R"(NULL)", R"(NULL)"};
+    ColumnPtr write_col = create_json(json, true);
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(5, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("nulls", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(4).name());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    for (size_t i = 0; i < json.size(); i++) {
+        EXPECT_EQ(json[i], read_col->debug_item(i));
+    }
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullFlatJson3) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+    ColumnPtr write_col = create_json(json, true);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+
+    b_path->children().emplace_back(std::move(b2_path));
+    root_path->children().emplace_back(std::move(b_path));
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(6, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("nulls", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(4).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(5).name());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b2: {"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b2: {"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b2: {"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b2: {"b3": "qwe", "bf": 4, "c1": {"c2": "d", "cg": 4}}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b2: {"b3": "sdf", "bg": 5, "c1": {"c2": "e", "ch": 5}}})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testDeepNullFlatJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+                                     R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1,2,3]}, "d": 32})",
+                                     R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1,2,3]})",
+                                     R"(NULL)", R"({"a": 5, "b": {"b1": 26, "b2": {}, "b4": 23}})"};
+
+    ColumnPtr write_col = create_json(json, true);
+    ColumnAccessPath root_path;
+    ColumnAccessPath::insert_json_path(&root_path, LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root_path, LogicalType::TYPE_JSON, "b.b2.b3");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root_path);
+
+    EXPECT_EQ(5, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("nulls", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(4).name());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc"})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg"})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz"})", read_col->debug_item(2));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: NULL})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperNullFlatJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"(NULL)"};
+    ColumnPtr write_col = create_json(json, true);
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    EXPECT_EQ(8, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    int index = 0;
+    EXPECT_EQ("nulls", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("ff.f1", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("gg", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(index++).name());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}', a: '1', ff.f1: 985, gg.g1: NULL})",
+            read_col->debug_item(0));
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}', a: '2', ff.f1: 984, gg.g1: NULL})",
+            read_col->debug_item(1));
+    EXPECT_EQ(
+            R"({b.b4.b5: 1, b.b2: '{"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}', a: '3', ff.f1: 983, gg.g1: NULL})",
+            read_col->debug_item(2));
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "qwe", "bf": 4, "c1": {"c2": "d", "cg": 4}}', a: '4', ff.f1: NULL, gg.g1: NULL})",
+            read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeRemainNullJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    // clang-format off
+    std::vector<std::string> jsons = {
+            R"({"a": 1, "b": 21, "c": 31})",
+            R"({"a": 2, "b": 22, "d": 32})",
+            R"({"a": 3, "b": 23, "e": [1,2,3]})",
+            R"({})",
+            R"(NULL)"
+    };
+    // clang-format on
+    ColumnPtr write_col = create_json(jsons, true);
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({"a": 1, "b": 21, "c": 31})", read_col->debug_item(0));
+    EXPECT_EQ(R"({"a": 2, "b": 22, "d": 32})", read_col->debug_item(1));
+    EXPECT_EQ(R"({"a": 3, "b": 23, "e": [1, 2, 3]})", read_col->debug_item(2));
+    EXPECT_EQ(R"({})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    // clang-format off
+    std::vector<std::string> jsons = {
+            R"({"a": 1, "b": 21, "c": 31})",
+            R"({"a": 2, "b": 22, "d": 32})",
+            R"({"a": 3, "b": 23, "e": [1,2,3]})",
+            R"({})",
+            R"(NULL)"
+    };
+    // clang-format on
+    ColumnPtr write_col = create_json(jsons, true);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "c", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ("{a: 1, c: 31}", read_col->debug_item(0));
+    EXPECT_EQ("{a: 2, c: NULL}", read_col->debug_item(1));
+    EXPECT_EQ("{a: 3, c: NULL}", read_col->debug_item(2));
+    EXPECT_EQ("{a: NULL, c: NULL}", read_col->debug_item(3));
+    EXPECT_EQ("NULL", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainNullJson2) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({})", R"(NULL)"};
+
+    ColumnPtr write_col = create_json(json, true);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b.b2", 0));
+
+    b_path->children().emplace_back(std::move(b2_path));
+    root_path->children().emplace_back(std::move(b_path));
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b2: {"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b2: {"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b2: {"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b2: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testDeepNullJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+                                     R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1,2,3]}, "d": 32})",
+                                     R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1,2,3]})",
+                                     R"({"a": 4, "b": {}, "g": {"x": 1}})", R"(NULL)"};
+
+    ColumnPtr write_col = create_json(json, true);
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc"})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg"})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz"})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperNullJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"(NULL)"};
+
+    auto write_col = create_json(json, true);
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc", a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg", a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz", a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe", a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperNullJson2) {
+    config::json_flat_null_factor = 0;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"(NULL)"};
+
+    auto write_col = create_json(json, true);
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc", a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg", a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz", a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe", a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeNullJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {}, "b4": {"b7": 2}}})", R"(NULL)"};
+
+    ColumnPtr write_col = create_json(json, true);
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "gg.g1");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'abc', a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'efg', a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: 'xyz', a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: NULL, a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperCastTypeNullJson) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {}})", R"(NULL)"};
+    ColumnPtr write_col = create_json(json, true);
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "b.b2");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '1', ff.f1: 985, gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '2', ff.f1: 984, gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2: NULL, a: '3', ff.f1: 983, gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '4', ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperCastTypeNullJson2) {
+    config::json_flat_null_factor = 1;
+    config::json_flat_sparsity_factor = 0.4;
+
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {}})", R"(NULL)"};
+    ColumnPtr write_col = create_json(json, true);
+
+    ColumnAccessPath root;
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "b.b2");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(&root, LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = write_col->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, &root);
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}', a: '1', ff.f1: 985, gg.g1: NULL})",
+            read_col->debug_item(0));
+    EXPECT_EQ(
+            R"({b.b4.b5: NULL, b.b2: '{"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}', a: '2', ff.f1: 984, gg.g1: NULL})",
+            read_col->debug_item(1));
+    EXPECT_EQ(
+            R"({b.b4.b5: 1, b.b2: '{"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}', a: '3', ff.f1: 983, gg.g1: NULL})",
+            read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '4', ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", read_col->debug_item(4));
 }
 
 } // namespace starrocks

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -1,0 +1,272 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/json_flattener.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+#include <velocypack/vpack.h>
+
+#include <string>
+#include <vector>
+
+#include "column/const_column.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "exprs/mock_vectorized_expr.h"
+#include "gtest/gtest-param-test.h"
+#include "gutil/casts.h"
+#include "gutil/strings/strip.h"
+#include "testutil/assert.h"
+#include "types/logical_type.h"
+#include "util/json.h"
+#include "util/json_flattener.h"
+
+namespace starrocks {
+
+class JsonPathDeriverTest
+        : public ::testing::TestWithParam<
+                  std::tuple<std::string, std::string, bool, std::vector<std::string>, std::vector<LogicalType>>> {};
+
+TEST_P(JsonPathDeriverTest, json_path_deriver_test) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    auto json_column = JsonColumn::create();
+    ColumnBuilder<TYPE_VARCHAR> builder(1);
+
+    std::string param_json1 = std::get<0>(GetParam());
+    std::string param_json2 = std::get<1>(GetParam());
+    bool param_has_remain = std::get<2>(GetParam());
+    std::vector<std::string> param_flat_path = std::get<3>(GetParam());
+    std::vector<LogicalType> param_flat_type = std::get<4>(GetParam());
+
+    auto json = JsonValue::parse(param_json1);
+    ASSERT_TRUE(json.ok());
+    json_column->append(&*json);
+
+    auto json2 = JsonValue::parse(param_json2);
+    ASSERT_TRUE(json2.ok());
+    json_column->append(&*json2);
+
+    std::vector<const Column*> columns{json_column.get()};
+    JsonPathDeriver jf;
+    jf.derived(columns);
+    std::vector<std::string> path = jf.flat_paths();
+    std::vector<LogicalType> type = jf.flat_types();
+
+    ASSERT_EQ(param_has_remain, jf.has_remain_json());
+    ASSERT_EQ(param_flat_path, path);
+    ASSERT_EQ(param_flat_type, type);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(JsonPathDeriverCases, JsonPathDeriverTest,
+    ::testing::Values(
+        // NORMAL
+        std::make_tuple(R"( {"k1": 1, "k2": 2} )", R"( {"k1": 3, "k2": 4} )", false, std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT}),
+        std::make_tuple(R"( {"k1": 1, "k2": 2} )", R"( {"k1": 3} )", true, std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_BIGINT}),
+        std::make_tuple(R"( {"k1": 1, "k2": 2} )", R"( {"k1": 3, "k3": 4} )", true, std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_BIGINT}),
+
+        // EMPTY
+        std::make_tuple(R"( {"k1": 1, "k2": {}} )", R"( {"k1": 3, "k2": {}} )", true, std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_BIGINT}),
+        std::make_tuple(R"( {} )", R"( {"k1": 3} )", true, std::vector<std::string> {}, std::vector<LogicalType> {}),
+
+        // DEEP
+        std::make_tuple(R"( {"k2": {"j1": 1, "j2": 2}} )", R"( {"k2": {"j1": 3, "j2": 4}} )", false, std::vector<std::string> {"k2.j1", "k2.j2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT}),
+        std::make_tuple(R"( {"k2": {"j1": 1, "j2": 2}} )", R"( {"k2": {"j1": 3, "j3": 4}} )", true, std::vector<std::string> {"k2.j1"}, std::vector<LogicalType> {TYPE_BIGINT}),
+        std::make_tuple(R"( {"k2": {"j1": 1, "j2": 2}} )", R"( {"k2": {"j1": 3, "j2": {"p1": "abc"}}} )", true, std::vector<std::string> {"k2.j1"}, std::vector<LogicalType> {TYPE_BIGINT}),
+        std::make_tuple(R"( {"k2": {"j1": 1, "j2": {"p1": [1,2,3,4]}}} )", R"( {"k2": {"j1": 3, "j2": {"p1": "abc"}}} )", false, std::vector<std::string> {"k2.j1", "k2.j2.p1"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_JSON})
+));
+// clang-format on
+
+class JsonFlattenerTest : public testing::Test {
+public:
+    JsonFlattenerTest() = default;
+
+    ~JsonFlattenerTest() override = default;
+
+protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+    std::vector<ColumnPtr> test_json(const std::vector<std::string>& inputs, const std::vector<std::string>& paths,
+                                     const std::vector<LogicalType>& types, bool has_remain) {
+        ColumnPtr input = JsonColumn::create();
+        JsonColumn* json_input = down_cast<JsonColumn*>(input.get());
+        for (const auto& json : inputs) {
+            ASSIGN_OR_ABORT(auto json_value, JsonValue::parse(json));
+            json_input->append(&json_value);
+        }
+
+        JsonFlattener flattener(paths, types, has_remain);
+        flattener.flatten(json_input);
+
+        auto result = flattener.mutable_result();
+        if (has_remain) {
+            for (size_t i = 0; i < result.size() - 1; i++) {
+                auto& c = result[i];
+                EXPECT_TRUE(c->is_nullable());
+                auto* nullable = down_cast<NullableColumn*>(c.get());
+                EXPECT_EQ(input->size(), nullable->size());
+            }
+            EXPECT_FALSE(result.back()->is_nullable());
+            EXPECT_EQ(input->size(), result.back()->size());
+            EXPECT_EQ(paths.size() + 1, result.size());
+        } else {
+            for (auto& c : result) {
+                EXPECT_TRUE(c->is_nullable());
+                auto* nullable = down_cast<NullableColumn*>(c.get());
+                EXPECT_EQ(input->size(), nullable->size());
+            }
+            EXPECT_EQ(paths.size(), result.size());
+        }
+
+        return result;
+    }
+
+    std::vector<ColumnPtr> test_null_json(const std::vector<std::string>& inputs, const std::vector<std::string>& paths,
+                                          const std::vector<LogicalType>& types, bool has_remain) {
+        ColumnPtr input = JsonColumn::create();
+        NullColumnPtr nulls = NullColumn::create();
+        JsonColumn* json_input = down_cast<JsonColumn*>(input.get());
+        for (const auto& json : inputs) {
+            if (json == "NULL") {
+                json_input->append_default();
+                nulls->append(1);
+            } else {
+                ASSIGN_OR_ABORT(auto json_value, JsonValue::parse(json));
+                json_input->append(&json_value);
+                nulls->append(0);
+            }
+        }
+
+        auto nullable_input = NullableColumn::create(input, nulls);
+        JsonFlattener flattener(paths, types, has_remain);
+        flattener.flatten(nullable_input.get());
+
+        auto result = flattener.mutable_result();
+        if (has_remain) {
+            for (size_t i = 0; i < result.size() - 1; i++) {
+                auto& c = result[i];
+                EXPECT_TRUE(c->is_nullable());
+                auto* nullable = down_cast<NullableColumn*>(c.get());
+                EXPECT_EQ(input->size(), nullable->size());
+            }
+            EXPECT_FALSE(result.back()->is_nullable());
+            EXPECT_EQ(input->size(), result.back()->size());
+            EXPECT_EQ(paths.size() + 1, result.size());
+        } else {
+            for (auto& c : result) {
+                EXPECT_TRUE(c->is_nullable());
+                auto* nullable = down_cast<NullableColumn*>(c.get());
+                EXPECT_EQ(input->size(), nullable->size());
+            }
+            EXPECT_EQ(paths.size(), result.size());
+        }
+        return result;
+    }
+};
+
+TEST_F(JsonFlattenerTest, testNormalJson) {
+    std::vector<std::string> json = {R"( {"k1": 1, "k2": 2} )", R"( {"k1": 3, "k2": 4} )"};
+
+    std::vector<std::string> paths = {"k1", "k2"};
+    std::vector<LogicalType> types = {TYPE_BIGINT, TYPE_BIGINT};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ("1", result[0]->debug_item(0));
+    EXPECT_EQ("4", result[1]->debug_item(1));
+}
+
+TEST_F(JsonFlattenerTest, testCastNormalJson) {
+    std::vector<std::string> json = {R"( {"k1": 1, "k2": 2} )", R"( {"k1": 3, "k2": [1,2,3,4]} )"};
+
+    std::vector<std::string> paths = {"k1", "k2"};
+    std::vector<LogicalType> types = {TYPE_BIGINT, TYPE_JSON};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ("1", result[0]->debug_item(0));
+    EXPECT_EQ("[1, 2, 3, 4]", result[1]->debug_item(1));
+}
+
+TEST_F(JsonFlattenerTest, testCastJson) {
+    std::vector<std::string> json = {R"( {"k1": 1, "k2": 2} )", R"( {"k1": 3, "k2": [1,2,3,4]} )"};
+
+    std::vector<std::string> paths = {"k1", "k2"};
+    std::vector<LogicalType> types = {TYPE_BIGINT, TYPE_BIGINT};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ("1", result[0]->debug_item(0));
+    EXPECT_EQ("NULL", result[1]->debug_item(1));
+}
+
+TEST_F(JsonFlattenerTest, testDeepJson) {
+    std::vector<std::string> json = {R"( {"k1": 1, "k2": 2} )",
+                                     R"( {"k1": {"c1": 123}, "k2": {"j1": "abc", "j2": 123}} )"};
+
+    std::vector<std::string> paths = {"k1", "k2.j1"};
+    std::vector<LogicalType> types = {TYPE_BIGINT, TYPE_VARCHAR};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ("1", result[0]->debug_item(0));
+    EXPECT_EQ("NULL", result[1]->debug_item(0));
+    EXPECT_EQ("NULL", result[0]->debug_item(1));
+    EXPECT_EQ("'abc'", result[1]->debug_item(1));
+}
+
+TEST_F(JsonFlattenerTest, testDeepJson2) {
+    std::vector<std::string> json = {R"( {"k1": 1, "k2": 2} )",
+                                     R"( {"k1": {"c1": 123}, "k2": {"j1": "abc", "j2": 123}} )"};
+
+    std::vector<std::string> paths = {"k1", "k2.j1", "k2.j2"};
+    std::vector<LogicalType> types = {TYPE_JSON, TYPE_JSON, TYPE_BIGINT};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ("1", result[0]->debug_item(0));
+    EXPECT_EQ(R"({"c1": 123})", result[0]->debug_item(1));
+    EXPECT_EQ("NULL", result[1]->debug_item(0));
+    EXPECT_EQ("\"abc\"", result[1]->debug_item(1));
+    EXPECT_EQ("NULL", result[2]->debug_item(0));
+    EXPECT_EQ("123", result[2]->debug_item(1));
+}
+
+TEST_F(JsonFlattenerTest, testDeepJson3) {
+    std::vector<std::string> json = {R"( {"k1": 1, "k2": 2} )",
+                                     R"( {"k1": {"c1": 123}, "k2": {"j1": "abc", "j2": 123}} )"};
+
+    std::vector<std::string> paths = {"k1", "k2.j1", "k2"};
+    std::vector<LogicalType> types = {TYPE_JSON, TYPE_JSON, TYPE_JSON};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ("1", result[0]->debug_item(0));
+    EXPECT_EQ(R"({"c1": 123})", result[0]->debug_item(1));
+    EXPECT_EQ("NULL", result[1]->debug_item(0));
+    EXPECT_EQ("\"abc\"", result[1]->debug_item(1));
+    EXPECT_EQ("NULL", result[2]->debug_item(0));
+    EXPECT_EQ("NULL", result[2]->debug_item(1));
+}
+
+TEST_F(JsonFlattenerTest, testMiddleJson) {
+    std::vector<std::string> json = {R"( {"k1": {"c1": {"d1":  123 }}, "k2": {"j1": "def", "j2": {"g1": [1,2,3]}}} )",
+                                     R"( {"k1": {"c1": {"d1": "abc"}}, "k2": {"j1": "abc", "j2": {"g1": 123}}} )"};
+
+    std::vector<std::string> paths = {"k1.c1", "k2.j2"};
+    std::vector<LogicalType> types = {TYPE_JSON, TYPE_JSON};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ(R"({"d1": 123})", result[0]->debug_item(0));
+    EXPECT_EQ(R"({"d1": "abc"})", result[0]->debug_item(1));
+    EXPECT_EQ(R"({"g1": [1, 2, 3]})", result[1]->debug_item(0));
+    EXPECT_EQ(R"({"g1": 123})", result[1]->debug_item(1));
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -359,6 +359,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_DEBUG_ALIVE_BACKEND_NUMBER = "cbo_debug_alive_backend_number";
     public static final String CBO_PRUNE_SUBFIELD = "cbo_prune_subfield";
     public static final String CBO_PRUNE_JSON_SUBFIELD = "cbo_prune_json_subfield";
+    public static final String CBO_PRUNE_JSON_SUBFIELD_DEPTH = "cbo_prune_json_subfield_depth";
     public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL =
             "enable_rewrite_groupingsets_to_union_all";
 
@@ -1043,6 +1044,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD)
     private boolean cboPruneJsonSubfield = true;
 
+    @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD_DEPTH, flag = VariableMgr.INVISIBLE)
+    private int cboPruneJsonSubfieldDepth = 20;
+
     @VarAttr(name = ENABLE_SQL_DIGEST, flag = VariableMgr.INVISIBLE)
     private boolean enableSQLDigest = false;
 
@@ -1511,6 +1515,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
+
+    public int getCboPruneJsonSubfieldDepth() {
+        return cboPruneJsonSubfieldDepth;
+    }
+
+    public void setCboPruneJsonSubfieldDepth(int cboPruneJsonSubfieldDepth) {
+        this.cboPruneJsonSubfieldDepth = cboPruneJsonSubfieldDepth;
+    }
 
     public boolean isEnableExecutionOnly() {
         return enableExecutionOnly;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -41,7 +42,6 @@ import java.util.stream.Collectors;
  * normalize expression to ColumnAccessPath
  */
 public class SubfieldAccessPathNormalizer {
-    public static int JSON_FLATTEN_DEPTH = 20;
     // simple json patten, same as BE's JsonPathPiece, match: abc[1][2], group: (abc)([1][2])
     private static final Pattern JSON_ARRAY_PATTEN = Pattern.compile("^([\\w#.]+)((?:\\[[\\d:*]+])*)");
 
@@ -81,6 +81,7 @@ public class SubfieldAccessPathNormalizer {
         }
     }
 
+
     public ColumnAccessPath normalizePath(ColumnRefOperator root, String columnName) {
         List<AccessPath> paths = allAccessPaths.stream().filter(path -> path.root().equals(root))
                 .sorted((o1, o2) -> Integer.compare(o2.paths.size(), o1.paths.size()))
@@ -89,11 +90,7 @@ public class SubfieldAccessPathNormalizer {
         ColumnAccessPath rootPath = new ColumnAccessPath(TAccessPathType.ROOT, columnName, Type.INVALID);
         for (AccessPath accessPath : paths) {
             ColumnAccessPath parentPath = rootPath;
-            int depth = accessPath.paths.size();
-            if (accessPath.root.getType().isJsonType()) {
-                depth = Math.min(depth, JSON_FLATTEN_DEPTH);
-            }
-            for (int i = 0; i < depth; i++) {
+            for (int i = 0; i < accessPath.paths.size(); i++) {
                 if (parentPath.hasChildPath(accessPath.paths.get(i))) {
                     ColumnAccessPath childPath = parentPath.getChildPath(accessPath.paths.get(i));
                     TAccessPathType pathType = accessPath.pathTypes.get(i);
@@ -151,6 +148,12 @@ public class SubfieldAccessPathNormalizer {
     }
 
     private static class Collector extends ScalarOperatorVisitor<Optional<AccessPath>, List<Optional<AccessPath>>> {
+        private final int jsonFlattenDepth;
+
+        public Collector(int jsonDepth) {
+            this.jsonFlattenDepth = jsonDepth;
+        }
+
         @Override
         public Optional<AccessPath> visit(ScalarOperator scalarOperator,
                                           List<Optional<AccessPath>> childrenAccessPaths) {
@@ -238,7 +241,7 @@ public class SubfieldAccessPathNormalizer {
         //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
         //  a.b.c -> [a, b, c]
         // when meet some unsupported path, return null
-        public static boolean formatJsonPath(String path, List<String> result) {
+        public boolean formatJsonPath(String path, List<String> result) {
             path = StringUtils.trimToEmpty(path);
             if (StringUtils.isBlank(path) || StringUtils.contains(path, "..") || StringUtils.equals("$", path) ||
                     StringUtils.countMatches(path, "\"") % 2 != 0) {
@@ -253,7 +256,7 @@ public class SubfieldAccessPathNormalizer {
             if (tokens.length < 1) {
                 return false;
             }
-            int size = JSON_FLATTEN_DEPTH;
+            int size = jsonFlattenDepth;
             int i = 0;
             if (tokens[0].equals("$")) {
                 size++;
@@ -308,7 +311,11 @@ public class SubfieldAccessPathNormalizer {
     }
 
     public void collect(List<ScalarOperator> scalarOperators) {
-        Collector collector = new Collector();
+        int jsonDepth = 20;
+        if (null != ConnectContext.get() && null != ConnectContext.get().getSessionVariable()) {
+            jsonDepth = ConnectContext.get().getSessionVariable().getCboPruneJsonSubfieldDepth();
+        }
+        Collector collector = new Collector(jsonDepth);
         List<Optional<AccessPath>> paths =
                 scalarOperators.stream().map(op -> collector.process(op, allAccessPaths)).collect(Collectors.toList());
         paths.forEach(p -> p.ifPresent(allAccessPaths::add));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -41,8 +41,7 @@ import java.util.stream.Collectors;
  * normalize expression to ColumnAccessPath
  */
 public class SubfieldAccessPathNormalizer {
-    // todo: BE only support one-layer json path, supported more layer in future
-    public static int JSON_FLATTEN_DEPTH = 1;
+    public static int JSON_FLATTEN_DEPTH = 20;
     // simple json patten, same as BE's JsonPathPiece, match: abc[1][2], group: (abc)([1][2])
     private static final Pattern JSON_ARRAY_PATTEN = Pattern.compile("^([\\w#.]+)((?:\\[[\\d:*]+])*)");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1133,4 +1133,28 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "ColumnAccessPath: [/a1/OFFSET]");
         assertContains(plan, "1:Project");
     }
+
+    @Test
+    public void testMultiLevelJson() throws Exception {
+        SubfieldAccessPathNormalizer.JSON_FLATTEN_DEPTH = 20;
+        String sql = "select " +
+                "get_json_int(j1, '$.a.b.c.d') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b/c/d(bigint(20))]");
+
+        sql = "select " +
+                "get_json_int(st1.j1, '$.a.b.c') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/st1/j1/a/b/c(bigint(20))]");
+
+        sql = "select " +
+                "get_json_int(ar1[1], '$.a.b.c'), " +
+                "get_json_int(mp1[1], '$.a.b.c') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/ar1/INDEX/a/b/c(bigint(20)), /mp1/INDEX/a/b/c(bigint(20))]");
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldAccessPathNormalizer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -114,7 +113,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
         connectContext.getSessionVariable().setCboCteReuse(true);
         connectContext.getSessionVariable().setCboCTERuseRatio(0);
-        SubfieldAccessPathNormalizer.JSON_FLATTEN_DEPTH = 2;
+        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(2);
     }
 
     @After
@@ -125,7 +124,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
         connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
-        SubfieldAccessPathNormalizer.JSON_FLATTEN_DEPTH = 1;
+        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(1);
     }
 
     @Test
@@ -1136,7 +1135,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
 
     @Test
     public void testMultiLevelJson() throws Exception {
-        SubfieldAccessPathNormalizer.JSON_FLATTEN_DEPTH = 20;
+        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(20);
         String sql = "select " +
                 "get_json_int(j1, '$.a.b.c.d') " +
                 "from js0;";

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -161,6 +161,10 @@ message JsonMetaPB {
     // Version 1: encode each JSON datum individually, as so called row-oriented format
     // Version 2(WIP): columnar encoding for JSON
     optional uint32 format_version = 1;
+
+    optional bool is_flat = 2;
+
+    optional bool has_remain = 3;
 }
 
 message ColumnMetaPB {


### PR DESCRIPTION
## Why I'm doing:
Before this PR, starrocks only support one-layer flat json, and will save origin data.
This PR is support multi-layer flat json, and doesn't save origin data.

## What I'm doing:
Will flat all leaf column in json column, the json meta will be:
![image](https://github.com/StarRocks/starrocks/assets/5609319/23d0c035-ceb5-43a3-9002-1349cac79d33)

the core file:
* `json_flattener.h`: to handle json flatten, json merge process...
* `json_column_iterator.h`: to handle read flat json, read whole json...
* `json_column_compactor.h`: to handle compaction flat json proces...
* `json_column_writer.h`: the logical is same as before

### Test result:
this pr for optimize load&data size
|  | Scalar Data | Json | Flat Json(Before PR) | FlatJson（This PR) |
| -- | -- | -- | -- | -- |
| time(s) | 373.069s | 687.961s | 1617.537s | 991.582s |
| Data Size | 58.828 GB | 152.616GB | 245.947 GB | 58.571 GB |
| compaction time | 4min30s | 35min20s | 46min51s | 23 min 30s |

because compaction task depend on `HeapMerge` or `MaskMerge`, we can't read flat json direct (may schema different), will merge all subfield to json to do compaction

### Write
* remove origin json data, only save flat json and remain data

flat json storage data&order:
* null data
* flat subfield data
* remain data

### Compaction (large different)
support multi mode compaction:

* read json and compaction to json (now)
* read json and compaction to flat json (now)
  * flatten json
* read flat json and compaction to flat json (can't use)
  * match type and path
  * cast flat json type to target
  * merge flat json to remain
  * extract flat json from remain 
* read flat json and compaction to json (can't use)
  * merge flat json to json

### Read (large different)
update read logical:

* support read from flat json
  * when read flat json
    * cast from remain json
    * extract from remain json or flat json
    * merge flat json and remain json, maybe need cast
    * when can't hit any flat json, we need return empty column 
  * when read whole json
    * merge all flat json 
* support read from json
  * when read flat json
    * dynamic flattern json 
  * when read json, return directly


## What type of PR is this:

core changes:
* refactor `JsonFlattern` class:
  * refactor `JsonFlattern`, split path deriver into `JsonPathDeriver`, split json flatten to `JsonFlattener`
  * add `JsonMerger`, for merge any flat json and remain to a json binary(vpack json)
    * support different mode:  
      * reset new root path: for read process, like flat json is `$.a.b`, `$.a.c`, but we read `$.a`, we need merge flat json and rebase the root to `$.a`
      * set exclude path: for compaction process, some json will be extract from remain, but some will be merge into remain, we need remove extract path from remain
  * support `HyperJsonTransfor`: for read&compaction, to split the merge task and flat task base on input json
* refactor `JsonColumnWriter`:
  * split write process to `JsonColumnWriter`, split compaction process to `JsonColumnCompactor`
  * support `FlatJsonColumnCompactor`  to handle compaction flat json to flat json
  * support `JsonColumnCompactor` to handle compaction flat json to json
* refactor `JsonColumnIterator`:
  * refactor `JsonFlatIterator` to handle read flat json
  * support `JsonMergeIterator` to handle read whole json 
  * `JsonDynamicIterator`: keep same
* update `SegmentWriteOptions` , add `is_compaction` to mark is compaction process
  * update OlapTable procees
  * update LakeTable process 
* FE update Json subfiled deriver limit

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
