### PR TITLE
[BugFix] Fixup NPE of AuditEncryptionChecker.needEncrypt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.ast.SubqueryRelation;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Responsible for determining whether the corresponding statement
@@ -62,7 +63,7 @@ public class AuditEncryptionChecker implements AstVisitor<Boolean, Void> {
         if (statement == null) {
             return false;
         }
-        return getInstance().visit(statement);
+        return Optional.ofNullable(getInstance().visit(statement)).orElse(false);
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
Some ParseNode has default visit method just return a null Boolean, so AuditEncryptionChecker.needEncrypt throw NPE when it tries to convert null which returned by  default visit method to boolean 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
