### PR TITLE
[Enhancement] support cloud native index downgrade from 3.3 to 3.2

### DIFF
--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -83,6 +83,8 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
         DCHECK(_persistent_index == nullptr);
 
         switch (metadata->persistent_index_type()) {
+        // 3.2 don't support CLOUD_NATIVE, so treat it as LOCAL.
+        case PersistentIndexTypePB::CLOUD_NATIVE:
         case PersistentIndexTypePB::LOCAL: {
             // Even if `enable_persistent_index` is enabled,
             // it may not take effect if is as compute node without any storage path.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2359,7 +2359,8 @@ public class OlapTable extends Table {
         }
 
         // only support LOCAL for now
-        if (persistentIndexType == TPersistentIndexType.LOCAL) {
+        if (persistentIndexType == TPersistentIndexType.LOCAL
+            || persistentIndexType == TPersistentIndexType.CLOUD_NATIVE) {
             tableProperty
                     .modifyTableProperties(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
                             TableProperty.persistentIndexTypeToString(persistentIndexType));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2360,7 +2360,7 @@ public class OlapTable extends Table {
 
         // only support LOCAL for now
         if (persistentIndexType == TPersistentIndexType.LOCAL
-            || persistentIndexType == TPersistentIndexType.CLOUD_NATIVE) {
+                || persistentIndexType == TPersistentIndexType.CLOUD_NATIVE) {
             tableProperty
                     .modifyTableProperties(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
                             TableProperty.persistentIndexTypeToString(persistentIndexType));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -555,6 +555,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
         String type = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");
         if (type.equals("LOCAL")) {
             persistentIndexType = TPersistentIndexType.LOCAL;
+        } else if (type.equals("CLOUD_NATIVE")) {
+            // treat CLOUD_NATIVE as LOCAL in 3.2
+            persistentIndexType = TPersistentIndexType.LOCAL;
         }
         return this;
     }
@@ -562,6 +565,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     public static String persistentIndexTypeToString(TPersistentIndexType type) {
         switch (type) {
             case LOCAL:
+                return "LOCAL";
+            case CLOUD_NATIVE:
+                // treat CLOUD_NATIVE as LOCAL in 3.2
                 return "LOCAL";
             default:
                 // shouldn't happen

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1302,9 +1302,6 @@ public class PropertyAnalyzer {
             properties.remove(PROPERTIES_PERSISTENT_INDEX_TYPE);
             if (type.equalsIgnoreCase("LOCAL")) {
                 return TPersistentIndexType.LOCAL;
-            } else if (type.equalsIgnoreCase("CLOUD_NATIVE")) {
-                // treat CLOUD_NATIVE as LOCAL in 3.2
-                return TPersistentIndexType.LOCAL;
             } else {
                 throw new AnalysisException("Invalid persistent index type: " + type);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1302,6 +1302,9 @@ public class PropertyAnalyzer {
             properties.remove(PROPERTIES_PERSISTENT_INDEX_TYPE);
             if (type.equalsIgnoreCase("LOCAL")) {
                 return TPersistentIndexType.LOCAL;
+            } else if (type.equalsIgnoreCase("CLOUD_NATIVE")) {
+                // treat CLOUD_NATIVE as LOCAL in 3.2
+                return TPersistentIndexType.LOCAL;
             } else {
                 throw new AnalysisException("Invalid persistent index type: " + type);
             }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -73,6 +73,7 @@ message RowsetMetadataPB {
 // the type is is to make it upgradable for compatibility.
 enum PersistentIndexTypePB {
     LOCAL = 0;
+    CLOUD_NATIVE = 1;
 }
 
 message TabletMetadataPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -91,6 +91,7 @@ struct TBinlogConfig {
 // don't forget to also add type to PersistentIndexTypePB
 enum TPersistentIndexType {
     LOCAL = 0
+    CLOUD_NATIVE = 1
 }
 
 struct TCreateTabletReq {


### PR DESCRIPTION
## Why I'm doing:
## What I'm doing:
When user create a PK table with `CLOUD_NATIVE` index in `3.3` SR cluster like:
```
PROPERTIES (
"enable_persistent_index" = "true",
"persistent_index_type" = "CLOUD_NATIVE",
);
```

And then user want to downgrade this SR cluster to `3.2`, we don't support `CLOUD_NATIVE` in `3.2`, so we treat it as `LOCAL` persistent index instead.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

