### PR TITLE
[BugFix] fix constant evaluation before expr open

### DIFF
--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -63,7 +63,8 @@ public:
     ~CastStringToArray() override = default;
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* input_chunk) override;
     Expr* clone(ObjectPool* pool) const override { return pool->add(new CastStringToArray(*this)); }
-    Status prepare(RuntimeState* state, ExprContext* context) override;
+    [[nodiscard]] Status open(RuntimeState* state, ExprContext* context,
+                              FunctionContext::FunctionStateScope scope) override;
 
 private:
     Slice _unquote(Slice slice) const;

--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -127,10 +127,12 @@ void array_delimeter_split(const Slice& src, std::vector<Slice>& res, std::vecto
     }
 }
 
-Status CastStringToArray::prepare(RuntimeState* state, ExprContext* context) {
-    RETURN_IF_ERROR(Expr::prepare(state, context));
-    if (is_constant()) {
-        ASSIGN_OR_RETURN(_constant_res, evaluate_const(context));
+Status CastStringToArray::open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+    RETURN_IF_ERROR(Expr::open(state, context, scope));
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        if (is_constant()) {
+            ASSIGN_OR_RETURN(_constant_res, evaluate_const(context));
+        }
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Why I'm doing:
ASAN will check evaluate operation should after open.

## What I'm doing:
Move the evaluate_const step in open.



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
