### PR TITLE
[BugFix] Correct the profile for datacache write stats to represent the actual data statistics written to datacache

### DIFF
--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -255,7 +255,7 @@ Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t 
             }
         }
         Status r = _cache->write_buffer(_cache_key, write_offset_cursor, write_size, src_cursor, &options);
-        if (r.ok() || r.is_already_exist()) {
+        if (r.ok()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += write_size;
             _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
@@ -444,7 +444,7 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
             options.allow_zero_copy = true;
         }
         Status r = _cache->write_buffer(_cache_key, off, size, buf, &options);
-        if (r.ok() || r.is_already_exist()) {
+        if (r.ok()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += size;
             _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
@@ -466,7 +466,8 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
 }
 
 bool CacheInputStream::_can_ignore_populate_error(const Status& status) const {
-    if (status.is_resource_busy() || status.is_mem_limit_exceeded() || status.is_capacity_limit_exceeded()) {
+    if (status.is_already_exist() || status.is_resource_busy() || status.is_mem_limit_exceeded() ||
+        status.is_capacity_limit_exceeded()) {
         return true;
     }
     return false;


### PR DESCRIPTION
## Why I'm doing:
Now when writing data to cache, if it already exist, we still treat this write successful and add its statistics to the profile.
This will cause the metrics in the profile, such as `DataCacheWriteBytes`,  is confused and cannot represent the actual data that be written to cache.

## What I'm doing:
Ignore the statistics data for the `EEXIST` status. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
