### PR TITLE
[BugFix] Fix NestLoop Join runtime filter not evaluate in Exchange node (backport #47348)

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -47,7 +47,7 @@ Status ExchangeSourceOperator::set_finishing(RuntimeState* state) {
 StatusOr<ChunkPtr> ExchangeSourceOperator::pull_chunk(RuntimeState* state) {
     auto chunk = std::make_unique<Chunk>();
     RETURN_IF_ERROR(_stream_recvr->get_chunk_for_pipeline(&chunk, _driver_sequence));
-
+    RETURN_IF_ERROR(eval_no_eq_join_runtime_in_filters(chunk.get()));
     eval_runtime_bloom_filters(chunk.get());
     return std::move(chunk);
 }

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -19,6 +19,7 @@
 
 #include "exec/exec_node.h"
 #include "exec/pipeline/query_context.h"
+#include "exprs/expr_context.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_filter_cache.h"
@@ -181,6 +182,30 @@ Status Operator::eval_conjuncts_and_in_filters(const std::vector<ExprContext*>& 
         RETURN_IF_ERROR(
                 starrocks::ExecNode::eval_conjuncts(_cached_conjuncts_and_in_filters, chunk, filter, apply_filter));
         auto after = chunk->num_rows();
+        _conjuncts_output_counter->update(after);
+    }
+
+    return Status::OK();
+}
+
+Status Operator::eval_no_eq_join_runtime_in_filters(Chunk* chunk) {
+    if (chunk == nullptr || chunk->is_empty()) {
+        return Status::OK();
+    }
+    _init_conjuct_counters();
+    {
+        SCOPED_TIMER(_conjuncts_timer);
+        auto& in_filters = runtime_in_filters();
+        std::vector<ExprContext*> selected_vector;
+        for (ExprContext* in_filter : in_filters) {
+            if (in_filter->build_from_only_in_filter()) {
+                selected_vector.push_back(in_filter);
+            }
+        }
+        size_t before = chunk->num_rows();
+        _conjuncts_input_counter->update(before);
+        RETURN_IF_ERROR(starrocks::ExecNode::eval_conjuncts(selected_vector, chunk, nullptr));
+        size_t after = chunk->num_rows();
         _conjuncts_output_counter->update(after);
     }
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -167,6 +167,10 @@ public:
     // equal to ExecNode::eval_conjuncts(_conjunct_ctxs, chunk), is used to apply in-filters to Operators.
     Status eval_conjuncts_and_in_filters(const std::vector<ExprContext*>& conjuncts, Chunk* chunk,
                                          FilterPtr* filter = nullptr, bool apply_filter = true);
+    // evaluate no eq join runtime in filters
+    // The no-eq join runtime filter does not have a companion bloom filter.
+    // This function only executes these filters to avoid the overhead of executing an additional runtime in filter.
+    Status eval_no_eq_join_runtime_in_filters(Chunk* chunk);
 
     // Evaluate conjuncts without cache
     Status eval_conjuncts(const std::vector<ExprContext*>& conjuncts, Chunk* chunk, FilterPtr* filter = nullptr);

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -117,6 +117,11 @@ public:
 
     bool error_if_overflow() const;
 
+    void set_build_from_only_in_filter(bool build_from_only_in_filter) {
+        _build_from_only_in_filter = build_from_only_in_filter;
+    }
+    bool build_from_only_in_filter() const { return _build_from_only_in_filter; }
+
 private:
     friend class Expr;
     friend class OlapScanNode;
@@ -140,6 +145,7 @@ private:
     bool _prepared;
     bool _opened;
     RuntimeState* _runtime_state = nullptr;
+    bool _build_from_only_in_filter{false};
     // In operator, the ExprContext::close method will be called concurrently
     std::atomic<bool> _closed;
 };

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -180,7 +180,9 @@ StatusOr<ExprContext*> RuntimeFilterHelper::rewrite_runtime_filter_in_cross_join
     new_expr->clear_children();
     new_expr->add_child(new_left);
     new_expr->add_child(literal);
-    return pool->add(new ExprContext(new_expr));
+    auto expr = pool->add(new ExprContext(new_expr));
+    expr->set_build_from_only_in_filter(true);
+    return expr;
 }
 
 struct FilterZoneMapWithMinMaxOp {

--- a/test/sql/test_nest_loop_join/R/test_nest_loop_join
+++ b/test/sql/test_nest_loop_join/R/test_nest_loop_join
@@ -479,3 +479,23 @@ select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
 -- result:
 152152	76076
 -- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(1, 2000000));
+-- result:
+-- !result
+insert into t2 select generate_series, generate_series from table(generate_series(1, 1));
+-- result:
+-- !result
+select t1.c1 from t1 join t2 on t1.c1 <= t2.c1;
+-- result:
+1
+-- !result
+with L as ( select  c1 lk from  t1),R as ( select  c1 rk from  t1),DIM as ( select 1000000 as mx_lo_orderkey, 999999 as mn_lo_orderkey)select count(*)from  L join [shuffle] R on lk = rk join DIM where rk >= mn_lo_orderkey and rk <= mx_lo_orderkey;
+-- result:
+2
+-- !result

--- a/test/sql/test_nest_loop_join/T/test_nest_loop_join
+++ b/test/sql/test_nest_loop_join/T/test_nest_loop_join
@@ -163,3 +163,14 @@ select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
 select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
 select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
 select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+
+
+-- nestloop join with runtiime filter
+truncate table t1;
+truncate table t2;
+insert into t1 select generate_series, generate_series from table(generate_series(1, 2000000));
+insert into t2 select generate_series, generate_series from table(generate_series(1, 1));
+-- apply to scan
+select t1.c1 from t1 join t2 on t1.c1 <= t2.c1;
+-- apply to exchange
+with L as ( select  c1 lk from  t1),R as ( select  c1 rk from  t1),DIM as ( select 1000000 as mx_lo_orderkey, 999999 as mn_lo_orderkey)select count(*)from  L join [shuffle] R on lk = rk join DIM where rk >= mn_lo_orderkey and rk <= mx_lo_orderkey;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Why I'm doing:
for such query runtime filter is generated but not evaluate in exchange node
```
with L as (
    select
        c1 lk
    from
        t1
),
R as (
    select
        c1 rk
    from
        t1
),
DIM as (
    select
        1000000 as mx_lo_orderkey,
        999999 as mn_lo_orderkey
)
select
    count(*)
from
    L
    join [shuffle] R on lk = rk
    join DIM
where
    rk >= mn_lo_orderkey
    and rk <= mx_lo_orderkey;
```

## What I'm doing:

lineorder is from SSB100G 1BE and set pipeline_dop=4;
base line:
```
+----------+
| count(*) |
+----------+
|        9 |
+----------+
1 row in set (25.59 sec)

```
patched:
```
+----------+
| count(*) |
+----------+
|        9 |
+----------+
1 row in set (2.45 sec)
```

benchmark case on: https://github.com/StarRocks/StarRocksBenchmark/pull/488

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

