### PR TITLE
[BugFix] Fix the bug of array out-of-bounds access

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -38,6 +38,7 @@
 #include "util/crc32c.h"
 #include "util/debug_util.h"
 #include "util/defer_op.h"
+#include "util/failpoint/fail_point.h"
 #include "util/faststring.h"
 #include "util/filesystem_util.h"
 #include "util/raw_container.h"
@@ -2938,6 +2939,7 @@ Status ImmutableIndex::check_not_exist(size_t n, const Slice* keys, size_t key_s
     return Status::OK();
 }
 
+DEFINE_FAIL_POINT(immutable_index_no_page_off);
 StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<RandomAccessFile>&& file,
                                                                bool load_bf_data) {
     ASSIGN_OR_RETURN(auto file_size, file->get_size());
@@ -3028,6 +3030,7 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
         } else {
             dest.data_size = src.data_size();
         }
+        FAIL_POINT_TRIGGER_EXECUTE(immutable_index_no_page_off, { meta.mutable_shards(i)->clear_page_off(); });
         if (src.page_off().size() == 0) {
             int off = 0;
             for (int i = 0; i < src.npage() + 1; i++) {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1,5 +1,4 @@
 // Copyright 2021-present StarRocks, Inc. All rights reserved.
-// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Why I'm doing
Pindex support page compression after version 3.1.13/3.2.9, and we will record each page compressed size into `page_off` which is a vector. However,  if you upgrade from old version and disable pindex shard compression in pre-version, the `page_off` only keep one element and you may meet out-of-bounds access.

The stack is following:

```
*** Aborted at 1720652163 (unix time) try "date -d @1720652163" if you are using GNU date ***
PC: @          0x515ebd2 starrocks::ImmutableIndex::_read_page()
*** SIGSEGV (@0x7f8d3df760b8) received by PID 383772 (TID 0x7f6fdb9dc700) from PID 1039622328; stack trace: ***
    @          0x653d642 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f90873acc17 os::Linux::chained_handler()
    @     0x7f90873b4565 JVM_handle_linux_signal
    @     0x7f90873a97b3 signalHandler()
    @     0x7f908684a630 (unknown)
    @          0x515ebd2 starrocks::ImmutableIndex::_read_page()
    @          0x5173158 starrocks::ImmutableIndex::_get_in_shard_by_page()
    @          0x5176bfa starrocks::ImmutableIndex::_get_in_shard()
    @          0x51772c6 starrocks::ImmutableIndex::get()
    @          0x5177c25 starrocks::PersistentIndex::_get_from_immutable_index()
    @          0x518481c starrocks::PersistentIndex::upsert()
    @          0x4dd1c05 starrocks::PrimaryIndex::_upsert_into_persistent_index()
    @          0x4dd1f76 starrocks::PrimaryIndex::upsert()
    @          0x4ed9b98 starrocks::TabletUpdates::_do_update()
    @          0x4eea126 starrocks::TabletUpdates::_apply_normal_rowset_commit()
    @          0x4eecd96 starrocks::TabletUpdates::_apply_rowset_commit()
    @          0x4eed0e6 starrocks::TabletUpdates::do_apply()
    @          0x2d0d8ed starrocks::ThreadPool::dispatch_thread()
    @          0x2d0733a starrocks::Thread::supervise_thread()
    @     0x7f9086842ea5 start_thread
    @     0x7f9085c43b0d __clone
    @                0x0 (unknown)
```

## What I'm doing:
Initial `page_off` if BE is upgrade from old version.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
