### PR TITLE
[Enhancement] make report audit statistics in sink operator asynchronous

### DIFF
--- a/be/src/exec/pipeline/olap_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/olap_table_sink_operator.cpp
@@ -51,11 +51,6 @@ bool OlapTableSinkOperator::is_finished() const {
 }
 
 bool OlapTableSinkOperator::pending_finish() const {
-    // audit report not finish, we need check until finish
-    if (!_is_audit_report_done) {
-        return true;
-    }
-
     // sink's open not finish, we need check util finish
     if (!_is_open_done) {
         if (!_sink->is_open_done()) {
@@ -110,9 +105,7 @@ Status OlapTableSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 
     if (_num_sinkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        _is_audit_report_done = false;
-        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx(),
-                                                                         &_is_audit_report_done);
+        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx());
     }
     if (_is_open_done && !_automatic_partition_chunk) {
         // sink's open already finish, we can try_close

--- a/be/src/exec/pipeline/olap_table_sink_operator.h
+++ b/be/src/exec/pipeline/olap_table_sink_operator.h
@@ -67,7 +67,6 @@ private:
     mutable bool _is_open_done = false;
     int32_t _sender_id;
     bool _is_cancelled = false;
-    bool _is_audit_report_done = true;
 
     // temporarily save chunk during automatic partition creation
     mutable ChunkPtr _automatic_partition_chunk;

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -366,11 +366,7 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
             << ", is_done=" << done;
 }
 
-void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) {
-    // It should be guaranteed that the done flag must be set to true in any cases.
-    // Set done flag to true after it has been submit, so it won't need to wait for report finish.
-    // It's important when handle high concurrent data ingestion.
-    DeferOp defer([&]() { *done = true; });
+void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) {
     auto query_statistics = query_ctx->final_query_statistic();
 
     TReportAuditStatisticsParams params;

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -368,14 +368,9 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
 
 void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) {
     // It should be guaranteed that the done flag must be set to true in any cases.
-    // If the async task is submitted successfully, the done flag will be set to true in the lambda function.
-    // Otherwise, the done flag will be set to true in the defer object.
-    bool submit_success = false;
-    DeferOp defer([&]() {
-        if (!submit_success) {
-            *done = true;
-        }
-    });
+    // Set done flag to true after it has been submit, so it won't need to wait for report finish.
+    // It's important when handle high concurrent data ingestion.
+    DeferOp defer([&]() { *done = true; });
     auto query_statistics = query_ctx->final_query_statistic();
 
     TReportAuditStatisticsParams params;
@@ -395,7 +390,6 @@ void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, Frag
     auto fragment_id = fragment_ctx->fragment_instance_id();
 
     auto report_task = [=]() {
-        *done = true;
         auto status = AuditStatisticsReporter::report_audit_statistics(params, exec_env, fe_addr);
         if (!status.ok()) {
             if (status.is_not_found()) {
@@ -410,8 +404,8 @@ void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, Frag
         }
     };
     auto st = this->_audit_statistics_reporter->submit(std::move(report_task));
-    if (st.ok()) {
-        submit_success = true;
+    if (!st.ok()) {
+        LOG(ERROR) << "submit audit statistics report fail, " << st.to_string();
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -52,7 +52,7 @@ public:
     virtual void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status,
                                    bool done, bool attach_profile) = 0;
 
-    virtual void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) = 0;
+    virtual void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) = 0;
 
     virtual void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const = 0;
 
@@ -78,7 +78,7 @@ public:
     void close() override;
     void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done,
                            bool attach_profile) override;
-    void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) override;
+    void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) override;
 
     void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const override;
 

--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -149,18 +149,12 @@ bool ExportSinkOperator::is_finished() const {
 
 Status ExportSinkOperator::set_finishing(RuntimeState* state) {
     if (_num_sinkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        _is_audit_report_done = false;
-        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx(),
-                                                                         &_is_audit_report_done);
+        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx());
     }
     return _export_sink_buffer->set_finishing();
 }
 
 bool ExportSinkOperator::pending_finish() const {
-    // audit report not finish, we need check until finish
-    if (!_is_audit_report_done) {
-        return true;
-    }
     return !_export_sink_buffer->is_finished();
 }
 

--- a/be/src/exec/pipeline/sink/export_sink_operator.h
+++ b/be/src/exec/pipeline/sink/export_sink_operator.h
@@ -64,7 +64,6 @@ public:
 private:
     std::shared_ptr<ExportSinkIOBuffer> _export_sink_buffer;
     std::atomic<int32_t>& _num_sinkers;
-    bool _is_audit_report_done = true;
 };
 
 class ExportSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/sink/iceberg_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/iceberg_table_sink_operator.cpp
@@ -62,9 +62,7 @@ bool IcebergTableSinkOperator::is_finished() const {
 
 Status IcebergTableSinkOperator::set_finishing(RuntimeState* state) {
     if (_num_sinkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        _is_audit_report_done = false;
-        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx(),
-                                                                         &_is_audit_report_done);
+        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx());
     }
 
     for (const auto& writer : _partition_writers) {
@@ -80,10 +78,6 @@ Status IcebergTableSinkOperator::set_finishing(RuntimeState* state) {
 }
 
 bool IcebergTableSinkOperator::pending_finish() const {
-    // audit report not finish, we need check until finish
-    if (!_is_audit_report_done) {
-        return true;
-    }
     return !is_finished();
 }
 

--- a/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
@@ -93,8 +93,6 @@ private:
     std::atomic<bool> _is_finished = false;
     bool _is_static_partition_insert = false;
     std::atomic<int32_t>& _num_sinkers;
-
-    bool _is_audit_report_done = true;
 };
 
 class IcebergTableSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
@@ -47,18 +47,12 @@ bool MemoryScratchSinkOperator::is_finished() const {
 Status MemoryScratchSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
     if (_num_sinkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        _is_audit_report_done = false;
-        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx(),
-                                                                         &_is_audit_report_done);
+        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx());
     }
     return Status::OK();
 }
 
 bool MemoryScratchSinkOperator::pending_finish() const {
-    // audit report not finish, we need check until finish
-    if (!_is_audit_report_done) {
-        return true;
-    }
     // After set_finishing, there may be data that has not been sent.
     // We need to ensure that all remaining data are put into the queue.
     const_cast<MemoryScratchSinkOperator*>(this)->try_to_put_sentinel();

--- a/be/src/exec/pipeline/sink/memory_scratch_sink_operator.h
+++ b/be/src/exec/pipeline/sink/memory_scratch_sink_operator.h
@@ -76,8 +76,6 @@ private:
     mutable std::shared_ptr<arrow::RecordBatch> _pending_result;
     bool _is_finished = false;
     bool _has_put_sentinel = false;
-
-    bool _is_audit_report_done = true;
 };
 
 class MemoryScratchSinkOperatorFactory final : public OperatorFactory {


### PR DESCRIPTION
## Why I'm doing:
In this PR #38032, we already introduce a asynchronous audit statistics reporter, but it doesn't work because we set `done` flag when this job begin to be execute and if too many jobs waiting to be executed, it will still make sink operator hang waiting report statistics finish.

## What I'm doing:
Sink operator won't wait for audit statistics report.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
