### PR TITLE
[BugFix] Fix not catching strong references to chunks sorter causing BE crash

### DIFF
--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -53,7 +53,7 @@ StatusOr<ChunkPtr> SpillProcessOperator::pull_chunk(RuntimeState* state) {
         }
     } else if (chunk_st.status().is_end_of_file()) {
         _channel->current_task().reset();
-    } else {
+    } else if (!chunk_st.status().ok()) {
         return chunk_st.status();
     }
 


### PR DESCRIPTION
## Why I'm doing:
The callback function is delayed executed, and in some cases the source operator will be is_finished earlier, at which point the sink operator will call set_finished and close, at which point this->chunks_sorter will become null. That's why we need to catch the chunks here. So we need to capture the shared_ptr of chunks_sorter here.

## What I'm doing:
Fix
```
 3.2.8 RELEASE (build 759cc78)
query_id:82f890ab-39d5-11ef-bc5c-6805caec647c, fragment_instance:82f890ab-39d5-11ef-bc5c-6805caec6488
tracker:process consumption: 64409519614
tracker:query_pool consumption: 3776331664
tracker:query_pool/connector_scan consumption: 0
tracker:load consumption: 263126838
tracker:metadata consumption: 7411767120
tracker:tablet_metadata consumption: 264735647
tracker:rowset_metadata consumption: 196720036
tracker:segment_metadata consumption: 726272887
tracker:column_metadata consumption: 6224038550
tracker:tablet_schema consumption: 11230199
tracker:segment_zonemap consumption: 100298285
tracker:short_key_index consumption: 605985523
tracker:column_zonemap_index consumption: 1704601750
tracker:ordinal_index consumption: 3985470592
tracker:bitmap_index consumption: 1740944
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 165371176
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 43892135456
tracker:update consumption: 3352714514
tracker:chunk_allocator consumption: 2083449064
tracker:clone consumption: 0
tracker:consistency consumption: 0
tracker:datacache consumption: 0
tracker:replication consumption: 0
*** Aborted at 1720077467 (unix time) try "date -d @1720077467" if you are using GNU date ***
PC: @          0x3853414 _ZNSt17_Function_handlerIFN9starrocks8StatusOrISt10shared_ptrINS0_5ChunkEEEEvEZNS0_24SpillProcessTasksBuilder7finallyIZNS0_8pipeline34SpillablePartitionSortSinkOperator13set_finishingEPNS0_12RuntimeStateEEUlSC_T_E0_EEvSD_EUlvE_E9_M_invokeERKSt9_Any_data
*** SIGSEGV (@0x90) received by PID 418760 (TID 0x2b5963a97700) from PID 144; stack trace: ***
    @          0x67c6d22 google::(anonymous namespace)::FailureSignalHandler()
    @     0x2b58c5bca2cb os::Linux::chained_handler()
    @     0x2b58c5bced5c JVM_handle_linux_signal
    @     0x2b58c5bc1c68 signalHandler()
    @     0x2b58c62b45e0 (unknown)
    @          0x3853414 _ZNSt17_Function_handlerIFN9starrocks8StatusOrISt10shared_ptrINS0_5ChunkEEEEvEZNS0_24SpillProcessTasksBuilder7finallyIZNS0_8pipeline34SpillablePartitionSortSinkOperator13set_finishingEPNS0_12RuntimeStateEEUlSC_T_E0_EEvSD_EUlvE_E9_M_invokeERKSt9_Any_data
    @          0x38e4328 starrocks::pipeline::SpillProcessOperator::pull_chunk()
    @          0x3868146 starrocks::pipeline::PipelineDriver::process()
    @          0x385a70e starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x2e7d84c starrocks::ThreadPool::dispatch_thread()
    @          0x2e774ca starrocks::Thread::supervise_thread()
    @     0x2b58c62ace25 start_thread
    @     0x2b58c6ee134d __clone
    @                0x0 (unknown)

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
