### PR TITLE
[BugFix] Fix NPE due to fail to get rollup function name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -15,9 +15,9 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
-import com.google.api.client.util.Lists;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
@@ -396,6 +396,11 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
                     List<ScalarOperator> newArgs = aggCall.getChildren();
                     newArgs.set(0, newArg0);
                     String rollupFuncName = getRollupFunctionName(aggCall, false);
+                    // eg: count(distinct) + rollup
+                    if (rollupFuncName == null) {
+                        logMVRewrite(mvRewriteContext, "Get rollup function name is null, aggCall:{}", aggCall);
+                        return AggRewriteInfo.NOT_REWRITE;
+                    }
                     Type[] argTypes = newArgs.stream().map(ScalarOperator::getType).toArray(Type[]::new);
                     Function newFunc = Expr.getBuiltinFunction(rollupFuncName, argTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
`new FunctionName(name)` wil verify name is not null, then NPE will be thrown when rollupFunctionName is null
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
