### PR TITLE
[BugFix] Disallow auto type conversion for the cols of Non-OLAP table that's being created from double/float to decimal type in CTAS (backport #47310)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -83,7 +83,7 @@ public class CreateTableAnalyzer {
         GBK,
     }
 
-    private static String analyzeEngineName(String engineName, String catalogName) {
+    protected static String analyzeEngineName(String engineName, String catalogName) {
         if (CatalogMgr.isInternalCatalog(catalogName)) {
             if (Strings.isNullOrEmpty(engineName)) {
                 return EngineType.defaultEngine().name();


### PR DESCRIPTION
## Why I'm doing:
The previous fix does not cover the case that cols cannot be inferred at this stage.
E.g.
create table temp.tbl1 as select col1, avg(col1) from temp.tbl2.

Furthermore, ensuring that Hive tables do not apply double type conversion optimization could prevent decimal value overflow.

![image](https://github.com/StarRocks/starrocks/assets/42195839/cdeb85a9-a714-4285-9a32-0f1f8778e4a4)

## What I'm doing:
Disallow auto type conversion for NON-OLAP tables' double/ float cols during analyzing stage.


Fixes #issues

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

