### PR TITLE
[BugFix] Fix incorrect connection state update when register/unregister conn (backport #48056)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class ConnectScheduler {
     private static final Logger LOG = LogManager.getLogger(ConnectScheduler.class);
@@ -49,7 +50,8 @@ public class ConnectScheduler {
     private final AtomicInteger nextConnectionId;
 
     private final Map<Long, ConnectContext> connectionMap = Maps.newConcurrentMap();
-    private final Map<String, AtomicInteger> connByUser = Maps.newConcurrentMap();
+    private final Map<String, AtomicInteger> connCountByUser = Maps.newConcurrentMap();
+    private final ReentrantLock connStatsLock = new ReentrantLock();
     private final ExecutorService executor = ThreadPoolManager
             .newDaemonCacheThreadPool(Config.max_connection_scheduler_threads_num, "connect-scheduler-pool", true);
 
@@ -116,42 +118,60 @@ public class ConnectScheduler {
      * @return a pair, first is success or not, second is error message(if any)
      */
     public Pair<Boolean, String> registerConnection(ConnectContext ctx) {
-        if (numberConnection.get() >= maxConnections.get()) {
-            return new Pair<>(false, "Reach cluster-wide connection limit, qe_max_connection=" + maxConnections +
-                    ", connectionMap.size=" + connectionMap.size() +
-                    ", node=" + ctx.getGlobalStateMgr().getNodeMgr().getSelfNode());
+        try {
+            connStatsLock.lock();
+            if (numberConnection.get() >= maxConnections.get()) {
+                return new Pair<>(false, "Reach cluster-wide connection limit, qe_max_connection=" + maxConnections +
+                        ", connectionMap.size=" + connectionMap.size() +
+                        ", node=" + ctx.getGlobalStateMgr().getNodeMgr().getSelfNode());
+            }
+            // Check user
+            connCountByUser.computeIfAbsent(ctx.getQualifiedUser(), k -> new AtomicInteger(0));
+            AtomicInteger currentConnAtomic = connCountByUser.get(ctx.getQualifiedUser());
+            int currentConn = currentConnAtomic.get();
+            long currentUserMaxConn;
+            if (ctx.getGlobalStateMgr().isUsingNewPrivilege()) {
+                currentUserMaxConn = ctx.getGlobalStateMgr().getAuthenticationManager().getMaxConn(ctx.getQualifiedUser());
+            } else {
+                currentUserMaxConn = ctx.getGlobalStateMgr().getAuth().getMaxConn(ctx.getQualifiedUser());
+            }
+            if (currentConn >= currentUserMaxConn) {
+                String userErrMsg = "Reach user-level(qualifiedUser: " + ctx.getQualifiedUser() +
+                        ", currUserIdentity: " + ctx.getCurrentUserIdentity() + ") connection limit, " +
+                        "currentUserMaxConn=" + currentUserMaxConn + ", connectionMap.size=" + connectionMap.size() +
+                        ", connByUser.totConn=" + connCountByUser.values().stream().mapToInt(AtomicInteger::get).sum() +
+                        ", user.currConn=" + currentConn +
+                        ", node=" + ctx.getGlobalStateMgr().getNodeMgr().getSelfNode();
+                LOG.info(userErrMsg + ", details: connectionId={}, connByUser={}",
+                        ctx.getConnectionId(), connCountByUser);
+                return new Pair<>(false, userErrMsg);
+            }
+            numberConnection.incrementAndGet();
+            currentConnAtomic.incrementAndGet();
+            connectionMap.put((long) ctx.getConnectionId(), ctx);
+            return new Pair<>(true, null);
+        } finally {
+            connStatsLock.unlock();
         }
-        // Check user
-        connByUser.computeIfAbsent(ctx.getQualifiedUser(), k -> new AtomicInteger(0));
-        int conns = connByUser.get(ctx.getQualifiedUser()).get();
-        long currentUserMaxConn;
-        if (ctx.getGlobalStateMgr().isUsingNewPrivilege()) {
-            currentUserMaxConn = ctx.getGlobalStateMgr().getAuthenticationManager().getMaxConn(ctx.getQualifiedUser());
-        } else {
-            currentUserMaxConn = ctx.getGlobalStateMgr().getAuth().getMaxConn(ctx.getQualifiedUser());
-        }
-        if (conns >= currentUserMaxConn) {
-            return new Pair<>(false, "Reach user-level(qualifiedUser: " + ctx.getQualifiedUser() +
-                    ", currUserIdentity: " + ctx.getCurrentUserIdentity() + ") connection limit, " +
-                    "currentUserMaxConn=" + currentUserMaxConn + ", connectionMap.size=" + connectionMap.size() +
-                    ", connByUser.totConn=" + connByUser.values().stream().mapToInt(AtomicInteger::get).sum() +
-                    ", node=" + ctx.getGlobalStateMgr().getNodeMgr().getSelfNode());
-        }
-        numberConnection.incrementAndGet();
-        connByUser.get(ctx.getQualifiedUser()).incrementAndGet();
-        connectionMap.put((long) ctx.getConnectionId(), ctx);
-        return new Pair<>(true, null);
     }
 
     public void unregisterConnection(ConnectContext ctx) {
-        if (connectionMap.remove((long) ctx.getConnectionId()) != null) {
-            numberConnection.decrementAndGet();
-            AtomicInteger conns = connByUser.get(ctx.getQualifiedUser());
-            if (conns != null) {
-                conns.decrementAndGet();
+        boolean removed;
+        try {
+            connStatsLock.lock();
+            removed = connectionMap.remove((long) ctx.getConnectionId()) != null;
+            if (removed) {
+                numberConnection.decrementAndGet();
+                AtomicInteger conns = connCountByUser.get(ctx.getQualifiedUser());
+                if (conns != null) {
+                    conns.decrementAndGet();
+                }
+                LOG.info("Connection closed. remote={}, connectionId={}, qualifiedUser={}, user.currConn={}",
+                        ctx.getMysqlChannel().getRemoteHostPortString(), ctx.getConnectionId(),
+                        ctx.getQualifiedUser(), conns != null ? Integer.toString(conns.get()) : "nil");
             }
-            LOG.info("Connection closed. remote={}, connectionId={}",
-                    ctx.getMysqlChannel().getRemoteHostPortString(), ctx.getConnectionId());
+        } finally {
+            connStatsLock.unlock();
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Connection state update is incorrect.

## What I'm doing:
Currently we need to update a few maps and counters when register/unregister
connection from FE, we don't have some sync mechanism to protect this update,
which may cause incorrect connection state and prompt "connection reach limit"
unexpectly to user login. Add lock protection when register/unregister connection,
the performance should be ok, we have moved some heavy operations like cleaning
tmp table outside of lock, and the rest are just some simple map get/put operations.

backport from https://github.com/StarRocks/starrocks/pull/48056

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

