### PR TITLE
[BugFix] Fix some bug of alter struct column.

### DIFF
--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -215,7 +215,7 @@ Status CompactionTask::_shortcut_compact(Statistics* statistics) {
     }
 
     if (data_rowsets.size() == 1 && !data_rowsets.back()->rowset_meta()->is_segments_overlapping() &&
-        _tablet->enable_shortcut_compaction()) {
+        _tablet->enable_shortcut_compaction() && data_rowsets[0]->schema()->id() == _tablet_schema->id()) {
         TRACE("[Compaction] start shortcut comapction data");
         int64_t max_rows_per_segment = CompactionUtils::get_segment_max_rows(
                 config::max_segment_file_size, _task_info.input_rows_num, _task_info.input_rowsets_size);

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -216,7 +216,7 @@ Status CompactionTask::_shortcut_compact(Statistics* statistics) {
 
     // if there is only one non-overlapping rowset, but the input rowset schema is different with output schema
     // we can not do shortcut compaction too.
-    // the reason is after we support add/drop field for struct column, we need to make sure the rowset schema is 
+    // the reason is after we support add/drop field for struct column, we need to make sure the rowset schema is
     // consistent with segment data because of some compatible issue. so we will skip shortcut compaction when we
     // found the scheam id is different.
     if (data_rowsets.size() == 1 && !data_rowsets.back()->rowset_meta()->is_segments_overlapping() &&

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -214,6 +214,11 @@ Status CompactionTask::_shortcut_compact(Statistics* statistics) {
         }
     }
 
+    // if there is only one non-overlapping rowset, but the input rowset schema is different with output schema
+    // we can not do shortcut compaction too.
+    // the reason is after we support add/drop field for struct column, we need to make sure the rowset schema is 
+    // consistent with segment data because of some compatible issue. so we will skip shortcut compaction when we
+    // found the scheam id is different.
     if (data_rowsets.size() == 1 && !data_rowsets.back()->rowset_meta()->is_segments_overlapping() &&
         _tablet->enable_shortcut_compaction() && data_rowsets[0]->schema()->id() == _tablet_schema->id()) {
         TRACE("[Compaction] start shortcut comapction data");

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -295,17 +295,16 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
         return Status::OK();
     } else if (_column_type == LogicalType::TYPE_STRUCT) {
         _sub_readers = std::make_unique<SubReaderList>();
-        LOG(INFO) << "meta children_columns_size:" << meta->children_columns_size();
         for (int i = 0; i < meta->children_columns_size(); ++i) {
             auto sub_column = (column != nullptr) ? column->subcolumn_ptr(i) : nullptr;
             if (sub_column != nullptr) {
-                // the type of unique_id in meta is uint32_t and the default value is -1
-                // so cast to int64 to compare
-                int64_t uid_in_meta = static_cast<int64_t>(meta->mutable_children_columns(i)->unique_id());
-                int64_t uid_in_col = static_cast<int64_t>(sub_column->unique_id());
+                // the type of unique_id in meta is uint32_t and the default value is -1(4294967295), but the type of 
+                // unique id in tablet column is int32_t. so cast to int32 to compare
+                int32_t uid_in_meta = static_cast<int32_t>(meta->mutable_children_columns(i)->unique_id());
+                int32_t uid_in_col = sub_column->unique_id();
                 if (uid_in_meta != uid_in_col) {
                     std::string msg =
-                            strings::Substitute("sub_column($0) unique id in meta($0) is not equal to schema($1)",
+                            strings::Substitute("sub_column($0) unique id in meta($1) is not equal to schema($2)",
                                                 sub_column->name(), uid_in_meta, uid_in_col);
                     LOG(ERROR) << msg;
                     return Status::InternalError(msg);

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -295,8 +295,22 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
         return Status::OK();
     } else if (_column_type == LogicalType::TYPE_STRUCT) {
         _sub_readers = std::make_unique<SubReaderList>();
+        LOG(INFO) << "meta children_columns_size:" << meta->children_columns_size();
         for (int i = 0; i < meta->children_columns_size(); ++i) {
             auto sub_column = (column != nullptr) ? column->subcolumn_ptr(i) : nullptr;
+            if (sub_column != nullptr) {
+                // the type of unique_id in meta is uint32_t and the default value is -1
+                // so cast to int64 to compare
+                int64_t uid_in_meta = static_cast<int64_t>(meta->mutable_children_columns(i)->unique_id());
+                int64_t uid_in_col = static_cast<int64_t>(sub_column->unique_id());
+                if (uid_in_meta != uid_in_col) {
+                    std::string msg =
+                            strings::Substitute("sub_column($0) unique id in meta($0) is not equal to schema($1)",
+                                                sub_column->name(), uid_in_meta, uid_in_col);
+                    LOG(ERROR) << msg;
+                    return Status::InternalError(msg);
+                }
+            }
             auto res = ColumnReader::create(meta->mutable_children_columns(i), _segment, sub_column);
             RETURN_IF_ERROR(res);
             _sub_readers->emplace_back(std::move(res).value());

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -298,7 +298,7 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
         for (int i = 0; i < meta->children_columns_size(); ++i) {
             auto sub_column = (column != nullptr) ? column->subcolumn_ptr(i) : nullptr;
             if (sub_column != nullptr) {
-                // the type of unique_id in meta is uint32_t and the default value is -1(4294967295), but the type of 
+                // the type of unique_id in meta is uint32_t and the default value is -1(4294967295), but the type of
                 // unique id in tablet column is int32_t. so cast to int32 to compare
                 int32_t uid_in_meta = static_cast<int32_t>(meta->mutable_children_columns(i)->unique_id());
                 int32_t uid_in_col = sub_column->unique_id();

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -124,7 +124,7 @@ Status DefaultValueColumnIterator::next_batch(const SparseRange<>& range, Column
     // if array column is nullable, range maybe empty. Before we support add/drop field for struct,
     // the element column iterator of array can not be default value column iterator.
     // However, if the element type of array is struct and we add a new field into the struct element,
-    // we may access `DefaultValueColumnIterator` right now. 
+    // we may access `DefaultValueColumnIterator` right now.
     // And when the range is empty, the `range.end()` will meet nullptr.
     // So if the range is empty, return ok is enough.
     if (to_read == 0) {

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -121,6 +121,15 @@ Status DefaultValueColumnIterator::next_batch(size_t* n, Column* dst) {
 
 Status DefaultValueColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
     size_t to_read = range.span_size();
+    // if array column is nullable, range maybe empty. Before we support add/drop field for struct,
+    // the element column iterator of array can not be default value column iterator.
+    // However, if the element type of array is struct and we add a new field into the struct element,
+    // we may access `DefaultValueColumnIterator` right now. 
+    // And when the range is empty, the `range.end()` will meet nullptr.
+    // So if the range is empty, return ok is enough.
+    if (to_read == 0) {
+        return Status::OK();
+    }
     if (_is_default_value_null) {
         [[maybe_unused]] bool ok = dst->append_nulls(to_read);
         _current_rowid = range.end();

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -177,7 +177,7 @@ protected:
             ASSERT_TRUE(f3_tablet_column.has_default_value());
             new_struct_column.add_sub_column(f3_tablet_column);
             {
-                auto f1_meta = meta2.children_columns(0);
+                auto f1_meta = meta2.mutable_children_columns(0);
                 f1_meta->set_unique_id(0);
                 auto res = ColumnReader::create(&meta2, segment.get(), &struct_column);
                 ASSERT_FALSE(res.ok());

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -176,6 +176,13 @@ protected:
             TabletColumn f3_tablet_column = create_int_value(3, STORAGE_AGGREGATE_NONE, true, "2");
             ASSERT_TRUE(f3_tablet_column.has_default_value());
             new_struct_column.add_sub_column(f3_tablet_column);
+            {
+                auto f1_meta = meta2.children_columns(0);
+                f1_meta->set_unique_id(0);
+                auto res = ColumnReader::create(&meta2, segment.get(), &struct_column);
+                ASSERT_FALSE(res.ok());
+                f1_meta->set_unique_id(1);
+            }
             auto res = ColumnReader::create(&meta2, segment.get(), &struct_column);
             ASSERT_TRUE(res.ok());
             auto struct_reader = std::move(res).value();

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -101,7 +101,7 @@ protected:
             // init integer sub column
             ColumnMetaPB* f1_meta = writer_opts.meta->add_children_columns();
             f1_meta->set_column_id(0);
-            f1_meta->set_unique_id(0);
+            f1_meta->set_unique_id(1);
             f1_meta->set_type(f1_tablet_column.type());
             f1_meta->set_length(f1_tablet_column.length());
             f1_meta->set_encoding(DEFAULT_ENCODING);
@@ -110,7 +110,7 @@ protected:
 
             ColumnMetaPB* f2_meta = writer_opts.meta->add_children_columns();
             f2_meta->set_column_id(0);
-            f2_meta->set_unique_id(0);
+            f2_meta->set_unique_id(2);
             f2_meta->set_type(f2_tablet_column.type());
             f2_meta->set_length(f2_tablet_column.length());
             f2_meta->set_encoding(DEFAULT_ENCODING);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
@@ -24,10 +24,11 @@ import java.util.Optional;
 import java.util.Set;
 
 public class AlterHelper {
+    private static final Logger LOG = LogManager.getLogger(AlterHelper.class);
     static Set<String> collectDroppedOrModifiedColumns(List<Column> oldColumns, List<Column> newColumns) {
         Set<Integer> columnUniqueIdSet = new HashSet<>();
         Set<String> modifiedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        Set<Integer> structColumnUniqueIdSet = new HashSet<>();
+        Set<Integer> complexColumnUniqueIdSet = new HashSet<>();
         // Collect modified columns
         for (Column column : newColumns) {
             Preconditions.checkState(column.getUniqueId() >= 0);
@@ -36,19 +37,20 @@ public class AlterHelper {
                 modifiedColumns.add(column.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PREFIX, column.getName()));
             }
         }
+        
         // Collect dropped columns
         for (Column column : oldColumns) {
             if (!columnUniqueIdSet.contains(column.getUniqueId())) {
                 modifiedColumns.add(column.getName());
-            } else if (column.getType().isStructType()) {
-                structColumnUniqueIdSet.add(column.getUniqueId());
+            } else if (!column.getType().isScalarType()) {
+                complexColumnUniqueIdSet.add(column.getUniqueId());
             }
         }
 
         // If column is struct column, we may add/drop field of column and these operation does not change
         // the uniqueId of struct column. 
         // So we need to do extra check for struct column.
-        for (Integer uid : structColumnUniqueIdSet) {
+        for (Integer uid : complexColumnUniqueIdSet) {
             Optional<Column> newCol = newColumns.stream().filter(c -> c.getUniqueId() == uid).findFirst();
             Optional<Column> oldCol = oldColumns.stream().filter(c -> c.getUniqueId() == uid).findFirst();
             if (!newCol.isPresent()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.Set;
 
 public class AlterHelper {
-    private static final Logger LOG = LogManager.getLogger(AlterHelper.class);
     static Set<String> collectDroppedOrModifiedColumns(List<Column> oldColumns, List<Column> newColumns) {
         Set<Integer> columnUniqueIdSet = new HashSet<>();
         Set<String> modifiedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
@@ -20,12 +20,14 @@ import com.starrocks.catalog.Column;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class AlterHelper {
     static Set<String> collectDroppedOrModifiedColumns(List<Column> oldColumns, List<Column> newColumns) {
         Set<Integer> columnUniqueIdSet = new HashSet<>();
         Set<String> modifiedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        Set<Integer> structColumnUniqueIdSet = new HashSet<>();
         // Collect modified columns
         for (Column column : newColumns) {
             Preconditions.checkState(column.getUniqueId() >= 0);
@@ -38,6 +40,22 @@ public class AlterHelper {
         for (Column column : oldColumns) {
             if (!columnUniqueIdSet.contains(column.getUniqueId())) {
                 modifiedColumns.add(column.getName());
+            } else if (column.getType().isStructType()) {
+                structColumnUniqueIdSet.add(column.getUniqueId());
+            }
+        }
+
+        // If column is struct column, we may add/drop field of column and these operation does not change
+        // the uniqueId of struct column. 
+        // So we need to do extra check for struct column.
+        for (Integer uid : structColumnUniqueIdSet) {
+            Optional<Column> newCol = newColumns.stream().filter(c -> c.getUniqueId() == uid).findFirst();
+            Optional<Column> oldCol = oldColumns.stream().filter(c -> c.getUniqueId() == uid).findFirst();
+            if (!newCol.isPresent()) {
+                continue;
+            }
+            if (!newCol.get().equals(oldCol.get())) {
+                modifiedColumns.add(oldCol.get().getName());
             }
         }
         return modifiedColumns;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
@@ -142,7 +142,8 @@ public class StructField {
         }
         StructField otherStructField = (StructField) other;
         // Both are named struct field
-        return StringUtils.equalsIgnoreCase(name, otherStructField.name) && Objects.equal(type, otherStructField.type);
+        return StringUtils.equalsIgnoreCase(name, otherStructField.name) && Objects.equal(type, otherStructField.type) &&
+                    (fieldId == otherStructField.fieldId);
     }
 
     @Override

--- a/test/sql/test_add_drop_field/R/test_add_drop_field
+++ b/test/sql/test_add_drop_field/R/test_add_drop_field
@@ -66,6 +66,26 @@ select * from tab1;
 2	{"v1":2,"v2":{"v3":2,"v4":2},"val1":null}
 3	{"v1":3,"v2":{"v3":3,"v4":3},"val1":3}
 -- !result
+CREATE MATERIALIZED VIEW mv1
+            distributed by hash(c0) as
+            SELECT * from tab1;
+-- result:
+[]
+-- !result
+function: wait_mv_refresh_count('test_add_drop_field_struct', 'mv1', 1)
+-- result:
+None
+-- !result
+SELECT count(*) FROM mv1;
+-- result:
+3
+-- !result
+select * from tab1;
+-- result:
+1	{"v1":1,"v2":{"v3":1,"v4":1},"val1":null}
+2	{"v1":2,"v2":{"v3":2,"v4":2},"val1":null}
+3	{"v1":3,"v2":{"v3":3,"v4":3},"val1":3}
+-- !result
 alter table tab1 modify column c1 drop field v2.v5;
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Analyze drop field definition failed: Drop field v5 is not found.')
@@ -178,6 +198,26 @@ select * from tab1;
 insert into tab1 values (3, [row(3,1,1), row(3,2,1)]);
 -- result:
 []
+-- !result
+select * from tab1;
+-- result:
+1	[{"v1":1,"v2":1,"val1":null},{"v1":1,"v2":2,"val1":null}]
+2	[{"v1":2,"v2":1,"val1":null},{"v1":2,"v2":2,"val1":null}]
+3	[{"v1":3,"v2":1,"val1":1},{"v1":3,"v2":2,"val1":1}]
+-- !result
+CREATE MATERIALIZED VIEW mv1
+            distributed by hash(c0) as
+            SELECT * from tab1;
+-- result:
+[]
+-- !result
+function: wait_mv_refresh_count('test_add_drop_field_array', 'mv1', 1)
+-- result:
+None
+-- !result
+SELECT count(*) FROM mv1;
+-- result:
+3
 -- !result
 select * from tab1;
 -- result:

--- a/test/sql/test_add_drop_field/T/test_add_drop_field
+++ b/test/sql/test_add_drop_field/T/test_add_drop_field
@@ -28,6 +28,13 @@ select * from tab1;
 insert into tab1 values (3, row(3, row(3,3), 3));
 select * from tab1;
 
+CREATE MATERIALIZED VIEW mv1
+            distributed by hash(c0) as
+            SELECT * from tab1;
+function: wait_mv_refresh_count('test_add_drop_field_struct', 'mv1', 1)
+SELECT count(*) FROM mv1;
+select * from tab1;
+
 alter table tab1 modify column c1 drop field v2.v5;
 alter table tab1 modify column c1 drop field v1;
 function: wait_alter_table_finish()
@@ -71,6 +78,13 @@ function: wait_alter_table_finish()
 select * from tab1;
 
 insert into tab1 values (3, [row(3,1,1), row(3,2,1)]);
+select * from tab1;
+
+CREATE MATERIALIZED VIEW mv1
+            distributed by hash(c0) as
+            SELECT * from tab1;
+function: wait_mv_refresh_count('test_add_drop_field_array', 'mv1', 1)
+SELECT count(*) FROM mv1;
 select * from tab1;
 
 alter table tab1 modify column c1 drop field [*].v1;


### PR DESCRIPTION
## Why I'm doing:
This pr fix two issues:
1. When we finish add/drop field of struct column, the related MV is still active. So the query result is not correct if query hits MV.
2. When we do compaction with multiple rowsets with different schema, we will generate a new rowset with the latest schema. However, if there is only one non-overlapping rowset which has data, we will do short-cut-compaction and only hard link the segment files. It will cause the inconsistent of rowset schema and segment data. Because we need to the rowset schema to specified struct field, so we need to make sure the consistent of rowset schema and segment data.

The solution is as following:
1. Add extra check for struct column and if we found inconsistent between two struct columns, inactive related MV.
2. Add schema check. If the rowset schema is not consistent with output rowset schema, we do not do short-cut-compaction.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
