### PR TITLE
[BugFix] Fix match of source ip for resource group (backport #47732)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -16,10 +16,10 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.util.NetUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TQueryType;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.net.util.SubnetUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -157,7 +157,7 @@ public class ResourceGroupClassifier {
             return false;
         }
         if (this.sourceIp != null && sourceIp != null) {
-            return new SubnetUtils(this.sourceIp).getInfo().isInRange(sourceIp);
+            return NetUtils.isIPInSubnet(sourceIp, this.sourceIp);
         }
         return true;
     }
@@ -180,8 +180,7 @@ public class ResourceGroupClassifier {
             w += 1 + 0.1 / queryTypes.size();
         }
         if (sourceIp != null) {
-            SubnetUtils.SubnetInfo subnetInfo = new SubnetUtils(sourceIp).getInfo();
-            w += 1 + (Long.numberOfLeadingZeros(subnetInfo.getAddressCountLong() + 2) - 32) / 64.0;
+            w += 1 + NetUtils.getCidrPrefixLength(sourceIp) / 64.0;
         }
         if (CollectionUtils.isNotEmpty(databaseIds)) {
             w += 10.0 * databaseIds.size();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
@@ -36,6 +36,7 @@ package com.starrocks.common.util;
 
 import com.google.common.base.Strings;
 import com.starrocks.common.Pair;
+import org.apache.commons.net.util.SubnetUtils;
 import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.io.IOException;
@@ -111,5 +112,24 @@ public class NetUtils {
             }
         }
         return accessible;
+    }
+
+    public static boolean isIPInSubnet(String ip, String subnetCidr) {
+        SubnetUtils subnetUtils = new SubnetUtils(subnetCidr);
+        subnetUtils.setInclusiveHostCount(true);
+        return subnetUtils.getInfo().isInRange(ip);
+    }
+
+    /**
+     * Get the prefix length of the CIDR, that is the `y` part of `xxx.xxx.xxx.xxx/y` in CIDR, e.g. 16 for `192.168.0.1/16`.
+     * @param cidr The CIDR format address.
+     * @return The length of the prefix. The range is within [0, 32].
+     */
+    public static int getCidrPrefixLength(String cidr) {
+        SubnetUtils subnetUtils = new SubnetUtils(cidr);
+        subnetUtils.setInclusiveHostCount(true);
+        // 2^(32 - prefixLength) = addressCount,
+        // so prefixLength = 32 - log2(addressCount) = 32 - (63 - leadingZeros(addressCount)) = leadingZeros(addressCount) - 31
+        return Long.numberOfLeadingZeros(subnetUtils.getInfo().getAddressCountLong()) - 31;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.persist.ResourceGroupOpEntry;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.persist.ResourceGroupOpEntry;
@@ -234,19 +233,19 @@ public class ResourceGroupStmtTest {
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
         String result = rowsToString(rows);
         String expect = "" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.459375, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=3.459375, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=2.359375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
+                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
+                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
                 "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
-                "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=3.459375, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
-                "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=2.359375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
+                "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
+                "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
                 "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
-                "rg3|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.459375, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg3|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
                 "rg3|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
-                "rg4|25|80.0%|null|1024|1024|1024|10|100%|NORMAL|(weight=1.359375, source_ip=192.168.7.1/24)\n" +
+                "rg4|25|80.0%|null|1024|1024|1024|10|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
                 "rg5|25|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg6|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.459375, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
-                "rg7|32|80.0%|null|0|0|0|10|30.0%|NORMAL|(weight=2.459375, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg6|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
+                "rg7|32|80.0%|null|0|0|0|10|30.0%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
                 "rt_rg1|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
@@ -576,7 +575,7 @@ public class ResourceGroupStmtTest {
         String result = rowsToString(rows);
         String expect = "" +
                 "rg5|25|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.459375, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
                 "rg3|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
@@ -633,19 +632,19 @@ public class ResourceGroupStmtTest {
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("SHOW RESOURCE GROUPS all");
         String result = rowsToString(rows);
         String expect = "" +
-                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=4.459375, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=3.459375, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
-                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=2.359375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
+                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
+                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
                 "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
-                "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=3.459375, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
-                "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=2.359375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
+                "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
+                "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
                 "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
-                "rg3|32|80.0%|3|0|0|0|23|100%|NORMAL|(weight=2.459375, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg3|32|80.0%|3|0|0|0|23|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
                 "rg3|32|80.0%|3|0|0|0|23|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
-                "rg4|13|41.0%|null|1024|1024|1024|23|100%|NORMAL|(weight=1.359375, source_ip=192.168.7.1/24)\n" +
+                "rg4|13|41.0%|null|1024|1024|1024|23|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
                 "rg5|25|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg6|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.459375, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
-                "rg7|32|80.0%|null|0|0|0|10|30.0%|NORMAL|(weight=2.459375, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg6|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
+                "rg7|32|80.0%|null|0|0|0|10|30.0%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
                 "rt_rg1|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
@@ -1373,6 +1372,24 @@ public class ResourceGroupStmtTest {
                 "Getting analyzing error. Detail message: At least one of ('user', 'role', 'query_type', 'db', " +
                         "'source_ip', 'plan_cpu_cost_range', 'plan_mem_cost_range') should be given",
                 SemanticException.class, () -> ResourceGroupAnalyzer.convertPredicateToClassifier(Collections.emptyList()));
+    }
+
+    @Test
+    public void testSourceIP() throws Exception {
+        String createSQL = "create resource group rg1\n" +
+                "to\n" +
+                "    (source_ip='192.168.2.1/32')\n" +
+                "with (\n" +
+                "    'cpu_core_limit' = '10',\n" +
+                "    'max_cpu_cores' = '8',\n" +
+                "    'mem_limit' = '20%'\n" +
+                ");";
+        starRocksAssert.executeResourceGroupDdlSql(createSQL);
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        assertThat(rowsToString(rows)).isEqualTo(
+                "rg1|10|20.0%|8|0|0|0|null|100%|NORMAL|(weight=1.5, source_ip=192.168.2.1/32)");
+
+        starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceGroupClassifierTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceGroupClassifierTest.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+public class ResourceGroupClassifierTest {
+    @Test
+    public void testSourceIP() {
+        ResourceGroupClassifier classifier = new ResourceGroupClassifier();
+
+        classifier.setSourceIp("192.168.0.1/32");
+        assertThat(classifier.isVisible("user", null, "192.168.0.1")).isTrue();
+        assertThat(classifier.isVisible("user", null, "192.168.0.2")).isFalse();
+
+        classifier.setSourceIp("192.168.0.1/31");
+        assertThat(classifier.isVisible("user", null, "192.168.0.1")).isTrue();
+        assertThat(classifier.isVisible("user", null, "192.168.0.2")).isFalse();
+
+        classifier.setSourceIp("192.168.0.1/30");
+        assertThat(classifier.isVisible("user", null, "192.168.0.1")).isTrue();
+        assertThat(classifier.isVisible("user", null, "192.168.0.2")).isTrue();
+        assertThat(classifier.isVisible("user", null, "192.168.1.1")).isFalse();
+    }
+
+    @Test
+    public void testWeight() {
+        ResourceGroupClassifier classifier = new ResourceGroupClassifier();
+
+        for (int i = 0; i <= 32; i++) {
+            classifier.setSourceIp("192.168.0.1/" + i);
+            assertThat(classifier.weight()).isCloseTo(1 + i / 64., within(1e-5));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/NetUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/NetUtilsTest.java
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NetUtilsTest {
+    @Test
+    public void testGetCidrPrefixLength() {
+        for (int i = 0; i <= 32; i++) {
+            String addr = "192.168.0.1/" + i;
+            assertThat(NetUtils.getCidrPrefixLength(addr)).isEqualTo(i);
+        }
+    }
+
+    @Test
+    public void testIsIPInSubnet() {
+        assertThat(NetUtils.isIPInSubnet("192.168.0.1", "192.168.0.1/32")).isTrue();
+        assertThat(NetUtils.isIPInSubnet("192.168.0.1", "192.168.1.1/32")).isFalse();
+
+        assertThat(NetUtils.isIPInSubnet("192.168.0.1", "192.168.0.1/24")).isTrue();
+        assertThat(NetUtils.isIPInSubnet("192.168.0.1", "192.168.0.2/24")).isTrue();
+        assertThat(NetUtils.isIPInSubnet("192.168.0.1", "192.168.1.0/24")).isFalse();
+
+        assertThat(NetUtils.isIPInSubnet("192.168.0.1", "10.0.0.0/8")).isFalse();
+    }
+}


### PR DESCRIPTION
CP from #47732.

## Why I'm doing:

## What I'm doing:

Fixes #47437.

1. Match
   `SubnetUtils::isInRange` doesn't consider the broadcast and network address as a usable endpoint by default. As a result, `127.0.0.1` cannot matched `127.0.0.1/32`.

2. Weight
The weight of `sourceIP` of a resource group classifier is `1 + cidrPrefixLength/64`. However, we calculate `cidrPrefixLength` by `Long.numberOfLeadingZeros(subnetUtils.getInfo().getAddressCountLong()) - 32`, which should be `Long.numberOfLeadingZeros(subnetUtils.getInfo().getAddressCountLong()) - 31`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
<hr>This is an automatic backport of pull request #47732 done by [Mergify](https://mergify.com).
## Why I'm doing:

## What I'm doing:

Fixes #47437.

1. Match
   `SubnetUtils::isInRange` doesn't consider the broadcast and network address as a usable endpoint by default. As a result, `127.0.0.1` cannot matched `127.0.0.1/32`.

2. Weight
The weight of `sourceIP` of a resource group classifier is `1 + cidrPrefixLength/64`. However, we calculate `cidrPrefixLength` by `Long.numberOfLeadingZeros(subnetUtils.getInfo().getAddressCountLong()) - 32`, which should be `Long.numberOfLeadingZeros(subnetUtils.getInfo().getAddressCountLong()) - 31`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr



