### PR TITLE
[Enhancement] Improve cache select performance

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -123,6 +123,15 @@ Status BlockCache::read_object(const CacheKey& cache_key, DataCacheHandle* handl
     return _kv_cache->read_object(cache_key, handle, options);
 }
 
+bool BlockCache::exist(const starcache::CacheKey& cache_key, off_t offset, size_t size) const {
+    if (size == 0) {
+        return true;
+    }
+    size_t index = offset / _block_size;
+    std::string block_key = fmt::format("{}/{}", cache_key, index);
+    return _kv_cache->exist(block_key);
+}
+
 Status BlockCache::remove(const CacheKey& cache_key, off_t offset, size_t size) {
     if (offset % _block_size != 0) {
         LOG(WARNING) << "remove block key: " << cache_key << " with invalid args, offset: " << offset

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -59,6 +59,8 @@ public:
     // function, the corresponding pointer will never be freed by the cache system.
     Status read_object(const CacheKey& cache_key, DataCacheHandle* handle, ReadCacheOptions* options = nullptr);
 
+    bool exist(const starcache::CacheKey& cache_key, off_t offset, size_t size) const;
+
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove(const CacheKey& cache_key, off_t offset, size_t size);
 

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -23,6 +23,19 @@
 
 namespace starrocks {
 
+// Options to control how to create DataCache instance
+struct DataCacheOptions {
+    bool enable_datacache = false;
+    bool enable_cache_select = false;
+    bool enable_populate_datacache = false;
+    bool enable_datacache_async_populate_mode = false;
+    bool enable_datacache_io_adaptor = false;
+    int64_t modification_time = 0;
+    int32_t datacache_evict_probability = 0;
+    int8_t datacache_priority = 0;
+    int64_t datacache_ttl_seconds = 0;
+};
+
 struct DirSpace {
     std::string path;
     size_t size;

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -31,7 +31,7 @@ struct DataCacheOptions {
     bool enable_datacache_async_populate_mode = false;
     bool enable_datacache_io_adaptor = false;
     int64_t modification_time = 0;
-    int32_t datacache_evict_probability = 0;
+    int32_t datacache_evict_probability = 100;
     int8_t datacache_priority = 0;
     int64_t datacache_ttl_seconds = 0;
 };

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -61,6 +61,8 @@ public:
 
     virtual Status read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) = 0;
 
+    virtual bool exist(const std::string& key) const = 0;
+
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove(const std::string& key) = 0;
 

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -125,6 +125,10 @@ Status StarCacheWrapper::read_object(const std::string& key, DataCacheHandle* ha
     return st;
 }
 
+bool StarCacheWrapper::exist(const std::string& key) const {
+    return _cache->exist(key);
+}
+
 Status StarCacheWrapper::remove(const std::string& key) {
     _cache->remove(key);
     return Status::OK();

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -38,6 +38,8 @@ public:
 
     Status read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) override;
 
+    bool exist(const std::string& key) const override;
+
     Status remove(const std::string& key) override;
 
     Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) override;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -116,7 +116,7 @@ Status HiveDataSource::open(RuntimeState* state) {
                                                   .enable_datacache_async_populate_mode = false,
                                                   .enable_datacache_io_adaptor = false,
                                                   .modification_time = _scan_range.modification_time,
-                                                  .datacache_evict_probability = 0,
+                                                  .datacache_evict_probability = 100,
                                                   .datacache_priority = datacache_priority,
                                                   .datacache_ttl_seconds = datacache_ttl_seconds};
         } else if (state->query_options().__isset.enable_scan_datacache &&
@@ -137,7 +137,7 @@ Status HiveDataSource::open(RuntimeState* state) {
             const bool enable_datacache_io_adaptor = state->query_options().__isset.enable_datacache_io_adaptor &&
                                                      state->query_options().enable_datacache_io_adaptor;
 
-            int32_t datacache_evict_probability = 0;
+            int32_t datacache_evict_probability = 100;
             if (state->query_options().__isset.datacache_evict_probability) {
                 datacache_evict_probability = state->query_options().datacache_evict_probability;
             }
@@ -156,6 +156,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     }
 
     // Don't use datacache when priority = -1
+    // todo: should remove it later
     if (_scan_range.__isset.datacache_options && _scan_range.datacache_options.__isset.priority &&
         _scan_range.datacache_options.priority == -1) {
         _datacache_options.enable_datacache = false;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -96,45 +96,75 @@ Status HiveDataSource::open(RuntimeState* state) {
     }
     RETURN_IF_ERROR(_check_all_slots_nullable());
 
-    _use_datacache = config::datacache_enable && BlockCache::instance()->available();
-    if (state->query_options().__isset.enable_scan_datacache) {
-        _use_datacache &= state->query_options().enable_scan_datacache;
+    // cache select doesn't rely on `enable_scan_datacache` session variable
+    if (config::datacache_enable && BlockCache::instance()->available()) {
+        int8_t datacache_priority = 0;
+        int64_t datacache_ttl_seconds = 0;
+        if (state->query_options().__isset.datacache_priority) {
+            datacache_priority = state->query_options().datacache_priority;
+        }
+        if (state->query_options().__isset.datacache_ttl_seconds) {
+            datacache_ttl_seconds = state->query_options().datacache_ttl_seconds;
+        }
+
+        if (state->query_options().__isset.enable_cache_select && state->query_options().enable_cache_select) {
+            // set datacache options for cache select
+            _datacache_options = DataCacheOptions{.enable_datacache = true,
+                                                  .enable_cache_select = true,
+                                                  .enable_populate_datacache = true,
+                                                  .enable_datacache_async_populate_mode = false,
+                                                  .enable_datacache_io_adaptor = false,
+                                                  .modification_time = _scan_range.modification_time,
+                                                  .datacache_evict_probability = 0,
+                                                  .datacache_priority = datacache_priority,
+                                                  .datacache_ttl_seconds = datacache_ttl_seconds};
+        } else if (state->query_options().__isset.enable_scan_datacache &&
+                   state->query_options().enable_scan_datacache) {
+            // set datacache options for normal query
+            bool enable_populate_datacache = false;
+            if (hdfs_scan_node.__isset.datacache_options &&
+                hdfs_scan_node.datacache_options.__isset.enable_populate_datacache) {
+                enable_populate_datacache = hdfs_scan_node.datacache_options.enable_populate_datacache;
+            } else if (state->query_options().__isset.enable_populate_datacache) {
+                enable_populate_datacache = state->query_options().enable_populate_datacache;
+            }
+
+            bool enable_datacache_aync_populate_mode =
+                    state->query_options().__isset.enable_datacache_async_populate_mode &&
+                    state->query_options().enable_datacache_async_populate_mode;
+            bool enable_datacache_io_adaptor = state->query_options().__isset.enable_datacache_io_adaptor &&
+                                               state->query_options().enable_datacache_io_adaptor;
+
+            int32_t datacache_evict_probability = 0;
+            if (state->query_options().__isset.datacache_evict_probability) {
+                datacache_evict_probability = state->query_options().datacache_evict_probability;
+            }
+
+            _datacache_options =
+                    DataCacheOptions{.enable_datacache = true,
+                                     .enable_cache_select = false,
+                                     .enable_populate_datacache = enable_populate_datacache,
+                                     .enable_datacache_async_populate_mode = enable_datacache_aync_populate_mode,
+                                     .enable_datacache_io_adaptor = enable_datacache_io_adaptor,
+                                     .modification_time = _scan_range.modification_time,
+                                     .datacache_evict_probability = datacache_evict_probability,
+                                     .datacache_priority = datacache_priority,
+                                     .datacache_ttl_seconds = datacache_ttl_seconds};
+        }
     }
-    if (_use_datacache && state->query_options().__isset.enable_cache_select) {
-        _enable_cache_select = state->query_options().enable_cache_select;
-    }
-    if (hdfs_scan_node.__isset.datacache_options &&
-        hdfs_scan_node.datacache_options.__isset.enable_populate_datacache) {
-        _enable_populate_datacache = hdfs_scan_node.datacache_options.enable_populate_datacache;
-    } else if (state->query_options().__isset.enable_populate_datacache) {
-        _enable_populate_datacache = state->query_options().enable_populate_datacache;
-    }
-    if (state->query_options().__isset.enable_datacache_async_populate_mode) {
-        _enable_datacache_aync_populate_mode = state->query_options().enable_datacache_async_populate_mode;
-    }
-    if (state->query_options().__isset.enable_datacache_io_adaptor) {
-        _enable_datacache_io_adaptor = state->query_options().enable_datacache_io_adaptor;
-    }
-    if (state->query_options().__isset.datacache_evict_probability) {
-        _datacache_evict_probability = state->query_options().datacache_evict_probability;
-    }
-    if (state->query_options().__isset.datacache_priority) {
-        _datacache_priority = state->query_options().datacache_priority;
-    }
-    if (state->query_options().__isset.datacache_ttl_seconds) {
-        _datacache_ttl_seconds = state->query_options().datacache_ttl_seconds;
-    }
-    if (state->query_options().__isset.enable_dynamic_prune_scan_range) {
-        _enable_dynamic_prune_scan_range = state->query_options().enable_dynamic_prune_scan_range;
-    }
+
     // Don't use datacache when priority = -1
     if (_scan_range.__isset.datacache_options && _scan_range.datacache_options.__isset.priority &&
         _scan_range.datacache_options.priority == -1) {
-        _use_datacache = false;
+        _datacache_options.enable_datacache = false;
     }
     _use_file_metacache = config::datacache_enable && BlockCache::instance()->has_mem_cache();
     if (state->query_options().__isset.enable_file_metacache) {
         _use_file_metacache &= state->query_options().enable_file_metacache;
+    }
+
+    if (state->query_options().__isset.enable_dynamic_prune_scan_range) {
+        _enable_dynamic_prune_scan_range = state->query_options().enable_dynamic_prune_scan_range;
     }
     if (state->query_options().__isset.enable_connector_split_io_tasks) {
         _enable_split_tasks = state->query_options().enable_connector_split_io_tasks;
@@ -427,11 +457,13 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
         _profile.shared_buffered_direct_io_timer = ADD_CHILD_TIMER(_runtime_profile, "DirectIOTime", prefix);
     }
 
-    if (_use_datacache) {
+    if (_datacache_options.enable_datacache) {
         static const char* prefix = "DataCache";
         ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
-        _profile.runtime_profile->add_info_string("DataCachePriority", std::to_string(_datacache_priority));
-        _profile.runtime_profile->add_info_string("DataCacheTTLSeconds", std::to_string(_datacache_ttl_seconds));
+        _profile.runtime_profile->add_info_string("DataCachePriority",
+                                                  std::to_string(_datacache_options.datacache_priority));
+        _profile.runtime_profile->add_info_string("DataCacheTTLSeconds",
+                                                  std::to_string(_datacache_options.datacache_ttl_seconds));
         _profile.datacache_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
         _profile.datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
@@ -535,7 +567,6 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.fs = _pool.add(fs.release());
     scanner_params.path = native_file_path;
     scanner_params.file_size = _scan_range.file_length;
-    scanner_params.modification_time = _scan_range.modification_time;
     scanner_params.tuple_desc = _tuple_desc;
     scanner_params.materialize_slots = _materialize_slots;
     scanner_params.materialize_index_in_chunk = _materialize_index_in_chunk;
@@ -580,13 +611,10 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     if (scan_range.__isset.paimon_deletion_file && !scan_range.paimon_deletion_file.path.empty()) {
         scanner_params.paimon_deletion_file = std::make_shared<TPaimonDeletionFile>(scan_range.paimon_deletion_file);
     }
-    scanner_params.use_datacache = _use_datacache;
-    scanner_params.enable_populate_datacache = _enable_populate_datacache;
-    scanner_params.enable_datacache_async_populate_mode = _enable_datacache_aync_populate_mode;
-    scanner_params.enable_datacache_io_adaptor = _enable_datacache_io_adaptor;
-    scanner_params.datacache_evict_probability = _datacache_evict_probability;
-    scanner_params.datacache_priority = _datacache_priority;
-    scanner_params.datacache_ttl_seconds = _datacache_ttl_seconds;
+
+    // setup options for datacache
+    scanner_params.datacache_options = _datacache_options;
+
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.can_use_min_max_count_opt = _can_use_min_max_count_opt;
     scanner_params.use_file_metacache = _use_file_metacache;
@@ -621,7 +649,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                                                             .hive_table = _hive_table,
                                                             .scan_range = &scan_range,
                                                             .scan_node = &hdfs_scan_node};
-    if (_enable_cache_select) {
+    if (_datacache_options.enable_cache_select) {
         scanner = new CacheSelectScanner();
     } else if (_use_partition_column_value_only) {
         DCHECK(_can_use_any_column);

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -109,16 +109,9 @@ private:
     ObjectPool _pool;
     RuntimeState* _runtime_state = nullptr;
     HdfsScanner* _scanner = nullptr;
-    bool _use_datacache = false;
-    bool _enable_cache_select = false;
-    bool _enable_populate_datacache = false;
-    bool _enable_datacache_aync_populate_mode = false;
-    bool _enable_datacache_io_adaptor = false;
-    int32_t _datacache_evict_probability = 0;
-    int8_t _datacache_priority = 0;
-    int64_t _datacache_ttl_seconds = 0;
-    bool _enable_dynamic_prune_scan_range = true;
+    DataCacheOptions _datacache_options{};
     bool _use_file_metacache = false;
+    bool _enable_dynamic_prune_scan_range = true;
     bool _enable_split_tasks = false;
 
     // ============ conjuncts =================

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -110,6 +110,7 @@ private:
     RuntimeState* _runtime_state = nullptr;
     HdfsScanner* _scanner = nullptr;
     bool _use_datacache = false;
+    bool _enable_cache_select = false;
     bool _enable_populate_datacache = false;
     bool _enable_datacache_aync_populate_mode = false;
     bool _enable_datacache_io_adaptor = false;

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -101,6 +101,7 @@ set(EXEC_FILES
     hdfs_scanner_parquet.cpp
     hdfs_scanner_text.cpp
     hdfs_scanner_partition.cpp
+    cache_select_scanner.cpp
     mor_processor.cpp
     json_scanner.cpp
     json_parser.cpp

--- a/be/src/exec/cache_select_scanner.cpp
+++ b/be/src/exec/cache_select_scanner.cpp
@@ -1,0 +1,289 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/cache_select_scanner.h"
+
+#include "formats/orc/orc_chunk_reader.h"
+#include "formats/orc/orc_input_stream.h"
+#include "formats/parquet/file_reader.h"
+#include "fs/fs.h"
+#include "io/shared_buffered_input_stream.h"
+
+namespace starrocks {
+
+Status CacheSelectScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    return Status::OK();
+}
+
+Status CacheSelectScanner::do_open(RuntimeState* runtime_state) {
+    RETURN_IF_ERROR(open_random_access_file());
+    return Status::OK();
+}
+
+Status CacheSelectScanner::open_random_access_file() {
+    OpenFileOptions options{};
+    options.fs = _scanner_params.fs;
+    options.path = _scanner_params.path;
+    options.file_size = _scanner_params.file_size;
+    options.fs_stats = &_fs_stats;
+    options.app_stats = &_app_stats;
+
+    if (_scanner_params.use_datacache) {
+        options.use_datacache = true;
+        options.use_cache_select = true;
+        options.modification_time = _scanner_params.modification_time;
+        options.datacache_priority = _scanner_params.datacache_priority;
+        options.datacache_ttl_seconds = _scanner_params.datacache_ttl_seconds;
+    }
+
+    ASSIGN_OR_RETURN(_file, create_random_access_file(_shared_buffered_input_stream, _cache_input_stream, options));
+    return Status::OK();
+}
+
+void CacheSelectScanner::do_update_counter(HdfsScanProfile* profile) {
+    const std::string prefix = "CacheSelect";
+    RuntimeProfile* root_profile = profile->runtime_profile;
+    ADD_COUNTER(root_profile, prefix, TUnit::NONE);
+
+    do_update_iceberg_v2_counter(root_profile, prefix);
+}
+
+void CacheSelectScanner::do_close(RuntimeState* runtime_state) noexcept {}
+
+Status CacheSelectScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
+    if (_scanner_params.scan_range->file_format == THdfsFileFormat::TEXT) {
+        RETURN_IF_ERROR(_fetch_textfile());
+    } else if (_scanner_params.scan_range->file_format == THdfsFileFormat::PARQUET) {
+        RETURN_IF_ERROR(_fetch_parquet());
+    } else if (_scanner_params.scan_range->file_format == THdfsFileFormat::ORC) {
+        RETURN_IF_ERROR(_fetch_orc());
+    } else {
+        return Status::InternalError("Unsupported file format in cache select: " +
+                                     to_string(_scanner_params.scan_range->file_format));
+    }
+
+    // handle iceberg delete files
+    if (!_scanner_params.deletes.empty()) {
+        RETURN_IF_ERROR(_fetch_iceberg_delete_files());
+    }
+
+    return Status::EndOfFile("");
+}
+
+Status CacheSelectScanner::_fetch_orc() {
+    std::unique_ptr<ORCHdfsFileStream> input_stream = std::make_unique<ORCHdfsFileStream>(
+            _file.get(), _file->get_size().value(), _shared_buffered_input_stream.get());
+    input_stream->set_app_stats(&_app_stats);
+
+    std::unique_ptr<orc::Reader> reader;
+    try {
+        orc::ReaderOptions options;
+        reader = orc::createReader(std::move(input_stream), options);
+    } catch (std::exception& e) {
+        return Status::InternalError(
+                strings::Substitute("CacheSelectScanner::_fetch_orc failed. reason = $0", e.what()));
+    }
+
+    // prepare SlotDescriptor
+    std::vector<SlotDescriptor*> slot_descriptors{};
+
+    // resolve columns
+    {
+        std::unordered_set<std::string> known_column_names;
+        OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
+                                              _scanner_ctx.case_sensitive, _scanner_ctx.orc_use_column_names);
+        RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
+        ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
+        if (skip) {
+            LOG(INFO) << "CacheSelectScanner: orc skip file for non existed slot conjuncts.";
+            return Status::EndOfFile("");
+        }
+
+        for (const auto& column : _scanner_ctx.materialized_columns) {
+            const auto col_name = Utils::format_name(column.name(), _scanner_ctx.case_sensitive);
+            if (known_column_names.contains(col_name)) {
+                slot_descriptors.emplace_back(column.slot_desc);
+            }
+        }
+    }
+
+    // get selected column ids
+    std::set<uint64_t> selected_column_ids;
+    {
+        std::list<uint64_t> selected_leaf_column_ids{};
+        OrcMappingOptions orc_mapping_options{};
+        orc_mapping_options.case_sensitive = _scanner_ctx.case_sensitive;
+        orc_mapping_options.filename = _file->filename();
+        orc_mapping_options.invalid_as_null = true;
+        ASSIGN_OR_RETURN(
+                std::unique_ptr<OrcMapping> orc_mapping,
+                OrcMappingFactory::build_mapping(slot_descriptors, reader->getType(), _scanner_ctx.orc_use_column_names,
+                                                 _scanner_ctx.hive_column_names, orc_mapping_options));
+
+        for (size_t i = 0; i < slot_descriptors.size(); i++) {
+            SlotDescriptor* desc = slot_descriptors[i];
+            // column not existed in orc file, ignore this SlotDescriptor
+            if (!orc_mapping->contains(i)) continue;
+            RETURN_IF_ERROR(orc_mapping->set_include_column_id(i, desc->type(), &selected_leaf_column_ids));
+        }
+
+        orc::RowReaderOptions row_reader_options{};
+        row_reader_options.includeTypes(selected_leaf_column_ids);
+        std::unique_ptr<orc::RowReader> row_reader = reader->createRowReader(row_reader_options);
+        // get selected column ids from RowReader
+        for (uint64_t i = 0; i < row_reader->getSelectedColumns().size(); i++) {
+            if (row_reader->getSelectedColumns()[i]) {
+                selected_column_ids.emplace(i);
+            }
+        }
+    }
+
+    std::vector<DiskRange> disk_ranges{};
+    {
+        uint64_t stripe_number = reader->getNumberOfStripes();
+        std::vector<DiskRange> stripe_disk_ranges{};
+
+        const auto* scan_range = _scanner_ctx.scan_range;
+        size_t scan_start = scan_range->offset;
+        size_t scan_end = scan_start + scan_range->length;
+
+        for (uint64_t idx = 0; idx < stripe_number; idx++) {
+            const auto& stripe_info = reader->getStripe(idx);
+            uint64_t stripe_offset = stripe_info->getOffset();
+            // Read stripes in this scan range
+            if (stripe_offset >= scan_start && stripe_offset < scan_end) {
+                int64_t length = stripe_info->getLength();
+                _app_stats.orc_stripe_sizes.push_back(length);
+
+                uint64_t cur_offset = stripe_offset;
+                for (uint64_t stream_id = 0; stream_id < stripe_info->getNumberOfStreams(); stream_id++) {
+                    const auto& stream_info = stripe_info->getStreamInformation(stream_id);
+                    if (selected_column_ids.contains(stream_info->getColumnId())) {
+                        disk_ranges.emplace_back(cur_offset, stream_info->getLength());
+                    }
+                    cur_offset += stream_info->getLength();
+                }
+            }
+        }
+    }
+
+    RETURN_IF_ERROR(_write_disk_ranges(_shared_buffered_input_stream, _cache_input_stream, disk_ranges));
+    return Status::OK();
+}
+
+Status CacheSelectScanner::_fetch_parquet() {
+    // create file reader
+    std::shared_ptr<parquet::FileReader> reader = std::make_shared<parquet::FileReader>(
+            4096, _file.get(), _file->get_size().value(), _scanner_params.modification_time,
+            _shared_buffered_input_stream.get(), nullptr);
+
+    RETURN_IF_ERROR(reader->init(&_scanner_ctx));
+
+    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
+    RETURN_IF_ERROR(reader->collect_scan_io_ranges(&io_ranges));
+
+    std::vector<DiskRange> disk_ranges{};
+    for (const auto& io_range : io_ranges) {
+        disk_ranges.emplace_back(io_range.offset, io_range.size);
+    }
+
+    RETURN_IF_ERROR(_write_disk_ranges(_shared_buffered_input_stream, _cache_input_stream, disk_ranges));
+    return Status::OK();
+}
+
+// Split text into multiply disk ranges, then fetch it
+Status CacheSelectScanner::_fetch_textfile() {
+    // If it's compressed file, we only handle scan range whose offset == 0.
+    if (get_compression_type_from_path(_scanner_params.path) != UNKNOWN_COMPRESSION &&
+        _scanner_params.scan_range->offset != 0) {
+        return Status::OK();
+    }
+
+    const int64_t start_offset = _scanner_params.scan_range->offset;
+    const int64_t end_offset = _scanner_params.scan_range->offset + _scanner_params.scan_range->length;
+
+    std::vector<DiskRange> disk_ranges{};
+    for (int64_t offset = start_offset; offset < end_offset;) {
+        const int64_t remain_length =
+                std::min(static_cast<int64_t>(config::io_coalesce_read_max_buffer_size), end_offset - offset);
+        disk_ranges.emplace_back(offset, remain_length);
+        offset += remain_length;
+    }
+
+    RETURN_IF_ERROR(_write_disk_ranges(_shared_buffered_input_stream, _cache_input_stream, disk_ranges));
+    return Status::OK();
+}
+
+// for iceberg delete files, we fetch an entire file directly
+Status CacheSelectScanner::_fetch_iceberg_delete_files() {
+    for (const auto* delete_file : _scanner_params.deletes) {
+        RETURN_IF_ERROR(_write_entire_file(delete_file->full_path, delete_file->length));
+    }
+
+    _app_stats.iceberg_delete_files_per_scan += _scanner_params.deletes.size();
+    return Status::OK();
+}
+
+Status CacheSelectScanner::_write_entire_file(const std::string& file_path, size_t file_size) {
+    OpenFileOptions options{};
+    options.fs = _scanner_params.fs;
+    options.path = _scanner_params.path;
+    options.file_size = _scanner_params.file_size;
+    options.fs_stats = &_fs_stats;
+    options.app_stats = &_app_stats;
+    options.compression_type = _compression_type;
+
+    options.use_datacache = true;
+    options.use_cache_select = true;
+    options.modification_time = _scanner_params.modification_time;
+    options.enable_populate_datacache = true;
+    options.datacache_priority = _scanner_params.datacache_priority;
+    options.datacache_ttl_seconds = _scanner_params.datacache_ttl_seconds;
+
+    std::shared_ptr<io::SharedBufferedInputStream> shared_buffered_input_stream;
+    std::shared_ptr<io::CacheInputStream> cache_input_stream;
+    ASSIGN_OR_RETURN(auto dummy_file,
+                     create_random_access_file(shared_buffered_input_stream, cache_input_stream, options));
+
+    std::vector<DiskRange> disk_ranges{};
+    disk_ranges.emplace_back(0, file_size);
+
+    RETURN_IF_ERROR(_write_disk_ranges(shared_buffered_input_stream, cache_input_stream, disk_ranges));
+    return Status::OK();
+}
+
+Status CacheSelectScanner::_write_disk_ranges(std::shared_ptr<io::SharedBufferedInputStream>& shared_input_stream,
+                                              std::shared_ptr<io::CacheInputStream>& cache_input_stream,
+                                              const std::vector<DiskRange>& disk_ranges) {
+    std::vector<DiskRange> merged_disk_ranges{};
+    DiskRangeHelper::merge_adjacent_disk_ranges(disk_ranges, config::io_coalesce_read_max_distance_size,
+                                                config::io_coalesce_read_max_buffer_size, merged_disk_ranges);
+
+    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
+    for (const DiskRange& disk_range : merged_disk_ranges) {
+        io_ranges.emplace_back(disk_range.get_offset(), disk_range.get_length());
+    }
+    RETURN_IF_ERROR(shared_input_stream->set_io_ranges(io_ranges));
+
+    io::CacheSelectInputStream* cache_select_input_stream =
+            down_cast<io::CacheSelectInputStream*>(cache_input_stream.get());
+
+    for (const DiskRange& merged_disk_range : merged_disk_ranges) {
+        RETURN_IF_ERROR(cache_select_input_stream->write_at_fully(merged_disk_range.get_offset(),
+                                                                  merged_disk_range.get_length()));
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/exec/cache_select_scanner.h
+++ b/be/src/exec/cache_select_scanner.h
@@ -34,9 +34,6 @@ public:
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
 
-protected:
-    Status open_random_access_file() override;
-
 private:
     Status _fetch_orc();
     Status _fetch_parquet();

--- a/be/src/exec/cache_select_scanner.h
+++ b/be/src/exec/cache_select_scanner.h
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/hdfs_scanner.h"
+#include "formats/disk_range.hpp"
+#include "io/cache_select_input_stream.hpp"
+
+namespace starrocks {
+
+// CacheSelectScanner is used by cache select
+// For textfile file, it will download files directly
+// For orc/parquet file, it will read and parse it's footer first, then according the column's offset and length, fetch it's data directly.
+// For iceberg v2 delete file, it will fetch entire file directly
+class CacheSelectScanner final : public HdfsScanner {
+public:
+    CacheSelectScanner() = default;
+    ~CacheSelectScanner() override = default;
+    Status do_open(RuntimeState* runtime_state) override;
+    void do_update_counter(HdfsScanProfile* profile) override;
+    void do_close(RuntimeState* runtime_state) noexcept override;
+    Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
+    Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
+
+protected:
+    Status open_random_access_file() override;
+
+private:
+    Status _fetch_orc();
+    Status _fetch_parquet();
+    Status _fetch_textfile();
+    Status _fetch_iceberg_delete_files();
+    Status _create_input_stream();
+    Status _write_entire_file(const std::string& file_path, size_t file_size);
+    static Status _write_disk_ranges(std::shared_ptr<io::SharedBufferedInputStream>& shared_input_stream,
+                                     std::shared_ptr<io::CacheInputStream>& cache_input_stream,
+                                     const std::vector<DiskRange>& disk_ranges);
+};
+
+} // namespace starrocks

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -243,11 +243,11 @@ StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_fi
             cache_input_stream->set_enable_async_populate_mode(datacache_options.enable_datacache_async_populate_mode);
             cache_input_stream->set_enable_cache_io_adaptor(datacache_options.enable_datacache_io_adaptor);
             cache_input_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
+            input_stream = cache_input_stream;
         }
         cache_input_stream->set_priority(datacache_options.datacache_priority);
         cache_input_stream->set_ttl_seconds(datacache_options.datacache_ttl_seconds);
         shared_buffered_input_stream->set_align_size(cache_input_stream->get_align_size());
-        input_stream = cache_input_stream;
     }
 
     // if compression

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -18,6 +18,7 @@
 #include "column/column_helper.h"
 #include "exec/exec_node.h"
 #include "fs/hdfs/fs_hdfs.h"
+#include "io/cache_select_input_stream.hpp"
 #include "io/compressed_input_stream.h"
 #include "io/shared_buffered_input_stream.h"
 #include "util/compression/compression_utils.h"
@@ -25,7 +26,7 @@
 
 namespace starrocks {
 
-class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
+class CountedSeekableInputStream final : public io::SeekableInputStreamWrapper {
 public:
     explicit CountedSeekableInputStream(const std::shared_ptr<io::SeekableInputStream>& stream, HdfsScanStats* stats)
             : io::SeekableInputStreamWrapper(stream.get(), kDontTakeOwnership), _stream(stream), _stats(stats) {}
@@ -211,45 +212,50 @@ void HdfsScanner::close() noexcept {
     _mor_processor->close(_runtime_state);
 }
 
-Status HdfsScanner::open_random_access_file() {
-    CHECK(_file == nullptr) << "File has already been opened";
-    ASSIGN_OR_RETURN(std::unique_ptr<RandomAccessFile> raw_file,
-                     _scanner_params.fs->new_random_access_file(_scanner_params.path))
-    const int64_t file_size = _scanner_params.file_size;
+StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_file(
+        std::shared_ptr<io::SharedBufferedInputStream>& shared_buffered_input_stream,
+        std::shared_ptr<io::CacheInputStream>& cache_input_stream, const OpenFileOptions& options) {
+    ASSIGN_OR_RETURN(std::unique_ptr<RandomAccessFile> raw_file, options.fs->new_random_access_file(options.path))
+    const int64_t file_size = options.file_size;
     raw_file->set_size(file_size);
     const std::string& filename = raw_file->filename();
 
     std::shared_ptr<io::SeekableInputStream> input_stream = raw_file->stream();
 
-    input_stream = std::make_shared<CountedSeekableInputStream>(input_stream, &_fs_stats);
+    input_stream = std::make_shared<CountedSeekableInputStream>(input_stream, options.fs_stats);
 
-    _shared_buffered_input_stream = std::make_shared<io::SharedBufferedInputStream>(input_stream, filename, file_size);
-    const io::SharedBufferedInputStream::CoalesceOptions options = {
+    shared_buffered_input_stream = std::make_shared<io::SharedBufferedInputStream>(input_stream, filename, file_size);
+    const io::SharedBufferedInputStream::CoalesceOptions shared_options = {
             .max_dist_size = config::io_coalesce_read_max_distance_size,
             .max_buffer_size = config::io_coalesce_read_max_buffer_size};
-    _shared_buffered_input_stream->set_coalesce_options(options);
-    input_stream = _shared_buffered_input_stream;
+    shared_buffered_input_stream->set_coalesce_options(shared_options);
+    input_stream = shared_buffered_input_stream;
 
     // input_stream = CacheInputStream(input_stream)
-    if (_scanner_params.use_datacache) {
-        _cache_input_stream = std::make_shared<io::CacheInputStream>(_shared_buffered_input_stream, filename, file_size,
-                                                                     _scanner_params.modification_time);
-        _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_datacache);
-        _cache_input_stream->set_enable_async_populate_mode(_scanner_params.enable_datacache_async_populate_mode);
-        _cache_input_stream->set_enable_cache_io_adaptor(_scanner_params.enable_datacache_io_adaptor);
-        _cache_input_stream->set_priority(_scanner_params.datacache_priority);
-        _cache_input_stream->set_ttl_seconds(_scanner_params.datacache_ttl_seconds);
-        _cache_input_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
-        _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
-        input_stream = _cache_input_stream;
+    if (options.use_datacache) {
+        if (options.use_cache_select) {
+            cache_input_stream = std::make_shared<io::CacheSelectInputStream>(shared_buffered_input_stream, filename,
+                                                                              file_size, options.modification_time);
+        } else {
+            cache_input_stream = std::make_shared<io::CacheInputStream>(shared_buffered_input_stream, filename,
+                                                                        file_size, options.modification_time);
+            cache_input_stream->set_enable_populate_cache(options.enable_populate_datacache);
+            cache_input_stream->set_enable_async_populate_mode(options.enable_datacache_async_populate_mode);
+            cache_input_stream->set_enable_cache_io_adaptor(options.enable_datacache_io_adaptor);
+            cache_input_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
+            input_stream = cache_input_stream;
+        }
+        cache_input_stream->set_priority(options.datacache_priority);
+        cache_input_stream->set_ttl_seconds(options.datacache_ttl_seconds);
+        shared_buffered_input_stream->set_align_size(cache_input_stream->get_align_size());
     }
 
     // if compression
     // input_stream = DecompressInputStream(input_stream)
-    if (_compression_type != CompressionTypePB::NO_COMPRESSION) {
+    if (options.compression_type != CompressionTypePB::NO_COMPRESSION) {
         using DecompressorPtr = std::shared_ptr<StreamCompression>;
         std::unique_ptr<StreamCompression> dec;
-        RETURN_IF_ERROR(StreamCompression::create_decompressor(_compression_type, &dec));
+        RETURN_IF_ERROR(StreamCompression::create_decompressor(options.compression_type, &dec));
         auto compressed_input_stream =
                 std::make_shared<io::CompressedInputStream>(input_stream, DecompressorPtr(dec.release()));
         input_stream = std::make_shared<io::CompressedSeekableInputStream>(compressed_input_stream);
@@ -257,11 +263,34 @@ Status HdfsScanner::open_random_access_file() {
 
     // input_stream = CountedInputStream(input_stream)
     // NOTE: make sure `CountedInputStream` is last applied, so io time can be accurately timed.
-    input_stream = std::make_shared<CountedSeekableInputStream>(input_stream, &_app_stats);
+    input_stream = std::make_shared<CountedSeekableInputStream>(input_stream, options.app_stats);
 
     // so wrap function is f(x) = (CountedInputStream (CacheInputStream (DecompressInputStream (CountedInputStream x))))
-    _file = std::make_unique<RandomAccessFile>(input_stream, filename);
-    _file->set_size(file_size);
+    auto file = std::make_unique<RandomAccessFile>(input_stream, filename);
+    file->set_size(file_size);
+    return file;
+}
+
+Status HdfsScanner::open_random_access_file() {
+    OpenFileOptions options{};
+    options.fs = _scanner_params.fs;
+    options.path = _scanner_params.path;
+    options.file_size = _scanner_params.file_size;
+    options.fs_stats = &_fs_stats;
+    options.app_stats = &_app_stats;
+    options.compression_type = _compression_type;
+
+    if (_scanner_params.use_datacache) {
+        options.use_datacache = true;
+        options.modification_time = _scanner_params.modification_time;
+        options.enable_populate_datacache = _scanner_params.enable_populate_datacache;
+        options.enable_datacache_async_populate_mode = _scanner_params.enable_datacache_async_populate_mode;
+        options.enable_datacache_io_adaptor = _scanner_params.enable_datacache_io_adaptor;
+        options.datacache_priority = _scanner_params.datacache_priority;
+        options.datacache_ttl_seconds = _scanner_params.datacache_ttl_seconds;
+    }
+
+    ASSIGN_OR_RETURN(_file, create_random_access_file(_shared_buffered_input_stream, _cache_input_stream, options));
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -174,9 +174,6 @@ struct HdfsScannerParams {
     // The file size. -1 means unknown.
     int64_t file_size = -1;
 
-    // The file last modification time
-    int64_t modification_time = 0;
-
     const TupleDescriptor* tuple_desc = nullptr;
 
     // columns read from file
@@ -214,13 +211,7 @@ struct HdfsScannerParams {
 
     std::shared_ptr<TPaimonDeletionFile> paimon_deletion_file = nullptr;
 
-    bool use_datacache = false;
-    bool enable_populate_datacache = false;
-    bool enable_datacache_async_populate_mode = false;
-    bool enable_datacache_io_adaptor = false;
-    int32_t datacache_evict_probability = 0;
-    int8_t datacache_priority = 0;
-    int64_t datacache_ttl_seconds = 0;
+    DataCacheOptions datacache_options;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool can_use_any_column = false;
@@ -293,8 +284,6 @@ struct HdfsScannerContext {
 
     bool use_file_metacache = false;
 
-    int32_t datacache_evict_probability = 0;
-
     std::string timezone;
 
     const TIcebergSchema* iceberg_schema = nullptr;
@@ -341,15 +330,7 @@ struct OpenFileOptions {
     HdfsScanStats* app_stats = nullptr;
 
     // for datacache
-    bool use_datacache = false;
-    bool use_cache_select = false;
-    int64_t modification_time = 0;
-    bool enable_populate_datacache = false;
-    bool enable_datacache_async_populate_mode = false;
-    bool enable_datacache_io_adaptor = false;
-    int32_t datacache_evict_probability = 0;
-    int8_t datacache_priority = 0;
-    int64_t datacache_ttl_seconds = 0;
+    DataCacheOptions datacache_options;
 
     // for compressed text file
     CompressionTypePB compression_type = CompressionTypePB::NO_COMPRESSION;
@@ -388,7 +369,7 @@ protected:
     static StatusOr<std::unique_ptr<RandomAccessFile>> create_random_access_file(
             std::shared_ptr<io::SharedBufferedInputStream>& shared_buffered_input_stream,
             std::shared_ptr<io::CacheInputStream>& cache_input_stream, const OpenFileOptions& options);
-    virtual Status open_random_access_file();
+    Status open_random_access_file();
     static CompressionTypePB get_compression_type_from_path(const std::string& filename);
 
     void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -333,6 +333,28 @@ struct HdfsScannerContext {
     void merge_split_tasks();
 };
 
+struct OpenFileOptions {
+    FileSystem* fs = nullptr;
+    std::string path;
+    int64_t file_size = -1;
+    HdfsScanStats* fs_stats = nullptr;
+    HdfsScanStats* app_stats = nullptr;
+
+    // for datacache
+    bool use_datacache = false;
+    bool use_cache_select = false;
+    int64_t modification_time = 0;
+    bool enable_populate_datacache = false;
+    bool enable_datacache_async_populate_mode = false;
+    bool enable_datacache_io_adaptor = false;
+    int32_t datacache_evict_probability = 0;
+    int8_t datacache_priority = 0;
+    int64_t datacache_ttl_seconds = 0;
+
+    // for compressed text file
+    CompressionTypePB compression_type = CompressionTypePB::NO_COMPRESSION;
+};
+
 class HdfsScanner {
 public:
     HdfsScanner() = default;
@@ -363,7 +385,10 @@ public:
     bool has_split_tasks() const { return _scanner_ctx.has_split_tasks; }
 
 protected:
-    Status open_random_access_file();
+    static StatusOr<std::unique_ptr<RandomAccessFile>> create_random_access_file(
+            std::shared_ptr<io::SharedBufferedInputStream>& shared_buffered_input_stream,
+            std::shared_ptr<io::CacheInputStream>& cache_input_stream, const OpenFileOptions& options);
+    virtual Status open_random_access_file();
     static CompressionTypePB get_compression_type_from_path(const std::string& filename);
 
     void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -211,12 +211,12 @@ struct HdfsScannerParams {
 
     std::shared_ptr<TPaimonDeletionFile> paimon_deletion_file = nullptr;
 
-    DataCacheOptions datacache_options;
+    DataCacheOptions datacache_options{};
+    bool use_file_metacache = false;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool can_use_any_column = false;
     bool can_use_min_max_count_opt = false;
-    bool use_file_metacache = false;
     bool orc_use_column_names = false;
     MORParams mor_params;
 

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -324,7 +324,7 @@ Status HdfsOrcScanner::build_iceberg_delete_builder() {
     SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
     const IcebergDeleteBuilder iceberg_delete_builder(_scanner_params.fs, _scanner_params.path,
                                                       _scanner_params.conjunct_ctxs, _scanner_params.materialize_slots,
-                                                      &_need_skip_rowids);
+                                                      &_need_skip_rowids, _scanner_params.datacache_options);
 
     for (const auto& tdelete_file : _scanner_params.deletes) {
         RETURN_IF_ERROR(iceberg_delete_builder.build_orc(_runtime_state->timezone(), *tdelete_file,
@@ -369,7 +369,7 @@ Status HdfsOrcScanner::build_stripes(orc::Reader* reader, std::vector<DiskRange>
 Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std::vector<DiskRange>& stripes) {
     bool tiny_stripe_read = true;
     for (const DiskRange& disk_range : stripes) {
-        if (disk_range.get_length() > config::orc_tiny_stripe_threshold_size) {
+        if (disk_range.length() > config::orc_tiny_stripe_threshold_size) {
             tiny_stripe_read = false;
             break;
         }
@@ -381,7 +381,7 @@ Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std
         DiskRangeHelper::merge_adjacent_disk_ranges(stripes, config::io_coalesce_read_max_distance_size,
                                                     config::orc_tiny_stripe_threshold_size, merged_disk_ranges);
         for (const auto& disk_range : merged_disk_ranges) {
-            io_ranges.emplace_back(disk_range.get_offset(), disk_range.get_length());
+            io_ranges.emplace_back(disk_range.offset(), disk_range.length());
         }
         for (const auto& it : io_ranges) {
             _app_stats.orc_total_tiny_stripe_size += it.size;
@@ -446,8 +446,8 @@ Status HdfsOrcScanner::build_split_tasks(orc::Reader* reader, const std::vector<
     for (const auto& info : stripes) {
         auto ctx = std::make_unique<SplitContext>();
         ctx->footer = footer;
-        ctx->split_start = info.get_offset();
-        ctx->split_end = info.get_offset() + info.get_length();
+        ctx->split_start = info.offset();
+        ctx->split_end = info.offset() + info.length();
         _scanner_ctx.split_tasks.emplace_back(std::move(ctx));
     }
     _scanner_ctx.merge_split_tasks();

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -369,7 +369,7 @@ Status HdfsOrcScanner::build_stripes(orc::Reader* reader, std::vector<DiskRange>
 Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std::vector<DiskRange>& stripes) {
     bool tiny_stripe_read = true;
     for (const DiskRange& disk_range : stripes) {
-        if (disk_range.length > config::orc_tiny_stripe_threshold_size) {
+        if (disk_range.get_length() > config::orc_tiny_stripe_threshold_size) {
             tiny_stripe_read = false;
             break;
         }
@@ -377,8 +377,12 @@ Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std
     // we need to start tiny stripe optimization if all stripe's size smaller than config::orc_tiny_stripe_threshold_size
     if (tiny_stripe_read) {
         std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
-        DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, stripes, config::io_coalesce_read_max_distance_size,
-                                                 config::orc_tiny_stripe_threshold_size);
+        std::vector<DiskRange> merged_disk_ranges{};
+        DiskRangeHelper::merge_adjacent_disk_ranges(stripes, config::io_coalesce_read_max_distance_size,
+                                                    config::orc_tiny_stripe_threshold_size, merged_disk_ranges);
+        for (const auto& disk_range : merged_disk_ranges) {
+            io_ranges.emplace_back(disk_range.get_offset(), disk_range.get_length());
+        }
         for (const auto& it : io_ranges) {
             _app_stats.orc_total_tiny_stripe_size += it.size;
         }
@@ -401,7 +405,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
 
     int src_slot_index = 0;
     for (const auto& column : _scanner_ctx.materialized_columns) {
-        auto col_name = OrcChunkReader::format_column_name(column.name(), _scanner_ctx.case_sensitive);
+        auto col_name = Utils::format_name(column.name(), _scanner_ctx.case_sensitive);
         if (known_column_names.find(col_name) == known_column_names.end()) continue;
         bool is_lazy_slot = _scanner_params.is_lazy_materialization_slot(column.slot_id());
         if (is_lazy_slot) {
@@ -442,8 +446,8 @@ Status HdfsOrcScanner::build_split_tasks(orc::Reader* reader, const std::vector<
     for (const auto& info : stripes) {
         auto ctx = std::make_unique<SplitContext>();
         ctx->footer = footer;
-        ctx->split_start = info.offset;
-        ctx->split_end = info.offset + info.length;
+        ctx->split_start = info.get_offset();
+        ctx->split_end = info.get_offset() + info.get_length();
         _scanner_ctx.split_tasks.emplace_back(std::move(ctx));
     }
     _scanner_ctx.merge_split_tasks();

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -17,9 +17,9 @@
 #include <orc/OrcFile.hh>
 
 #include "exec/hdfs_scanner.h"
+#include "formats/disk_range.hpp"
 #include "formats/orc/orc_chunk_reader.h"
 #include "formats/orc/orc_input_stream.h"
-#include "formats/orc/utils.h"
 
 namespace starrocks {
 

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -18,7 +18,6 @@
 #include "exec/iceberg/iceberg_delete_builder.h"
 #include "exec/paimon/paimon_delete_file_builder.h"
 #include "formats/parquet/file_reader.h"
-#include "runtime/descriptors.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -28,9 +27,9 @@ static const std::string kParquetProfileSectionPrefix = "Parquet";
 Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
     if (!scanner_params.deletes.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
-        std::unique_ptr<IcebergDeleteBuilder> iceberg_delete_builder(
-                new IcebergDeleteBuilder(scanner_params.fs, scanner_params.path, scanner_params.conjunct_ctxs,
-                                         scanner_params.materialize_slots, &_need_skip_rowids));
+        std::unique_ptr<IcebergDeleteBuilder> iceberg_delete_builder(new IcebergDeleteBuilder(
+                scanner_params.fs, scanner_params.path, scanner_params.conjunct_ctxs, scanner_params.materialize_slots,
+                &_need_skip_rowids, scanner_params.datacache_options));
         for (const auto& tdelete_file : scanner_params.deletes) {
             RETURN_IF_ERROR(iceberg_delete_builder->build_parquet(
                     runtime_state->timezone(), *tdelete_file, scanner_params.mor_params.equality_slots,
@@ -157,7 +156,7 @@ Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(open_random_access_file());
     // create file reader
     _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _file.get(), _file->get_size().value(),
-                                                    _scanner_params.modification_time,
+                                                    _scanner_params.datacache_options,
                                                     _shared_buffered_input_stream.get(), &_need_skip_rowids);
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
     RETURN_IF_ERROR(_reader->init(&_scanner_ctx));

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -191,7 +191,8 @@ Status ParquetEqualityDeleteBuilder::build(const std::string& timezone, const st
 
     std::unique_ptr<parquet::FileReader> reader;
     try {
-        reader = std::make_unique<parquet::FileReader>(state->chunk_size(), file.get(), file->get_size().value(), 0);
+        reader = std::make_unique<parquet::FileReader>(state->chunk_size(), file.get(), file->get_size().value(),
+                                                       _datacache_options);
     } catch (std::exception& e) {
         const auto s = strings::Substitute(
                 "ParquetEqualityDeleteBuilder::build create parquet::FileReader failed. reason = $0", e.what());

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(Formats STATIC
         parquet/column_chunk_writer.cpp
         parquet/column_read_order_ctx.cpp
         parquet/statistics_helper.cpp
+        disk_range.hpp
         )
 
 add_subdirectory(orc/apache-orc)

--- a/be/src/formats/disk_range.hpp
+++ b/be/src/formats/disk_range.hpp
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <glog/logging.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace starrocks {
+
+class DiskRange {
+public:
+    DiskRange(const int64_t off, const int64_t len) : _offset(off), _length(len) {
+        DCHECK(off >= 0);
+        DCHECK(len > 0);
+    }
+
+    /**
+    * Returns the minimal DiskRange that encloses both this DiskRange
+    * and otherDiskRange. If there was a gap between the ranges the
+    * new range will cover that gap.
+    */
+    inline DiskRange span(const DiskRange& other_disk_range) const {
+        const int64_t start = std::min(get_offset(), other_disk_range.get_offset());
+        const int64_t end = std::max(get_end(), other_disk_range.get_end());
+        return {start, end - start};
+    }
+
+    inline int64_t get_end() const { return _offset + _length; }
+
+    inline int64_t get_offset() const { return _offset; }
+
+    inline int64_t get_length() const { return _length; }
+
+private:
+    int64_t _offset = 0;
+    int64_t _length = 0;
+};
+
+class DiskRangeHelper {
+public:
+    /**
+     * Merge disk ranges that are closer than max_merge_distance.
+     * If merged disk range is larger than max_merged_size, we will not merge it anymore
+     */
+    static void merge_adjacent_disk_ranges(std::vector<DiskRange> disk_ranges, const int64_t max_merge_distance,
+                                           const int64_t max_merged_size, std::vector<DiskRange>& merged_disk_ranges) {
+        if (disk_ranges.empty()) {
+            return;
+        }
+
+        std::sort(disk_ranges.begin(), disk_ranges.end(),
+                  [](const DiskRange& a, const DiskRange& b) { return a.get_offset() < b.get_offset(); });
+
+        DiskRange last = disk_ranges[0];
+        for (size_t i = 1; i < disk_ranges.size(); i++) {
+            DiskRange current = disk_ranges[i];
+            DiskRange merged = last.span(current);
+            if (merged.get_length() <= max_merged_size && last.get_end() + max_merge_distance >= current.get_offset()) {
+                last = merged;
+            } else {
+                merged_disk_ranges.emplace_back(last.get_offset(), last.get_length());
+                last = current;
+            }
+        }
+        merged_disk_ranges.emplace_back(last.get_offset(), last.get_length());
+    }
+};
+
+} // namespace starrocks

--- a/be/src/formats/disk_range.hpp
+++ b/be/src/formats/disk_range.hpp
@@ -33,16 +33,16 @@ public:
     * new range will cover that gap.
     */
     inline DiskRange span(const DiskRange& other_disk_range) const {
-        const int64_t start = std::min(get_offset(), other_disk_range.get_offset());
-        const int64_t end = std::max(get_end(), other_disk_range.get_end());
-        return {start, end - start};
+        const int64_t start_off = std::min(offset(), other_disk_range.offset());
+        const int64_t end_off = std::max(end(), other_disk_range.end());
+        return {start_off, end_off - start_off};
     }
 
-    inline int64_t get_end() const { return _offset + _length; }
+    inline int64_t end() const { return _offset + _length; }
 
-    inline int64_t get_offset() const { return _offset; }
+    inline int64_t offset() const { return _offset; }
 
-    inline int64_t get_length() const { return _length; }
+    inline int64_t length() const { return _length; }
 
 private:
     int64_t _offset = 0;
@@ -62,20 +62,20 @@ public:
         }
 
         std::sort(disk_ranges.begin(), disk_ranges.end(),
-                  [](const DiskRange& a, const DiskRange& b) { return a.get_offset() < b.get_offset(); });
+                  [](const DiskRange& a, const DiskRange& b) { return a.offset() < b.offset(); });
 
         DiskRange last = disk_ranges[0];
         for (size_t i = 1; i < disk_ranges.size(); i++) {
             DiskRange current = disk_ranges[i];
             DiskRange merged = last.span(current);
-            if (merged.get_length() <= max_merged_size && last.get_end() + max_merge_distance >= current.get_offset()) {
+            if (merged.length() <= max_merged_size && last.end() + max_merge_distance >= current.offset()) {
                 last = merged;
             } else {
-                merged_disk_ranges.emplace_back(last.get_offset(), last.get_length());
+                merged_disk_ranges.emplace_back(last.offset(), last.length());
                 last = current;
             }
         }
-        merged_disk_ranges.emplace_back(last.get_offset(), last.get_length());
+        merged_disk_ranges.emplace_back(last.offset(), last.length());
     }
 };
 

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -95,13 +95,13 @@ void OrcChunkReader::build_column_name_set(std::unordered_set<std::string>* name
         // build hive column names index.
         int size = std::min(hive_column_names->size(), root_type.getSubtypeCount());
         for (int i = 0; i < size; i++) {
-            std::string col_name = format_column_name(hive_column_names->at(i), case_sensitive);
+            std::string col_name = Utils::format_name(hive_column_names->at(i), case_sensitive);
             name_set->insert(col_name);
         }
     } else {
         // build orc column names index.
         for (int i = 0; i < root_type.getSubtypeCount(); i++) {
-            std::string col_name = format_column_name(root_type.getFieldName(i), case_sensitive);
+            std::string col_name = Utils::format_name(root_type.getFieldName(i), case_sensitive);
             name_set->insert(col_name);
         }
     }

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -108,9 +108,6 @@ public:
     static void build_column_name_set(std::unordered_set<std::string>* name_set,
                                       const std::vector<std::string>* hive_column_names, const orc::Type& root_type,
                                       bool case_sensitive, bool use_orc_column_names);
-    static std::string format_column_name(const std::string& col_name, bool case_sensitive) {
-        return case_sensitive ? col_name : boost::algorithm::to_lower_copy(col_name);
-    }
 
     void set_runtime_state(RuntimeState* state) { _state = state; }
     RuntimeState* runtime_state() { return _state; }

--- a/be/src/formats/orc/orc_input_stream.h
+++ b/be/src/formats/orc/orc_input_stream.h
@@ -14,14 +14,9 @@
 
 #pragma once
 
-#include <exec/hdfs_scanner.h>
-
-#include <boost/algorithm/string.hpp>
 #include <orc/OrcFile.hh>
 
-#include "exprs/expr.h"
-#include "exprs/expr_context.h"
-#include "exprs/runtime_filter_bank.h"
+#include "exec/hdfs_scanner.h"
 #include "io/shared_buffered_input_stream.h"
 namespace starrocks {
 

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -37,53 +37,6 @@ public:
     const RuntimeFilterProbeCollector* rf_collector;
 };
 
-class DiskRange {
-public:
-    DiskRange(int64_t off, int64_t len) : offset(off), length(len) {
-        DCHECK(off >= 0);
-        DCHECK(len > 0);
-    }
-
-    /**
-    * Returns the minimal DiskRange that encloses both this DiskRange
-    * and otherDiskRange. If there was a gap between the ranges the
-    * new range will cover that gap.
-    */
-    DiskRange span(const DiskRange& otherDiskRange) const {
-        const int64_t start = std::min(offset, otherDiskRange.offset);
-        const int64_t end = std::max(get_end(), otherDiskRange.get_end());
-        return DiskRange(start, end - start);
-    }
-
-    int64_t get_end() const { return offset + length; }
-
-    int64_t offset;
-    int64_t length;
-};
-
-class DiskRangeHelper {
-public:
-    static void mergeAdjacentDiskRanges(std::vector<io::SharedBufferedInputStream::IORange>& io_ranges,
-                                        const std::vector<DiskRange>& disk_ranges, const int64_t max_merge_distance,
-                                        const int64_t max_merged_size) {
-        if (disk_ranges.empty()) {
-            return;
-        }
-        DiskRange last = disk_ranges[0];
-        for (size_t i = 1; i < disk_ranges.size(); i++) {
-            DiskRange current = disk_ranges[i];
-            DiskRange merged = last.span(current);
-            if (merged.length <= max_merged_size && last.get_end() + max_merge_distance >= current.offset) {
-                last = merged;
-            } else {
-                io_ranges.emplace_back(last.offset, last.length, true);
-                last = current;
-            }
-        }
-        io_ranges.emplace_back(last.offset, last.length, true);
-    }
-};
-
 // Hive ORC char type will pad trailing spaces.
 // https://docs.cloudera.com/documentation/enterprise/6/6.3/topics/impala_char.html
 static inline size_t remove_trailing_spaces(const char* s, size_t size) {

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -192,6 +192,15 @@ FileMetaData* FileReader::get_file_metadata() {
     return _file_metadata.get();
 }
 
+Status FileReader::collect_scan_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* io_ranges) {
+    int64_t dummy_offset = 0;
+    for (auto& r : _row_group_readers) {
+        r->collect_io_ranges(io_ranges, &dummy_offset, ColumnIOType::PAGE_INDEX);
+        r->collect_io_ranges(io_ranges, &dummy_offset, ColumnIOType::PAGES);
+    }
+    return Status::OK();
+}
+
 Status FileReader::_parse_footer(FileMetaDataPtr* file_metadata_ptr, int64_t* file_metadata_size) {
     std::vector<char> footer_buffer;
     ASSIGN_OR_RETURN(uint32_t footer_read_size, _get_footer_read_size());

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <cstdint>
 #include <memory>
 #include <set>
@@ -67,7 +65,8 @@ using FileMetaDataPtr = std::shared_ptr<FileMetaData>;
 
 class FileReader {
 public:
-    FileReader(int chunk_size, RandomAccessFile* file, size_t file_size, int64_t file_mtime,
+    FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
+               const DataCacheOptions& datacache_options = DataCacheOptions(),
                io::SharedBufferedInputStream* sb_stream = nullptr,
                const std::set<int64_t>* _need_skip_rowids = nullptr);
     ~FileReader();
@@ -138,7 +137,7 @@ private:
 
     RandomAccessFile* _file = nullptr;
     uint64_t _file_size = 0;
-    int64_t _file_mtime = 0;
+    const DataCacheOptions _datacache_options;
 
     std::vector<std::shared_ptr<GroupReader>> _row_group_readers;
     size_t _cur_row_group_idx = 0;

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -23,18 +23,15 @@
 #include <vector>
 
 #include "block_cache/block_cache.h"
-#include "column/chunk.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "common/statusor.h"
-#include "exprs/function_context.h"
 #include "formats/parquet/group_reader.h"
 #include "formats/parquet/meta_helper.h"
 #include "formats/parquet/metadata.h"
 #include "gen_cpp/parquet_types.h"
 #include "io/shared_buffered_input_stream.h"
 #include "runtime/runtime_state.h"
-#include "util/runtime_profile.h"
 
 namespace tparquet {
 class ColumnMetaData;
@@ -80,6 +77,8 @@ public:
     Status get_next(ChunkPtr* chunk);
 
     FileMetaData* get_file_metadata();
+
+    Status collect_scan_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* io_ranges);
 
 private:
     int _chunk_size;

--- a/be/src/io/CMakeLists.txt
+++ b/be/src/io/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(IO STATIC
         s3_input_stream.cpp
         s3_output_stream.cpp
         cache_input_stream.cpp
+        cache_select_input_stream.hpp
         shared_buffered_input_stream.cpp
         async_flush_output_stream.cpp
         direct_s3_output_stream.cpp

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -23,7 +23,7 @@
 
 namespace starrocks::io {
 
-class CacheInputStream final : public SeekableInputStreamWrapper {
+class CacheInputStream : public SeekableInputStreamWrapper {
 public:
     struct Stats {
         int64_t read_cache_ns = 0;
@@ -86,7 +86,7 @@ public:
         return _sb_stream->skip(count);
     }
 
-private:
+protected:
     struct BlockBuffer {
         int64_t offset;
         IOBuffer buffer;
@@ -94,9 +94,9 @@ private:
     using SharedBufferPtr = SharedBufferedInputStream::SharedBufferPtr;
 
     // Read block from local, if not found, will return Status::NotFound();
-    Status _read_block_from_local(const int64_t offset, const int64_t size, char* out);
+    virtual Status _read_block_from_local(const int64_t offset, const int64_t size, char* out);
     // Read multiple blocks from remote
-    Status _read_blocks_from_remote(const int64_t offset, const int64_t size, char* out);
+    virtual Status _read_blocks_from_remote(const int64_t offset, const int64_t size, char* out);
     Status _populate_to_cache(const int64_t offset, const int64_t size, char* src, const SharedBufferPtr& sb);
     void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count, const SharedBufferPtr& sb);
     void _deduplicate_shared_buffer(const SharedBufferPtr& sb);

--- a/be/src/io/cache_select_input_stream.hpp
+++ b/be/src/io/cache_select_input_stream.hpp
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "io/cache_input_stream.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::io {
+
+class CacheSelectInputStream final : public CacheInputStream {
+public:
+    explicit CacheSelectInputStream(const std::shared_ptr<SharedBufferedInputStream>& stream,
+                                    const std::string& filename, size_t size, int64_t modification_time)
+            : CacheInputStream(stream, filename, size, modification_time) {
+        set_enable_populate_cache(true);
+        set_enable_async_populate_mode(false);
+        set_enable_cache_io_adaptor(false);
+        set_enable_block_buffer(false);
+    }
+
+    ~CacheSelectInputStream() override = default;
+
+    Status write_at_fully(int64_t offset, int64_t count) {
+        RETURN_IF_ERROR(read_at_fully(offset, nullptr, count));
+        _sb_stream->release_to_offset(offset + count);
+        return Status::OK();
+    }
+
+protected:
+    Status _read_block_from_local(const int64_t offset, const int64_t size, char* out) override {
+        if (UNLIKELY(size == 0)) {
+            return Status::OK();
+        }
+        DCHECK(size <= _block_size);
+        const int64_t block_id = offset / _block_size;
+        const int64_t block_offset = block_id * _block_size;
+        const int64_t load_size = std::min(_block_size, _size - block_offset);
+
+        // check block existed
+        int64_t read_cache_ns = 0;
+        bool existed = false;
+        {
+            SCOPED_RAW_TIMER(&read_cache_ns);
+            existed = _cache->exist(_cache_key, block_offset, load_size);
+        }
+
+        _stats.read_cache_ns += read_cache_ns;
+        if (existed) {
+            _stats.read_cache_bytes += load_size;
+            _stats.read_cache_count += 1;
+            return Status::OK();
+        } else {
+            return Status::NotFound("Not Found");
+        }
+    }
+
+    Status _read_blocks_from_remote(const int64_t offset, const int64_t size, char* out) override {
+        const int64_t start_block_id = offset / _block_size;
+        const int64_t end_block_id = (offset + size - 1) / _block_size;
+
+        // We will load range=[read_start_offset, read_end_offset) from remote
+        const int64_t block_start_offset = start_block_id * _block_size;
+        const int64_t block_end_offset = std::min(end_block_id * _block_size + _block_size, _size);
+
+        for (int64_t read_offset_cursor = block_start_offset; read_offset_cursor < block_end_offset;) {
+            // Everytime read at most one buffer size
+            const int64_t read_size = std::min(_buffer_size, block_end_offset - read_offset_cursor);
+            RETURN_IF_ERROR(_sb_stream->read_at_fully(read_offset_cursor, _buffer.data(), read_size));
+            char* src = _buffer.data();
+
+            RETURN_IF_ERROR(_populate_to_cache(read_offset_cursor, read_size, src, nullptr));
+            read_offset_cursor += read_size;
+        }
+        return Status::OK();
+    }
+};
+
+} // namespace starrocks::io

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -196,6 +196,7 @@ set(EXEC_FILES
         ./formats/parquet/parquet_ut_base.cpp
         ./formats/parquet/page_index_test.cpp
         ./formats/parquet/statistics_helper_test.cpp
+        ./formats/disk_range_test.cpp
         ./geo/geo_types_test.cpp
         ./geo/wkt_parse_test.cpp
         ./http/http_client_test.cpp

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1955,7 +1955,7 @@ TEST_F(HdfsScannerTest, TestCSVWithoutEndDelemeter) {
 #if defined(WITH_STARCACHE)
         status = _init_datacache(50 * 1024 * 1024, "starcache"); // 50MB
         ASSERT_TRUE(status.ok()) << status.message();
-        param->use_datacache = true;
+        param->datacache_options.enable_datacache = true;
 #endif
         build_hive_column_names(param, tuple_desc, true);
         auto scanner = std::make_shared<HdfsTextScanner>();

--- a/be/test/exec/iceberg/iceberg_delete_builder_test.cpp
+++ b/be/test/exec/iceberg/iceberg_delete_builder_test.cpp
@@ -35,8 +35,9 @@ protected:
 };
 
 TEST_F(IcebergDeleteBuilderTest, TestParquetBuilder) {
+    const DataCacheOptions data_cache_options{};
     std::unique_ptr<ParquetPositionDeleteBuilder> parquet_builder(
-            new ParquetPositionDeleteBuilder(FileSystem::Default(), _parquet_data_path));
+            new ParquetPositionDeleteBuilder(FileSystem::Default(), data_cache_options, _parquet_data_path));
     ASSERT_OK(parquet_builder->build(TQueryGlobals().time_zone, _parquet_delete_path, 845, &_need_skip_rowids));
     ASSERT_EQ(1, _need_skip_rowids.size());
 }

--- a/be/test/formats/disk_range_test.cpp
+++ b/be/test/formats/disk_range_test.cpp
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/disk_range.hpp"
+
+#include <common/config.h>
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(DiskRangeTest, TestMergeEmptyDiskRanges) {
+    std::vector<DiskRange> disk_ranges{};
+    std::vector<DiskRange> merged_io_ranges{};
+    DiskRangeHelper::merge_adjacent_disk_ranges(disk_ranges, config::io_coalesce_read_max_distance_size,
+                                                config::io_coalesce_read_max_buffer_size, merged_io_ranges);
+    EXPECT_EQ(0, merged_io_ranges.size());
+}
+
+TEST(DiskRangeTest, TestMergeTinyDiskRanges) {
+    std::vector<DiskRange> disk_ranges{};
+    constexpr int64_t KB = 1024;
+    disk_ranges.emplace_back(0, 1 * KB);
+    disk_ranges.emplace_back(10 * KB, 30 * KB);
+    disk_ranges.emplace_back(800 * KB, 100 * KB);
+    std::vector<DiskRange> merged_disk_ranges{};
+    DiskRangeHelper::merge_adjacent_disk_ranges(disk_ranges, config::io_coalesce_read_max_distance_size,
+                                                config::io_coalesce_read_max_buffer_size, merged_disk_ranges);
+    EXPECT_EQ(1, merged_disk_ranges.size());
+    EXPECT_EQ(0, merged_disk_ranges.at(0).get_offset());
+    EXPECT_EQ(900 * KB, merged_disk_ranges.at(0).get_length());
+}
+
+TEST(DiskRangeTest, TestMergeBigDiskRanges) {
+    std::vector<DiskRange> disk_ranges{};
+    constexpr int64_t MB = 1024 * 1024;
+    disk_ranges.emplace_back(0, 100 * MB);
+    disk_ranges.emplace_back(200 * MB, 100 * MB);
+    std::vector<DiskRange> merged_disk_ranges{};
+    DiskRangeHelper::merge_adjacent_disk_ranges(disk_ranges, config::io_coalesce_read_max_distance_size,
+                                                config::io_coalesce_read_max_buffer_size, merged_disk_ranges);
+    EXPECT_EQ(2, merged_disk_ranges.size());
+    EXPECT_EQ(0, merged_disk_ranges.at(0).get_offset());
+    EXPECT_EQ(200 * MB, merged_disk_ranges.at(1).get_offset());
+}
+
+} // namespace starrocks

--- a/be/test/formats/disk_range_test.cpp
+++ b/be/test/formats/disk_range_test.cpp
@@ -37,8 +37,8 @@ TEST(DiskRangeTest, TestMergeTinyDiskRanges) {
     DiskRangeHelper::merge_adjacent_disk_ranges(disk_ranges, config::io_coalesce_read_max_distance_size,
                                                 config::io_coalesce_read_max_buffer_size, merged_disk_ranges);
     EXPECT_EQ(1, merged_disk_ranges.size());
-    EXPECT_EQ(0, merged_disk_ranges.at(0).get_offset());
-    EXPECT_EQ(900 * KB, merged_disk_ranges.at(0).get_length());
+    EXPECT_EQ(0, merged_disk_ranges.at(0).offset());
+    EXPECT_EQ(900 * KB, merged_disk_ranges.at(0).length());
 }
 
 TEST(DiskRangeTest, TestMergeBigDiskRanges) {
@@ -50,8 +50,8 @@ TEST(DiskRangeTest, TestMergeBigDiskRanges) {
     DiskRangeHelper::merge_adjacent_disk_ranges(disk_ranges, config::io_coalesce_read_max_distance_size,
                                                 config::io_coalesce_read_max_buffer_size, merged_disk_ranges);
     EXPECT_EQ(2, merged_disk_ranges.size());
-    EXPECT_EQ(0, merged_disk_ranges.at(0).get_offset());
-    EXPECT_EQ(200 * MB, merged_disk_ranges.at(1).get_offset());
+    EXPECT_EQ(0, merged_disk_ranges.at(0).offset());
+    EXPECT_EQ(200 * MB, merged_disk_ranges.at(1).offset());
 }
 
 } // namespace starrocks

--- a/be/test/formats/orc/utils_test.cpp
+++ b/be/test/formats/orc/utils_test.cpp
@@ -14,47 +14,7 @@
 
 #include "formats/orc/utils.h"
 
-#include <common/config.h>
 #include <gtest/gtest.h>
-
-namespace starrocks {
-
-TEST(UtilsTest, TestMergeEmptyDiskRanges) {
-    std::vector<DiskRange> disk_ranges{};
-    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
-    DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, disk_ranges, config::io_coalesce_read_max_distance_size,
-                                             config::io_coalesce_read_max_buffer_size);
-    EXPECT_EQ(0, io_ranges.size());
-}
-
-TEST(UtilsTest, TestMergeTinyDiskRanges) {
-    std::vector<DiskRange> disk_ranges{};
-    constexpr int64_t KB = 1024;
-    disk_ranges.emplace_back(0, 1 * KB);
-    disk_ranges.emplace_back(10 * KB, 30 * KB);
-    disk_ranges.emplace_back(800 * KB, 100 * KB);
-    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
-    DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, disk_ranges, config::io_coalesce_read_max_distance_size,
-                                             config::io_coalesce_read_max_buffer_size);
-    EXPECT_EQ(1, io_ranges.size());
-    EXPECT_EQ(0, io_ranges.at(0).offset);
-    EXPECT_EQ(900 * KB, io_ranges.at(0).size);
-}
-
-TEST(UtilsTest, TestMergeBigDiskRanges) {
-    std::vector<DiskRange> disk_ranges{};
-    constexpr int64_t MB = 1024 * 1024;
-    disk_ranges.emplace_back(0, 100 * MB);
-    disk_ranges.emplace_back(200 * MB, 100 * MB);
-    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
-    DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, disk_ranges, config::io_coalesce_read_max_distance_size,
-                                             config::io_coalesce_read_max_buffer_size);
-    EXPECT_EQ(2, io_ranges.size());
-    EXPECT_EQ(0, io_ranges.at(0).offset);
-    EXPECT_EQ(200 * MB, io_ranges.at(1).offset);
-}
-
-} // namespace starrocks
 
 namespace orc {
 

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -76,7 +76,7 @@ protected:
                const std::string& expected_value, const size_t expected_rows, bool is_failed = false) {
         auto file = _create_file(filepath);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(filepath), 0);
+                                                        std::filesystem::file_size(filepath));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -50,6 +50,7 @@ public:
 
 protected:
     std::unique_ptr<RandomAccessFile> _create_file(const std::string& file_path);
+    DataCacheOptions _mock_datacache_options();
 
     HdfsScannerContext* _create_scan_context();
 
@@ -232,6 +233,18 @@ protected:
 
 std::unique_ptr<RandomAccessFile> FileReaderTest::_create_file(const std::string& file_path) {
     return *FileSystem::Default()->new_random_access_file(file_path);
+}
+
+DataCacheOptions FileReaderTest::_mock_datacache_options() {
+    return DataCacheOptions{.enable_datacache = true,
+                            .enable_cache_select = false,
+                            .enable_populate_datacache = true,
+                            .enable_datacache_async_populate_mode = true,
+                            .enable_datacache_io_adaptor = true,
+                            .modification_time = 100000,
+                            .datacache_evict_probability = 0,
+                            .datacache_priority = 0,
+                            .datacache_ttl_seconds = 0};
 }
 
 HdfsScannerContext* FileReaderTest::_create_scan_context() {
@@ -848,7 +861,7 @@ ChunkPtr FileReaderTest::_create_chunk_for_not_exist() {
 TEST_F(FileReaderTest, TestInit) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path), 100000);
+                                                    std::filesystem::file_size(_file1_path), _mock_datacache_options());
     // init
     auto* ctx = _create_file1_base_context();
     Status status = file_reader->init(ctx);
@@ -858,7 +871,7 @@ TEST_F(FileReaderTest, TestInit) {
 TEST_F(FileReaderTest, TestGetNext) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path), 100000);
+                                                    std::filesystem::file_size(_file1_path), _mock_datacache_options());
     // init
     auto* ctx = _create_file1_base_context();
     Status status = file_reader->init(ctx);
@@ -880,7 +893,7 @@ TEST_F(FileReaderTest, TestGetNextWithSkipID) {
     auto file = _create_file(_file1_path);
     auto file_reader =
             std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(_file1_path),
-                                         0, nullptr, &need_skip_rowids);
+                                         _mock_datacache_options(), nullptr, &need_skip_rowids);
     // init
     auto* ctx = _create_file1_base_context();
     Status status = file_reader->init(ctx);
@@ -899,7 +912,7 @@ TEST_F(FileReaderTest, TestGetNextWithSkipID) {
 TEST_F(FileReaderTest, TestGetNextPartition) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path), 100000);
+                                                    std::filesystem::file_size(_file1_path), _mock_datacache_options());
     // init
     auto* ctx = _create_context_for_partition();
     Status status = file_reader->init(ctx);
@@ -918,7 +931,7 @@ TEST_F(FileReaderTest, TestGetNextPartition) {
 TEST_F(FileReaderTest, TestGetNextEmpty) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path), 100000);
+                                                    std::filesystem::file_size(_file1_path), _mock_datacache_options());
     // init
     auto* ctx = _create_context_for_not_exist();
     Status status = file_reader->init(ctx);
@@ -936,8 +949,9 @@ TEST_F(FileReaderTest, TestGetNextEmpty) {
 
 TEST_F(FileReaderTest, TestMinMaxConjunct) {
     auto file = _create_file(_file2_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path), 100000, nullptr);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(_file2_path),
+                                         _mock_datacache_options(), nullptr);
     // init
     auto* ctx = _create_context_for_min_max();
     Status status = file_reader->init(ctx);
@@ -959,7 +973,7 @@ TEST_F(FileReaderTest, TestMinMaxConjunct) {
 TEST_F(FileReaderTest, TestFilterFile) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path), 100000);
+                                                    std::filesystem::file_size(_file2_path), _mock_datacache_options());
     // init
     auto* ctx = _create_context_for_filter_file();
     Status status = file_reader->init(ctx);
@@ -983,7 +997,7 @@ TEST_F(FileReaderTest, TestGetNextDictFilter) {
     auto wrap_file = std::make_unique<RandomAccessFile>(shared_buffered_input_stream, file->filename());
 
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, wrap_file.get(),
-                                                    std::filesystem::file_size(_file2_path), 100000,
+                                                    std::filesystem::file_size(_file2_path), _mock_datacache_options(),
                                                     shared_buffered_input_stream.get());
     // init
     auto* ctx = _create_context_for_dict_filter();
@@ -1015,7 +1029,7 @@ TEST_F(FileReaderTest, TestGetNextDictFilter) {
 TEST_F(FileReaderTest, TestGetNextOtherFilter) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path), 100000);
+                                                    std::filesystem::file_size(_file2_path), _mock_datacache_options());
     // init
     auto* ctx = _create_context_for_other_filter();
     Status status = file_reader->init(ctx);
@@ -1042,7 +1056,7 @@ TEST_F(FileReaderTest, TestGetNextOtherFilter) {
 TEST_F(FileReaderTest, TestSkipRowGroup) {
     auto file = _create_file(_file2_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file2_path), 100000);
+                                                    std::filesystem::file_size(_file2_path), _mock_datacache_options());
     // c1 > 10000
     auto* ctx = _create_context_for_skip_group();
     Status status = file_reader->init(ctx);
@@ -1061,7 +1075,7 @@ TEST_F(FileReaderTest, TestSkipRowGroup) {
 TEST_F(FileReaderTest, TestMultiFilterWithMultiPage) {
     auto file = _create_file(_file3_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file3_path), 100000);
+                                                    std::filesystem::file_size(_file3_path), _mock_datacache_options());
     // c3 = "c", c1 >= 4
     auto* ctx = _create_context_for_multi_filter();
     Status status = file_reader->init(ctx);
@@ -1096,7 +1110,7 @@ TEST_F(FileReaderTest, TestMultiFilterWithMultiPage) {
 TEST_F(FileReaderTest, TestOtherFilterWithMultiPage) {
     auto file = _create_file(_file3_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file3_path), 100000);
+                                                    std::filesystem::file_size(_file3_path), _mock_datacache_options());
     // c1 >= 4080
     auto* ctx = _create_context_for_late_materialization();
     Status status = file_reader->init(ctx);
@@ -1121,7 +1135,7 @@ TEST_F(FileReaderTest, TestOtherFilterWithMultiPage) {
 TEST_F(FileReaderTest, TestReadStructUpperColumns) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path), 100000);
+                                                    std::filesystem::file_size(_file4_path), _mock_datacache_options());
     ;
 
     // init
@@ -1155,7 +1169,7 @@ TEST_F(FileReaderTest, TestReadStructUpperColumns) {
 TEST_F(FileReaderTest, TestReadWithUpperPred) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path), 100000);
+                                                    std::filesystem::file_size(_file4_path), _mock_datacache_options());
 
     // init
     auto* ctx = _create_context_for_upper_pred();
@@ -1182,7 +1196,7 @@ TEST_F(FileReaderTest, TestReadWithUpperPred) {
 TEST_F(FileReaderTest, TestReadArray2dColumn) {
     auto file = _create_file(_file5_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file5_path), 100000);
+                                                    std::filesystem::file_size(_file5_path), _mock_datacache_options());
 
     //init
     auto* ctx = _create_file5_base_context();
@@ -1221,7 +1235,7 @@ TEST_F(FileReaderTest, TestReadArray2dColumn) {
 TEST_F(FileReaderTest, TestReadRequiredArrayColumns) {
     auto file = _create_file(_file6_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file6_path), 100000);
+                                                    std::filesystem::file_size(_file6_path), _mock_datacache_options());
 
     // init
     auto* ctx = _create_file6_base_context();
@@ -1243,7 +1257,8 @@ TEST_F(FileReaderTest, TestReadRequiredArrayColumns) {
 TEST_F(FileReaderTest, TestReadMapCharKeyColumn) {
     auto file = _create_file(_file_map_char_key_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_map_char_key_path), 100000);
+                                                    std::filesystem::file_size(_file_map_char_key_path),
+                                                    _mock_datacache_options());
 
     //init
     auto* ctx = _create_file_map_char_key_context();
@@ -1282,8 +1297,9 @@ TEST_F(FileReaderTest, TestReadMapCharKeyColumn) {
 
 TEST_F(FileReaderTest, TestReadMapColumn) {
     auto file = _create_file(_file_map_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_map_path), 100000);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(_file_map_path), _mock_datacache_options());
 
     //init
     auto* ctx = _create_file_map_base_context();
@@ -1339,7 +1355,7 @@ TEST_F(FileReaderTest, TestReadMapColumn) {
 TEST_F(FileReaderTest, TestReadStruct) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path), 100000);
+                                                    std::filesystem::file_size(_file4_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1426,7 +1442,7 @@ TEST_F(FileReaderTest, TestReadStruct) {
 TEST_F(FileReaderTest, TestReadStructSubField) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path), 100000);
+                                                    std::filesystem::file_size(_file4_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1508,7 +1524,7 @@ TEST_F(FileReaderTest, TestReadStructSubField) {
 TEST_F(FileReaderTest, TestReadStructAbsentSubField) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path), 100000);
+                                                    std::filesystem::file_size(_file4_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1565,7 +1581,7 @@ TEST_F(FileReaderTest, TestReadStructAbsentSubField) {
 TEST_F(FileReaderTest, TestReadStructCaseSensitive) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path), 100000);
+                                                    std::filesystem::file_size(_file4_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1618,7 +1634,7 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitive) {
 TEST_F(FileReaderTest, TestReadStructCaseSensitiveError) {
     auto file = _create_file(_file4_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file4_path), 100000);
+                                                    std::filesystem::file_size(_file4_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1662,8 +1678,9 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitiveError) {
 
 TEST_F(FileReaderTest, TestReadStructNull) {
     auto file = _create_file(_file_struct_null_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_struct_null_path), 100000);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(_file_struct_null_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1723,8 +1740,9 @@ TEST_F(FileReaderTest, TestReadStructNull) {
 
 TEST_F(FileReaderTest, TestReadBinary) {
     auto file = _create_file(_file_binary_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_binary_path), 100000);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(_file_binary_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1762,8 +1780,9 @@ TEST_F(FileReaderTest, TestReadBinary) {
 
 TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
     auto file = _create_file(_file_map_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_map_path), 100000);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(_file_map_path), _mock_datacache_options());
 
     //init
     auto* ctx = _create_file_map_partial_materialize_context();
@@ -1823,7 +1842,8 @@ TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
 TEST_F(FileReaderTest, TestReadNotNull) {
     auto file = _create_file(_file_col_not_null_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_col_not_null_path), 100000);
+                                                    std::filesystem::file_size(_file_col_not_null_path),
+                                                    _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1878,7 +1898,7 @@ TEST_F(FileReaderTest, TestTwoNestedLevelArray) {
     const std::string filepath = "./be/test/exec/test_data/parquet_data/two_level_nested_array.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1940,8 +1960,9 @@ TEST_F(FileReaderTest, TestTwoNestedLevelArray) {
 
 TEST_F(FileReaderTest, TestReadMapNull) {
     auto file = _create_file(_file_map_null_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_map_null_path), 100000);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(_file_map_null_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1993,8 +2014,9 @@ TEST_F(FileReaderTest, TestReadArrayMap) {
     // }
 
     auto file = _create_file(_file_array_map_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_array_map_path), 100000);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(_file_array_map_path), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2059,8 +2081,8 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
     // With config's vector chunk size
     {
         auto file = _create_file(filepath);
-        auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(filepath), 100000);
+        auto file_reader = std::make_shared<FileReader>(
+                config::vector_chunk_size, file.get(), std::filesystem::file_size(filepath), _mock_datacache_options());
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -2134,7 +2156,8 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
     // With 1024 chunk size
     {
         auto file = _create_file(filepath);
-        auto file_reader = std::make_shared<FileReader>(1024, file.get(), std::filesystem::file_size(filepath), 100000);
+        auto file_reader = std::make_shared<FileReader>(1024, file.get(), std::filesystem::file_size(filepath),
+                                                        _mock_datacache_options());
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -2225,7 +2248,7 @@ TEST_F(FileReaderTest, TestComplexTypeNotNull) {
     std::string filepath = "./be/test/exec/test_data/parquet_data/complex_subfield_not_null.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2301,7 +2324,7 @@ TEST_F(FileReaderTest, TestHudiMORTwoNestedLevelArray) {
     const std::string filepath = "./be/test/exec/test_data/parquet_data/hudi_mor_two_level_nested_array.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2364,7 +2387,7 @@ TEST_F(FileReaderTest, TestLateMaterializationAboutRequiredComplexType) {
     const std::string filepath = "./be/test/formats/parquet/test_data/map_struct_subfield_required.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2445,7 +2468,7 @@ TEST_F(FileReaderTest, TestLateMaterializationAboutOptionalComplexType) {
     const std::string filepath = "./be/test/formats/parquet/test_data/map_struct_subfield_optional.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2508,7 +2531,7 @@ TEST_F(FileReaderTest, CheckDictOutofBouds) {
     const std::string filepath = "./be/test/exec/test_data/parquet_scanner/type_mismatch_decode_min_max.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2597,7 +2620,7 @@ TEST_F(FileReaderTest, CheckLargeParquetHeader) {
     const std::string filepath = "./be/test/formats/parquet/test_data/large_page_header.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2652,7 +2675,7 @@ TEST_F(FileReaderTest, TestMinMaxForIcebergTable) {
             "./be/test/formats/parquet/test_data/iceberg_schema_evolution/iceberg_string_map_string.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -2828,7 +2851,7 @@ TEST_F(FileReaderTest, TestRandomReadWith2PageSize) {
                                                     &ctx->conjunct_ctxs_by_slot[0]);
 
                 auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                                std::filesystem::file_size(file_path), 0);
+                                                                std::filesystem::file_size(file_path));
 
                 Status status = file_reader->init(ctx);
                 ASSERT_TRUE(status.ok());
@@ -2931,7 +2954,7 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
     _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "55",
                                                     &ctx->conjunct_ctxs_by_slot[3]);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(struct_in_struct_file_path), 0);
+                                                    std::filesystem::file_size(struct_in_struct_file_path));
 
     auto chunk = std::make_shared<Chunk>();
     chunk->append_column(ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), true),
@@ -2996,7 +3019,7 @@ TEST_F(FileReaderTest, TestReadRoundByRound) {
     // c1 <= 100
     _create_int_conjunct_ctxs(TExprOpcode::LE, 1, 100, &ctx->conjunct_ctxs_by_slot[1]);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(file_path), 1000);
+                                                    std::filesystem::file_size(file_path), _mock_datacache_options());
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
     size_t total_row_nums = 0;
@@ -3030,7 +3053,7 @@ TEST_F(FileReaderTest, TestStructSubfieldNoDecodeNotOutput) {
     _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 1, type_struct_in_struct, subfield_path, "55",
                                                     &ctx->conjunct_ctxs_by_slot[1]);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(struct_in_struct_file_path), 0);
+                                                    std::filesystem::file_size(struct_in_struct_file_path));
 
     auto chunk = std::make_shared<Chunk>();
     chunk->append_column(ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), true),
@@ -3069,7 +3092,7 @@ TEST_F(FileReaderTest, TestReadFooterCache) {
 
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path), 100000);
+                                                    std::filesystem::file_size(_file1_path), _mock_datacache_options());
     file_reader->_cache = cache.get();
 
     // first init, populcate footer cache
@@ -3081,8 +3104,8 @@ TEST_F(FileReaderTest, TestReadFooterCache) {
     ASSERT_EQ(ctx->stats->footer_cache_read_count, 0);
     ASSERT_EQ(ctx->stats->footer_cache_write_count, 1);
 
-    auto file_reader2 = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                     std::filesystem::file_size(_file1_path), 100000);
+    auto file_reader2 = std::make_shared<FileReader>(
+            config::vector_chunk_size, file.get(), std::filesystem::file_size(_file1_path), _mock_datacache_options());
     file_reader2->_cache = cache.get();
 
     // second init, read footer cache
@@ -3102,7 +3125,7 @@ TEST_F(FileReaderTest, TestTime) {
     const std::string filepath = "./be/test/formats/parquet/test_data/test_parquet_time_type.parquet";
     auto file = _create_file(filepath);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath), 100000);
+                                                    std::filesystem::file_size(filepath), _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -3159,7 +3182,8 @@ TEST_F(FileReaderTest, TestTime) {
 TEST_F(FileReaderTest, TestReadNoMinMaxStatistics) {
     auto file = _create_file(_file_no_min_max_stats_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_no_min_max_stats_path), 100000);
+                                                    std::filesystem::file_size(_file_no_min_max_stats_path),
+                                                    _mock_datacache_options());
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -3212,7 +3236,7 @@ TEST_F(FileReaderTest, TestReadNoMinMaxStatistics) {
 TEST_F(FileReaderTest, TestIsNotNullStatistics) {
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path), 100000);
+                                                    std::filesystem::file_size(_file1_path), _mock_datacache_options());
     // init
     auto* ctx = _create_file1_base_context();
     std::vector<TExpr> t_conjuncts;
@@ -3228,7 +3252,7 @@ TEST_F(FileReaderTest, TestIsNullStatistics) {
     const std::string small_page_file = "./be/test/formats/parquet/test_data/read_range_test.parquet";
     auto file = _create_file(small_page_file);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(small_page_file), 0);
+                                                    std::filesystem::file_size(small_page_file));
 
     auto ctx = _create_file_random_read_context(small_page_file);
     std::vector<TExpr> t_conjuncts;
@@ -3245,7 +3269,7 @@ TEST_F(FileReaderTest, TestInFilterStatitics) {
     const std::string multi_rg_file = "./be/test/formats/parquet/test_data/page_index_big_page.parquet";
     auto file = _create_file(multi_rg_file);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(multi_rg_file), 0);
+                                                    std::filesystem::file_size(multi_rg_file));
 
     auto ctx = _create_file_random_read_context(multi_rg_file);
     // min value and max value in this file, so it will be in the first and last row group

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -115,7 +115,7 @@ protected:
         auto ctx = _create_scan_context(type_descs);
         ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_file_path));
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
-        auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), file_size, 0);
+        auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), file_size);
 
         auto st = file_reader->init(ctx);
         if (!st.ok()) {

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -118,7 +118,7 @@ protected:
 TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -200,7 +200,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
 TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -270,7 +270,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
 TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -338,7 +338,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
 TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -406,7 +406,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
 TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -566,7 +566,7 @@ static void _create_null_conjunct_ctxs(SlotId slot_id, std::vector<ExprContext*>
 TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -639,7 +639,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
     // --------------init context---------------
     auto ctx = _create_scan_context();
     TIcebergSchema schema = TIcebergSchema{};
@@ -682,7 +682,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -726,7 +726,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -787,7 +787,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                    std::filesystem::file_size(add_struct_subfield_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -842,7 +842,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
 TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
     auto file = _create_file(no_field_id_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(no_field_id_file_path), 0);
+                                                    std::filesystem::file_size(no_field_id_file_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -903,7 +903,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
     {
         auto file = _create_file(add_struct_subfield_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                        std::filesystem::file_size(add_struct_subfield_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -965,7 +965,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
     {
         auto file = _create_file(add_struct_subfield_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                        std::filesystem::file_size(add_struct_subfield_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1022,7 +1022,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
     {
         auto file = _create_file(add_struct_subfield_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                        std::filesystem::file_size(add_struct_subfield_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1064,7 +1064,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
     {
         auto file = _create_file(add_struct_subfield_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(add_struct_subfield_file_path), 0);
+                                                        std::filesystem::file_size(add_struct_subfield_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1105,7 +1105,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
     {
         auto file = _create_file(struct_map_array_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(struct_map_array_file_path), 0);
+                                                        std::filesystem::file_size(struct_map_array_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1182,7 +1182,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
     {
         auto file = _create_file(struct_map_array_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(struct_map_array_file_path), 0);
+                                                        std::filesystem::file_size(struct_map_array_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1259,7 +1259,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
     {
         auto file = _create_file(struct_map_array_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(struct_map_array_file_path), 0);
+                                                        std::filesystem::file_size(struct_map_array_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1304,7 +1304,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
     {
         auto file = _create_file(struct_map_array_file_path);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(struct_map_array_file_path), 0);
+                                                        std::filesystem::file_size(struct_map_array_file_path));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -21,15 +21,12 @@
 #include "column/column_helper.h"
 #include "exec/hdfs_scanner.h"
 #include "exprs/binary_predicate.h"
-#include "exprs/expr_context.h"
 #include "formats/parquet/file_reader.h"
 #include "formats/parquet/group_reader.h"
 #include "formats/parquet/parquet_test_util/util.h"
 #include "formats/parquet/parquet_ut_base.h"
 #include "fs/fs.h"
 #include "io/shared_buffered_input_stream.h"
-#include "runtime/descriptor_helper.h"
-#include "runtime/mem_tracker.h"
 
 namespace starrocks::parquet {
 
@@ -280,7 +277,7 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                 std::cout << "file path: " << file_path << ", " << _print_predicate(single_flag) << std::endl;
 
                 auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                                std::filesystem::file_size(file_path), 100000);
+                                                                std::filesystem::file_size(file_path));
 
                 Status status = file_reader->init(ctx);
                 ASSERT_TRUE(status.ok());
@@ -362,7 +359,7 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
 
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(small_page_file), 100000);
+                                                    std::filesystem::file_size(small_page_file));
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
@@ -441,9 +438,9 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
 
     auto shared_buffer = std::make_shared<io::SharedBufferedInputStream>(file->stream(), small_page_file,
                                                                          std::filesystem::file_size(small_page_file));
-    auto file_reader =
-            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                         std::filesystem::file_size(small_page_file), 100000, shared_buffer.get());
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                                    std::filesystem::file_size(small_page_file), DataCacheOptions(),
+                                                    shared_buffer.get());
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
@@ -525,9 +522,9 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
 
     auto shared_buffer = std::make_shared<io::SharedBufferedInputStream>(file->stream(), small_page_file,
                                                                          std::filesystem::file_size(small_page_file));
-    auto file_reader =
-            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                         std::filesystem::file_size(small_page_file), 100000, shared_buffer.get());
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                                    std::filesystem::file_size(small_page_file), DataCacheOptions(),
+                                                    shared_buffer.get());
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -47,7 +47,7 @@ public:
         // create temporary reader to load schema.
         FileMetaData* file_metadata = nullptr;
         std::shared_ptr<FileReader> reader =
-                std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath), 0);
+                std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath));
         {
             HdfsScannerContext ctx;
             HdfsScanStats stats;
@@ -77,7 +77,7 @@ public:
         _make_column_info_vector(_scanner_ctx->tuple_desc, &_scanner_ctx->materialized_columns);
         _scanner_ctx->scan_range = scan_range;
 
-        _file_reader = std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath), 0);
+        _file_reader = std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath));
         RETURN_IF_ERROR(_file_reader->init(_scanner_ctx.get()));
 
         return Status::OK();

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -30,8 +30,6 @@
 #include "formats/parquet/parquet_test_util/util.h"
 #include "fs/fs.h"
 #include "fs/fs_memory.h"
-#include "gutil/casts.h"
-#include "runtime/descriptor_helper.h"
 #include "testutil/assert.h"
 
 namespace starrocks::formats {
@@ -90,7 +88,7 @@ protected:
         auto ctx = _create_scan_context(type_descs);
         ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_file_path));
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
-        auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size, 0);
+        auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
 
         auto st = file_reader->init(ctx);
         if (!st.ok()) {

--- a/be/test/formats/parquet/parquet_footer_test.cpp
+++ b/be/test/formats/parquet/parquet_footer_test.cpp
@@ -38,8 +38,8 @@ protected:
 TEST_F(ParquetFooterTest, TestEmptyParquetFile) {
     const std::string file_path = "./be/test/formats/parquet/test_data/empty.parquet";
     auto file = open_file(file_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(file_path), 0);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
     Status status = file_reader->init(&ctx);
     EXPECT_TRUE(status.is_corruption());
 }
@@ -47,8 +47,8 @@ TEST_F(ParquetFooterTest, TestEmptyParquetFile) {
 TEST_F(ParquetFooterTest, TestEncryptedParquetFile) {
     const std::string file_path = "./be/test/formats/parquet/test_data/encrypt_columns_and_footer.parquet.encrypted";
     auto file = open_file(file_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(file_path), 0);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
     Status status = file_reader->init(&ctx);
     EXPECT_TRUE(status.is_not_supported());
 }

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -51,6 +51,7 @@ public class DataCacheSelectExecutor {
         tmpSessionVariable.setDataCacheEvictProbability(100);
         tmpSessionVariable.setDataCachePriority(statement.getPriority());
         tmpSessionVariable.setDatacacheTTLSeconds(statement.getTTLSeconds());
+        tmpSessionVariable.setEnableCacheSelect(true);
         connectContext.setSessionVariable(tmpSessionVariable);
 
         InsertStmt insertStmt = statement.getInsertStmt();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1680,6 +1680,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     private long datacacheTTLSeconds = 0L;
 
+    private boolean enableCacheSelect = false;
+
     @VariableMgr.VarAttr(name = ENABLE_DYNAMIC_PRUNE_SCAN_RANGE)
     private boolean enableDynamicPruneScanRange = true;
 
@@ -2375,6 +2377,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setDatacacheTTLSeconds(long datacacheTTLSeconds) {
         this.datacacheTTLSeconds = datacacheTTLSeconds;
+    }
+
+    public void setEnableCacheSelect(boolean enableCacheSelect) {
+        this.enableCacheSelect = enableCacheSelect;
     }
 
     public boolean isCboUseDBLock() {
@@ -4196,6 +4202,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setDatacache_evict_probability(datacacheEvictProbability);
         tResult.setDatacache_priority(datacachePriority);
         tResult.setDatacache_ttl_seconds(datacacheTTLSeconds);
+        tResult.setEnable_cache_select(enableCacheSelect);
         tResult.setEnable_file_metacache(enableFileMetaCache);
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -315,6 +315,7 @@ struct TQueryOptions {
   133: optional bool enable_datacache_io_adaptor;
   134: optional i32 datacache_priority;
   135: optional i64 datacache_ttl_seconds;
+  136: optional bool enable_cache_select;
 
   140: optional string catalog;
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2109,3 +2109,13 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
             times += 1
         tools.assert_true(rc > 0, "wait row count > 0 error, timeout 300s")
 
+    def assert_cache_select_is_success(self, query):
+        """
+        Check cache select is success, make sure that read_cache_size + write_cache_size > 0
+        """
+        res = self.execute_sql(query,True,)
+        result = res["result"][0]
+        # remove unit
+        read_cache_size = int(result[0].replace("B", "").replace("KB", ""))
+        write_cache_size = int(result[1].replace("B", "").replace("KB", ""))
+        tools.assert_true(read_cache_size + write_cache_size > 0, "cache select is failed, read_cache_size + write_cache_size must larger than 0 bytes")

--- a/test/sql/test_datacache/R/test_datacache_select
+++ b/test/sql/test_datacache/R/test_datacache_select
@@ -17,6 +17,12 @@ create table t1 (c1 string, c2 string);
 insert into t1 values ("hello", "world"), ("smith", "blossom");
 -- result:
 -- !result
+create table t1_orc properties("file_format"="orc") as select * from t1;
+-- result:
+-- !result
+create table t1_textfile properties("file_format"="textfile") as select * from t1;
+-- result:
+-- !result
 submit task cache_select as cache select * from t1;
 -- result:
 cache_select	SUBMITTED
@@ -48,7 +54,37 @@ drop task cache_select_where;
 select * from default_catalog.information_schema.tasks where catalog='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}';
 -- result:
 -- !result
+function: assert_cache_select_is_success("cache select * from t1;")
+-- result:
+None
+-- !result
+function: assert_cache_select_is_success("cache select c2 from t1;")
+-- result:
+None
+-- !result
+function: assert_cache_select_is_success("cache select * from t1_orc;")
+-- result:
+None
+-- !result
+function: assert_cache_select_is_success("cache select c2 from t1_orc;")
+-- result:
+None
+-- !result
+function: assert_cache_select_is_success("cache select * from t1_textfile;")
+-- result:
+None
+-- !result
+function: assert_cache_select_is_success("cache select c2 from t1_textfile;")
+-- result:
+None
+-- !result
 drop table t1 force;
+-- result:
+-- !result
+drop table t1_orc force;
+-- result:
+-- !result
+drop table t1_textfile force;
 -- result:
 -- !result
 drop database cache_select_db_${uuid0};

--- a/test/sql/test_datacache/T/test_datacache_select
+++ b/test/sql/test_datacache/T/test_datacache_select
@@ -9,6 +9,9 @@ use cache_select_db_${uuid0};
 create table t1 (c1 string, c2 string);
 insert into t1 values ("hello", "world"), ("smith", "blossom");
 
+create table t1_orc properties("file_format"="orc") as select * from t1;
+create table t1_textfile properties("file_format"="textfile") as select * from t1;
+
 submit task cache_select as cache select * from t1;
 submit task cache_select_where as cache select c1 from t1 where c1="hello";
 
@@ -27,7 +30,17 @@ drop task cache_select_where;
 -- no tasks any more
 select * from default_catalog.information_schema.tasks where catalog='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}';
 
+function: assert_cache_select_is_success("cache select * from t1;")
+function: assert_cache_select_is_success("cache select c2 from t1;")
+function: assert_cache_select_is_success("cache select * from t1_orc;")
+function: assert_cache_select_is_success("cache select c2 from t1_orc;")
+function: assert_cache_select_is_success("cache select * from t1_textfile;")
+function: assert_cache_select_is_success("cache select c2 from t1_textfile;")
+
+-- clean tables
 drop table t1 force;
+drop table t1_orc force;
+drop table t1_textfile force;
 drop database cache_select_db_${uuid0};
 set catalog default_catalog;
 drop catalog hive_datacache_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
Original cache select is reuse query process, it will require high CPU & memory and is also slow. 

## What I'm doing:
For textfile: download it directly, and write it to DataCache
For orc/parquet: Read the footer first, then load the selected column's data into DataCache

Propose `DiskRange` concept to avoid coupling with IORange in SharedBufferInputStream. IORange is an inner class in SharedBufferInputStream, shouldn't use it outside.

## Performance report

First read(Result is not 100% correctly, because of network jitter)

| Table      | Previous Implementataion | New Implemention |
| ----------- | ----------- | ------------ |
| 2.2G TEXT 100Gtpch customer      | 10s       | 8.5s | 
| 25.2G Parquet 100Gtpch lineitem   | 45.87s        | 16.8s | 
| 15.7G ORC 100G tpch lineitem | 20.01s | 18.48s | 
| 5.8MB, 50,000 iceberg delete files | 13.06s | 2.05s |

Assume all data is already cached in DataCache

| Table      | Previous Implementataion | New Implemention |
| ----------- | ----------- | ------------ |
| 2.2G TEXT 100Gtpch customer      | 1.46s       | 0.02s | 
| 25.2G Parquet 100Gtpch lineitem   | 6.52s        | 0.09s | 
| 15.7G ORC 100G tpch lineitem | 7.3s | 0.41s | 
| 5.8MB, 50,000 iceberg delete files | 11.7s | 0.22s |


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
