### PR TITLE
[BugFix] MV shold not rewrite if its defined query contains non determinic time functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -643,6 +643,12 @@ public class FunctionSet {
                     .add()
                     .build();
 
+    // Contains all non-deterministic functions both time and non-time functions.
+    public static final Set<String> allNonDeterministicFunctions = ImmutableSet.<String>builder()
+            .addAll(nonDeterministicFunctions)
+            .addAll(nonDeterministicTimeFunctions)
+            .build();
+
     public static final Set<String> onlyAnalyticUsedFunctions = ImmutableSet.<String>builder()
             .add(FunctionSet.DENSE_RANK)
             .add(FunctionSet.RANK)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -70,6 +70,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.privilege.AccessDeniedException;
@@ -99,6 +100,7 @@ import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
@@ -131,6 +133,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -1520,6 +1523,66 @@ public class AnalyzerUtils {
                 return null;
             }
         }.visit(node);
+    }
+
+    static class NonDeterministicAnalyzeVisitor extends AstTraverser<Void, Void> {
+        Optional<String> nonDeterministicFunctionOpt = Optional.empty();
+
+        public Pair<Boolean, String> getResult() {
+            return Pair.create(nonDeterministicFunctionOpt.isPresent(), nonDeterministicFunctionOpt.orElse(null));
+        }
+
+        private boolean containsNonDeterministicFunction(FunctionCallExpr expr) {
+            FunctionName functionName = expr.getFnName();
+            if (functionName == null) {
+                return false;
+            }
+            return FunctionSet.allNonDeterministicFunctions.contains(functionName.getFunction());
+        }
+
+        @Override
+        public Void visitSelect(SelectRelation node, Void context) {
+            if (node.getSelectList() != null) {
+                for (SelectListItem item : node.getSelectList().getItems()) {
+                    Expr expr = item.getExpr();
+                    if (expr instanceof FunctionCallExpr) {
+                        FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
+                        if (containsNonDeterministicFunction(functionCallExpr)) {
+                            nonDeterministicFunctionOpt = Optional.of(functionCallExpr.getFnName().getFunction());
+                            return null;
+                        }
+                    }
+                }
+            }
+            return super.visitSelect(node, context);
+        }
+
+        @Override
+        public Void visitFunctionCall(FunctionCallExpr expr, Void context) {
+            if (containsNonDeterministicFunction(expr)) {
+                nonDeterministicFunctionOpt = Optional.of(expr.getFn().functionName());
+                return null;
+            }
+            for (Expr param : expr.getParams().exprs()) {
+                visit(param);
+                if (nonDeterministicFunctionOpt.isPresent()) {
+                    return null;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Check if the function is a non-deterministic function with strict mode, eg current_date/current_timestamp also
+     * is treated as non-deterministic function too.
+     * @param node the node to check
+     * @return true if node contains non-deterministic functions, false otherwise.
+     */
+    public static Pair<Boolean, String> containsNonDeterministicFunction(ParseNode node) {
+        NonDeterministicAnalyzeVisitor visitor = new NonDeterministicAnalyzeVisitor();
+        visitor.visit(node);
+        return visitor.getResult();
     }
 
     public static void checkAutoPartitionTableLimit(FunctionCallExpr functionCallExpr, String prePartitionGranularity) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1563,7 +1563,7 @@ public class AnalyzerUtils {
                 nonDeterministicFunctionOpt = Optional.of(expr.getFn().functionName());
                 return null;
             }
-            for (Expr param : expr.getParams().exprs()) {
+            for (Expr param : expr.getChildren()) {
                 visit(param);
                 if (nonDeterministicFunctionOpt.isPresent()) {
                     return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -19,6 +19,8 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -52,11 +54,23 @@ public class MaterializedViewOptimizer {
         if (mv.getRefreshScheme().isSync()) {
             optimizerConfig.disableRule(RuleType.TF_MATERIALIZED_VIEW);
         }
-
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         String mvSql = mv.getViewDefineSql();
+        // parse mv's defined query
+        StatementBase stmt = MvUtils.parse(mv, mvSql, connectContext);
+        if (stmt == null) {
+            return new MvPlanContext(false, "MV Plan parse failed");
+        }
+        // check whether mv's defined query contains non-deterministic functions
+        Pair<Boolean, String> containsNonDeterministicFunctions = AnalyzerUtils.containsNonDeterministicFunction(stmt);
+        if (containsNonDeterministicFunctions != null && containsNonDeterministicFunctions.first) {
+            String invalidPlanReason = String.format("MV contains non-deterministic functions(%s)",
+                    containsNonDeterministicFunctions.second);
+            return new MvPlanContext(false, invalidPlanReason);
+        }
+        // get optimized plan of mv's defined query
         Pair<OptExpression, LogicalPlan> plans =
-                MvUtils.getRuleOptimizedLogicalPlan(mv, mvSql, columnRefFactory, connectContext, optimizerConfig, inlineView);
+                MvUtils.getRuleOptimizedLogicalPlan(stmt, columnRefFactory, connectContext, optimizerConfig, inlineView);
         if (plans == null) {
             return new MvPlanContext(false, "No query plan for it");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/NonDeterministicVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/NonDeterministicVisitor.java
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.Map;
+import java.util.Set;
+
+public class NonDeterministicVisitor extends OptExpressionVisitor<Boolean, Void> {
+    private final Set<String> nonDeterministicFunctions = FunctionSet.nonDeterministicFunctions;
+    public NonDeterministicVisitor() {
+    }
+
+    private boolean checkColumnRefMap(Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
+        if (columnRefMap == null) {
+            return false;
+        }
+        for (ScalarOperator ref : columnRefMap.values()) {
+            if (hasNonDeterministicFunc(ref)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasNonDeterministicFunc(ScalarOperator scalarOperator) {
+        if (scalarOperator instanceof CallOperator) {
+            String fnName = ((CallOperator) scalarOperator).getFnName();
+            if (nonDeterministicFunctions.contains(fnName)) {
+                return true;
+            }
+        } else if (scalarOperator instanceof LambdaFunctionOperator) {
+            LambdaFunctionOperator lambdaOp = (LambdaFunctionOperator) scalarOperator;
+            Map<ColumnRefOperator, ScalarOperator> columnRefMap = lambdaOp.getColumnRefMap();
+            if (checkColumnRefMap(columnRefMap)) {
+                return true;
+            }
+        }
+        for (ScalarOperator child : scalarOperator.getChildren()) {
+            if (hasNonDeterministicFunc(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean checkAggCall(Map<ColumnRefOperator, CallOperator> aggregations) {
+        for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregations.entrySet()) {
+            CallOperator aggCall = entry.getValue();
+            for (ScalarOperator arg : aggCall.getArguments()) {
+                if (hasNonDeterministicFunc(arg)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean checkProject(Projection projection) {
+        if (projection == null) {
+            return false;
+        }
+        Map<ColumnRefOperator, ScalarOperator> columnRefMap =
+                projection.getColumnRefMap();
+        if (columnRefMap == null) {
+            return false;
+        }
+        for (ScalarOperator scalarOperator : columnRefMap.values()) {
+            if (hasNonDeterministicFunc(scalarOperator)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean checkOptExpression(OptExpression optExpression) {
+        Operator operator = optExpression.getOp();
+        // projections
+        if (operator.getProjection() != null && checkProject(operator.getProjection())) {
+            return true;
+        }
+        // predicates
+        if (operator.getPredicate() != null &&
+                hasNonDeterministicFunc(operator.getPredicate())) {
+            return true;
+        }
+        return visitChildren(optExpression);
+    }
+
+    private Boolean visitChildren(OptExpression optExpression) {
+        for (OptExpression input : optExpression.getInputs()) {
+            if (checkOptExpression(input)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visit(OptExpression optExpression, Void context) {
+        return visitChildren(optExpression);
+    }
+
+    @Override
+    public Boolean visitLogicalTableScan(OptExpression optExpression, Void context) {
+        return checkOptExpression(optExpression);
+    }
+
+    @Override
+    public Boolean visitLogicalJoin(OptExpression optExpression, Void context) {
+        LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
+        if (joinOperator.getOnPredicate() != null &&
+                hasNonDeterministicFunc(joinOperator.getOnPredicate())) {
+            return true;
+        }
+        return visitChildren(optExpression);
+    }
+
+    @Override
+    public Boolean visitLogicalAggregate(OptExpression optExpression, Void context) {
+        LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) optExpression.getOp();
+        if (checkAggCall(aggregationOperator.getAggregations())) {
+            return true;
+        }
+        return visitChildren(optExpression);
+    }
+
+    @Override
+    public Boolean visitLogicalWindow(OptExpression optExpression, Void context) {
+        LogicalWindowOperator operator = (LogicalWindowOperator) optExpression.getOp();
+        if (checkAggCall(operator.getWindowCall())) {
+            return true;
+        }
+        return visitChildren(optExpression);
+    }
+
+    @Override
+    public Boolean visitLogicalProject(OptExpression optExpression, Void context) {
+        Map<ColumnRefOperator, ScalarOperator> map = ((LogicalProjectOperator) optExpression.getOp())
+                .getColumnRefMap();
+        for (ScalarOperator scalarOperator : map.values()) {
+            if (hasNonDeterministicFunc(scalarOperator)) {
+                return true;
+            }
+        }
+        return visitChildren(optExpression);
+    }
+
+    @Override
+    public Boolean visitLogicalFilter(OptExpression optExpression, Void context) {
+        LogicalFilterOperator filter = (LogicalFilterOperator) optExpression.getOp();
+        if (filter.getPredicate() != null && hasNonDeterministicFunc(filter.getPredicate()))  {
+            return true;
+        }
+        return visitChildren(optExpression);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/NonDeterministicVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/NonDeterministicVisitor.java
@@ -117,7 +117,7 @@ public class NonDeterministicVisitor extends OptExpressionVisitor<Boolean, Void>
     }
 
     private Boolean visitChildren(OptExpression optExpression) {
-        for (OptExpression child: optExpression.getInputs()) {
+        for (OptExpression child : optExpression.getInputs()) {
             if (checkCommon(child)) {
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
@@ -15,31 +15,17 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.CTEContext;
 import com.starrocks.sql.optimizer.OptExpression;
-import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.OptimizerContext;
-import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
-import com.starrocks.sql.optimizer.operator.Projection;
-import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
-import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.NonDeterministicVisitor;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * If the opt expression contains non-deterministic function, force cte reuse to avoid producing wrong result.
@@ -52,7 +38,7 @@ public class ForceCTEReuseRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        if (NonDeterministicVisitor.hasNonDeterministicFunction(input)) {
+        if (hasNonDeterministicFunction(input)) {
             LogicalCTEProduceOperator produce = (LogicalCTEProduceOperator) input.getOp();
             CTEContext cteContext = context.getCteContext();
             int cteId = produce.getCteId();
@@ -62,157 +48,7 @@ public class ForceCTEReuseRule extends TransformationRule {
         return Collections.emptyList();
     }
 
-    private static class NonDeterministicVisitor extends OptExpressionVisitor<Boolean, Void> {
-        public static boolean hasNonDeterministicFunction(OptExpression root) {
-            return new NonDeterministicVisitor().visit(root, null);
-        }
-
-        boolean checkColumnRefMap(Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
-            if (columnRefMap == null) {
-                return false;
-            }
-            for (ScalarOperator ref : columnRefMap.values()) {
-                if (hasNonDeterministicFunc(ref)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private boolean hasNonDeterministicFunc(ScalarOperator scalarOperator) {
-            if (scalarOperator instanceof CallOperator) {
-                String fnName = ((CallOperator) scalarOperator).getFnName();
-                if (FunctionSet.nonDeterministicFunctions.contains(fnName)) {
-                    return true;
-                }
-            } else if (scalarOperator instanceof LambdaFunctionOperator) {
-                LambdaFunctionOperator lambdaOp = (LambdaFunctionOperator) scalarOperator;
-                Map<ColumnRefOperator, ScalarOperator> columnRefMap = lambdaOp.getColumnRefMap();
-                if (checkColumnRefMap(columnRefMap)) {
-                    return true;
-                }
-            }
-            for (ScalarOperator child : scalarOperator.getChildren()) {
-                if (hasNonDeterministicFunc(child)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private boolean checkAggCall(Map<ColumnRefOperator, CallOperator> aggregations) {
-            for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregations.entrySet()) {
-                CallOperator aggCall = entry.getValue();
-                for (ScalarOperator arg : aggCall.getArguments()) {
-                    if (hasNonDeterministicFunc(arg)) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        private boolean checkProject(Projection projection) {
-            if (projection == null) {
-                return false;
-            }
-            Map<ColumnRefOperator, ScalarOperator> columnRefMap =
-                    projection.getColumnRefMap();
-            if (columnRefMap == null) {
-                return false;
-            }
-            for (ScalarOperator scalarOperator : columnRefMap.values()) {
-                if (hasNonDeterministicFunc(scalarOperator)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private boolean checkOptExpression(OptExpression optExpression) {
-            Operator operator = optExpression.getOp();
-            // projections
-            if (operator.getProjection() != null && checkProject(operator.getProjection())) {
-                return true;
-            }
-            // predicates
-            if (operator.getPredicate() != null &&
-                    hasNonDeterministicFunc(operator.getPredicate())) {
-                return true;
-            }
-            return optExpression.getOp().accept(this, optExpression, null);
-        }
-
-        private Boolean visitChildren(OptExpression optExpression) {
-            for (OptExpression input : optExpression.getInputs()) {
-                if (checkOptExpression(input)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Boolean visit(OptExpression optExpression, Void context) {
-            return visitChildren(optExpression);
-        }
-
-        @Override
-        public Boolean visitLogicalTableScan(OptExpression optExpression, Void context) {
-            LogicalScanOperator scanOperator = (LogicalScanOperator) optExpression.getOp();
-            if (scanOperator.getPredicate() != null && hasNonDeterministicFunc(scanOperator.getPredicate())) {
-                return true;
-            }
-            return false;
-        }
-
-        @Override
-        public Boolean visitLogicalJoin(OptExpression optExpression, Void context) {
-            LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
-            if (joinOperator.getOnPredicate() != null &&
-                    hasNonDeterministicFunc(joinOperator.getOnPredicate())) {
-                return true;
-            }
-            return visitChildren(optExpression);
-        }
-
-        @Override
-        public Boolean visitLogicalAggregate(OptExpression optExpression, Void context) {
-            LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) optExpression.getOp();
-            if (checkAggCall(aggregationOperator.getAggregations())) {
-                return true;
-            }
-            return visitChildren(optExpression);
-        }
-
-        @Override
-        public Boolean visitLogicalWindow(OptExpression optExpression, Void context) {
-            LogicalWindowOperator operator = (LogicalWindowOperator) optExpression.getOp();
-            if (checkAggCall(operator.getWindowCall())) {
-                return true;
-            }
-            return visitChildren(optExpression);
-        }
-
-        @Override
-        public Boolean visitLogicalProject(OptExpression optExpression, Void context) {
-            Map<ColumnRefOperator, ScalarOperator> map = ((LogicalProjectOperator) optExpression.getOp())
-                    .getColumnRefMap();
-            for (ScalarOperator scalarOperator : map.values()) {
-                if (hasNonDeterministicFunc(scalarOperator)) {
-                    return true;
-                }
-            }
-            return visitChildren(optExpression);
-        }
-
-        @Override
-        public Boolean visitLogicalFilter(OptExpression optExpression, Void context) {
-            LogicalFilterOperator filter = (LogicalFilterOperator) optExpression.getOp();
-            if (filter.getPredicate() != null && hasNonDeterministicFunc(filter.getPredicate()))  {
-                return true;
-            }
-            return visitChildren(optExpression);
-        }
+    private boolean hasNonDeterministicFunction(OptExpression root) {
+        return root.getOp().accept(new NonDeterministicVisitor(), root, null);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -450,13 +450,9 @@ public class MvUtils {
                 || (operator instanceof LogicalAggregationOperator);
     }
 
-    public static Pair<OptExpression, LogicalPlan> getRuleOptimizedLogicalPlan(
-            MaterializedView mv,
-            String sql,
-            ColumnRefFactory columnRefFactory,
-            ConnectContext connectContext,
-            OptimizerConfig optimizerConfig,
-            boolean inlineView) {
+    public static StatementBase parse(MaterializedView mv,
+                                      String sql,
+                                      ConnectContext connectContext) {
         StatementBase mvStmt;
         try {
             List<StatementBase> statementBases =
@@ -467,6 +463,14 @@ public class MvUtils {
             LOG.warn("parse mv{}'s sql:{} failed", mv.getName(), sql, parsingException);
             return null;
         }
+        return mvStmt;
+    }
+
+    public static Pair<OptExpression, LogicalPlan> getRuleOptimizedLogicalPlan(StatementBase mvStmt,
+                                                                               ColumnRefFactory columnRefFactory,
+                                                                               ConnectContext connectContext,
+                                                                               OptimizerConfig optimizerConfig,
+                                                                               boolean inlineView) {
         Preconditions.checkState(mvStmt instanceof QueryStatement);
         Analyzer.analyze(mvStmt, connectContext);
         QueryRelation query = ((QueryStatement) mvStmt).getQueryRelation();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -411,7 +411,6 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
 
     @Test
     public void testMVRewriteWithNonDeterministicFunctions() {
-        setTracLogModule("MV");
         starRocksAssert.withMaterializedView("create materialized view mv0" +
                 " distributed by random" +
                 " as select current_date(), t1a, t1b from test.test_all_type ;", () -> {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -408,4 +408,17 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
             }
         });
     }
+
+    @Test
+    public void testMVRewriteWithNonDeterministicFunctions() {
+        setTracLogModule("MV");
+        starRocksAssert.withMaterializedView("create materialized view mv0" +
+                " distributed by random" +
+                " as select current_date(), t1a, t1b from test.test_all_type ;", () -> {
+            {
+                String query = " select current_date(), t1a, t1b from test.test_all_type";
+                sql(query).nonMatch("mv0");
+            }
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -913,7 +913,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
 
     @Test
     public void testAggregateWithGroupByKeyExpr1() {
-        setTracLogModule("MV");
         testRewriteOK("select empid, deptno," +
                         " sum(salary) as total, count(salary) + 1 as cnt" +
                         " from emps group by empid, deptno ",

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
@@ -344,4 +344,16 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
         // TODO: support text based view for more patterns, now only rewrite the same query and subquery
         testRewriteFail(mv, query);
     }
+
+    @Test
+    public void testMVRewriteWithNonDeterministicFunctions() {
+        starRocksAssert.withMaterializedView("create materialized view mv0" +
+                " distributed by random" +
+                " as select current_date(), t1a, t1b from test.test_all_type ;", () -> {
+            {
+                String query = " select current_date(), t1a, t1b from test.test_all_type";
+                sql(query).nonMatch("mv0");
+            }
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
@@ -15,9 +15,11 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Strings;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateViewStmt;
@@ -387,5 +389,23 @@ public class AnalyzeUtilTest {
         Assert.assertEquals("[test.tprimary2, test.tprimary]", m.keySet().toString());
         Assert.assertEquals("[[*, v2], [pk]]", m.values().toString());
 
+    }
+
+    @Test
+    public void testContainsNonDeterministicFunction() {
+        String[] sqls = {
+                "select current_date(), a.v2, a.v1 from db1.t0 a",
+                "select a.v2, a.v1 from db1.t0 a where current_date() > '2024-08-06'",
+                "select a.v2, a.v1 from db1.t0 a where curdate() > '2024-08-06'",
+                "select a.v2, a.v1 from db1.t0 a where now() > '2024-08-06'",
+                "select * from (select current_date(), a.v2, a.v1 from db1.t0 a) t",
+                "with cte as (select * from (select current_date(), a.v2, a.v1 from db1.t0 a) t) select * from cte",
+        };
+        for (String sql : sqls) {
+            StatementBase statementBase = analyzeSuccess(sql);
+            Pair<Boolean, String> result = AnalyzerUtils.containsNonDeterministicFunction(statementBase);
+            Assert.assertEquals(true, result.first);
+            Assert.assertTrue(!Strings.isNullOrEmpty(result.second));
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
- If mv's defined query contains `current_date`/`current_timestamp`, this mv should not be used for mv rewrite; otherwise the rewritten result may be wrong.

## What I'm doing:
- Add `NonDeterministicAnalyzeVisitor` to determine whether mv contains non-deterministic functions, set it invalid if it contains;
- Refactor `NonDeterministicVisitor` class from `ForceCTEReuseRule`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
