### PR TITLE
[BugFix] Fix BE crash because ThriftRpcHelper is not setup before calling rpc

### DIFF
--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -202,7 +202,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     // set up thrift client before providing any service to the external
     // because these services may use thrift client, for example, stream
-    // load needs to send thrift rpc to FE
+    // load will send thrift rpc to FE after http server is started
     ThriftRpcHelper::setup(exec_env);
 
     // Start thrift server

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -200,6 +200,11 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
         LOG(INFO) << process_name << " starts by skipping the datacache initialization";
     }
 
+    // set up thrift client before providing any service to the external
+    // because these services may use thrift client, for example, stream
+    // load needs to send thrift rpc to FE
+    ThriftRpcHelper::setup(exec_env);
+
     // Start thrift server
     int thrift_port = config::be_port;
     if (as_cn && config::thrift_port != 0) {
@@ -273,7 +278,6 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     // Start heartbeat server
     std::unique_ptr<ThriftServer> heartbeat_server;
-    ThriftRpcHelper::setup(exec_env);
     if (auto ret = create_heartbeat_server(exec_env, config::heartbeat_service_port,
                                            config::heartbeat_service_thread_count);
         !ret.ok()) {

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -53,7 +53,7 @@ using apache::thrift::transport::TSocket;
 using apache::thrift::transport::TTransport;
 using apache::thrift::transport::TBufferedTransport;
 
-ExecEnv* ThriftRpcHelper::_s_exec_env;
+ExecEnv* ThriftRpcHelper::_s_exec_env = nullptr;
 
 void ThriftRpcHelper::setup(ExecEnv* exec_env) {
     _s_exec_env = exec_env;

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -113,6 +113,11 @@ Status ThriftRpcHelper::rpc_impl(std::function<void(ClientConnection<TFileBroker
 template <typename T>
 Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
                             std::function<void(ClientConnection<T>&)> callback, int timeout_ms) {
+    if (UNLIKELY(_s_exec_env == nullptr)) {
+        return Status::ThriftRpcError(
+                "Thrift client has not been setup to send rpc. Maybe BE has not been started completely. Please retry "
+                "later");
+    }
     TNetworkAddress address = make_network_address(ip, port);
     Status status;
     ClientConnection<T> client(_s_exec_env->get_client_cache<T>(), address, timeout_ms, &status);


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/8012
When http server is started, it can deal with stream load request, and stream load will send thrift rpc to FE via ThriftRpcHelper. But ThriftRpcHelper is setup after http server is started, and if sending stream load to BE before ThriftRpcHelper setup, BE will crash because ThriftRpcHelper::_s_exec_env is invalid

## What I'm doing:
1. set up ThriftRpcHelper before providing any service to the external because these services may use thrift client
2. check whether ThriftRpcHelper::_s_exec_env is invalid to avoid unexpected crash 

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
