### PR TITLE
[BugFix] get_json_xx return same column ptr

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -588,7 +588,7 @@ StatusOr<ColumnPtr> JsonFunctions::_flat_json_query_impl(FunctionContext* contex
             chunk.append_column(flat_column, 0);
             return state->cast_expr->evaluate_checked(nullptr, &chunk);
         }
-        return flat_column;
+        return flat_column->clone();
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
```
|   1:Project                                                                                                           |
|   |  <slot 20> : get_json_int(6: data, '$.l_orderkey')                                                                |
|   |  <slot 26> : get_json_int(6: data, '$.l_suppkey')                                                                 |
|   |  <slot 28> : get_json_int(6: data, '$.l_partkey')                                                                 |
|   |  <slot 31> : get_json_double(6: data, '$.l_extendedprice')                                                        |
|   |  <slot 32> : get_json_double(6: data, '$.l_discount')                                                             |
|   |  <slot 34> : get_json_double(6: data, '$.l_quantity')                                                             |
|   |  <slot 37> : 45: get_json_int                                                                                     |
|   |  <slot 38> : 46: get_json_int                                                                                     |
|   |  common expressions:                                                                                              |
|   |  <slot 45> : get_json_int(6: data, '$.l_suppkey')                                                                 |
|   |  <slot 46> : get_json_int(6: data, '$.l_partkey')                                                                 |
|   |                                                                                                                   |
|   0:OlapScanNode                                                                                                      |
|      TABLE: lineitem_json                                                                                             |
|      PREAGGREGATION: ON                                                                                               |
|      PREDICATES: get_json_int(6: data, '$.l_suppkey') IS NOT NULL, get_json_int(6: data, '$.l_partkey') IS NOT NULL   |
|      partitions=1/1                                                                                                   |
|      rollup: lineitem_json                                                                                            |
|      tabletRatio=96/96                                                                                                |
|      tabletList=3623381,3623383,3623385,3623387,3623389,3623391,3623393,3623395,3623397,3623399 ...                   |
|      cardinality=4860984                                                                                              |
|      avgRowSize=8.0                                                                                                   |
+-----------------------------------------------------------------------------------------------------------------------+

```

in Tpch sql,  column 37 column 26 will use same column, it's hard to contruct test case

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
