### PR TITLE
[Enhancement] support count distinct on constant semi-type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -312,7 +312,6 @@ public class FunctionCallExpr extends Expr {
     }
 
     public boolean isDistinct() {
-        Preconditions.checkState(isAggregateFunction());
         return fnParams.isDistinct();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -806,6 +806,12 @@ public abstract class Type implements Cloneable {
         if (isArrayType()) {
             return ((ArrayType) this).getItemType().canDistinct();
         }
+        if (isStructType()) {
+            return ((StructType) this).getFields().stream().allMatch(sf -> sf.getType().canDistinct());
+        }
+        if (isMapType()) {
+            return ((MapType) this).getKeyType().canDistinct() && ((MapType) this).getValueType().canDistinct();
+        }
         return !isOnlyMetricType() && !isJsonType() && !isFunctionType() && !isBinaryType() && !isStructType() &&
                 !isMapType();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -14,9 +14,12 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.common.ErrorType;
@@ -28,13 +31,16 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,13 +60,21 @@ public class RewriteMultiDistinctRule extends TransformationRule {
     public boolean check(OptExpression input, OptimizerContext context) {
         LogicalAggregationOperator agg = (LogicalAggregationOperator) input.getOp();
 
+        // any aggregate function is distinct and constant, we replace it to any_value
+        if (isComplexConstantCountDistinct(input)) {
+            return true;
+        }
+
         Optional<List<ColumnRefOperator>> distinctCols = Utils.extractCommonDistinctCols(agg.getAggregations().values());
 
         // all distinct function use the same distinct columns, we use the split rule to rewrite
-        return !distinctCols.isPresent();
+        return distinctCols.isEmpty();
     }
 
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        if (isComplexConstantCountDistinct(input)) {
+            return rewriteComplexConstantDistinct(input);
+        }
         if (useCteToRewrite(input, context)) {
             MultiDistinctByCTERewriter rewriter = new MultiDistinctByCTERewriter();
             return rewriter.transformImpl(input, context);
@@ -68,6 +82,40 @@ public class RewriteMultiDistinctRule extends TransformationRule {
             MultiDistinctByMultiFuncRewriter rewriter = new MultiDistinctByMultiFuncRewriter();
             return rewriter.transformImpl(input, context);
         }
+    }
+
+    private boolean isComplexConstantCountDistinct(OptExpression input) {
+        LogicalAggregationOperator agg = (LogicalAggregationOperator) input.getOp();
+        // sr support count(distinct constant array/struct/map) in four-phase aggregate,
+        // but doesn't support in two-phase aggregate, we replace it to any_value
+        return agg.getAggregations().values().stream()
+                .anyMatch(c -> c.isDistinct() && c.isConstant() && FunctionSet.COUNT.equalsIgnoreCase(c.getFnName()) &&
+                        (c.getChildren().size() == 1) && c.getChild(0).getType().isComplexType());
+    }
+
+    private List<OptExpression> rewriteComplexConstantDistinct(OptExpression input) {
+        LogicalAggregationOperator agg = (LogicalAggregationOperator) input.getOp();
+        Map<ColumnRefOperator, CallOperator> newAggregations = Maps.newHashMap();
+
+        agg.getAggregations().forEach((k, v) -> {
+            if (v.isDistinct() && v.isConstant() && FunctionSet.COUNT.equalsIgnoreCase(v.getFnName()) &&
+                    (v.getChildren().size() == 1) && v.getChild(0).getType().isComplexType()) {
+                Preconditions.checkState(v.getType() == Type.BIGINT);
+                IsNullPredicateOperator isNull = new IsNullPredicateOperator(true, v.getChild(0));
+                CastOperator cast = new CastOperator(Type.BIGINT, isNull);
+                Function fn = Expr.getBuiltinFunction(FunctionSet.ANY_VALUE, new Type[] {Type.BIGINT},
+                        Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                CallOperator anyValue =
+                        new CallOperator(FunctionSet.ANY_VALUE, v.getType(), Lists.newArrayList(cast), fn, false);
+                newAggregations.put(k, anyValue);
+            } else {
+                newAggregations.put(k, v);
+            }
+        });
+
+        LogicalAggregationOperator newAgg =
+                LogicalAggregationOperator.builder().withOperator(agg).setAggregations(newAggregations).build();
+        return Lists.newArrayList(OptExpression.create(newAgg, input.getInputs()));
     }
 
     private boolean useCteToRewrite(OptExpression input, OptimizerContext context) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -319,4 +319,20 @@ public class StructTypePlanTest extends PlanTestBase {
         sql = "select c1.b[1].a, c1.b from test";
         assertVerbosePlanContains(sql, "c1.b[true][1].a[true]", "c1.b[true]");
     }
+
+    @Test
+    public void testSemiTypeCountDistinct() throws Exception {
+        String sql = "select count(distinct row(1, 2))";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: any_value(CAST(row(1, 2) IS NOT NULL AS BIGINT))");
+
+        sql = "select count(distinct [1,2,3])";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "output: any_value(CAST([1,2,3] IS NOT NULL AS BIGINT))");
+
+        sql = "select count(distinct map{'a': 1})";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "output: any_value(CAST(map{'a':1} IS NOT NULL AS BIGINT))");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
![image](https://github.com/user-attachments/assets/e2cf9997-4336-4b55-9e82-5ab7a1bca649)

cast count/sum(distinct xxx) to any_value(xxx)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
