### PR TITLE
[BugFix] Fix the data correctness issue for datacache caused by inconsistent data lifetime during asynchronous cache population. (backport #48241)

### DIFF
--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -192,10 +192,12 @@ Status CacheInputStream::_read_blocks_from_remote(const int64_t offset, const in
 
         // check [read_offset_cursor, read_size) is already in SharedBuffer
         // If existed, we can use zero copy to avoid copy data from SharedBuffer to _buffer
+        SharedBufferPtr sb = nullptr;
         auto ret = _sb_stream->find_shared_buffer(read_offset_cursor, read_size);
         if (ret.ok()) {
+            sb = ret.value();
             const uint8_t* buffer = nullptr;
-            RETURN_IF_ERROR(_sb_stream->get_bytes(&buffer, read_offset_cursor, read_size, ret.value()));
+            RETURN_IF_ERROR(_sb_stream->get_bytes(&buffer, read_offset_cursor, read_size, sb));
             src = (char*)buffer;
         } else {
             RETURN_IF_ERROR(_sb_stream->read_at_fully(read_offset_cursor, _buffer.data(), read_size));
@@ -215,7 +217,7 @@ Status CacheInputStream::_read_blocks_from_remote(const int64_t offset, const in
         }
 
         if (_enable_populate_cache) {
-            RETURN_IF_ERROR(_populate_to_cache(read_offset_cursor, read_size, src));
+            RETURN_IF_ERROR(_populate_to_cache(read_offset_cursor, read_size, src, sb));
         }
 
         read_offset_cursor += read_size;
@@ -227,7 +229,8 @@ Status CacheInputStream::_read_blocks_from_remote(const int64_t offset, const in
     return Status::OK();
 }
 
-Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t size, char* src) {
+Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t size, char* src,
+                                            const SharedBufferPtr& sb) {
     SCOPED_RAW_TIMER(&_stats.write_cache_ns);
     const int64_t write_end_offset = offset + size;
     char* src_cursor = src;
@@ -239,10 +242,7 @@ Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t 
         options.evict_probability = _datacache_evict_probability;
         const int64_t write_size = std::min(_block_size, write_end_offset - write_offset_cursor);
 
-        SharedBufferPtr sb = nullptr;
-        auto ret = _sb_stream->find_shared_buffer(write_offset_cursor, write_size);
-        if (ret.ok() && options.async) {
-            sb = ret.value();
+        if (options.async && sb) {
             auto cb = [sb](int code, const std::string& msg) {
                 // We only need to keep the shared buffer pointer
                 LOG_IF(WARNING, code != 0 && code != EEXIST) << "write block cache failed, errmsg: " << msg;
@@ -431,7 +431,7 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
         WriteCacheOptions options;
         options.async = _enable_async_populate_mode;
         options.evict_probability = _datacache_evict_probability;
-        if (options.async) {
+        if (options.async && sb) {
             auto cb = [sb](int code, const std::string& msg) {
                 // We only need to keep the shared buffer pointer
                 LOG_IF(WARNING, code != 0 && code != EEXIST) << "write block cache failed, errmsg: " << msg;

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -93,7 +93,7 @@ private:
     Status _read_block_from_local(const int64_t offset, const int64_t size, char* out);
     // Read multiple blocks from remote
     Status _read_blocks_from_remote(const int64_t offset, const int64_t size, char* out);
-    Status _populate_to_cache(const int64_t offset, const int64_t size, char* src);
+    Status _populate_to_cache(const int64_t offset, const int64_t size, char* src, const SharedBufferPtr& sb);
     void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count, const SharedBufferPtr& sb);
     void _deduplicate_shared_buffer(const SharedBufferPtr& sb);
     bool _can_ignore_populate_error(const Status& status) const;


### PR DESCRIPTION
## Why I'm doing:
Now we set the `allow_zero_copy` option when populating datacache asynchronously if the data exist in shared buffer. So we need to keep the shared buffer lifetime until the data are truly written into the cache. 
However, the range of different shared buffer may overlap because we align them with block size. So if we find the corresponding shared buffer with different ranges, even if they contain each other, we may still find different shared buffer objects. If we can not correctly find the shared buffer corresponding to the data that will be written to datacache,  the shared buffer may be released early and we will write the incorrect data into the cache.

## What I'm doing:
Use the shared buffer corresponding to the target data directly instead of finding the shared buffer again to avoid finding a different one.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

