### PR TITLE
[BugFix] Fix overflow for array_sortby

### DIFF
--- a/be/src/exec/sorting/sort_permute.h
+++ b/be/src/exec/sorting/sort_permute.h
@@ -55,13 +55,17 @@ using Permutation = std::vector<PermutationItem>;
 using PermutationView = array_view<PermutationItem>;
 using SmallPermutation = std::vector<SmallPermuteItem>;
 
-template <class T, class Container>
-static inline InlinePermutation<T> create_inline_permutation(const SmallPermutation& other,
-                                                             const Container& container) {
+template <class T, bool CheckBound = false>
+static inline InlinePermutation<T> create_inline_permutation(const SmallPermutation& other, const auto& container) {
     InlinePermutation<T> inlined(other.size());
     for (int i = 0; i < other.size(); i++) {
         int index = other[i].index_in_chunk;
         inlined[i].index_in_chunk = index;
+        if constexpr (CheckBound) {
+            if (index >= container.size()) {
+                continue;
+            }
+        }
         inlined[i].inline_value = container[index];
     }
     return inlined;

--- a/test/sql/test_array_fn/R/test_array_sortby
+++ b/test/sql/test_array_fn/R/test_array_sortby
@@ -269,7 +269,7 @@ with w1 as (
 select ifnull(sum(murmur_hash3_32(x)), 0)
 from w2;
 -- result:
--1020409667098526
+-1020412010001672
 -- !result
 CREATE TABLE t3 (
     id INT(11) not null,
@@ -421,4 +421,16 @@ E: (1064, "Input arrays' size are not equal in array_sortby.")
 select array_sortby([1,2,3,4,5,6], ['a', 'b', null, null, 'b', 'a'], [11, 22, 32, 31, null, null, 1]);
 -- result:
 E: (1064, "Input arrays' size are not equal in array_sortby.")
+-- !result
+-- name: test_array_sortby_3
+with w1 as (select column_0 as source, column_1 as key1, column_2 as key2 from (values
+          ([1, 2], null, [1, 1]),
+          ([3, 4], [40, 30], [1, 1]),
+          ([5, 6], null, [1, 1])
+) t)
+select array_sortby(source, key1, key2), source, key1, key2 from w1;
+-- result:
+[1,2]	[1,2]	None	[1,1]
+[4,3]	[3,4]	[40,30]	[1,1]
+[5,6]	[5,6]	None	[1,1]
 -- !result

--- a/test/sql/test_array_fn/T/test_array_sortby
+++ b/test/sql/test_array_fn/T/test_array_sortby
@@ -25,6 +25,7 @@ INSERT INTO t1 VALUES
 (8, [21, 22, 23], [19.19, 20.20, 19.19], ['a', 't', 'a'], ['2023-01-19', '2023-01-20', '2023-01-21']),
 (9, [24, 25, 26], NULL, ['y', 'y', 'z'], ['2023-01-25', '2023-01-24', '2023-01-26']),
 (10, [24, 25, 26], NULL, ['y', 'y', 'z'], ['2023-01-25', NULL, '2023-01-26']);
+
 select id, array_col1, array_col2, array_sortby(array_col1, array_col2) from t1 order by id asc;
 select id, array_col1, array_col2, array_col3, array_sortby(array_col1, array_col2, array_col3) from t1 order by id asc;
 select id, array_col1, array_col2, array_col3, array_col4, array_sortby(array_col1, array_col2, array_col3, array_col4) from t1 order by id asc;
@@ -268,3 +269,12 @@ select array_sortby([1,2,null,4,5,6], ['a', 'b', 'c', 'c', 'b', 'a', 1], [11, 22
 select array_sortby([1,2,null,4,5,6], ['a', 'b', 'c', 'c', 'b', 'a', 1], cast(null as array<int>), [11, 22, 32, 31, 21, 12]);
 select array_sortby([1,2,3,4,5,6], ['a', 'b', null, null, 'b', 'a', 1], [11, 22, 32, 31, 21, 12]);
 select array_sortby([1,2,3,4,5,6], ['a', 'b', null, null, 'b', 'a'], [11, 22, 32, 31, null, null, 1]);
+
+
+-- name: test_array_sortby_3
+with w1 as (select column_0 as source, column_1 as key1, column_2 as key2 from (values
+          ([1, 2], null, [1, 1]),
+          ([3, 4], [40, 30], [1, 1]),
+          ([5, 6], null, [1, 1])
+) t)
+select array_sortby(source, key1, key2), source, key1, key2 from w1;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```sql
select array_sortby(source_col, key_col_1, ..., key_col_m);
```

### Issue 1
We sort each key element column by `sort_and_tie_column(key_column, permutation, ranges)`, where 
- `permutation` is the sorting index of source element column and its initial value is `[0, ..., n-1]`.
- `ranges`[i] should be `[source_offsets[i], source_offsets[i+1])`, **but we sometimes use `[key_offsets[i], key_offsets[i+1])` as `ranges[i]` mistakenly`.**
- We need shift `permutation` before sorting a key column based on the `key_offsets` and `source_offsets`, in order to make the index values of `permutation[ranges[i].begin~ranges[i].end]` always be related to this range of `key_column`.

An example is as follows:

```sql
with w1 as (select column_0 as source, column_1 as key1, column_2 as key2 from (values 
    ([1, 2], null, [1, 1]),
    ([3, 4], [30, 40], [1, 1]),
    ([5, 6], null, [1, 1])
) t)
select array_sortby(source, key1, key2) from w1;
```

<img src="https://github.com/user-attachments/assets/542fcc4e-1142-4851-8c0c-fd8ec72b276e" width="50%">


### Issue 2

When sorting a `FixedLengthColumn`, we will create a inlined permutation and store values into it by `inlined_perm[i].value = column[perm[i].index]`. Therefore, we must guarantee that `column.size()` is not less than the maximum `index` of `perm`.

However, as for `array_sortby`, we cannot guarantee this. Because some row of a key array column may be null (see the above example image).
Therefore, we need check before setting `inlined_perm[i].value = column[perm[i].index]`



Introduced by #47798.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
