### PR TITLE
[BugFix] normalized CTE name to lower case for trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -335,7 +335,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
 
         return new CTERelation(
                 RelationId.of(queryStatement.getQueryRelation()).hashCode(),
-                node.getName().getValue(),
+                node.getName().getValue().toLowerCase(),
                 getColumnNames(node.getColumnNames()),
                 queryStatement);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -703,6 +703,12 @@ public class TrinoQueryTest extends TrinoTestBase {
         sql = "with x0 as (select * from t0) " +
                 "select * from x0 x,t1 y where v1 in (select v2 from x0 z where z.v1 = x.v1)";
         assertPlanContains(sql, "8:NESTLOOP JOIN", "LEFT SEMI JOIN (PARTITIONED)");
+
+        sql = "with C1 as (select * from t0) select * from C1";
+        assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
+
+        sql = "with C1 as (select * from t0) select * from C1 a where a.v1 = 1";
+        assertPlanContains(sql, "PREDICATES: 1: v1 = 1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -707,6 +707,9 @@ public class TrinoQueryTest extends TrinoTestBase {
         sql = "with C1 as (select * from t0) select * from C1";
         assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
 
+        sql = "with C1 as (select * from t0) select * from c1";
+        assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
+
         sql = "with C1 as (select * from t0) select * from C1 a where a.v1 = 1";
         assertPlanContains(sql, "PREDICATES: 1: v1 = 1");
     }


### PR DESCRIPTION
## Why I'm doing:
query analyzer report failed  when CTE name is upper case for trino paser, becase all table name normalized to lowercase in trino parser, but CTE name keep case sensetive.
## What I'm doing:
normalized CTE name to lower case fro trino parser
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
