### PR TITLE
[Enhancement] remove the indirect dependency on log4j1.2.17 to avoid FE introducing security vulnerabilities of log4j1.2

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -757,6 +757,13 @@ under the License.
                 <groupId>org.apache.hudi</groupId>
                 <artifactId>hudi-common</artifactId>
                 <version>${hudi.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.hudi/hudi-hadoop-mr -->


### PR DESCRIPTION
## Why I'm doing:
hudi-common0.14.1 depends on log4j1.2.7, which causes fe-core to indirectly depend on log4j1.2.7. log4j2.19.0 has an API compatible with log4j1.2, so log4j1.2.7 is not necessary for fe-core.  delete the dependency on log4j1.2.7 to avoid introducing security vulnerabilities in log4j1.2.

## What I'm doing:
Modify pom.xml under fe-core to exclude hudi-common's dependency on log4j

Fixes #48179

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
