### PR TITLE
[BugFix] Use copyOnlyForQuery instead of deepCopy to avoid time costs in mv refresh's collectBaseTableSnapshotInfos

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -117,6 +117,7 @@ import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TWriteQuorumType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -324,8 +325,8 @@ public class OlapTable extends Table {
         olapTable.name = this.name;
         olapTable.type = this.type;
         olapTable.fullSchema = Lists.newArrayList(this.fullSchema);
-        olapTable.nameToColumn = Maps.newLinkedHashMap(this.nameToColumn);
-        olapTable.idToColumn = Maps.newLinkedHashMap(this.idToColumn);
+        olapTable.nameToColumn = new CaseInsensitiveMap(this.nameToColumn);
+        olapTable.idToColumn = new CaseInsensitiveMap(this.idToColumn);
         olapTable.state = this.state;
         olapTable.indexNameToId = Maps.newHashMap(this.indexNameToId);
         olapTable.indexIdToMeta = Maps.newHashMap(this.indexIdToMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
@@ -52,6 +52,10 @@ public class TableSnapshotInfo {
         return baseTable.getName();
     }
 
+    /**
+     * NOTE: Base table is only copied from the real table if it's an OlapTable or MaterializedView,
+     * otherwise the real table is returned.
+     */
     public Table getBaseTable() {
         return baseTable;
     }


### PR DESCRIPTION
## Why I'm doing:
- DeepCopy.copyWithGson is very time costing, use `copyOnlyForQuery` to reduce the cost.

```
2024-07-11 21:27:42.553+08:00 INFO (starrocks-taskrun-pool-8|2229) [PartitionBasedMvRefreshProcessor.collectBaseTables():1474] Collect base table snapshot infos for materialized view: , cost: 155289 ms
2024-07-11 21:32:30.110+08:00 INFO (starrocks-taskrun-pool-8|2229) [PartitionBasedMvRefreshProcessor.collectBaseTables():1474] Collect base table snapshot infos for materialized view:, cost: 180511 ms
2024-07-11 21:35:43.858+08:00 INFO (starrocks-taskrun-pool-7|2005) [PartitionBasedMvRefreshProcessor.collectBaseTables():1474] Collect base table snapshot infos for materialized view:, cost: 193695 ms
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
