### PR TITLE
[Enhancement] (Multi Ref Base Table Part3) Supports to track multi ref base tables in partition compensate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
@@ -34,7 +34,18 @@ public class MvBaseTableUpdateInfo {
     // The mapping of partition name to partition range
     private final Map<String, PCell> nameToPartKeys = Maps.newHashMap();
 
+    // If the base table is a mv, needs to record the mapping of mv partition name to partition range
+    private final Map<String, PCell> mvPartitionNameToCellMap = Maps.newHashMap();
+
     public MvBaseTableUpdateInfo() {
+    }
+
+    public Map<String, PCell> getMvPartitionNameToCellMap() {
+        return mvPartitionNameToCellMap;
+    }
+
+    public void addMVPartitionNameToCellMap(Map<String, PCell> partitionNameToRangeMap) {
+        mvPartitionNameToCellMap.putAll(partitionNameToRangeMap);
     }
 
     public Set<String> getToRefreshPartitionNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -177,6 +177,7 @@ public class MvRefreshArbiter {
                 }
                 // NOTE: if base table is mv, check to refresh partition names as the base table's update info.
                 baseUpdatedPartitionNames.addAll(mvUpdateInfo.getMvToRefreshPartitionNames());
+                baseTableUpdateInfo.addMVPartitionNameToCellMap(mvUpdateInfo.getMvPartitionNameToCellMap());
             }
             // update base table's partition info
             baseTableUpdateInfo.addToRefreshPartitionNames(baseUpdatedPartitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -16,9 +16,13 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.common.Config;
+import com.starrocks.sql.common.PCell;
 
 import java.util.Map;
 import java.util.Set;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.shrinkToSize;
 
 /**
  * Store the update information of MV used for mv rewrite(mv refresh can use it later).
@@ -36,6 +40,9 @@ public class MvUpdateInfo {
     private final Map<String, Map<Table, Set<String>>> mvPartToBasePartNames = Maps.newHashMap();
     // The consistency mode of query rewrite
     private final TableProperty.QueryRewriteConsistencyMode queryRewriteConsistencyMode;
+
+    // If the base table is a mv, needs to record the mapping of mv partition name to partition range
+    private final Map<String, PCell> mvPartitionNameToCellMap = Maps.newHashMap();
 
     /**
      * Marks the type of mv refresh later.
@@ -93,13 +100,22 @@ public class MvUpdateInfo {
         return queryRewriteConsistencyMode;
     }
 
+    public void addMVPartitionNameToCellMap(Map<String, PCell> m) {
+        mvPartitionNameToCellMap.putAll(m);
+    }
+
+    public Map<String, PCell> getMvPartitionNameToCellMap() {
+        return mvPartitionNameToCellMap;
+    }
+
     @Override
     public String toString() {
+        int maxLength = Config.max_mv_task_run_meta_message_values_length;
         return "MvUpdateInfo{" +
                 "refreshType=" + mvToRefreshType +
-                ", mvToRefreshPartitionNames=" + mvToRefreshPartitionNames +
-                ", basePartToMvPartNames=" + basePartToMvPartNames +
-                ", mvPartToBasePartNames=" + mvPartToBasePartNames +
+                ", mvToRefreshPartitionNames=" + shrinkToSize(mvToRefreshPartitionNames, maxLength) +
+                ", basePartToMvPartNames=" + shrinkToSize(basePartToMvPartNames, maxLength) +
+                ", mvPartToBasePartNames=" + shrinkToSize(mvPartToBasePartNames, maxLength) +
                 '}';
     }
 
@@ -139,7 +155,7 @@ public class MvUpdateInfo {
         if (mvPartToBasePartNames == null || mvPartToBasePartNames.isEmpty()) {
             return null;
         }
-        // MV's partition names to refresh is not only affected by the ref base table, but also other base tables.
+        // MV's partition names to refresh are not only affected by the ref base table, but also other base tables.
         // Deduce the partition names to refresh of the ref base table from the partition names to refresh of the mv.
         Set<String> refBaseTableToRefreshPartitionNames = Sets.newHashSet();
         for (String mvPartName : mvToRefreshPartitionNames) {
@@ -149,8 +165,10 @@ public class MvUpdateInfo {
                 continue;
             }
             Set<String> partNames = baseTableToPartNames.get(refBaseTable);
+            // Continue since mvPartName to refresh is not triggerred by the base table since multi base tables has been
+            // supported.
             if (partNames == null) {
-                return null;
+                continue;
             }
             refBaseTableToRefreshPartitionNames.addAll(partNames);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -24,12 +24,15 @@ import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
 import static com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable;
@@ -135,15 +138,16 @@ public abstract class MVTimelinessArbiter {
             return needRefreshMvPartitionNames;
         }
         for (Map.Entry<Table, Set<String>> entry : baseChangedPartitionNames.entrySet()) {
-            if (!baseToMvNameRef.containsKey(entry.getKey())) {
+            Table baseTable = entry.getKey();
+            if (!baseToMvNameRef.containsKey(baseTable)) {
                 throw new AnalysisException(String.format("Can't find base table %s from baseToMvNameRef",
-                        entry.getKey().getName()));
+                        baseTable.getName()));
             }
-            Map<String, Set<String>> baseTableRefMvPartNames = baseToMvNameRef.get(entry.getKey());
+            Map<String, Set<String>> baseTableRefMvPartNames = baseToMvNameRef.get(baseTable);
             for (String partitionName : entry.getValue()) {
                 if (!baseTableRefMvPartNames.containsKey(partitionName)) {
                     throw new AnalysisException(String.format("Can't find base table %s from baseToMvNameRef",
-                            entry.getKey().getName()));
+                            baseTable.getName()));
                 }
                 needRefreshMvPartitionNames.addAll(baseTableRefMvPartNames.get(partitionName));
             }
@@ -162,10 +166,28 @@ public abstract class MVTimelinessArbiter {
         for (Map.Entry<Table, Column> e : refBaseTableAndColumns.entrySet()) {
             Table baseTable = e.getKey();
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, baseTable,
-                    true, true);
+                    true, isQueryRewrite);
             mvUpdateInfo.getBaseTableUpdateInfos().put(baseTable, mvBaseTableUpdateInfo);
+            // If base table is a mv, its to-update partitions may not be created yet, skip it
             baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPartitionNames());
         }
         return baseChangedPartitionNames;
+    }
+
+    /**
+     * If base table is materialized view, add partition name to cell mapping into base table partition mapping;
+     * otherwise base table(mv) may lose partition names of the real base table changed partitions.
+     * @param baseTableUpdateInfoMap base table update info from MvTimelinessInfo
+     * @return the base table to its changed partition and cell map if it's mv, empty else
+     */
+    protected void collectExtraBaseTableChangedPartitions(
+            Map<Table, MvBaseTableUpdateInfo> baseTableUpdateInfoMap,
+            Consumer<Map.Entry<Table, Map<String, PCell>>> consumer) {
+        Map<Table, Map<String, PCell>> extraChangedPartitions = baseTableUpdateInfoMap.entrySet().stream()
+                .filter(e -> !e.getValue().getMvPartitionNameToCellMap().isEmpty())
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getMvPartitionNameToCellMap()));
+        for (Map.Entry<Table, Map<String, PCell>> entry : extraChangedPartitions.entrySet()) {
+            consumer.accept(entry);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -324,9 +324,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         try {
             LOG.info("Do mv refresh, mv:{}, refBaseTablePartitionExprMap:{}," +
                             "refBaseTablePartitionSlotMap:{}, refBaseTablePartitionColumnMap:{}," +
-                            "refBaseTablePartitionColumn:{}, baseTableInfos:{}", materializedView.getName(),
+                            "baseTableInfos:{}", materializedView.getName(),
                     materializedView.getRefBaseTablePartitionExprs(), materializedView.getRefBaseTablePartitionSlots(),
-                    materializedView.getRefBaseTablePartitionColumns(), materializedView.getRefBaseTablePartitionColumn(),
+                    materializedView.getRefBaseTablePartitionColumns(),
                     MvUtils.formatBaseTableInfos(materializedView.getBaseTableInfos()));
         } catch (Throwable e) {
             LOG.warn("Log mv basic info failed:", e);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -171,6 +171,7 @@ public abstract class MVPCTRefreshPartitioner {
         Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
         for (Map.Entry<Table, Column> e : refBaseTableAndColumns.entrySet()) {
             Table baseTable = e.getKey();
+            
             // refresh all mv partitions when the ref base table is not supported partition refresh
             if (!isPartitionRefreshSupported(baseTable)) {
                 LOG.info("The ref base table {} is not supported partition refresh, refresh all " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
@@ -215,10 +215,10 @@ public final class ListPartitionDiffer extends PartitionDiffer {
      * @param tableRefIdxes result to collect mv's ref indexes to the base table's partition columns
      * @return true if success, otherwise false
      */
-    private static boolean syncBaseTablePartitionInfos(MaterializedView mv,
-                                                       Map<Table, Map<String, PListCell>> basePartitionMaps,
-                                                       Map<String, PListCell> allBasePartitionItems,
-                                                       Map<Table, List<Integer>> tableRefIdxes) {
+    public static boolean syncBaseTablePartitionInfos(MaterializedView mv,
+                                                      Map<Table, Map<String, PListCell>> basePartitionMaps,
+                                                      Map<String, PListCell> allBasePartitionItems,
+                                                      Map<Table, List<Integer>> tableRefIdxes) {
         Map<Table, Column> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
         try {
             for (Map.Entry<Table, Column> e1 : partitionTableAndColumn.entrySet()) {
@@ -265,6 +265,14 @@ public final class ListPartitionDiffer extends PartitionDiffer {
             logMVPrepare(mv, "Partitioned mv collect base table infos failed");
             return null;
         }
+        return computeListPartitionDiff(mv, refBaseTablePartitionMap, allBasePartitionItems, tableRefIdxes);
+    }
+
+    public static ListPartitionDiffResult computeListPartitionDiff(
+            MaterializedView mv,
+            Map<Table, Map<String, PListCell>> refBaseTablePartitionMap,
+            Map<String, PListCell> allBasePartitionItems,
+            Map<Table, List<Integer>> tableRefIdxes) {
         // TODO: prune the partitions based on ttl
         Map<String, PListCell> mvPartitionNameToListMap = mv.getListPartitionItems();
         ListPartitionDiff diff = ListPartitionDiffer.getListPartitionDiff(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -218,13 +218,13 @@ public final class RangePartitionDiffer extends PartitionDiffer {
     /**
      * Collect the ref base table's partition range map.
      * @param mv the materialized view to compute diff
-     * @param extBTMVPartitionNameMap the external base table's partition name map which to be updated
+     * @param basePartitionMaps the external base table's partition name map which to be updated
      * @return the ref base table's partition range map: <ref base table, <partition name, partition range>>
      */
-    private static Map<Table, Map<String, Range<PartitionKey>>> collectRBTPartitionKeyMap(
+    public static Map<Table, Map<String, Range<PartitionKey>>> syncBaseTablePartitionInfos(
             MaterializedView mv,
             Expr mvPartitionExpr,
-            Map<Table, Map<String, Set<String>>> extBTMVPartitionNameMap) {
+            Map<Table, Map<String, Set<String>>> basePartitionMaps) {
         Map<Table, Column> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
         if (partitionTableAndColumn.isEmpty()) {
             return Maps.newHashMap();
@@ -244,7 +244,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
                 // To solve multi partition columns' problem of external table, record the mv partition name to all the same
                 // partition names map here.
                 if (!refBT.isNativeTableOrMaterializedView()) {
-                    extBTMVPartitionNameMap.put(refBT,
+                    basePartitionMaps.put(refBT,
                             PartitionUtil.getMVPartitionNameMapOfExternalTable(refBT,
                                     refBTPartitionColumn, PartitionUtil.getPartitionNames(refBT)));
                 }
@@ -336,22 +336,31 @@ public final class RangePartitionDiffer extends PartitionDiffer {
                                                                      Range<PartitionKey> rangeToInclude,
                                                                      boolean isQueryRewrite) {
         Expr mvPartitionExpr = mv.getPartitionExpr();
-        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
-        Preconditions.checkArgument(!refBaseTableAndColumns.isEmpty());
-
-        // get the materialized view's partition range map
-        Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
         // collect all ref base table's partition range map
         Map<Table, Map<String, Set<String>>> extRBTMVPartitionNameMap = Maps.newHashMap();
-        Map<Table, Map<String, Range<PartitionKey>>> rBTPartitionMap = collectRBTPartitionKeyMap(mv, mvPartitionExpr,
+        Map<Table, Map<String, Range<PartitionKey>>> rBTPartitionMap = syncBaseTablePartitionInfos(mv, mvPartitionExpr,
                 extRBTMVPartitionNameMap);
+        return computeRangePartitionDiff(mv, rangeToInclude, extRBTMVPartitionNameMap, rBTPartitionMap, isQueryRewrite);
+    }
+
+    public static RangePartitionDiffResult computeRangePartitionDiff(
+            MaterializedView mv,
+            Range<PartitionKey> rangeToInclude,
+            Map<Table, Map<String, Set<String>>> extRBTMVPartitionNameMap,
+            Map<Table, Map<String, Range<PartitionKey>>> rBTPartitionMap,
+            boolean isQueryRewrite) {
+        Expr mvPartitionExpr = mv.getPartitionExpr();
+        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
+        Preconditions.checkArgument(!refBaseTableAndColumns.isEmpty());
+        // get the materialized view's partition range map
+        Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
+
         // merge all ref base tables' partition range map to avoid intersected partitions
         Map<String, Range<PartitionKey>> mergedRBTPartitionKeyMap = mergeRBTPartitionKeyMap(mvPartitionExpr, rBTPartitionMap);
         if (mergedRBTPartitionKeyMap == null) {
             LOG.warn("Merge materialized view {} with base tables failed.", mv.getName());
             return null;
         }
-
         // only used for checking unaligned partitions in unit test
         if (FeConstants.runningUnitTest) {
             try {
@@ -369,7 +378,6 @@ public final class RangePartitionDiffer extends PartitionDiffer {
                 return null;
             }
         }
-
         try {
             // NOTE: Use all refBaseTables' partition range to compute the partition difference between MV and refBaseTables.
             // Merge all deletes of each refBaseTab's diff may cause dropping needed partitions, the deletes should use

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -29,11 +29,11 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensation;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.TableScanDesc;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensation;
 import org.apache.commons.collections4.SetUtils;
 
 import java.util.Collections;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -883,7 +883,7 @@ public class Utils {
         if (op == null) {
             return;
         }
-        op.setOpRuleMask(op.getOpRuleMask() | (~ ruleMask));
+        op.resetOpRuleMask(ruleMask);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -165,6 +165,10 @@ public abstract class Operator {
         this.opRuleMask |= bit;
     }
 
+    public void resetOpRuleMask(int bit) {
+        this.opRuleMask &= (~ bit);
+    }
+
     public boolean isOpRuleMaskSet(int bit) {
         return (opRuleMask & bit) != 0;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -14,13 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.analysis.TableName;
-import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.Table;
-import com.starrocks.connector.TableVersionRange;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -28,7 +22,6 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
-import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFileScanOperator;
@@ -42,12 +35,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.OptDistributionPruner;
 import com.starrocks.sql.optimizer.rewrite.OptExternalPartitionPruner;
 import com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner;
-import org.apache.iceberg.Snapshot;
 
 import java.util.List;
-import java.util.Optional;
-
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES;
 
 public class MVPartitionPruner {
     private final OptimizerContext optimizerContext;
@@ -152,113 +141,6 @@ public class MVPartitionPruner {
             return OptExpression.create(scanOperator);
         }
 
-        public OptExpression visit(OptExpression optExpression, Void context) {
-            List<OptExpression> children = Lists.newArrayList();
-            for (int i = 0; i < optExpression.arity(); ++i) {
-                children.add(optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), null));
-            }
-            return OptExpression.create(optExpression.getOp(), children);
-        }
-    }
-
-    /**
-     * Rewrite specific olap scan operator with specific selected partition ids.
-     */
-    public static OptExpression getOlapTableCompensatePlan(OptExpression optExpression,
-                                                           LogicalScanOperator mvRefScanOperator,
-                                                           List<Long> refTableCompensatePartitionIds) {
-        OptScanOperatorCompensator scanOperatorCompensator = new OptScanOperatorCompensator(
-                refTableCompensatePartitionIds, mvRefScanOperator);
-        return optExpression.getOp().accept(scanOperatorCompensator, optExpression, null);
-    }
-
-    /**
-     * Rewrite specific external scan operator with specific selected partition ids.
-     */
-    public static OptExpression getExternalTableCompensatePlan(OptExpression optExpression,
-                                                               LogicalScanOperator mvRefScanOperator,
-                                                               ScalarOperator extraPredicate) {
-        OptScanOperatorCompensator scanOperatorCompensator = new OptScanOperatorCompensator(
-                mvRefScanOperator, extraPredicate);
-        return optExpression.getOp().accept(scanOperatorCompensator, optExpression, null);
-    }
-
-    /**
-     * Rewrite specific olap scan operator with specific selected partition ids.
-     */
-    static class OptScanOperatorCompensator extends OptExpressionVisitor<OptExpression, Void> {
-        private final List<Long> olapTableCompensatePartitionIds;
-        private final LogicalScanOperator refScanOperator;
-        private final ScalarOperator externalExtraPredicate;
-
-        // for olap table
-        public OptScanOperatorCompensator(List<Long> refTableCompensatePartitionIds,
-                                          LogicalScanOperator scanOperator) {
-            this.refScanOperator = scanOperator;
-            this.olapTableCompensatePartitionIds = refTableCompensatePartitionIds;
-            this.externalExtraPredicate = null;
-        }
-
-        // for external table
-        public OptScanOperatorCompensator(LogicalScanOperator mvRefScanOperator,
-                                          ScalarOperator extraPredicate) {
-            this.refScanOperator = mvRefScanOperator;
-            this.olapTableCompensatePartitionIds = null;
-            this.externalExtraPredicate = extraPredicate;
-        }
-
-        @Override
-        public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
-            LogicalScanOperator scanOperator = optExpression.getOp().cast();
-            if (scanOperator != refScanOperator) {
-                return optExpression;
-            }
-            // reset the partition prune flag to be pruned again.
-            Utils.resetOpAppliedRule(scanOperator, Operator.OP_PARTITION_PRUNE_BIT);
-
-            if (scanOperator instanceof LogicalOlapScanOperator) {
-                LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
-                final LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
-                Preconditions.checkState(olapTableCompensatePartitionIds != null);
-                // reset original partition predicates to prune partitions/tablets again
-                builder.withOperator(olapScanOperator)
-                        .setSelectedPartitionId(olapTableCompensatePartitionIds)
-                        .setSelectedTabletId(Lists.newArrayList());
-                return OptExpression.create(builder.build());
-            } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(scanOperator.getOpType())) {
-                final LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(refScanOperator);
-                // reset original partition predicates to prune partitions/tablets again
-                builder.withOperator(refScanOperator);
-                Preconditions.checkState(externalExtraPredicate != null);
-                ScalarOperator finalPredicate = Utils.compoundAnd(refScanOperator.getPredicate(), externalExtraPredicate);
-                builder.setPredicate(finalPredicate);
-
-                if (scanOperator.getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN) {
-                    // refresh iceberg table's metadata
-                    Table refBaseTable = refScanOperator.getTable();
-                    IcebergTable cachedIcebergTable = (IcebergTable) refBaseTable;
-                    String catalogName = cachedIcebergTable.getCatalogName();
-                    String dbName = cachedIcebergTable.getRemoteDbName();
-                    TableName tableName = new TableName(catalogName, dbName, cachedIcebergTable.getName());
-                    Table currentTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName).orElse(null);
-                    if (currentTable == null) {
-                        return null;
-                    }
-
-                    builder.setTable(currentTable);
-                    TableVersionRange versionRange = TableVersionRange.withEnd(
-                            Optional.ofNullable(((IcebergTable) currentTable).getNativeTable().currentSnapshot())
-                                    .map(Snapshot::snapshotId));
-                    builder.setTableVersionRange(versionRange);
-                }
-                LogicalScanOperator newScanOperator = builder.build();
-                return OptExpression.create(newScanOperator);
-            } else {
-                return optExpression;
-            }
-        }
-
-        @Override
         public OptExpression visit(OptExpression optExpression, Void context) {
             List<OptExpression> children = Lists.newArrayList();
             for (int i = 0; i < optExpression.arity(); ++i) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -80,6 +80,7 @@ import com.starrocks.sql.optimizer.rewrite.JoinPredicatePushdown;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.scalar.MvNormalizePredicateRule;
 import com.starrocks.sql.optimizer.rule.mv.JoinDeriveContext;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensation;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -28,12 +28,14 @@ import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
@@ -65,6 +67,10 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.BaseCompensation;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensation;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensationBuilder;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.OptCompensator;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import org.apache.logging.log4j.LogManager;
@@ -72,14 +78,13 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import static com.starrocks.connector.PartitionUtil.generateMVPartitionName;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 import static com.starrocks.sql.optimizer.operator.Operator.OP_UNION_ALL_BIT;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty;
@@ -144,188 +149,10 @@ public class MvPartitionCompensator {
             return MVCompensation.createNoCompensateState(sessionVariable);
         }
 
-        // If no partition table and columns, no need compensate
-        MaterializedView mv = mvContext.getMv();
-        Pair<Table, Column> partitionTableAndColumns = mv.getRefBaseTablePartitionColumn();
-        if (partitionTableAndColumns == null) {
-            logMVRewrite(mvContext, "MV's partition table and columns is null, unknown state");
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-        Table refBaseTable = partitionTableAndColumns.first;
-
-        // If ref table contains no partitions to refresh, no need compensate.
-        // If the mv is partitioned and non-ref table need refresh, then all partitions need to be refreshed,
-        // it can not be a candidate.
-        Set<String> refTablePartitionNameToRefresh = mvUpdateInfo.getBaseTableToRefreshPartitionNames(refBaseTable);
-        if (refTablePartitionNameToRefresh == null) {
-            logMVRewrite(mvContext, "MV's ref base to refresh partition is null, unknown state");
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-        if (refTablePartitionNameToRefresh.isEmpty()) {
-            logMVRewrite(mvContext, "MV's ref base to refresh partition is empty, no need compensate");
-            return MVCompensation.createNoCompensateState(sessionVariable);
-        }
-
-        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlan);
-        // If no scan operator, no need compensate
-        if (scanOperators.isEmpty()) {
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-        if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-
-        // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
-        LogicalScanOperator refScanOperator = getRefBaseTableScanOperator(scanOperators, refBaseTable);
-        if (refScanOperator == null) {
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-
-        Table table = refScanOperator.getTable();
-        // If table's not partitioned, no need compensate
-        if (table.isUnPartitioned()) {
-            // TODO: Support this later.
-            logMVRewrite(mvContext, "MV's is un-partitioned, unknown state");
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-
-        if (refScanOperator instanceof LogicalOlapScanOperator) {
-            return getMvCompensationForOlap(mvContext, refBaseTable, refTablePartitionNameToRefresh,
-                    (LogicalOlapScanOperator) refScanOperator);
-        } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(refScanOperator.getOpType())) {
-            return getMvCompensationForExternal(mvContext, refTablePartitionNameToRefresh, refScanOperator);
-        } else {
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-    }
-
-    private static MVCompensation getMvCompensationForOlap(MaterializationContext mvContext,
-                                                           Table refBaseTable,
-                                                           Set<String> refTablePartitionNameToRefresh,
-                                                           LogicalOlapScanOperator olapScanOperator) {
-        OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
-        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
-        List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
-        if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-            return MVCompensation.createNoCompensateState(sessionVariable);
-        }
-
-        // if any of query's select partition ids has not been refreshed, then no rewrite with this mv.
-        if (selectPartitionIds.stream()
-                .map(id -> olapTable.getPartition(id))
-                .noneMatch(part -> refTablePartitionNameToRefresh.contains(part.getName()))) {
-            return MVCompensation.createNoCompensateState(sessionVariable);
-        }
-
-        // if mv's to refresh partitions contains any of query's select partition ids, then rewrite with compensate.
-        List<Long> toRefreshRefTablePartitions = getMvRefTableCompensatePartitionsForOlap(refTablePartitionNameToRefresh,
-                refBaseTable, olapScanOperator);
-        if (toRefreshRefTablePartitions == null) {
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-
-        if (Sets.newHashSet(toRefreshRefTablePartitions).containsAll(selectPartitionIds)) {
-            logMVRewrite(mvContext, "All table {}'s selected partitions {} need to refresh, no rewrite",
-                    refBaseTable.getName(), selectPartitionIds);
-            return MVCompensation.createNoRewriteState(sessionVariable);
-        }
-
-        return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE,
-                toRefreshRefTablePartitions, null);
-    }
-
-    private static MVCompensation getMvCompensationForExternal(MaterializationContext mvContext,
-                                                               Set<String> refTablePartitionNamesToRefresh,
-                                                               LogicalScanOperator refScanOperator) {
-        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
-        try {
-            ScanOperatorPredicates scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
-            Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
-            if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-                // see OptExternalPartitionPruner#computePartitionInfo:
-                // it's not the same meaning when selectPartitionIds is null and empty for hive and other tables
-                if (refScanOperator.getOpType() == OperatorType.LOGICAL_HIVE_SCAN) {
-                    return MVCompensation.createNoCompensateState(sessionVariable);
-                } else {
-                    return MVCompensation.createUnkownState(sessionVariable);
-                }
-            }
-            List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
-            if (selectPartitionKeys.stream()
-                    .map(PartitionUtil::generateMVPartitionName)
-                    .noneMatch(x -> refTablePartitionNamesToRefresh.contains(x))) {
-                return MVCompensation.createNoCompensateState(sessionVariable);
-            }
-            // if mv's to refresh partitions contains any of query's select partition ids, then rewrite with compensate.
-            List<PartitionKey> toRefreshRefTablePartitions = getMvRefTableCompensatePartitionsForExternal(
-                    refTablePartitionNamesToRefresh, refScanOperator);
-            if (toRefreshRefTablePartitions == null) {
-                return MVCompensation.createUnkownState(sessionVariable);
-            }
-            Table table = refScanOperator.getTable();
-            if (Sets.newHashSet(toRefreshRefTablePartitions).containsAll(selectPartitionKeys)) {
-                logMVRewrite(mvContext, "All table {}'s selected partitions {} need to refresh, no rewrite",
-                        table.getName(), selectPartitionIds);
-                return MVCompensation.createNoRewriteState(sessionVariable);
-            }
-            return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE, null,
-                    toRefreshRefTablePartitions);
-        } catch (AnalysisException e) {
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-    }
-
-    /**
-     * Get mv's compensate partitions for ref table(olap table).
-     * @param refBaseTable: materialized view's ref base table
-     * @param refScanOperator: ref base table's scan operator.
-     * @return: need to compensate partition ids of the materialized view.
-     */
-    private static List<Long> getMvRefTableCompensatePartitionsForOlap(Set<String> refTablePartitionNameToRefresh,
-                                                                       Table refBaseTable,
-                                                                       LogicalScanOperator refScanOperator) {
-
-        LogicalOlapScanOperator olapScanOperator = ((LogicalOlapScanOperator) refScanOperator);
-        if (olapScanOperator.getSelectedPartitionId() == null) {
-            return null;
-        }
-        List<Long> refTableCompensatePartitionIds = Lists.newArrayList();
-        List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
-        for (Long selectPartitionId : selectPartitionIds) {
-            Partition partition = refBaseTable.getPartition(selectPartitionId);
-            // If this partition has updated, add it into compensate partition ids.
-            if (refTablePartitionNameToRefresh.contains(partition.getName())) {
-                refTableCompensatePartitionIds.add(selectPartitionId);
-            }
-        }
-        return refTableCompensatePartitionIds;
-    }
-
-    private static List<PartitionKey> getMvRefTableCompensatePartitionsForExternal(Set<String> refTablePartitionNamesToRefresh,
-                                                                                   LogicalScanOperator refScanOperator)
-            throws AnalysisException {
-        ScanOperatorPredicates scanOperatorPredicates = null;
-        try {
-            scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
-        } catch (Exception e) {
-            return null;
-        }
-        if (scanOperatorPredicates == null) {
-            return null;
-        }
-        List<PartitionKey> refTableCompensatePartitionKeys = Lists.newArrayList();
-        List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
-        // different behavior for different external table types
-        if (selectPartitionKeys.isEmpty() && refScanOperator.getOpType() != OperatorType.LOGICAL_HIVE_SCAN) {
-            return null;
-        }
-        for (PartitionKey partitionKey : selectPartitionKeys) {
-            String partitionName = generateMVPartitionName(partitionKey);
-            if (refTablePartitionNamesToRefresh.contains(partitionName)) {
-                refTableCompensatePartitionKeys.add(partitionKey);
-            }
-        }
-        return refTableCompensatePartitionKeys;
+        MVCompensationBuilder mvCompensationBuilder = new MVCompensationBuilder(mvContext, mvUpdateInfo);
+        MVCompensation mvCompensation = mvCompensationBuilder.buildMvCompensation(queryPlan);
+        logMVRewrite(mvContext, "MV compensation:{}", mvCompensation);
+        return mvCompensation;
     }
 
     /**
@@ -342,8 +169,11 @@ public class MvPartitionCompensator {
         final List<ColumnRefOperator> orgMvScanOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv,
                 mvScanOperator);
         mvScanBuilder.withOperator(mvScanOperator);
-        OptExpression mvScanOptExpression = OptExpression.create(mvScanBuilder.build());
+
+        final LogicalOlapScanOperator newMvScanOperator = mvScanBuilder.build();
+        OptExpression mvScanOptExpression = OptExpression.create(newMvScanOperator);
         deriveLogicalProperty(mvScanOptExpression);
+
         // duplicate mv's plan and output columns
         OptExpressionDuplicator duplicator = new OptExpressionDuplicator(mvContext);
         OptExpression newMvScanPlan = duplicator.duplicate(mvScanOptExpression);
@@ -384,47 +214,13 @@ public class MvPartitionCompensator {
                                                          MVCompensation mvCompensation,
                                                          OptExpression mvQueryPlan) {
         MaterializedView mv = mvContext.getMv();
-        Pair<Table, Column> partitionTableAndColumns = mv.getRefBaseTablePartitionColumn();
-        if (partitionTableAndColumns == null) {
+        Map<Table, Column> refBaseTableAndColumnMap = mv.getRefBaseTablePartitionColumns();
+        if (refBaseTableAndColumnMap == null) {
             return null;
         }
-        // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
-        Table refBaseTable = partitionTableAndColumns.first;
-        LogicalScanOperator mvRefScanOperator = getRefBaseTableScanOperator(mvQueryPlan, refBaseTable);
-        if (mvRefScanOperator == null) {
-            return null;
-        }
-
-        if (mvRefScanOperator instanceof LogicalOlapScanOperator) {
-            List<Long> refTableCompensatePartitionIds = mvCompensation.getOlapCompensatePartitionIds();
-            if (refTableCompensatePartitionIds == null) {
-                logMVRewrite(mvContext, "Get ref olap base table's compensation partition ids is null");
-                return null;
-            }
-            return MVPartitionPruner.getOlapTableCompensatePlan(mvQueryPlan, mvRefScanOperator, refTableCompensatePartitionIds);
-        } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(mvRefScanOperator.getOpType())) {
-            List<PartitionKey> refTableCompensatePartitionKeys = mvCompensation.getExternalCompensatePartitionKeys();
-            if (refTableCompensatePartitionKeys == null) {
-                logMVRewrite(mvContext, "Get ref external base table's compensation partition ids is null");
-                return null;
-            }
-
-            // NOTE: This is necessary because iceberg's physical plan will not use selectedPartitionIds to
-            // prune partitions.
-            Column mvPartitionColumn = partitionTableAndColumns.second;
-            ColumnRefOperator partitionColumnRef = mvRefScanOperator.getColumnReference(mvPartitionColumn);
-            Preconditions.checkState(partitionColumnRef != null);
-            ScalarOperator partitionPredicates = convertPartitionKeysToListPredicate(partitionColumnRef,
-                    refTableCompensatePartitionKeys);
-            Preconditions.checkState(partitionPredicates != null);
-            partitionPredicates.setRedundant(true);
-            return MVPartitionPruner.getExternalTableCompensatePlan(mvQueryPlan, mvRefScanOperator,
-                    partitionPredicates);
-        } else {
-            logMVRewrite(mvContext, "Unsupported ref base table's scan operator type:{}",
-                    mvRefScanOperator.getOpType().name());
-            return null;
-        }
+        Map<Table, BaseCompensation<?>> refTableCompensations = mvCompensation.getCompensations();
+        return OptCompensator.getMVCompensatePlan(mvContext.getOptimizerContext(),
+                mv, refTableCompensations, mvQueryPlan);
     }
 
     /**
@@ -663,7 +459,7 @@ public class MvPartitionCompensator {
 
         List<Range<PartitionKey>> ranges = Lists.newArrayList();
         MaterializedView mv = mvContext.getMv();
-        Pair<Table, Column> partitionTableAndColumns = mv.getRefBaseTablePartitionColumn();
+        Pair<Table, Column> partitionTableAndColumns = getRefBaseTablePartitionColumn(mv);
         if (partitionTableAndColumns == null) {
             return null;
         }
@@ -806,18 +602,7 @@ public class MvPartitionCompensator {
                 return null;
             }
         }
-        return convertPartitionKeysToListPredicate(partitionColRef, keys);
-    }
-
-    public static ScalarOperator convertPartitionKeysToListPredicate(ScalarOperator partitionColRef,
-                                                                     Collection<PartitionKey> partitionRanges) {
-        List<ScalarOperator> values = Lists.newArrayList();
-        for (PartitionKey partitionKey : partitionRanges) {
-            LiteralExpr literalExpr = partitionKey.getKeys().get(0);
-            ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
-            values.add(upperBound);
-        }
-        return MvUtils.convertToInPredicate(partitionColRef, values);
+        return MvUtils.convertPartitionKeysToListPredicate(partitionColRef, keys);
     }
 
     private static ScalarOperator convertPartitionKeysToPredicate(ScalarOperator partitionColumn,
@@ -832,6 +617,37 @@ public class MvPartitionCompensator {
         }
     }
 
+    /**
+     * Materialized View's partition column can only refer one base table's partition column, get the referred
+     * base table and its partition column.
+     * @return : The materialized view's referred base table and its partition column.
+     * TODO: Support multi-column partitions later.
+     * TODO: Use getRefBaseTablePartitionColumns instead since SR v3.3 has supported multi-tables partition change tracking.
+     */
+    @Deprecated
+    private static Pair<Table, Column> getRefBaseTablePartitionColumn(MaterializedView mv) {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        if (mv.getPartitionRefTableExprs() == null || !(partitionInfo.isRangePartition() || partitionInfo.isListPartition())) {
+            return null;
+        }
+        Expr partitionExpr = mv.getPartitionRefTableExprs().get(0);
+        List<SlotRef> slotRefs = Lists.newArrayList();
+        partitionExpr.collect(SlotRef.class, slotRefs);
+        Preconditions.checkState(slotRefs.size() == 1);
+        SlotRef partitionSlotRef = slotRefs.get(0);
+        for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
+            Table table = MvUtils.getTableChecked(baseTableInfo);
+            if (partitionSlotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
+                return Pair.create(table, table.getColumn(partitionSlotRef.getColumnName()));
+            }
+        }
+        String baseTableNames = mv.getBaseTableInfos().stream()
+                .map(tableInfo -> MvUtils.getTableChecked(tableInfo).getName()).collect(Collectors.joining(","));
+        throw new RuntimeException(
+                String.format("can not find partition info for mv:%s on base tables:%s",
+                        mv.getName(), baseTableNames));
+    }
+
     // try to get partial partition predicates of partitioned mv.
     // eg, mv1's base partition table is t1, partition column is k1 and has two partition:
     // p1:[2022-01-01, 2022-01-02), p1 is updated(refreshed),
@@ -843,7 +659,7 @@ public class MvPartitionCompensator {
             MaterializedView mv,
             OptExpression mvPlan,
             Set<String> mvPartitionNamesToRefresh) throws AnalysisException {
-        Pair<Table, Column> partitionTableAndColumns = mv.getRefBaseTablePartitionColumn();
+        Pair<Table, Column> partitionTableAndColumns = getRefBaseTablePartitionColumn(mv);
         if (partitionTableAndColumns == null) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -165,7 +165,7 @@ public class MvUtils {
                 newMvIds.addAll(mvIds);
             } else if (currentLevel == 0) {
                 logMVPrepare("Table/MaterializedView {} has no related materialized views, " +
-                                "identifier:{}", table.getName(), table.getTableIdentifier());
+                        "identifier:{}", table.getName(), table.getTableIdentifier());
             }
         }
         if (newMvIds.isEmpty()) {
@@ -738,7 +738,7 @@ public class MvUtils {
      * NOTE:
      * 1. `canonizePredicateForRewrite` will do more optimizations than `canonizePredicate`.
      * 2. if you need to rewrite src predicate to target predicate, should use `canonizePredicateForRewrite`
-     *  both rather than one use `canonizePredicate` or `canonizePredicateForRewrite`.
+     * both rather than one use `canonizePredicate` or `canonizePredicateForRewrite`.
      */
     public static ScalarOperator canonizePredicateForRewrite(QueryMaterializationContext queryMaterializationContext,
                                                              ScalarOperator predicate) {
@@ -975,8 +975,9 @@ public class MvUtils {
 
     /**
      * Convert partition range to IN predicate
+     *
      * @param slotRef the comparison column
-     * @param values the target partition values
+     * @param values  the target partition values
      * @return in predicate
      */
     public static Expr convertToInPredicate(Expr slotRef, List<Expr> values) {
@@ -989,7 +990,8 @@ public class MvUtils {
 
     /**
      * Convert partition range to IN predicate scalar operator
-     * @param col the comparison operator
+     *
+     * @param col    the comparison operator
      * @param values the target scalar operators
      * @return in predicate scalar operator
      */
@@ -1068,7 +1070,6 @@ public class MvUtils {
     }
 
 
-
     public static String toString(Object o) {
         if (o == null) {
             return "";
@@ -1080,7 +1081,7 @@ public class MvUtils {
     /**
      * Return the max refresh timestamp of all partition infos.
      */
-    public static long  getMaxTablePartitionInfoRefreshTime(
+    public static long getMaxTablePartitionInfoRefreshTime(
             Collection<Map<String, MaterializedView.BasePartitionInfo>> partitionInfos) {
         return partitionInfos.stream()
                 .flatMap(x -> x.values().stream())
@@ -1122,7 +1123,7 @@ public class MvUtils {
     }
 
     public static boolean isSupportViewDelta(JoinOperator joinOperator) {
-        return  joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin();
+        return joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin();
     }
 
     public static SlotRef extractPartitionSlotRef(Expr paritionExpr) {
@@ -1276,6 +1277,7 @@ public class MvUtils {
 
     /**
      * Check whether opt expression or its children have applied mv union rewrite.
+     *
      * @param optExpression: opt expression to check
      * @return : true if opt expression or its children have applied mv union rewrite, false otherwise.
      */
@@ -1285,9 +1287,10 @@ public class MvUtils {
 
     /**
      * Return mv's plan context. If mv's plan context is not in cache, optimize it.
+     *
      * @param connectContext: connect context
-     * @param mv: input mv
-     * @param isInlineView: whether to inline mv's difined query.
+     * @param mv:             input mv
+     * @param isInlineView:   whether to inline mv's difined query.
      */
     public static MvPlanContext getMVPlanContext(ConnectContext connectContext,
                                                  MaterializedView mv,
@@ -1305,7 +1308,8 @@ public class MvUtils {
 
     /**
      * Get column refs of scanMvOperator by MV's defined output columns order.
-     * @param mv: mv to be referenced for output's order
+     *
+     * @param mv:       mv to be referenced for output's order
      * @param scanMvOp: scan mv operator which contains mv
      * @return: column refs of scanMvOperator in the defined order
      */
@@ -1443,9 +1447,10 @@ public class MvUtils {
 
     /**
      * Trim the input set if its size is larger than maxLength.
+     *
      * @return the trimmed set.
      */
-    public static Set<String> shrinkToSize(Set<String> set, int maxLength) {
+    public static <K> Set<K> shrinkToSize(Set<K> set, int maxLength) {
         if (set != null && set.size() > maxLength) {
             return set.stream().limit(maxLength).collect(Collectors.toSet());
         }
@@ -1454,9 +1459,10 @@ public class MvUtils {
 
     /**
      * Trim the input map if its size is larger than maxLength.
+     *
      * @return the trimmed map.
      */
-    public static Map<String, Set<String>> shrinkToSize(Map<String, Set<String>> map, int maxLength) {
+    public static <K, V> Map<K, V> shrinkToSize(Map<K, V> map, int maxLength) {
         if (map != null && map.size() > maxLength) {
             return map.entrySet().stream().limit(maxLength).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
@@ -1465,8 +1471,9 @@ public class MvUtils {
 
     /**
      * Get the mv partition expr by partition expr maps and table.
+     *
      * @param partitionExprMaps partition expr maps of the specific mv
-     * @param table the base table to find the specific partition expr
+     * @param table             the base table to find the specific partition expr
      * @return the mv partition expr if found, otherwise empty
      */
     public static Optional<MVPartitionExpr> getMvPartitionExpr(Map<Expr, SlotRef> partitionExprMaps, Table table) {
@@ -1481,6 +1488,7 @@ public class MvUtils {
 
     /**
      * Get the column by slot ref from table's columns
+     *
      * @param columns base table's columns
      * @param slotRef the base table's partition slot ref to find
      * @return the column if found, otherwise empty
@@ -1492,6 +1500,7 @@ public class MvUtils {
 
     /**
      * Format the base table infos to readable string.
+     *
      * @param baseTableInfos: input base table infos
      * @return formatted string
      */
@@ -1500,5 +1509,16 @@ public class MvUtils {
             return "";
         }
         return baseTableInfos.stream().map(BaseTableInfo::getReadableString).collect(Collectors.joining(","));
+    }
+
+    public static ScalarOperator convertPartitionKeysToListPredicate(ScalarOperator partitionColRef,
+                                                                     Collection<PartitionKey> partitionRanges) {
+        List<ScalarOperator> values = Lists.newArrayList();
+        for (PartitionKey partitionKey : partitionRanges) {
+            LiteralExpr literalExpr = partitionKey.getKeys().get(0);
+            ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+            values.add(upperBound);
+        }
+        return MvUtils.convertToInPredicate(partitionColRef, values);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/BaseCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/BaseCompensation.java
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.compensation;
+
+import java.util.List;
+
+/**
+ * To support mv compensation(transparent) rewrite, we need to compensate some partitions from the defined query of mv
+ * if some of mv's base tables have updated/refreshed.
+ * </p>
+ * There are some differences for different types of tables to compensate:
+ * - OlapTable, partition ids that are already updated.
+ * - ExternalTable, partition keys that are already changed.
+ * @param <T>
+ */
+public abstract class BaseCompensation<T> {
+    private List<T> compensations;
+
+    public BaseCompensation(List<T> compensations) {
+        this.compensations = compensations;
+    }
+
+    public List<T> getCompensations() {
+        return compensations;
+    }
+
+    @Override
+    public abstract String toString();
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/ExternalTableCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/ExternalTableCompensation.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.compensation;
+
+import com.starrocks.catalog.PartitionKey;
+
+import java.util.List;
+
+public class ExternalTableCompensation extends BaseCompensation {
+    public ExternalTableCompensation(List<PartitionKey> partitionKeys) {
+        super(partitionKeys);
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalTableCompensation{" +
+                "partitionKeys=" + getCompensations() +
+                '}';
+    }
+}
+
+

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
@@ -1,0 +1,388 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.compensation;
+
+import com.google.api.client.util.Lists;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvBaseTableUpdateInfo;
+import com.starrocks.catalog.MvUpdateInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTransparentState;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.starrocks.connector.PartitionUtil.generateMVPartitionName;
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+
+/**
+ * MVCompensationBuilder is used to build a mv compensation for materialized view in mv rewrite.
+ */
+public class MVCompensationBuilder {
+    private static final Logger LOG = LogManager.getLogger(MVCompensationBuilder.class);
+
+    private final MaterializationContext mvContext;
+    private final MvUpdateInfo mvUpdateInfo;
+    private final SessionVariable sessionVariable;
+
+    public MVCompensationBuilder(MaterializationContext mvContext,
+                                 MvUpdateInfo mvUpdateInfo) {
+        this.mvContext = mvContext;
+        this.mvUpdateInfo = mvUpdateInfo;
+        this.sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
+    }
+
+    /**
+     * Get mv compensation info by mv's update info.
+     */
+    public MVCompensation buildMvCompensation(OptExpression queryPlan) {
+        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlan);
+        // If no scan operator, no need compensate
+        if (scanOperators.isEmpty()) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+        if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+
+        // If no partition to refresh, return directly.
+        Set<String> mvToRefreshPartitionNames = mvUpdateInfo.getMvToRefreshPartitionNames();
+        if (CollectionUtils.isEmpty(mvToRefreshPartitionNames)) {
+            return MVCompensation.createNoCompensateState(sessionVariable);
+        }
+
+        // If no scan operator, no need compensate
+        if (scanOperators.isEmpty()) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+        if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+
+        MaterializedView mv = mvContext.getMv();
+        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
+        if (CollectionUtils.sizeIsEmpty(refBaseTableAndColumns)) {
+            logMVRewrite("MV's not partitioned, failed to get partition keys: {}", mv.getName());
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+
+        Map<Table, BaseCompensation<?>> compensations = Maps.newHashMap();
+        for (LogicalScanOperator scanOperator : scanOperators) {
+            Table refBaseTable = scanOperator.getTable();
+            if (!refBaseTableAndColumns.containsKey(refBaseTable)) {
+                continue;
+            }
+            // If the ref table contains no partitions to refresh, no need compensate.
+            // If the mv is partitioned and non-ref table needs refresh, then all partitions need to be refreshed;
+            // it cannot be a candidate.
+            Set<String> partitionNamesToRefresh = mvUpdateInfo.getBaseTableToRefreshPartitionNames(refBaseTable);
+            if (partitionNamesToRefresh == null) {
+                logMVRewrite(mvContext, "MV's ref base table {} to refresh partition is null, unknown state",
+                        refBaseTable.getName());
+                return MVCompensation.createUnkownState(sessionVariable);
+            }
+            if (partitionNamesToRefresh.isEmpty()) {
+                logMVRewrite(mvContext, "MV's ref base table {} to refresh partition is empty, no need compensate",
+                        refBaseTable.getName());
+                continue;
+            }
+            MVCompensation subCompensation = getMVCompensationOfTable(refBaseTable, partitionNamesToRefresh, scanOperator);
+            if (subCompensation.getState().isNoCompensate()) {
+                continue;
+            }
+            if (!subCompensation.getState().isCompensate()) {
+                return subCompensation;
+            }
+            compensations.putAll(subCompensation.getCompensations());
+        }
+        return ofBaseTableCompensations(compensations);
+    }
+
+    /**
+     * Build compensation for transparent mv which has no input query plan but to compensate a consistent mv.
+     */
+    public MVCompensation buildMvCompensation() {
+        // If no partition to refresh, return directly.
+        Set<String> mvToRefreshPartitionNames = mvUpdateInfo.getMvToRefreshPartitionNames();
+        if (CollectionUtils.isEmpty(mvToRefreshPartitionNames)) {
+            return MVCompensation.createNoCompensateState(sessionVariable);
+        }
+
+        MaterializedView mv = mvContext.getMv();
+        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
+        if (CollectionUtils.sizeIsEmpty(refBaseTableAndColumns)) {
+            logMVRewrite("MV's not partitioned, failed to get partition keys: {}", mv.getName());
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+        Map<Table, BaseCompensation<?>> compensations = Maps.newHashMap();
+        Map<Table, MvBaseTableUpdateInfo> baseTableUpdateInfoMap = mvUpdateInfo.getBaseTableUpdateInfos();
+        for (Map.Entry<Table, MvBaseTableUpdateInfo> e : baseTableUpdateInfoMap.entrySet()) {
+            Table refBaseTable = e.getKey();
+            if (!refBaseTableAndColumns.containsKey(refBaseTable)) {
+                continue;
+            }
+            // If the ref table contains no partitions to refresh, no need compensate.
+            // If the mv is partitioned and non-ref table needs refresh, then all partitions need to be refreshed;
+            // it cannot be a candidate.
+            Set<String> partitionNamesToRefresh = mvUpdateInfo.getBaseTableToRefreshPartitionNames(refBaseTable);
+            if (partitionNamesToRefresh == null) {
+                logMVRewrite(mvContext, "MV's ref base table {} to refresh partition is null, unknown state",
+                        refBaseTable.getName());
+                return MVCompensation.createUnkownState(sessionVariable);
+            }
+            if (partitionNamesToRefresh.isEmpty()) {
+                logMVRewrite(mvContext, "MV's ref base table {} to refresh partition is empty, no need compensate",
+                        refBaseTable.getName());
+                continue;
+            }
+
+            MVCompensation subCompensation = getMVCompensationOfTable(refBaseTable, partitionNamesToRefresh);
+            if (subCompensation.getState().isNoCompensate()) {
+                continue;
+            }
+
+            if (!subCompensation.getState().isCompensate()) {
+                return subCompensation;
+            }
+            compensations.putAll(subCompensation.getCompensations());
+        }
+        return ofBaseTableCompensations(compensations);
+    }
+
+    private MVCompensation getMVCompensationOfTable(Table refBaseTable,
+                                                    Set<String> refTablePartitionNamesToRefresh) {
+        if (refBaseTable.isNativeTableOrMaterializedView()) {
+            // What if nested mv?
+            List<Long> refTablePartitionIdsToRefresh = refTablePartitionNamesToRefresh.stream()
+                    .map(name -> refBaseTable.getPartition(name))
+                    .filter(Objects::nonNull)
+                    .map(p -> p.getId())
+                    .collect(Collectors.toList());
+            return ofOlapTableCompensation(refBaseTable, refTablePartitionIdsToRefresh);
+        } else if (MvPartitionCompensator.isTableSupportedPartitionCompensate(refBaseTable)) {
+            MvBaseTableUpdateInfo mvBaseTableUpdateInfo =
+                    mvUpdateInfo.getBaseTableUpdateInfos().get(refBaseTable);
+            if (mvBaseTableUpdateInfo == null) {
+                return null;
+            }
+            Map<String, Range<PartitionKey>> refTablePartitionNameWithRanges =
+                    mvBaseTableUpdateInfo.getPartitionNameWithRanges();
+            List<PartitionKey> partitionKeys = Lists.newArrayList();
+            try {
+                for (String partitionName : refTablePartitionNamesToRefresh) {
+                    Preconditions.checkState(refTablePartitionNameWithRanges.containsKey(partitionName));
+                    Range<PartitionKey> partitionKeyRange = refTablePartitionNameWithRanges.get(partitionName);
+                    partitionKeys.add(partitionKeyRange.lowerEndpoint());
+                }
+            } catch (Exception e) {
+                logMVRewrite("Failed to get partition keys for ref base table: {}", refBaseTable.getName(),
+                        DebugUtil.getStackTrace(e));
+                return MVCompensation.createUnkownState(sessionVariable);
+            }
+            return ofExternalTableCompensation(refBaseTable, partitionKeys);
+        } else {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+    }
+
+    private MVCompensation getMVCompensationOfTable(Table refBaseTable,
+                                                    Set<String> partitionNamesToRefresh,
+                                                    LogicalScanOperator scanOperator) {
+        if (scanOperator instanceof LogicalOlapScanOperator) {
+            return getMVCompensationOfOlapTable(refBaseTable, partitionNamesToRefresh,
+                    (LogicalOlapScanOperator) scanOperator);
+        } else if (MvPartitionCompensator.isTableSupportedPartitionCompensate(refBaseTable)) {
+            return getMVCompensationForExternal(partitionNamesToRefresh, scanOperator);
+        } else {
+            SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+    }
+
+    private MVCompensation getMVCompensationOfOlapTable(Table refBaseTable,
+                                                        Set<String> partitionNamesToRefresh,
+                                                        LogicalOlapScanOperator olapScanOperator) {
+        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
+        OlapTable olapTable = (OlapTable) refBaseTable;
+        List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
+        if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
+            return MVCompensation.createNoCompensateState(sessionVariable);
+        }
+        // if any of query's select partition ids has not been refreshed, then no rewrite with this mv.
+        if (selectPartitionIds.stream()
+                .map(id -> olapTable.getPartition(id))
+                .noneMatch(part -> partitionNamesToRefresh.contains(part.getName()))) {
+            return MVCompensation.createNoCompensateState(sessionVariable);
+        }
+
+        // if mv's to refresh partitions contains any of query's select partition ids, then rewrite with compensate.
+        List<Long> toRefreshRefTablePartitions = getMVCompensatePartitionsOfOlap(partitionNamesToRefresh,
+                refBaseTable, olapScanOperator);
+        if (toRefreshRefTablePartitions == null) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+
+        Set<Long> toRefreshPartitionIds = Sets.newHashSet(toRefreshRefTablePartitions);
+        if (toRefreshPartitionIds.containsAll(selectPartitionIds)) {
+            logMVRewrite(mvContext, "All olap table {}'s selected partitions {} need to refresh, no rewrite",
+                    refBaseTable.getName(), selectPartitionIds);
+            return MVCompensation.createNoRewriteState(sessionVariable);
+        }
+        return ofOlapTableCompensation(refBaseTable, toRefreshRefTablePartitions);
+    }
+
+    private MVCompensation ofOlapTableCompensation(Table refBaseTable,
+                                                   List<Long> toRefreshRefTablePartitions) {
+        BaseCompensation<Long> compensation = new OlapTableCompensation(toRefreshRefTablePartitions);
+        Map<Table, BaseCompensation<?>> compensationMap = Collections.singletonMap(refBaseTable, compensation);
+        return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE, compensationMap);
+    }
+
+    private MVCompensation ofExternalTableCompensation(Table refBaseTable,
+                                                       List<PartitionKey> toRefreshRefTablePartitions) {
+        Map<Table, BaseCompensation<?>> compensationMap = Collections.singletonMap(refBaseTable,
+                new ExternalTableCompensation(toRefreshRefTablePartitions));
+        return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE, compensationMap);
+    }
+
+    private MVCompensation ofBaseTableCompensations(Map<Table, BaseCompensation<?>> compensations) {
+        if (compensations.isEmpty()) {
+            return MVCompensation.createNoCompensateState(sessionVariable);
+        } else {
+            return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE, compensations);
+        }
+    }
+
+    private MVCompensation getMVCompensationForExternal(Set<String> refTablePartitionNamesToRefresh,
+                                                        LogicalScanOperator refScanOperator) {
+        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
+        try {
+            ScanOperatorPredicates scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
+            Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
+            if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
+                // see OptExternalPartitionPruner#computePartitionInfo:
+                // it's not the same meaning when selectPartitionIds is null and empty for hive and other tables
+                if (refScanOperator.getOpType() == OperatorType.LOGICAL_HIVE_SCAN) {
+                    return MVCompensation.createNoCompensateState(sessionVariable);
+                } else {
+                    return MVCompensation.createUnkownState(sessionVariable);
+                }
+            }
+            List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
+            if (selectPartitionKeys.stream()
+                    .map(PartitionUtil::generateMVPartitionName)
+                    .noneMatch(x -> refTablePartitionNamesToRefresh.contains(x))) {
+                return MVCompensation.createNoCompensateState(sessionVariable);
+            }
+            // if mv's to refresh partitions contains any of query's select partition ids, then rewrite with compensate.
+            List<PartitionKey> toRefreshRefTablePartitions = getMVCompensatePartitionsOfExternal(
+                    refTablePartitionNamesToRefresh, refScanOperator);
+            if (toRefreshRefTablePartitions == null) {
+                return MVCompensation.createUnkownState(sessionVariable);
+            }
+            Table table = refScanOperator.getTable();
+            if (Sets.newHashSet(toRefreshRefTablePartitions).containsAll(selectPartitionKeys)) {
+                logMVRewrite(mvContext, "All external table {}'s selected partitions {} need to refresh, no rewrite",
+                        table.getName(), selectPartitionIds);
+                return MVCompensation.createNoRewriteState(sessionVariable);
+            }
+            return ofExternalTableCompensation(table, toRefreshRefTablePartitions);
+        } catch (AnalysisException e) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+    }
+
+    /**
+     * Get mv's compensate partitions for ref table(olap table).
+     * @param refBaseTable: materialized view's ref base table
+     * @param refScanOperator: ref base table's scan operator.
+     * @return: need to compensate partition ids of the materialized view.
+     */
+    private List<Long> getMVCompensatePartitionsOfOlap(Set<String> partitionNamesToRefresh,
+                                                       Table refBaseTable,
+                                                       LogicalScanOperator refScanOperator) {
+        LogicalOlapScanOperator olapScanOperator = ((LogicalOlapScanOperator) refScanOperator);
+        if (olapScanOperator.getSelectedPartitionId() == null) {
+            return null;
+        }
+        List<Long> refTableCompensatePartitionIds = Lists.newArrayList();
+        List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
+        for (Long selectPartitionId : selectPartitionIds) {
+            Partition partition = refBaseTable.getPartition(selectPartitionId);
+            // If this partition has updated, add it into compensate partition ids.
+            if (partitionNamesToRefresh.contains(partition.getName())) {
+                refTableCompensatePartitionIds.add(selectPartitionId);
+            }
+        }
+        return refTableCompensatePartitionIds;
+    }
+
+    private List<PartitionKey> getMVCompensatePartitionsOfExternal(Set<String> refTablePartitionNamesToRefresh,
+                                                                   LogicalScanOperator refScanOperator)
+            throws AnalysisException {
+        ScanOperatorPredicates scanOperatorPredicates = null;
+        try {
+            scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
+        } catch (Exception e) {
+            return null;
+        }
+        if (scanOperatorPredicates == null) {
+            return null;
+        }
+        List<PartitionKey> refTableCompensatePartitionKeys = Lists.newArrayList();
+        List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
+        // different behavior for different external table types
+        if (selectPartitionKeys.isEmpty() && refScanOperator.getOpType() != OperatorType.LOGICAL_HIVE_SCAN) {
+            return null;
+        }
+        for (PartitionKey partitionKey : selectPartitionKeys) {
+            String partitionName = generateMVPartitionName(partitionKey);
+            if (refTablePartitionNamesToRefresh.contains(partitionName)) {
+                refTableCompensatePartitionKeys.add(partitionKey);
+            }
+        }
+        return refTableCompensatePartitionKeys;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OlapTableCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OlapTableCompensation.java
@@ -1,0 +1,30 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.compensation;
+
+import java.util.List;
+
+public class OlapTableCompensation extends BaseCompensation<Long> {
+    public OlapTableCompensation(List<Long> partitionIds) {
+        super(partitionIds);
+    }
+
+    @Override
+    public String toString() {
+        return "OlapTableCompensation{" +
+                "partitionIds=" + getCompensations() +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OptCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OptCompensator.java
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.compensation;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.TableVersionRange;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.apache.iceberg.Snapshot;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.convertPartitionKeysToListPredicate;
+
+/**
+ * Compensate the scan operator with the partition compensation.
+ */
+public class OptCompensator extends OptExpressionVisitor<OptExpression, Void> {
+    private final OptimizerContext optimizerContext;
+    private final MaterializedView mv;
+    private final Map<Table, BaseCompensation<?>> compensations;
+    private final Map<Table, Column> partitionTableAndColumns;
+    // for olap table
+    public OptCompensator(OptimizerContext optimizerContext,
+                          MaterializedView mv,
+                          Map<Table, BaseCompensation<?>> compensations) {
+        this.optimizerContext = optimizerContext;
+        this.mv = mv;
+        this.compensations = compensations;
+        this.partitionTableAndColumns = mv.getRefBaseTablePartitionColumns();
+    }
+
+    @Override
+    public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
+        LogicalScanOperator scanOperator = optExpression.getOp().cast();
+        Table refBaseTable = scanOperator.getTable();
+        if (partitionTableAndColumns == null || !partitionTableAndColumns.containsKey(refBaseTable)) {
+            return optExpression;
+        }
+
+        // reset the partition prune flag to be pruned again.
+        Utils.resetOpAppliedRule(scanOperator, Operator.OP_PARTITION_PRUNE_BIT);
+        if (refBaseTable.isNativeTableOrMaterializedView()) {
+            List<Long> olapTableCompensatePartitionIds = Lists.newArrayList();
+            if (compensations.containsKey(refBaseTable)) {
+                BaseCompensation<?> compensation = compensations.get(refBaseTable);
+                BaseCompensation<Long> olapTableCompensation = (BaseCompensation<Long>) compensation;
+                olapTableCompensatePartitionIds = olapTableCompensation.getCompensations();
+            }
+            LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
+            LogicalScanOperator newScanOperator = getOlapTableCompensatePlan(olapScanOperator, olapTableCompensatePartitionIds);
+            return OptExpression.create(newScanOperator);
+        } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(scanOperator.getOpType())) {
+            List<PartitionKey> partitionKeys = Lists.newArrayList();
+            if (compensations.containsKey(refBaseTable)) {
+                BaseCompensation<?> compensation = compensations.get(refBaseTable);
+                BaseCompensation<PartitionKey> externalTableCompensation = (BaseCompensation<PartitionKey>) compensation;
+                partitionKeys = externalTableCompensation.getCompensations();
+            }
+            LogicalScanOperator newScanOperator = getExternalTableCompensatePlan(scanOperator, partitionKeys);
+            return OptExpression.create(newScanOperator);
+        } else {
+            return optExpression;
+        }
+    }
+
+    private LogicalScanOperator getOlapTableCompensatePlan(LogicalOlapScanOperator scanOperator,
+                                                           List<Long> olapTableCompensatePartitionIds) {
+        final LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
+        Preconditions.checkState(olapTableCompensatePartitionIds != null);
+        // reset original partition predicates to prune partitions/tablets again
+        builder.withOperator(scanOperator)
+                .setSelectedPartitionId(olapTableCompensatePartitionIds)
+                .setSelectedTabletId(Lists.newArrayList());
+        return builder.build();
+    }
+
+    private LogicalScanOperator getExternalTableCompensatePlan(LogicalScanOperator scanOperator,
+                                                               List<PartitionKey> partitionKeys) {
+
+        Table refBaseTable = scanOperator.getTable();
+        final LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(scanOperator);
+        // reset original partition predicates to prune partitions/tablets again
+        builder.withOperator(scanOperator);
+
+        // NOTE: This is necessary because iceberg's physical plan will not use selectedPartitionIds to
+        // prune partitions.
+        Column refBaseTablePartitionCol = partitionTableAndColumns.get(refBaseTable);
+        Preconditions.checkState(refBaseTablePartitionCol != null);
+        ColumnRefOperator partitionColumnRef = scanOperator.getColumnReference(refBaseTablePartitionCol);
+        Preconditions.checkState(partitionColumnRef != null);
+
+        ScalarOperator externalExtraPredicate = convertPartitionKeysToListPredicate(partitionColumnRef,
+                partitionKeys);
+        Preconditions.checkState(externalExtraPredicate != null);
+        externalExtraPredicate.setRedundant(true);
+
+        Preconditions.checkState(externalExtraPredicate != null);
+        ScalarOperator finalPredicate = Utils.compoundAnd(scanOperator.getPredicate(), externalExtraPredicate);
+        builder.setPredicate(finalPredicate);
+        if (scanOperator.getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN) {
+            // refresh iceberg table's metadata
+            IcebergTable cachedIcebergTable = (IcebergTable) refBaseTable;
+            String catalogName = cachedIcebergTable.getCatalogName();
+            String dbName = cachedIcebergTable.getRemoteDbName();
+            TableName tableName = new TableName(catalogName, dbName, cachedIcebergTable.getName());
+            Table currentTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName).orElse(null);
+            if (currentTable == null) {
+                return null;
+            }
+
+            builder.setTable(currentTable);
+            TableVersionRange versionRange = TableVersionRange.withEnd(
+                    Optional.ofNullable(((IcebergTable) currentTable).getNativeTable().currentSnapshot())
+                            .map(Snapshot::snapshotId));
+            builder.setTableVersionRange(versionRange);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public OptExpression visit(OptExpression optExpression, Void context) {
+        List<OptExpression> children = Lists.newArrayList();
+        for (int i = 0; i < optExpression.arity(); ++i) {
+            children.add(optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), null));
+        }
+        return OptExpression.create(optExpression.getOp(), children);
+    }
+
+    /**
+     * Get the compensation plan for the mv.
+     * @param mv the mv to compensate
+     * @param compensations the compensations for the mv, including ref base table's compensations
+     * @param optExpression query plan with the ref base table
+     * @return the compensation plan for the mv
+     */
+    public static OptExpression getMVCompensatePlan(OptimizerContext optimizerContext,
+                                                    MaterializedView mv,
+                                                    Map<Table, BaseCompensation<?>> compensations,
+                                                    OptExpression optExpression) {
+        OptCompensator scanOperatorCompensator = new OptCompensator(optimizerContext, mv, compensations);
+        return optExpression.getOp().accept(scanOperatorCompensator, optExpression, null);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -35,10 +35,10 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.BestMvSelector;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.IMaterializedViewRewriter;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensation;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensation;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -26,6 +26,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
+import com.starrocks.planner.MaterializedViewTestBase;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.ShowExecutor;
@@ -290,7 +291,7 @@ public class MaterializedViewTest {
         connectContext.executeSql("refresh materialized view mv_to_rename with sync mode");
         Optional<Long> maxTime = oldMv.maxBaseTableRefreshTimestamp();
         Assert.assertTrue(maxTime.isPresent());
-        Pair<Table, Column> pair = oldMv.getRefBaseTablePartitionColumn();
+        Pair<Table, Column> pair = MaterializedViewTestBase.getRefBaseTablePartitionColumn(oldMv);
         Assert.assertEquals("tbl1", pair.first.getName());
 
         String alterSql = "alter materialized view mv_to_rename rename mv_new_name;";

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -16,10 +16,9 @@ package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.MvRefreshArbiter;
-import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.scheduler.Task;
@@ -33,8 +32,6 @@ import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
@@ -43,6 +40,7 @@ import org.junit.BeforeClass;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -325,5 +323,12 @@ public class MaterializedViewTestBase extends PlanTestBase {
         String tableName = matcher.group(1);
         starRocksAssert.withMaterializedView(sql);
         refreshMaterializedView(db, tableName);
+    }
+
+    public static Pair<Table, Column> getRefBaseTablePartitionColumn(MaterializedView mv) {
+        Map<Table, Column> result = mv.getRefBaseTablePartitionColumns();
+        Assert.assertTrue(result.size() == 1);
+        Map.Entry<Table, Column> e = result.entrySet().iterator().next();
+        return Pair.create(e.getKey(), e.getValue());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -306,7 +306,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
                 "GROUP BY " +
                 "`l_orderkey`, `l_suppkey`, `l_shipdate`;";
         String plan = getFragmentPlan(query1);
-        PlanTestBase.assertContains(plan, "hive_partitioned_mv", "UNION");
+        PlanTestBase.assertContains(plan, "hive_partitioned_mv");
         dropMv("test", "hive_partitioned_mv");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -67,6 +67,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.starrocks.planner.MaterializedViewTestBase.getRefBaseTablePartitionColumn;
+
 public class MvRewritePreprocessorTest extends MvRewriteTestBase {
     @BeforeClass
     public static void before() throws Exception {
@@ -219,7 +221,7 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             Assert.assertEquals("mv_4", materializationContext.getMv().getName());
 
             MaterializedView mv = getMv("test", "mv_4");
-            Pair<Table, Column> partitionTableAndColumn = mv.getRefBaseTablePartitionColumn();
+            Pair<Table, Column> partitionTableAndColumn = getRefBaseTablePartitionColumn(mv);
             Assert.assertEquals("tbl_with_mv", partitionTableAndColumn.first.getName());
 
             ScalarOperator scalarOperator = materializationContext.getMvPartialPartitionPredicate();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithHiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithHiveTableTest.java
@@ -217,13 +217,16 @@ public class MvTransparentRewriteWithHiveTableTest extends MvRewriteTestBase {
 
             {
                 String[] sqls = {
-                        "SELECT * FROM mv0 WHERE l_shipdate >= '1998-01-01' and l_suppkey > 100;",
                         "SELECT * FROM mv0 WHERE l_shipdate != '1998-01-01' and l_suppkey > 100;",
+                        "SELECT * FROM mv0 WHERE l_shipdate >= '1998-01-01' and l_suppkey > 100;",
                         "SELECT * FROM mv0 WHERE l_shipdate <= '1998-01-05' and l_suppkey > 100;",
                 };
                 for (String query : sqls) {
+                    System.out.println(query);
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    // transparent plan will contain union, but it can be pruned
+                    PlanTestBase.assertNotContains(plan, "UNION");
+                    PlanTestBase.assertContains(plan, ": mv0");
                 }
             }
         });

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
@@ -314,23 +314,39 @@ public class MvTransparentUnionRewriteHiveTest extends MvRewriteTestBase {
     @Test
     public void testTransparentRewriteWithJoinMv2() {
         withPartialJoinMv(() -> {
-            String[] sqls = {
-                    "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
-                            " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
-                            " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
-                            "WHERE a.l_shipdate >= '1998-01-01';",
-                    "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
-                            " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
-                            " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
-                            "WHERE a.l_shipdate != '1998-01-01' and a.l_suppkey > 100;",
-                    "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
-                            " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
-                            " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
-                            "WHERE a.l_shipdate <= '1998-01-05' and a.l_suppkey > 100;",
-            };
-            for (String query : sqls) {
-                String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+            {
+                String[] sqls = {
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate >= '1998-01-01';",
+                };
+                // lineitem and order have no intersected dates.
+                for (String query : sqls) {
+                    System.out.println(query);
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                }
+            }
+
+            {
+                String[] sqls = {
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate != '1998-01-01' and a.l_suppkey > 100;",
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate <= '1998-01-05' and a.l_suppkey > 100;",
+                };
+                // lineitem and order have no intersected dates.
+                for (String query : sqls) {
+                    System.out.println(query);
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ": lineitem_par");
+                    PlanTestBase.assertNotContains(plan, ":UNION", ": mv0");
+                }
             }
         });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
@@ -29,6 +29,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
@@ -204,5 +205,18 @@ public class MvUtilsTest {
             Assert.assertEquals(20, upperDate.getDay());
             Assert.assertEquals(0, upperDate.getHour());
         }
+    }
+
+    @Test
+    public void testResetOpAppliedRule() {
+        LogicalScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
+        Operator op = builder.build();
+        Assert.assertFalse(Utils.isOpAppliedRule(op, Operator.OP_PARTITION_PRUNE_BIT));
+        // set
+        Utils.setOpAppliedRule(op, Operator.OP_PARTITION_PRUNE_BIT);
+        Assert.assertTrue(Utils.isOpAppliedRule(op, Operator.OP_PARTITION_PRUNE_BIT));
+        // reset
+        Utils.resetOpAppliedRule(op, Operator.OP_PARTITION_PRUNE_BIT);
+        Assert.assertFalse(Utils.isOpAppliedRule(op, Operator.OP_PARTITION_PRUNE_BIT));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -117,6 +117,7 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.system.BackendResourceStat;
 import mockit.Mock;
 import mockit.MockUp;
@@ -1144,7 +1145,9 @@ public class StarRocksAssert {
 
         public void explainContains(String... keywords) throws Exception {
             String plan = explainQuery();
-            Assert.assertTrue(plan, Stream.of(keywords).allMatch(plan::contains));
+            for (String keyword : keywords) {
+                PlanTestBase.assertContains(plan, keyword);
+            }
         }
 
         public void explainContains(String keywords, int count) throws Exception {
@@ -1152,7 +1155,7 @@ public class StarRocksAssert {
         }
 
         public void explainWithout(String s) throws Exception {
-            Assert.assertFalse(explainQuery().contains(s));
+            PlanTestBase.assertNotContains(explainQuery(), s);
         }
 
         public String explainQuery() throws Exception {

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_hive
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_hive
@@ -1071,26 +1071,25 @@ True
 SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
 -- result:
 2020-06-15	3
-2020-06-15	3
 2020-06-15	9
+2020-06-16	3
 -- !result
 SELECT dt, num FROM test_mv1 where dt='2020-06-15' order by 1, 2 limit 3;
 -- result:
-2020-06-15	3
 2020-06-15	3
 2020-06-15	9
 -- !result
 SELECT dt, num FROM test_mv1 where dt!='2020-06-15' order by 1, 2 limit 3;
 -- result:
 2020-06-16	3
-2020-06-16	3
 2020-06-18	5
+2020-06-18	8
 -- !result
 SELECT dt, num FROM test_mv1 where dt>='2020-06-15' order by 1, 2 limit 3;
 -- result:
 2020-06-15	3
-2020-06-15	3
 2020-06-15	9
+2020-06-16	3
 -- !result
 SELECT dt, num FROM test_mv1 where dt>='2020-06-15' and num > 10 order by 1, 2 limit 3;
 -- result:
@@ -1098,73 +1097,73 @@ SELECT dt, num FROM test_mv1 where dt>='2020-06-15' and num > 10 order by 1, 2 l
 SELECT dt, num FROM test_mv1 where dt>='2020-06-15' and 1 < num < 10 order by 1, 2 limit 3;
 -- result:
 2020-06-15	3
-2020-06-15	3
 2020-06-15	9
+2020-06-16	3
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	15
+2020-06-15	12
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	15
-2020-06-16	6
+2020-06-15	12
+2020-06-16	3
 2020-06-18	13
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	15
+2020-06-15	12
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	15
+2020-06-15	12
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	15
-2020-06-16	6
+2020-06-15	12
+2020-06-16	3
 2020-06-18	13
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-07-02	9
-2020-07-05	15
-2020-07-08	21
+2020-07-02	6
+2020-07-05	10
+2020-07-08	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	15
-2020-06-16	6
+2020-06-15	12
+2020-06-16	3
 2020-06-18	13
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_iceberg_part2
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_iceberg_part2
@@ -497,68 +497,68 @@ True
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	9
+2020-06-15	6
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	9
-2020-06-16	6
+2020-06-15	6
+2020-06-16	3
 2020-06-18	13
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-16	6
+2020-06-16	3
 2020-06-18	13
-2020-06-21	21
+2020-06-21	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	9
+2020-06-15	6
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	9
+2020-06-15	6
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	9
-2020-06-16	6
+2020-06-15	6
+2020-06-16	3
 2020-06-18	13
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-07-02	9
-2020-07-05	15
-2020-07-08	21
+2020-07-02	6
+2020-07-05	10
+2020-07-08	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	9
-2020-06-16	6
+2020-06-15	6
+2020-06-16	3
 2020-06-18	13
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_olap
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_olap
@@ -1115,8 +1115,8 @@ SELECT dt, num FROM test_mv1 where dt='2020-06-15' order by 1, 2 limit 3;
 SELECT dt, num FROM test_mv1 where dt!='2020-06-15' order by 1, 2 limit 3;
 -- result:
 2020-06-18 00:00:00	5
-2020-06-18 00:00:00	5
 2020-06-18 00:00:00	8
+2020-06-21 00:00:00	7
 -- !result
 SELECT dt, num FROM test_mv1 where dt>='2020-06-15' order by 1, 2 limit 3;
 -- result:
@@ -1139,39 +1139,39 @@ SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
-2020-06-24 00:00:00	27
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
+2020-06-24 00:00:00	18
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
 2020-06-15 00:00:00	9
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
-2020-06-24 00:00:00	27
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
+2020-06-24 00:00:00	18
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
-2020-06-24 00:00:00	27
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
+2020-06-24 00:00:00	18
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
-2020-06-24 00:00:00	27
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
+2020-06-24 00:00:00	18
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
-2020-07-02 00:00:00	9
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
+2020-07-02 00:00:00	6
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
 -- result:
@@ -1184,20 +1184,20 @@ SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
 2020-06-15 00:00:00	9
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-07-02 00:00:00	9
-2020-07-05 00:00:00	15
-2020-07-08 00:00:00	21
+2020-07-02 00:00:00	6
+2020-07-05 00:00:00	10
+2020-07-08 00:00:00	14
 -- !result
 SELECT dt,sum(num) FROM test_mv1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
 2020-06-15 00:00:00	9
-2020-06-18 00:00:00	18
-2020-06-21 00:00:00	21
+2020-06-18 00:00:00	13
+2020-06-21 00:00:00	14
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 -- result:
@@ -1309,8 +1309,8 @@ SELECT dt, num FROM test_mv1 where dt='2020-06-15' order by 1, 2 limit 3;
 SELECT dt, num FROM test_mv1 where dt!='2020-06-15' order by 1, 2 limit 3;
 -- result:
 2020-06-18 00:00:00	2
-2020-06-18 00:00:00	2
 2020-06-18 00:00:00	3
+2020-06-21 00:00:00	3
 -- !result
 SELECT dt, num FROM test_mv1 where dt>='2020-06-15' order by 1, 2 limit 3;
 -- result:
@@ -1333,39 +1333,39 @@ SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	10
-2020-06-21 00:00:00	14
-2020-06-24 00:00:00	18
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
 2020-06-15 00:00:00	6
-2020-06-18 00:00:00	10
-2020-06-21 00:00:00	14
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	10
-2020-06-21 00:00:00	14
-2020-06-24 00:00:00	18
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	10
-2020-06-21 00:00:00	14
-2020-06-24 00:00:00	18
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	10
-2020-06-21 00:00:00	14
-2020-06-24 00:00:00	18
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-18 00:00:00	10
-2020-06-21 00:00:00	14
-2020-07-02 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
 -- result:
@@ -1378,14 +1378,14 @@ SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
 2020-06-15 00:00:00	6
-2020-06-18 00:00:00	10
-2020-06-21 00:00:00	14
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
 -- !result
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-07-02 00:00:00	6
-2020-07-05 00:00:00	10
-2020-07-08 00:00:00	14
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 -- result:


### PR DESCRIPTION
## Why I'm doing:

This is the last pr to replace original ref base table with  multi ref base tables in partition compention and mv rewrite.

## What I'm doing:
- Supports to track multi ref base tables in partition compensate instead of original single ref base table;
- Fix mv timeliness check for nested mvs: if base table is mv which may lose some partitions to refresh, so needs to compensate its partitions from the base tables(mv)' base tables;
- Fix wrong results introduced by Part1;
- Remove `getRefBaseTableAndColumn` from `MaterializedView`;

Fixes  https://github.com/StarRocks/starrocks/issues/48354

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
