### PR TITLE
[UT] [BugFix] Trigger to refresh related mvs when base tables has deleted rows

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/listener/GlobalLoadJobListenerBus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/GlobalLoadJobListenerBus.java
@@ -88,4 +88,16 @@ public class GlobalLoadJobListenerBus {
         }
         listeners.stream().forEach(listener -> listener.onStreamLoadTransactionFinish(transactionState));
     }
+
+    /**
+     * Do all callbacks after `delete` transaction is finished.
+     * @param db database of the target table
+     * @param table table of the target table
+     */
+    public void onDeleteJobTransactionFinish(Database db, Table table) {
+        if (db == null || table == null) {
+            return;
+        }
+        listeners.stream().forEach(listener -> listener.onDeleteJobTransactionFinish(db, table));
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobListener.java
@@ -50,4 +50,11 @@ public interface LoadJobListener {
      * @param table target table that has changed
      */
     void onInsertOverwriteJobCommitFinish(Database db, Table table);
+
+    /**
+     * Listener after `Delete` transaction is finished, which is only triggered without an error.
+     * @param db database of the target table
+     * @param table target table that has changed
+     */
+    void onDeleteJobTransactionFinish(Database db, Table table);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
@@ -160,4 +160,9 @@ public class LoadJobMVListener implements LoadJobListener {
         }
         return new ArrayList<>(tableCommitInfo.getIdToPartitionCommitInfo().values());
     }
+
+    @Override
+    public void onDeleteJobTransactionFinish(Database db, Table table) {
+        triggerToRefreshRelatedMVs(db, table);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
@@ -90,4 +90,9 @@ public class LoadJobStatsListener implements LoadJobListener {
             LOG.warn("refresh mv after publish version failed:", DebugUtil.getStackTrace(t));
         }
     }
+
+    @Override
+    public void onDeleteJobTransactionFinish(Database db, Table table) {
+        // do nothing
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -98,6 +98,7 @@ import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.planner.PartitionColumnFilter;
 import com.starrocks.planner.RangePartitionPruner;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
 import com.starrocks.qe.QueryStateException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -215,6 +216,13 @@ public class DeleteMgr implements Writable, MemoryTrackable {
             }
 
             deleteJob.run(stmt, db, table, partitions);
+        } catch (QueryStateException e) {
+            // If delete success, it will throw QueryStateException(QueryState.MysqlStateType.OK, sb.toString()).
+            if (e.getQueryState().getStateType() == QueryState.MysqlStateType.OK) {
+                // trigger after a delete job finished
+                GlobalStateMgr.getCurrentState().getOperationListenerBus().onDeleteJobTransactionFinish(db, table);
+            }
+            throw e;
         } finally {
             if (!FeConstants.runningUnitTest) {
                 clearJob(deleteJob);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -930,10 +930,10 @@ public class StarRocksAssert {
         TaskRunManager taskRunManager = tm.getTaskRunManager();
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         TaskRun taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
-        int maxTimes = 120;
+        int maxTimes = 1200;
         int count = 0;
         while (taskRun != null && count < maxTimes) {
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(300L);
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(500L);
             taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
             count += 1;
         }
@@ -968,8 +968,6 @@ public class StarRocksAssert {
         Assert.assertTrue(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;
         getCtx().executeSql(sql);
-        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
-
         waitRefreshFinished(mv.getId());
         return this;
     }

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
@@ -1,4 +1,10 @@
 -- name: test_mv_refresh_list_partitions_with_nullable
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
 CREATE TABLE t3 (
       id BIGINT,
       province VARCHAR(64),
@@ -70,7 +76,7 @@ function: check_hit_materialized_view("select id, dt, province, age from t3 wher
 -- result:
 None
 -- !result
-select id, dt, province, age from t3 where id > 1 order by 1, 2;
+select id, dt, province, age from t3 where id > 1 order by 1, 2, 3, 4;
 -- result:
 2	2024-01-01	guangdong	20
 3	2024-01-02	guangdong	20
@@ -83,7 +89,7 @@ function: check_hit_materialized_view("select id, dt, province, age from t3 wher
 -- result:
 None
 -- !result
-select id, dt, province, age from t3 where id > 1 order by 1, 2;
+select id, dt, province, age from t3 where id > 1 order by 1, 2, 3, 4;
 -- result:
 2	2024-01-01	beijing	20
 2	2024-01-01	guangdong	20

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_delete
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_delete
@@ -1,0 +1,89 @@
+-- name: test_mv_refresh_with_delete
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE (k1) (
+START ("2020-10-01") END ("2022-03-04") EVERY (INTERVAL 15 day)
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+-- result:
+-- !result
+CREATE TABLE `t2` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO t1 VALUES ("2020-11-10",1,1);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ("2020-11-10",2,2);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY k3
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH ASYNC
+PROPERTIES ("partition_refresh_number"="-1")
+AS SELECT t2.k1 as k1, t2.k2 as k2, t1.k1 as k3, t1.k2 as k4
+FROM t1 join t2 on t1.k1=t2.k1;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	2	2020-11-10	1
+-- !result
+INSERT INTO t2 VALUES ("2020-11-10",3, 3);
+-- result:
+-- !result
+INSERT INTO t1 VALUES ("2020-11-10",4,4);
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	2	2020-11-10	1
+2020-11-10	2	2020-11-10	4
+2020-11-10	3	2020-11-10	1
+2020-11-10	3	2020-11-10	4
+-- !result
+DELETE FROM t2 WHERE k2=2;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+select * from test_mv1 order by k1, k2;
+-- result:
+2020-11-10	3	2020-11-10	1
+2020-11-10	3	2020-11-10	4
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
@@ -1,5 +1,8 @@
 -- name: test_mv_refresh_list_partitions_with_nullable
 
+create database db_${uuid0};
+use db_${uuid0};
+
 CREATE TABLE t3 (
       id BIGINT,
       province VARCHAR(64),
@@ -54,10 +57,10 @@ as select id, dt, province, age from t3 where id > 1;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 function: check_hit_materialized_view("select id, dt, province, age from t3 where id > 1;", "test_mv1")
-select id, dt, province, age from t3 where id > 1 order by 1, 2;
+select id, dt, province, age from t3 where id > 1 order by 1, 2, 3, 4;
 INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
 function: check_hit_materialized_view("select id, dt, province, age from t3 where id > 1;", "test_mv1")
-select id, dt, province, age from t3 where id > 1 order by 1, 2;
+select id, dt, province, age from t3 where id > 1 order by 1, 2, 3, 4;
 
 drop materialized view test_mv1;
 

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_delete
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_delete
@@ -1,0 +1,47 @@
+-- name: test_mv_refresh_with_delete
+
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE `t1` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE (k1) (
+START ("2020-10-01") END ("2022-03-04") EVERY (INTERVAL 15 day)
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+CREATE TABLE `t2` (
+    `k1` date,
+    `k2` int,
+    `k3` int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+
+INSERT INTO t1 VALUES ("2020-11-10",1,1);
+INSERT INTO t2 VALUES ("2020-11-10",2,2);
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY k3
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH ASYNC
+PROPERTIES ("partition_refresh_number"="-1")
+AS SELECT t2.k1 as k1, t2.k2 as k2, t1.k1 as k3, t1.k2 as k4
+FROM t1 join t2 on t1.k1=t2.k1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+select * from test_mv1 order by k1, k2;
+
+INSERT INTO t2 VALUES ("2020-11-10",3, 3);
+INSERT INTO t1 VALUES ("2020-11-10",4,4);
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+select * from test_mv1 order by k1, k2;
+
+DELETE FROM t2 WHERE k2=2;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+select * from test_mv1 order by k1, k2;
+
+drop table t1;
+drop table t2;
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Trigger to refresh related mvs when base tables has deleted rows
- Fix some unstable tests.

https://github.com/StarRocks/StarRocksTest/issues/8062



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
