### PR TITLE
[Refactor] add TableVersionRange to connectorMetadata interface

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -41,7 +41,6 @@ import com.starrocks.thrift.TTableType;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
@@ -55,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -68,11 +66,6 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 public class IcebergTable extends Table {
     private static final Logger LOG = LogManager.getLogger(IcebergTable.class);
 
-    private Optional<Snapshot> snapshot = null;
-    private static final String JSON_KEY_ICEBERG_DB = "database";
-    private static final String JSON_KEY_ICEBERG_TABLE = "table";
-    private static final String JSON_KEY_RESOURCE_NAME = "resource";
-    private static final String JSON_KEY_ICEBERG_PROPERTIES = "icebergProperties";
     private static final String PARQUET_FORMAT = "parquet";
 
     private String catalogName;
@@ -126,14 +119,6 @@ public class IcebergTable extends Table {
         return remoteTableName;
     }
 
-    public Optional<Snapshot> getSnapshot() {
-        if (snapshot != null) {
-            return snapshot;
-        } else {
-            snapshot = Optional.ofNullable(getNativeTable().currentSnapshot());
-            return snapshot;
-        }
-    }
 
     @Override
     public String getUUID() {
@@ -220,10 +205,6 @@ public class IcebergTable extends Table {
     // day(dt) -> identity dt
     public boolean hasPartitionTransformedEvolution() {
         return getNativeTable().spec().fields().stream().anyMatch(field -> field.transform().isVoid());
-    }
-
-    public void resetSnapshot() {
-        snapshot = Optional.empty();
     }
 
     public boolean isV2Format() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -17,6 +17,7 @@ package com.starrocks.connector;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
@@ -115,8 +116,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, long snapshotId) {
-        return normal.listPartitionNames(databaseName, tableName, snapshotId);
+    public List<String> listPartitionNames(String databaseName, String tableName, TableVersionRange version) {
+        return normal.listPartitionNames(databaseName, tableName, version);
     }
 
     @Override
@@ -136,6 +137,16 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public TableVersionRange getTableVersionRange(Table table) {
+        // TODO: refactor this in time travel patch
+        if (table instanceof IcebergTable) {
+            return normal.getTableVersionRange(table);
+        } else {
+            return TableVersionRange.empty();
+        }
+    }
+
+    @Override
     public boolean tableExists(String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfDb(dbName);
         return metadata.tableExists(dbName, tblName);
@@ -147,9 +158,9 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, long snapshotId,
+    public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, TableVersionRange version,
                                                    ScalarOperator predicate, List<String> fieldNames, long limit) {
-        return normal.getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames, limit);
+        return normal.getRemoteFileInfos(table, partitionKeys, version, predicate, fieldNames, limit);
     }
 
     @Override
@@ -180,13 +191,14 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
 
     @Override
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
-                                         List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit) {
-        return normal.getTableStatistics(session, table, columns, partitionKeys, predicate, limit);
+                                         List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
+                                         TableVersionRange version) {
+        return normal.getTableStatistics(session, table, columns, partitionKeys, predicate, limit, version);
     }
 
     @Override
-    public List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit) {
-        return normal.getPrunedPartitions(table, predicate, limit);
+    public List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit, TableVersionRange version) {
+        return normal.getPrunedPartitions(table, predicate, limit, version);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -93,10 +93,10 @@ public interface ConnectorMetadata {
      *
      * @param databaseName the name of the database
      * @param tableName the name of the table
-     * @param snapshotId table snapshot id, default value is -1
+     * @param tableVersionRange table version range in the query
      * @return a list of partition names
      */
-    default List<String> listPartitionNames(String databaseName, String tableName, long snapshotId) {
+    default List<String> listPartitionNames(String databaseName, String tableName, TableVersionRange tableVersionRange) {
         return Lists.newArrayList();
     }
 
@@ -124,6 +124,11 @@ public interface ConnectorMetadata {
         return null;
     }
 
+    // TODO: add connector table version params in the next patch
+    default TableVersionRange getTableVersionRange(Table table) {
+        return TableVersionRange.empty();
+    }
+
     default boolean tableExists(String dbName, String tblName) {
         return listTableNames(dbName).contains(tblName);
     }
@@ -147,7 +152,7 @@ public interface ConnectorMetadata {
      *
      * @param table
      * @param partitionKeys selected partition columns
-     * @param snapshotId selected snapshot id
+     * @param tableVersionRange table version range in the query
      * @param predicate used to filter metadata for iceberg, etc
      * @param fieldNames all selected columns (including partition columns)
      * @param limit scan limit nums if needed
@@ -155,7 +160,7 @@ public interface ConnectorMetadata {
      * @return the remote file information of the query to scan.
      */
     default List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                    long snapshotId, ScalarOperator predicate,
+                                                    TableVersionRange tableVersionRange, ScalarOperator predicate,
                                                     List<String> fieldNames, long limit) {
         return Lists.newArrayList();
     }
@@ -195,6 +200,7 @@ public interface ConnectorMetadata {
      * @param partitionKeys selected partition keys
      * @param predicate used to filter metadata for iceberg, etc
      * @param limit scan limit if needed, default value is -1
+     * @param tableVersionRange table version range in the query
      *
      * @return the table statistics for the table.
      */
@@ -203,7 +209,8 @@ public interface ConnectorMetadata {
                                           Map<ColumnRefOperator, Column> columns,
                                           List<PartitionKey> partitionKeys,
                                           ScalarOperator predicate,
-                                          long limit) {
+                                          long limit,
+                                          TableVersionRange tableVersionRange) {
         return Statistics.builder().build();
     }
 
@@ -211,7 +218,8 @@ public interface ConnectorMetadata {
         return true;
     }
 
-    default List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit) {
+    default List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate,
+                                                   long limit, TableVersionRange version) {
         throw new StarRocksConnectorException("This connector doesn't support pruning partitions");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/MetaPreparationItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/MetaPreparationItem.java
@@ -17,15 +17,19 @@ package com.starrocks.connector;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
+import java.util.StringJoiner;
+
 public class MetaPreparationItem {
     private final Table table;
     private final ScalarOperator predicate;
     private final long limit;
+    private final TableVersionRange version;
 
-    public MetaPreparationItem(Table table, ScalarOperator predicate, long limit) {
+    public MetaPreparationItem(Table table, ScalarOperator predicate, long limit, TableVersionRange version) {
         this.table = table;
         this.predicate = predicate;
         this.limit = limit;
+        this.version = version;
     }
 
     public Table getTable() {
@@ -40,13 +44,17 @@ public class MetaPreparationItem {
         return limit;
     }
 
+    public TableVersionRange getVersion() {
+        return version;
+    }
+
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("MetaPreparationItem{");
-        sb.append("table=").append(table);
-        sb.append(", predicate=").append(predicate);
-        sb.append(", limit=").append(limit);
-        sb.append('}');
-        return sb.toString();
+        return new StringJoiner(", ", MetaPreparationItem.class.getSimpleName() + "[", "]")
+                .add("table=" + table)
+                .add("predicate=" + predicate)
+                .add("limit=" + limit)
+                .add("version=" + version)
+                .toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
@@ -44,6 +44,10 @@ public class PredicateSearchKey {
         return tableName;
     }
 
+    public long getSnapshotId() {
+        return snapshotId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/TableVersionRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/TableVersionRange.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Objects;
+import java.util.Optional;
+
+// This is a query options. The main function is to ensure that the same version is used during the query process.
+// For tables that support time travel with query period, before calling the `ConnectorMetadata` interface,
+// you need to obtain the table version by `getTableVersionRange` interface for passing,
+// otherwise it will be used as an empty table.
+
+public class TableVersionRange {
+    private final Optional<Long> start;
+    private final Optional<Long> end;
+
+    public static TableVersionRange empty() {
+        return new TableVersionRange(Optional.empty(), Optional.empty());
+    }
+
+    public static TableVersionRange withEnd(Optional<Long> end) {
+        return new TableVersionRange(Optional.empty(), end);
+    }
+
+    public TableVersionRange(Optional<Long> start, Optional<Long> end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public Optional<Long> start() {
+        return start;
+    }
+
+    public Optional<Long> end() {
+        return end;
+    }
+
+    public boolean isEmpty() {
+        return start.isEmpty() && end.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("start", start)
+                .append("end", end)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TableVersionRange that = (TableVersionRange) o;
+        return Objects.equals(start, that.start) && Objects.equals(end, that.end);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -34,6 +34,7 @@ import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.PartitionUpdate.UpdateMode;
 import com.starrocks.credential.CloudConfiguration;
@@ -202,7 +203,7 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tblName, long snapshotId) {
+    public List<String> listPartitionNames(String dbName, String tblName, TableVersionRange version) {
         return hmsOps.getPartitionKeys(dbName, tblName);
     }
 
@@ -214,7 +215,7 @@ public class HiveMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate,
+                                                   TableVersionRange tableVersionRange, ScalarOperator predicate,
                                                    List<String> fieldNames, long limit) {
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
@@ -283,7 +284,8 @@ public class HiveMetadata implements ConnectorMetadata {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate,
-                                         long limit) {
+                                         long limit,
+                                         TableVersionRange version) {
         Statistics statistics = null;
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList(columns.keySet());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -27,6 +27,7 @@ import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveCacheUpdateProcessor;
 import com.starrocks.connector.hive.HiveMetastoreOperations;
@@ -91,7 +92,7 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tblName, long snapshotId) {
+    public List<String> listPartitionNames(String dbName, String tblName, TableVersionRange version) {
         return hmsOps.getPartitionKeys(dbName, tblName);
     }
 
@@ -134,7 +135,7 @@ public class HudiMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate,
+                                                   TableVersionRange version, ScalarOperator predicate,
                                                    List<String> fieldNames, long limit) {
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
@@ -164,7 +165,7 @@ public class HudiMetadata implements ConnectorMetadata {
                                          Table table,
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
-                                         ScalarOperator predicate, long limit) {
+                                         ScalarOperator predicate, long limit, TableVersionRange version) {
         Statistics statistics = null;
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList(columns.keySet());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -47,6 +47,7 @@ import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteMetaSplit;
 import com.starrocks.connector.SerializedMetaSpec;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.cost.IcebergStatisticProvider;
@@ -366,12 +367,20 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public TableVersionRange getTableVersionRange(Table table) {
+        IcebergTable icebergTable = (IcebergTable) table;
+        Optional<Long> snapshotId = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot())
+                .map(Snapshot::snapshotId);
+        return TableVersionRange.withEnd(snapshotId);
+    }
+
+    @Override
     public boolean tableExists(String dbName, String tblName) {
         return icebergCatalog.tableExists(dbName, tblName);
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tblName, long snapshotId) {
+    public List<String> listPartitionNames(String dbName, String tblName, TableVersionRange version) {
         IcebergCatalogType nativeType = icebergCatalog.getIcebergCatalogType();
 
         if (nativeType != HIVE_CATALOG && nativeType != REST_CATALOG && nativeType != GLUE_CATALOG) {
@@ -379,13 +388,15 @@ public class IcebergMetadata implements ConnectorMetadata {
                     "Do not support get partitions from catalog type: " + nativeType);
         }
 
+        long snapshotId = version.end().isPresent() ? version.end().get() : -1;
         return icebergCatalog.listPartitionNames(dbName, tblName, snapshotId, jobPlanningExecutor);
     }
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate,
+                                                   TableVersionRange version, ScalarOperator predicate,
                                                    List<String> fieldNames, long limit) {
+        long snapshotId = version.end().isPresent() ? version.end().get() : -1;
         return getRemoteFileInfos((IcebergTable) table, snapshotId, predicate, limit);
     }
 
@@ -502,12 +513,12 @@ public class IcebergMetadata implements ConnectorMetadata {
         icebergTable = (IcebergTable) item.getTable();
         String dbName = icebergTable.getRemoteDbName();
         String tableName = icebergTable.getRemoteTableName();
-        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
-        if (snapshot.isEmpty()) {
+        TableVersionRange versionRange = item.getVersion();
+        if (versionRange.end().isEmpty()) {
             return true;
         }
 
-        key = PredicateSearchKey.of(dbName, tableName, snapshot.get().snapshotId(), item.getPredicate());
+        key = PredicateSearchKey.of(dbName, tableName, versionRange.end().get(), item.getPredicate());
         if (!preparedTables.add(key)) {
             return true;
         }
@@ -582,16 +593,16 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
     }
 
-    public List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit) {
+    @Override
+    public List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit, TableVersionRange version) {
         IcebergTable icebergTable = (IcebergTable) table;
         String dbName = icebergTable.getRemoteDbName();
         String tableName = icebergTable.getRemoteTableName();
-        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
-        if (snapshot.isEmpty()) {
+        if (version.end().isEmpty()) {
             return new ArrayList<>();
         }
 
-        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, snapshot.get().snapshotId(), predicate);
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, version.end().get(), predicate);
         triggerIcebergPlanFilesIfNeeded(key, icebergTable, predicate, limit);
 
         List<PartitionKey> partitionKeys = new ArrayList<>();
@@ -660,13 +671,12 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                             ScalarOperator predicate, long limit, Tracers tracers,
                                                             ConnectContext connectContext) {
         IcebergTable icebergTable = (IcebergTable) table;
-        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
+        long snapshotId = key.getSnapshotId();
         // empty table
-        if (snapshot.isEmpty()) {
+        if (snapshotId == -1) {
             return;
         }
 
-        long snapshotId = snapshot.get().snapshotId();
         String dbName = icebergTable.getRemoteDbName();
         String tableName = icebergTable.getRemoteTableName();
 
@@ -850,12 +860,12 @@ public class IcebergMetadata implements ConnectorMetadata {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate,
-                                         long limit) {
+                                         long limit,
+                                         TableVersionRange version) {
         IcebergTable icebergTable = (IcebergTable) table;
-        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
         long snapshotId;
-        if (snapshot.isPresent()) {
-            snapshotId = snapshot.get().snapshotId();
+        if (version.end().isPresent()) {
+            snapshotId = version.end().get();
         } else {
             Statistics.Builder statisticsBuilder = Statistics.builder();
             statisticsBuilder.setOutputRowCount(1);
@@ -878,7 +888,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 return statisticProvider.getCardinalityStats(columns, icebergScanTasks);
             }
         } else {
-            return statisticProvider.getTableStatistics(icebergTable, columns, session, predicate);
+            return statisticProvider.getTableStatistics(icebergTable, columns, session, predicate, version);
         }
     }
 
@@ -960,7 +970,6 @@ public class IcebergMetadata implements ConnectorMetadata {
                     nativeTable.name(), ei.getMessage());
         }
 
-        icebergTable.resetSnapshot();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -30,6 +30,7 @@ import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -219,7 +220,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, long snapshotId) {
+    public List<String> listPartitionNames(String databaseName, String tableName, TableVersionRange version) {
         return partitionNamesCache.get(new JDBCTableName(null, databaseName, tableName),
                 k -> {
                     try (Connection connection = getConnection()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -29,6 +29,7 @@ import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HivePartitionStats;
 import com.starrocks.connector.hive.IHiveMetastore;
@@ -256,7 +257,7 @@ public class KuduMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate,
+                                                   TableVersionRange versionRange, ScalarOperator predicate,
                                                    List<String> fieldNames, long limit) {
         RemoteFileInfo remoteFileInfo = new RemoteFileInfo();
         KuduTable kuduTable = (KuduTable) table;
@@ -306,7 +307,8 @@ public class KuduMetadata implements ConnectorMetadata {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate,
-                                         long limit) {
+                                         long limit,
+                                         TableVersionRange versionRange) {
         Statistics.Builder builder = Statistics.builder();
         for (ColumnRefOperator columnRefOperator : columns.keySet()) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataExecutor.java
@@ -39,6 +39,7 @@ public class MetadataExecutor {
             parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             execPlan = StatementPlanner.plan(parsedStmt, context, job.getSinkType());
         } catch (Exception e) {
+            LOG.error("Failed to execute metadata collect job", e);
             context.getState().setError(e.getMessage());
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
@@ -50,6 +50,7 @@ import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.aliyun.AliyunCloudConfiguration;
@@ -219,7 +220,7 @@ public class OdpsMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, long snapshotId) {
+    public List<String> listPartitionNames(String databaseName, String tableName, TableVersionRange version) {
         OdpsTableName odpsTableName = OdpsTableName.of(databaseName, tableName);
         // TODO: perhaps not good to support users to fetch whole tables?
         List<Partition> partitions = get(partitionCache, odpsTableName);
@@ -266,7 +267,8 @@ public class OdpsMetadata implements ConnectorMetadata {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate,
-                                         long limit) {
+                                         long limit,
+                                         TableVersionRange version) {
         Statistics.Builder builder = Statistics.builder();
         for (ColumnRefOperator columnRefOperator : columns.keySet()) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
@@ -312,15 +314,15 @@ public class OdpsMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate,
+                                                   TableVersionRange versionRange, ScalarOperator predicate,
                                                    List<String> columnNames, long limit) {
         // add scanBuilder param for mock
-        return getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, columnNames, limit,
+        return getRemoteFileInfos(table, partitionKeys, versionRange, predicate, columnNames, limit,
                 new TableReadSessionBuilder());
     }
 
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate,
+                                                   TableVersionRange versionRange, ScalarOperator predicate,
                                                    List<String> columnNames, long limit,
                                                    TableReadSessionBuilder scanBuilder) {
         RemoteFileInfo remoteFileInfo = new RemoteFileInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.NullablePartitionKey;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.iceberg.PartitionField;
@@ -64,7 +65,7 @@ public class IcebergPartitionTraits extends DefaultTraits {
     @Override
     public Optional<Long> maxPartitionRefreshTs() {
         IcebergTable icebergTable = (IcebergTable) table;
-        return icebergTable.getSnapshot().map(Snapshot::timestampMillis);
+        return Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot()).map(Snapshot::timestampMillis);
     }
 
     @Override
@@ -74,9 +75,10 @@ public class IcebergPartitionTraits extends DefaultTraits {
         }
 
         IcebergTable icebergTable = (IcebergTable) table;
-        long snapshotId = icebergTable.getSnapshot().isPresent() ? icebergTable.getSnapshot().get().snapshotId() : -1;
+        Optional<Long> snapshotId = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot())
+                .map(Snapshot::snapshotId);
         return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
-                table.getCatalogName(), getDbName(), getTableName(), snapshotId);
+                table.getCatalogName(), getDbName(), getTableName(), TableVersionRange.withEnd(snapshotId));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -27,6 +27,7 @@ import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.SerializedMetaSpec;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.hive.HiveMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
@@ -120,6 +121,12 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public TableVersionRange getTableVersionRange(Table table) {
+        ConnectorMetadata metadata = metadataOfTable(table);
+        return metadata.getTableVersionRange(table);
+    }
+
+    @Override
     public List<String> listDbNames() {
         return hiveMetadata.listDbNames();
     }
@@ -130,9 +137,9 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, long snapshotId) {
+    public List<String> listPartitionNames(String databaseName, String tableName, TableVersionRange versionRange) {
         ConnectorMetadata metadata = metadataOfTable(databaseName, tableName);
-        return metadata.listPartitionNames(databaseName, tableName, snapshotId);
+        return metadata.listPartitionNames(databaseName, tableName, versionRange);
     }
 
     @Override
@@ -155,10 +162,10 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, long snapshotId,
+    public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, TableVersionRange version,
                                                    ScalarOperator predicate, List<String> fieldNames, long limit) {
         ConnectorMetadata metadata = metadataOfTable(table);
-        return metadata.getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames, limit);
+        return metadata.getRemoteFileInfos(table, partitionKeys, version, predicate, fieldNames, limit);
     }
 
     @Override
@@ -175,16 +182,17 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit) {
+    public List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit, TableVersionRange version) {
         ConnectorMetadata metadata = metadataOfTable(table);
-        return metadata.getPrunedPartitions(table, predicate, limit);
+        return metadata.getPrunedPartitions(table, predicate, limit, version);
     }
 
     @Override
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
-                                         List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit) {
+                                         List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
+                                         TableVersionRange version) {
         ConnectorMetadata metadata = metadataOfTable(table);
-        return metadata.getTableStatistics(session, table, columns, partitionKeys, predicate, limit);
+        return metadata.getTableStatistics(session, table, columns, partitionKeys, predicate, limit, version);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -29,6 +29,7 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.delta.DeltaLakeRemoteFileDesc;
 import com.starrocks.connector.delta.DeltaUtils;
 import com.starrocks.connector.delta.FileScanTask;
@@ -60,6 +61,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
@@ -136,7 +138,7 @@ public class DeltaLakeScanNode extends ScanNode {
         Map<PartitionKey, Long> partitionKeys = Maps.newHashMap();
 
         List<RemoteFileInfo> splits = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                catalogName, deltaLakeTable, null, snapshotId, predicate, fieldNames, -1);
+                catalogName, deltaLakeTable, null, TableVersionRange.withEnd(Optional.of(snapshotId)), predicate, fieldNames, -1);
         if (splits.isEmpty()) {
             LOG.warn("There is no scan tasks after planFiles on {}.{} and predicate: [{}]", dbName, tableName, predicate);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -35,6 +35,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.connector.iceberg.IcebergRemoteFileDesc;
@@ -90,6 +91,7 @@ public class IcebergScanNode extends ScanNode {
     private CloudConfiguration cloudConfiguration = null;
     private final List<Integer> deleteColumnSlotIds = new ArrayList<>();
     private final TupleDescriptor equalityDeleteTupleDesc;
+    private Optional<Long> snapshotId;
 
     public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName, TupleDescriptor equalityDeleteTupleDesc) {
         super(id, desc, planNodeName);
@@ -128,6 +130,10 @@ public class IcebergScanNode extends ScanNode {
     @Override
     public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
         return result;
+    }
+
+    public void setSnapshotId(Optional<Long> snapshotId) {
+        this.snapshotId = snapshotId;
     }
 
     public static BiMap<Integer, PartitionField> getIdentityPartitions(PartitionSpec partitionSpec) {
@@ -173,17 +179,16 @@ public class IcebergScanNode extends ScanNode {
     }
 
     public void setupScanRangeLocations(DescriptorTable descTbl) throws UserException {
-        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
-        if (snapshot.isEmpty()) {
+        Preconditions.checkNotNull(snapshotId, "snapshot id is null");
+        if (snapshotId.isEmpty()) {
             LOG.warn(String.format("Table %s has no snapshot!", icebergTable.getRemoteTableName()));
             return;
         }
 
         String catalogName = icebergTable.getCatalogName();
-        long snapshotId = snapshot.get().snapshotId();
 
         List<RemoteFileInfo> splits = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                catalogName, icebergTable, null, snapshotId, predicate, null, -1);
+                catalogName, icebergTable, null, TableVersionRange.withEnd(snapshotId), predicate, null, -1);
 
         if (splits.isEmpty()) {
             LOG.warn("There is no scan tasks after planFies on {}.{} and predicate: [{}]",
@@ -382,10 +387,9 @@ public class IcebergScanNode extends ScanNode {
         }
 
         if (detailLevel == TExplainLevel.VERBOSE && !isResourceMappingCatalog(icebergTable.getCatalogName())) {
-            long snapshotId = icebergTable.getSnapshot().isPresent() ? icebergTable.getSnapshot().get().snapshotId() : -1;
             List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                     icebergTable.getCatalogName(), icebergTable.getRemoteDbName(),
-                    icebergTable.getRemoteTableName(), snapshotId);
+                    icebergTable.getRemoteTableName(), TableVersionRange.withEnd(snapshotId));
 
             output.append(prefix).append(
                     String.format("partitions=%s/%s", scanNodePredicates.getSelectedPartitionIds().size(),

--- a/fe/fe-core/src/main/java/com/starrocks/planner/KuduScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/KuduScanNode.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.kudu.KuduRemoteFileDesc;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.server.GlobalStateMgr;
@@ -90,7 +91,7 @@ public class KuduScanNode extends ScanNode {
         List<String> fieldNames =
                 tupleDescriptor.getSlots().stream().map(s -> s.getColumn().getName()).collect(Collectors.toList());
         List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                kuduTable.getCatalogName(), kuduTable, null, -1, predicate, fieldNames, -1);
+                kuduTable.getCatalogName(), kuduTable, null, TableVersionRange.empty(), predicate, fieldNames, -1);
         KuduRemoteFileDesc remoteFileDesc = (KuduRemoteFileDesc) fileInfos.get(0).getFiles().get(0);
         List<KuduScanToken> tokens = remoteFileDesc.getKuduScanTokens();
         if (tokens.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.odps.OdpsRemoteFileDesc;
 import com.starrocks.connector.odps.OdpsSplitsInfo;
@@ -89,7 +90,7 @@ public class OdpsScanNode extends ScanNode {
         List<String> fieldNames =
                 tupleDescriptor.getSlots().stream().map(s -> s.getColumn().getName()).collect(Collectors.toList());
         List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                table.getCatalogName(), table, partitionKeys, -1, predicate, fieldNames, -1);
+                table.getCatalogName(), table, partitionKeys, TableVersionRange.empty(), predicate, fieldNames, -1);
         OdpsRemoteFileDesc remoteFileDesc = (OdpsRemoteFileDesc) fileInfos.get(0).getFiles().get(0);
         OdpsSplitsInfo splitsInfo = remoteFileDesc.getOdpsSplitsInfo();
         if (splitsInfo.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.paimon.PaimonRemoteFileDesc;
 import com.starrocks.connector.paimon.PaimonSplitsInfo;
 import com.starrocks.credential.CloudConfiguration;
@@ -127,7 +128,7 @@ public class PaimonScanNode extends ScanNode {
         List<String> fieldNames =
                 tupleDescriptor.getSlots().stream().map(s -> s.getColumn().getName()).collect(Collectors.toList());
         List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                paimonTable.getCatalogName(), paimonTable, null, -1, predicate, fieldNames, -1);
+                paimonTable.getCatalogName(), paimonTable, null, TableVersionRange.empty(), predicate, fieldNames, -1);
         PaimonRemoteFileDesc remoteFileDesc = (PaimonRemoteFileDesc) fileInfos.get(0).getFiles().get(0);
         PaimonSplitsInfo splitsInfo = remoteFileDesc.getPaimonSplitsInfo();
         String predicateInfo = encodeObjectToString(splitsInfo.getPredicate());

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -54,6 +54,7 @@ import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.SerializedMetaSpec;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.qe.ConnectContext;
@@ -510,6 +511,12 @@ public class MetadataMgr {
         return database.getTable(tableId);
     }
 
+    public TableVersionRange getTableVersionRange(Table table) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
+        return connectorMetadata.map(metadata -> metadata.getTableVersionRange(table))
+                .orElse(TableVersionRange.empty().empty());
+    }
+
     public Optional<Database> getDatabase(BaseTableInfo baseTableInfo) {
         if (baseTableInfo.isInternalCatalog()) {
             return Optional.ofNullable(getDb(baseTableInfo.getDbId()));
@@ -593,15 +600,15 @@ public class MetadataMgr {
     }
 
     public List<String> listPartitionNames(String catalogName, String dbName, String tableName) {
-        return listPartitionNames(catalogName, dbName, tableName, -1);
+        return listPartitionNames(catalogName, dbName, tableName, TableVersionRange.empty());
     }
 
-    public List<String> listPartitionNames(String catalogName, String dbName, String tableName, long snapshotId) {
+    public List<String> listPartitionNames(String catalogName, String dbName, String tableName, TableVersionRange versionRange) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         ImmutableSet.Builder<String> partitionNames = ImmutableSet.builder();
         if (connectorMetadata.isPresent()) {
             try {
-                connectorMetadata.get().listPartitionNames(dbName, tableName, snapshotId).forEach(partitionNames::add);
+                connectorMetadata.get().listPartitionNames(dbName, tableName, versionRange).forEach(partitionNames::add);
             } catch (Exception e) {
                 LOG.error("Failed to listPartitionNames on [{}.{}]", catalogName, dbName, e);
                 throw e;
@@ -635,11 +642,12 @@ public class MetadataMgr {
         return ImmutableList.copyOf(partitionNames.build());
     }
 
-    public List<PartitionKey> getPrunedPartitions(String catalogName, Table table, ScalarOperator predicate, long limit) {
+    public List<PartitionKey> getPrunedPartitions(String catalogName, Table table, ScalarOperator predicate,
+                                                  long limit, TableVersionRange version) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         if (connectorMetadata.isPresent()) {
             try {
-                return connectorMetadata.get().getPrunedPartitions(table, predicate, limit);
+                return connectorMetadata.get().getPrunedPartitions(table, predicate, limit, version);
             } catch (Exception e) {
                 LOG.error("Failed to getPrunedPartitions on [{}.{}]", catalogName, table, e);
                 throw e;
@@ -688,7 +696,8 @@ public class MetadataMgr {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate,
-                                         long limit) {
+                                         long limit,
+                                         TableVersionRange versionRange) {
         // FIXME: In testing env, `_statistics_.external_column_statistics` is not created, ignore query columns stats from it.
         // Get basic/histogram stats from internal statistics.
         Statistics internalStatistics = FeConstants.runningUnitTest ? null :
@@ -703,7 +712,7 @@ public class MetadataMgr {
             } else {
                 Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
                 Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
-                        session, table, columns, partitionKeys, predicate, limit)).orElse(null);
+                        session, table, columns, partitionKeys, predicate, limit, versionRange)).orElse(null);
                 if (connectorBasicStats != null && internalStatistics != null &&
                         internalStatistics.getColumnStatistics().values().stream().anyMatch(
                                 columnStatistic -> columnStatistic.getHistogram() != null)) {
@@ -737,7 +746,7 @@ public class MetadataMgr {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate) {
-        return getTableStatistics(session, catalogName, table, columns, partitionKeys, predicate, -1);
+        return getTableStatistics(session, catalogName, table, columns, partitionKeys, predicate, -1, TableVersionRange.empty());
     }
 
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<String> partitionNames) {
@@ -773,17 +782,17 @@ public class MetadataMgr {
     }
 
     public List<RemoteFileInfo> getRemoteFileInfos(String catalogName, Table table, List<PartitionKey> partitionKeys) {
-        return getRemoteFileInfos(catalogName, table, partitionKeys, -1, null, null, -1);
+        return getRemoteFileInfos(catalogName, table, partitionKeys, TableVersionRange.empty(), null, null, -1);
     }
 
     public List<RemoteFileInfo> getRemoteFileInfos(String catalogName, Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate, List<String> fieldNames,
+                                                   TableVersionRange version, ScalarOperator predicate, List<String> fieldNames,
                                                    long limit) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         ImmutableSet.Builder<RemoteFileInfo> files = ImmutableSet.builder();
         if (connectorMetadata.isPresent()) {
             try {
-                connectorMetadata.get().getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames, limit)
+                connectorMetadata.get().getRemoteFileInfos(table, partitionKeys, version, predicate, fieldNames, limit)
                         .forEach(files::add);
             } catch (Exception e) {
                 LOG.error("Failed to list remote file's metadata on catalog [{}], table [{}]", catalogName, table, e);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -316,7 +316,6 @@ public class AnalyzeStmtAnalyzer {
                                             OptimizerConfig.defaultConfig()),
                                     tableName.getCatalog(), analyzeTable, Maps.newHashMap(), keys, null);
                     totalRows = tableStats.getOutputRowCount();
-
                 }
                 double sampleRows = totalRows *
                         Double.parseDouble(properties.get(StatsConstants.HISTOGRAM_SAMPLE_RATIO));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
@@ -42,11 +43,29 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
                 colRefToColumnMetaMap,
                 columnMetaToColRefMap,
                 limit,
-                predicate, null);
+                predicate, null, TableVersionRange.empty());
 
         Preconditions.checkState(table instanceof IcebergTable);
         IcebergTable icebergTable = (IcebergTable) table;
-        partitionColumns.addAll(icebergTable.getPartitionColumns().stream().map(x -> x.getName()).collect(Collectors.toList()));
+        partitionColumns.addAll(icebergTable.getPartitionColumns().stream().map(Column::getName).collect(Collectors.toList()));
+    }
+
+    public LogicalIcebergScanOperator(Table table,
+                                      Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                      Map<Column, ColumnRefOperator> columnMetaToColRefMap,
+                                      long limit,
+                                      ScalarOperator predicate,
+                                      TableVersionRange versionRange) {
+        super(OperatorType.LOGICAL_ICEBERG_SCAN,
+                table,
+                colRefToColumnMetaMap,
+                columnMetaToColRefMap,
+                limit,
+                predicate, null, versionRange);
+
+        Preconditions.checkState(table instanceof IcebergTable);
+        IcebergTable icebergTable = (IcebergTable) table;
+        partitionColumns.addAll(icebergTable.getPartitionColumns().stream().map(Column::getName).collect(Collectors.toList()));
     }
 
     private LogicalIcebergScanOperator() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
@@ -281,5 +281,10 @@ public abstract class LogicalScanOperator extends LogicalOperator {
             builder.table = table;
             return (B) this;
         }
+
+        public B setTableVersionRange(TableVersionRange tableVersionRange) {
+            builder.tableVersionRange = tableVersionRange;
+            return (B) this;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.planner.PartitionColumnFilter;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -61,6 +62,7 @@ public abstract class LogicalScanOperator extends LogicalOperator {
     protected Set<String> partitionColumns = Sets.newHashSet();
     protected ImmutableList<ColumnAccessPath> columnAccessPaths;
     protected ScanOptimzeOption scanOptimzeOption;
+    protected TableVersionRange tableVersionRange;
 
     public LogicalScanOperator(
             OperatorType type,
@@ -70,12 +72,25 @@ public abstract class LogicalScanOperator extends LogicalOperator {
             long limit,
             ScalarOperator predicate,
             Projection projection) {
+        this(type, table, colRefToColumnMetaMap, columnMetaToColRefMap, limit, predicate, projection, TableVersionRange.empty());
+    }
+
+    public LogicalScanOperator(
+            OperatorType type,
+            Table table,
+            Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+            Map<Column, ColumnRefOperator> columnMetaToColRefMap,
+            long limit,
+            ScalarOperator predicate,
+            Projection projection,
+            TableVersionRange tableVersionRange) {
         super(type, limit, predicate, projection);
         this.table = Objects.requireNonNull(table, "table is null");
         this.colRefToColumnMetaMap = ImmutableMap.copyOf(colRefToColumnMetaMap);
         this.columnMetaToColRefMap = ImmutableMap.copyOf(columnMetaToColRefMap);
         this.columnAccessPaths = ImmutableList.of();
         this.scanOptimzeOption = new ScanOptimzeOption();
+        this.tableVersionRange = tableVersionRange;
         buildColumnFilters(predicate);
     }
 
@@ -85,6 +100,7 @@ public abstract class LogicalScanOperator extends LogicalOperator {
         this.columnMetaToColRefMap = ImmutableMap.of();
         this.columnAccessPaths = ImmutableList.of();
         this.scanOptimzeOption = new ScanOptimzeOption();
+        this.tableVersionRange = TableVersionRange.empty();
     }
 
     public Table getTable() {
@@ -119,6 +135,15 @@ public abstract class LogicalScanOperator extends LogicalOperator {
     public ScanOptimzeOption getScanOptimzeOption() {
         return scanOptimzeOption;
     }
+
+    public TableVersionRange getTableVersionRange() {
+        return tableVersionRange;
+    }
+
+    public void setTableVersionRange(TableVersionRange tableVersionRange) {
+        this.tableVersionRange = tableVersionRange;
+    }
+
     // for mark empty partitions/empty tablet
     public boolean isEmptyOutputRows() {
         return false;
@@ -225,6 +250,7 @@ public abstract class LogicalScanOperator extends LogicalOperator {
             builder.columnAccessPaths = scanOperator.columnAccessPaths;
             builder.scanOptimzeOption = scanOperator.scanOptimzeOption;
             builder.partitionColumns = scanOperator.partitionColumns;
+            builder.tableVersionRange = scanOperator.tableVersionRange;
             return (B) this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.RowOutputInfo;
 import com.starrocks.sql.optimizer.ScanOptimzeOption;
@@ -47,6 +48,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
     protected ImmutableMap<ColumnRefOperator, Column> colRefToColumnMetaMap;
     protected ImmutableList<ColumnAccessPath> columnAccessPaths;
     protected ScanOptimzeOption scanOptimzeOption;
+    protected TableVersionRange tableVersionRange;
 
     protected PhysicalScanOperator(OperatorType type) {
         super(type);
@@ -57,6 +59,15 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
                                 long limit,
                                 ScalarOperator predicate,
                                 Projection projection) {
+        this(type, table, colRefToColumnMetaMap, limit, predicate, projection, TableVersionRange.empty());
+    }
+
+    public PhysicalScanOperator(OperatorType type, Table table,
+                                Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                long limit,
+                                ScalarOperator predicate,
+                                Projection projection,
+                                TableVersionRange tableVersionRange) {
         super(type);
         this.table = Objects.requireNonNull(table, "table is null");
         this.colRefToColumnMetaMap = ImmutableMap.copyOf(colRefToColumnMetaMap);
@@ -65,6 +76,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
         this.projection = projection;
         this.columnAccessPaths = ImmutableList.of();
         this.scanOptimzeOption = new ScanOptimzeOption();
+        this.tableVersionRange = tableVersionRange;
 
         updateOutputColumns();
     }
@@ -93,7 +105,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
 
     public PhysicalScanOperator(OperatorType type, LogicalScanOperator scanOperator) {
         this(type, scanOperator.getTable(), scanOperator.getColRefToColumnMetaMap(), scanOperator.getLimit(),
-                scanOperator.getPredicate(), scanOperator.getProjection());
+                scanOperator.getPredicate(), scanOperator.getProjection(), scanOperator.getTableVersionRange());
         this.scanOptimzeOption = scanOperator.getScanOptimzeOption().copy();
     }
 
@@ -119,6 +131,10 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
 
     public void setScanOptimzeOption(ScanOptimzeOption opt) {
         this.scanOptimzeOption = opt.copy();
+    }
+
+    public TableVersionRange getTableVersionRange() {
+        return tableVersionRange;
     }
 
     public Table getTable() {
@@ -184,6 +200,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
             builder.colRefToColumnMetaMap = operator.colRefToColumnMetaMap;
             builder.columnAccessPaths = operator.columnAccessPaths;
             builder.scanOptimzeOption = operator.scanOptimzeOption;
+            builder.tableVersionRange = operator.tableVersionRange;
             return (B) this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
@@ -60,9 +60,6 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
     public static final PruneHDFSScanColumnRule TABLE_FUNCTION_TABLE_SCAN =
             new PruneHDFSScanColumnRule(OperatorType.LOGICAL_TABLE_FUNCTION_TABLE_SCAN);
 
-    public static final PruneHDFSScanColumnRule ICEBERG_METADATA_SCAN =
-            new PruneHDFSScanColumnRule(OperatorType.LOGICAL_ICEBERG_METADATA_SCAN);
-
     public PruneHDFSScanColumnRule(OperatorType logicalOperatorType) {
         super(RuleType.TF_PRUNE_OLAP_SCAN_COLUMNS, Pattern.create(logicalOperatorType));
     }
@@ -145,6 +142,7 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
                                 scanOperator.getPredicate());
                 newScanOperator.getScanOptimzeOption().setCanUseAnyColumn(canUseAnyColumn);
                 newScanOperator.setScanOperatorPredicates(scanOperator.getScanOperatorPredicates());
+                newScanOperator.setTableVersionRange(scanOperator.getTableVersionRange());
 
                 return Lists.newArrayList(new OptExpression(newScanOperator));
             } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -154,7 +154,8 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                     newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
         } else if (scanOperator instanceof LogicalIcebergScanOperator) {
             newMetaScan = new LogicalIcebergScanOperator(scanOperator.getTable(),
-                    newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
+                    newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate(),
+                    scanOperator.getTableVersionRange());
         } else if (scanOperator instanceof LogicalFileScanOperator) {
             newMetaScan = new LogicalFileScanOperator(scanOperator.getTable(),
                     newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -244,7 +244,7 @@ public class MVPartitionPruner {
                     if (currentTable == null) {
                         return null;
                     }
-                    // Iceberg table's snapshot is cached in the mv's plan cache, need to reset it to get the latest snapshot
+
                     builder.setTable(currentTable);
                     TableVersionRange versionRange = TableVersionRange.withEnd(
                             Optional.ofNullable(((IcebergTable) currentTable).getNativeTable().currentSnapshot())

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -41,8 +42,10 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.OptDistributionPruner;
 import com.starrocks.sql.optimizer.rewrite.OptExternalPartitionPruner;
 import com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner;
+import org.apache.iceberg.Snapshot;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES;
 
@@ -226,10 +229,10 @@ public class MVPartitionPruner {
                 final LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(refScanOperator);
                 // reset original partition predicates to prune partitions/tablets again
                 builder.withOperator(refScanOperator);
-
                 Preconditions.checkState(externalExtraPredicate != null);
                 ScalarOperator finalPredicate = Utils.compoundAnd(refScanOperator.getPredicate(), externalExtraPredicate);
                 builder.setPredicate(finalPredicate);
+
                 if (scanOperator.getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN) {
                     // refresh iceberg table's metadata
                     Table refBaseTable = refScanOperator.getTable();
@@ -243,6 +246,10 @@ public class MVPartitionPruner {
                     }
                     // Iceberg table's snapshot is cached in the mv's plan cache, need to reset it to get the latest snapshot
                     builder.setTable(currentTable);
+                    TableVersionRange versionRange = TableVersionRange.withEnd(
+                            Optional.ofNullable(((IcebergTable) currentTable).getNativeTable().currentSnapshot())
+                                    .map(Snapshot::snapshotId));
+                    builder.setTableVersionRange(versionRange);
                 }
                 LogicalScanOperator newScanOperator = builder.build();
                 return OptExpression.create(newScanOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -71,7 +71,8 @@ public class PrepareCollectMetaTask extends OptimizerTask {
             CompletableFuture<Void> allFutures = CompletableFuture.allOf(scanOperators.stream()
                     .map(op -> CompletableFuture.supplyAsync(() ->
                                     metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
-                                            new MetaPreparationItem(op.getTable(), op.getPredicate(), op.getLimit()),
+                                            new MetaPreparationItem(op.getTable(), op.getPredicate(),
+                                                    op.getLimit(), op.getTableVersionRange()),
                                             tracers, connectContext),
                             executorService)).toArray(CompletableFuture[]::new));
             allFutures.join();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.elasticsearch.EsTablePartitions;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.connector.metadata.MetadataTableType;
@@ -535,6 +536,9 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                     new ExpressionMapping(node.getScope(), outputVariables), columnRefFactory);
         }
 
+        TableVersionRange tableVersionRange = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTableVersionRange(node.getTable());
+
         LogicalScanOperator scanOperator;
         if (node.getTable().isNativeTableOrMaterializedView()) {
             DistributionSpec distributionSpec = getTableDistributionSpec(node, columnMetaToColRefMap);
@@ -576,7 +580,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                         catalogName, dbName, node.getTable(), Lists.newArrayList(), true);
             }
             scanOperator = new LogicalIcebergScanOperator(node.getTable(), colRefToColumnMetaMapBuilder.build(),
-                    columnMetaToColRefMap, Operator.DEFAULT_LIMIT, partitionPredicate);
+                    columnMetaToColRefMap, Operator.DEFAULT_LIMIT, partitionPredicate, tableVersionRange);
         } else if (Table.TableType.HUDI.equals(node.getTable().getType())) {
             scanOperator = new LogicalHudiScanOperator(node.getTable(), colRefToColumnMetaMapBuilder.build(),
                     columnMetaToColRefMap, Operator.DEFAULT_LIMIT, partitionPredicate);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1406,6 +1406,7 @@ public class PlanFragmentBuilder {
                 }
 
                 icebergScanNode.preProcessIcebergPredicate(node.getPredicate());
+                icebergScanNode.setSnapshotId(node.getTableVersionRange().end());
                 icebergScanNode.setupScanRangeLocations(context.getDescTbl());
 
                 HDFSScanNodePredicates scanNodePredicates = icebergScanNode.getScanNodePredicates();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -302,7 +302,7 @@ public class StatisticUtils {
             }
         } else if (table.isIcebergTable()) {
             IcebergTable icebergTable = (IcebergTable) table;
-            Optional<Snapshot> snapshot = icebergTable.getSnapshot();
+            Optional<Snapshot> snapshot = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot());
             return snapshot.map(value -> LocalDateTime.ofInstant(Instant.ofEpochMilli(value.timestampMillis()).
                             plusSeconds(60), Clock.systemDefaultZone().getZone())).orElse(null);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -172,7 +172,7 @@ public class CatalogConnectorMetadataTest {
                 times = 1;
 
                 connectorMetadata.clear();
-                connectorMetadata.listPartitionNames("test_db", "test_tbl", -1);
+                connectorMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
                 connectorMetadata.dropTable(null);
                 connectorMetadata.refreshTable("test_db", null, null, false);
                 connectorMetadata.alterMaterializedView(null);
@@ -195,10 +195,10 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.createTable(null);
                 connectorMetadata.createDb("test_db");
                 connectorMetadata.dropDb("test_db", false);
-                connectorMetadata.getRemoteFileInfos(null, null, 0, null, null, -1);
+                connectorMetadata.getRemoteFileInfos(null, null, TableVersionRange.empty(), null, null, -1);
                 connectorMetadata.getPartitions(null, null);
                 connectorMetadata.getMaterializedViewIndex("test_db", "test_tbl");
-                connectorMetadata.getTableStatistics(null, null, null, null, null, -1);
+                connectorMetadata.getTableStatistics(null, null, null, null, null, -1, TableVersionRange.empty());
             }
         };
 
@@ -209,7 +209,7 @@ public class CatalogConnectorMetadataTest {
         );
 
         catalogConnectorMetadata.clear();
-        catalogConnectorMetadata.listPartitionNames("test_db", "test_tbl", -1);
+        catalogConnectorMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
         catalogConnectorMetadata.dropTable(null);
         catalogConnectorMetadata.refreshTable("test_db", null, null, false);
         catalogConnectorMetadata.alterMaterializedView(null);
@@ -232,9 +232,9 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.createTable(null);
         catalogConnectorMetadata.createDb("test_db");
         catalogConnectorMetadata.dropDb("test_db", false);
-        catalogConnectorMetadata.getRemoteFileInfos(null, null, 0, null, null, -1);
+        catalogConnectorMetadata.getRemoteFileInfos(null, null, TableVersionRange.empty(), null, null, -1);
         catalogConnectorMetadata.getPartitions(null, null);
         catalogConnectorMetadata.getMaterializedViewIndex("test_db", "test_tbl");
-        catalogConnectorMetadata.getTableStatistics(null, null, null, null, null, -1);
+        catalogConnectorMetadata.getTableStatistics(null, null, null, null, null, -1, TableVersionRange.empty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
@@ -168,7 +169,7 @@ public class DeltaLakeMetadataTest {
             }
         };
         List<String> partitionNames = deltaLakeMetadata.listPartitionNames("db1", "table1",
-                -1);
+                TableVersionRange.empty());
         Assert.assertEquals(3, partitionNames.size());
         Assert.assertEquals("ts=1999", partitionNames.get(0));
         Assert.assertEquals("ts=2000", partitionNames.get(1));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -39,6 +39,7 @@ import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.RemotePathKey;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
@@ -153,7 +154,8 @@ public class HiveMetadataTest {
 
     @Test
     public void testGetPartitionKeys() {
-        Assert.assertEquals(Lists.newArrayList("col1"), hiveMetadata.listPartitionNames("db1", "tbl1", -1));
+        Assert.assertEquals(
+                Lists.newArrayList("col1"), hiveMetadata.listPartitionNames("db1", "tbl1", TableVersionRange.empty()));
     }
 
     @Test
@@ -199,7 +201,7 @@ public class HiveMetadataTest {
                 Lists.newArrayList("2"), hiveTable.getPartitionColumns());
 
         List<RemoteFileInfo> remoteFileInfos = hiveMetadata.getRemoteFileInfos(
-                hiveTable, Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), -1, null, null, -1);
+                hiveTable, Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), TableVersionRange.empty(), null, null, -1);
         Assert.assertEquals(2, remoteFileInfos.size());
 
         RemoteFileInfo fileInfo = remoteFileInfos.get(0);
@@ -249,7 +251,7 @@ public class HiveMetadataTest {
         columns.put(partColumnRefOperator, null);
         columns.put(dataColumnRefOperator, null);
         Statistics statistics = hiveMetadata.getTableStatistics(optimizerContext, hiveTable, columns,
-                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1);
+                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1, TableVersionRange.empty());
         Assert.assertEquals(1, statistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(2, statistics.getColumnStatistics().size());
         Assert.assertTrue(statistics.getColumnStatistics().get(partColumnRefOperator).isUnknown());
@@ -271,13 +273,13 @@ public class HiveMetadataTest {
 
         Statistics statistics = hiveMetadata.getTableStatistics(
                 optimizerContext, hiveTable, columns, Lists.newArrayList(hivePartitionKey1, hivePartitionKey2),
-                null, -1);
+                null, -1, TableVersionRange.empty());
         Assert.assertEquals(1, statistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(2, statistics.getColumnStatistics().size());
 
         cachingHiveMetastore.getPartitionStatistics(hiveTable, Lists.newArrayList("col1=1", "col1=2"));
         statistics = hiveMetadata.getTableStatistics(optimizerContext, hiveTable, columns,
-                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1);
+                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1, TableVersionRange.empty());
 
         Assert.assertEquals(100, statistics.getOutputRowCount(), 0.001);
         Map<ColumnRefOperator, ColumnStatistic> columnStatistics = statistics.getColumnStatistics();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -41,6 +41,7 @@ import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -123,7 +124,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tableName, long snapshotId) {
+    public List<String> listPartitionNames(String dbName, String tableName, TableVersionRange version) {
         readLock();
         try {
             return MOCK_TABLE_MAP.get(dbName).get(tableName).partitionNames;
@@ -156,7 +157,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     @Override
     public List<String> listPartitionNamesByValue(String databaseName, String tableName,
                                                   List<Optional<String>> partitionValues) {
-        List<String> partitionNames = listPartitionNames(databaseName, tableName, -1);
+        List<String> partitionNames = listPartitionNames(databaseName, tableName, TableVersionRange.empty());
         List<String> ret = new ArrayList<>();
         for (String p : partitionNames) {
             if (isPartitionNameValueMatched(p, partitionValues)) {
@@ -184,7 +185,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     @Override
     public Statistics getTableStatistics(OptimizerContext session, com.starrocks.catalog.Table table,
                                          Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
-                                         ScalarOperator predicate, long limit) {
+                                         ScalarOperator predicate, long limit, TableVersionRange version) {
         HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
         String hiveDb = hmsTable.getDbName();
         String tblName = hmsTable.getTableName();
@@ -209,7 +210,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(com.starrocks.catalog.Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate,
+                                                   TableVersionRange version, ScalarOperator predicate,
                                                    List<String> fieldNames, long limit) {
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
         int size = partitionKeys.size();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -21,6 +21,7 @@ import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileOperations;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.hive.CachingHiveMetastore;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
@@ -117,7 +118,8 @@ public class HudiMetadataTest {
 
     @Test
     public void testGetPartitionKeys() {
-        Assert.assertEquals(Lists.newArrayList("col1"), hudiMetadata.listPartitionNames("db1", "tbl1", -1));
+        Assert.assertEquals(
+                Lists.newArrayList("col1"), hudiMetadata.listPartitionNames("db1", "tbl1", TableVersionRange.empty()));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -425,7 +426,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tableName, long snapshotId) {
+    public List<String> listPartitionNames(String dbName, String tableName, TableVersionRange version) {
         readLock();
         try {
             return MOCK_TABLE_MAP.get(dbName).get(tableName).partitionNames;
@@ -454,7 +455,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     @Override
     public Statistics getTableStatistics(OptimizerContext session, com.starrocks.catalog.Table table,
                                          Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
-                                         ScalarOperator predicate, long limit) {
+                                         ScalarOperator predicate, long limit, TableVersionRange version) {
         MockIcebergTable icebergTable = (MockIcebergTable) table;
         String hiveDb = icebergTable.getRemoteDbName();
         String tblName = icebergTable.getName();
@@ -478,7 +479,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<PartitionKey> getPrunedPartitions(com.starrocks.catalog.Table table, ScalarOperator predicate, long limit) {
+    public List<PartitionKey> getPrunedPartitions(com.starrocks.catalog.Table table, ScalarOperator predicate,
+                                                  long limit, TableVersionRange version) {
         return new ArrayList<>();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.iceberg.TableTestBase;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.iceberg.cost.IcebergFileStats.convertObjectToOptionalDouble;
@@ -66,7 +68,9 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         colRefToColumnMetaMap.put(columnRefOperator1, new Column("id", Type.INT));
         colRefToColumnMetaMap.put(columnRefOperator2, new Column("data", Type.STRING));
 
-        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, null);
+        TableVersionRange version = TableVersionRange.withEnd(Optional.of(
+                mockedNativeTableA.currentSnapshot().snapshotId()));
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, null, version);
         Assert.assertEquals(1.0, statistics.getOutputRowCount(), 0.001);
     }
 
@@ -105,7 +109,8 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         ColumnRefOperator columnRefOperator2 = new ColumnRefOperator(4, Type.STRING, "data", true);
         colRefToColumnMetaMap.put(columnRefOperator1, new Column("id", Type.INT));
         colRefToColumnMetaMap.put(columnRefOperator2, new Column("data", Type.STRING));
-        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, null);
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap,
+                null, null, TableVersionRange.empty());
         Assert.assertEquals(1.0, statistics.getOutputRowCount(), 0.001);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.TableVersionRange;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -161,7 +162,7 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tableName, long snapshotId) {
+    public List<String> listPartitionNames(String dbName, String tableName, TableVersionRange versionRange) {
         readLock();
         try {
             if (tableName.equals(MOCKED_PARTITIONED_TABLE_NAME2)) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.UtFrameUtils;
 import com.zaxxer.hikari.HikariDataSource;
@@ -149,7 +150,7 @@ public class MysqlSchemaResolverTest {
     public void testListPartitionNames() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", -1);
+            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", TableVersionRange.empty());
             Assert.assertFalse(partitionNames.isEmpty());
         } catch (Exception e) {
             System.out.println(e.getMessage());
@@ -162,14 +163,14 @@ public class MysqlSchemaResolverTest {
         try {
             JDBCCacheTestUtil.openCacheEnable(connectContext);
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", -1);
+            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", TableVersionRange.empty());
             Assert.assertFalse(partitionNames.isEmpty());
-            List<String> partitionNamesWithCache = jdbcMetadata.listPartitionNames("test", "tbl1", -1);
+            List<String> partitionNamesWithCache = jdbcMetadata.listPartitionNames("test", "tbl1", TableVersionRange.empty());
             Assert.assertFalse(partitionNamesWithCache.isEmpty());
             JDBCCacheTestUtil.closeCacheEnable(connectContext);
             Map<String, String> properties = new HashMap<>();
             jdbcMetadata.refreshCache(properties);
-            List<String> partitionNamesWithOutCache = jdbcMetadata.listPartitionNames("test", "tbl1", -1);
+            List<String> partitionNamesWithOutCache = jdbcMetadata.listPartitionNames("test", "tbl1", TableVersionRange.empty());
             Assert.assertTrue(partitionNamesWithOutCache.isEmpty());
         } catch (Exception e) {
             System.out.println(e.getMessage());
@@ -188,7 +189,7 @@ public class MysqlSchemaResolverTest {
                 }
             };
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", -1);
+            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", TableVersionRange.empty());
             Assert.assertTrue(partitionNames.size() == 0);
         } catch (Exception e) {
             System.out.println(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -143,7 +144,7 @@ public class KuduMetadataTest {
         };
         Table table = metadata.getTable("db1", "tbl1");
         KuduTable kuduTable = (KuduTable) table;
-        List<RemoteFileInfo> remoteFileInfos = metadata.getRemoteFileInfos(kuduTable, null, -1,
+        List<RemoteFileInfo> remoteFileInfos = metadata.getRemoteFileInfos(kuduTable, null, TableVersionRange.empty(),
                 null, requiredNames, -1);
         Assert.assertEquals(1, remoteFileInfos.size());
         Assert.assertEquals(1, remoteFileInfos.get(0).getFiles().size());
@@ -171,7 +172,7 @@ public class KuduMetadataTest {
         Table table = metadata.getTable("db1", "tbl1");
         KuduTable kuduTable = (KuduTable) table;
         Statistics statistics = metadata.getTableStatistics(
-                null, kuduTable, Collections.emptyMap(), Collections.emptyList(), null, -1);
+                null, kuduTable, Collections.emptyMap(), Collections.emptyList(), null, -1, TableVersionRange.empty());
         Assert.assertEquals(1D, statistics.getOutputRowCount(), 0.01);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/MockedBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/MockedBase.java
@@ -184,9 +184,9 @@ public class MockedBase {
 
         RemoteFileInfo fileInfo = new RemoteFileInfo();
         fileInfo.setFiles(ImmutableList.of(OdpsRemoteFileDesc.createOdpsRemoteFileDesc(odpsSplitsInfo)));
-        when(metadataMgr.getRemoteFileInfos(any(), any(), any(), anyLong(), any(), any(), anyLong())).thenReturn(
+        when(metadataMgr.getRemoteFileInfos(any(), any(), any(), any(), any(), any(), anyLong())).thenReturn(
                 ImmutableList.of(fileInfo));
-        when(odpsMetadata.getRemoteFileInfos(any(), any(), anyLong(), any(), any(), anyLong(), any())).thenReturn(
+        when(odpsMetadata.getRemoteFileInfos(any(), any(), any(), any(), any(), anyLong(), any())).thenReturn(
                 ImmutableList.of(fileInfo));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsMetadataTest.java
@@ -25,6 +25,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.credential.CloudType;
 import com.starrocks.credential.aliyun.AliyunCloudConfiguration;
 import com.starrocks.sql.ast.PartitionValue;
@@ -109,7 +110,7 @@ public class OdpsMetadataTest extends MockedBase {
 
     @Test
     public void testListPartitionNames() {
-        List<String> partitionNames = odpsMetadata.listPartitionNames("project", "tableName", -1);
+        List<String> partitionNames = odpsMetadata.listPartitionNames("project", "tableName", TableVersionRange.empty());
         Assert.assertEquals(Collections.singletonList("p1=a/p2=b"), partitionNames);
     }
 
@@ -127,7 +128,7 @@ public class OdpsMetadataTest extends MockedBase {
     @Test
     public void testGetPartitions() {
         Table table = odpsMetadata.getTable("db", "tbl");
-        List<String> partitionNames = odpsMetadata.listPartitionNames("db", "tbl", -1);
+        List<String> partitionNames = odpsMetadata.listPartitionNames("db", "tbl", TableVersionRange.empty());
         List<PartitionInfo> partitions = odpsMetadata.getPartitions(table, partitionNames);
         Assert.assertEquals(1, partitions.size());
         PartitionInfo partitionInfo = partitions.get(0);
@@ -155,7 +156,7 @@ public class OdpsMetadataTest extends MockedBase {
                 PartitionKey.createPartitionKey(ImmutableList.of(new PartitionValue("a"), new PartitionValue("b")),
                         odpsTable.getPartitionColumns());
         List<RemoteFileInfo> remoteFileInfos =
-                odpsMetadata.getRemoteFileInfos(odpsTable, ImmutableList.of(partitionKey), -1, null,
+                odpsMetadata.getRemoteFileInfos(odpsTable, ImmutableList.of(partitionKey), TableVersionRange.empty(), null,
                         odpsTable.getPartitionColumnNames(), -1, mockTableReadSessionBuilder);
         Assert.assertEquals(1, remoteFileInfos.size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
 import com.starrocks.server.MetadataMgr;
@@ -251,7 +252,7 @@ public class PaimonMetadataTest {
                 result = mockRecordReader;
             }
         };
-        List<String> result = metadata.listPartitionNames("db1", "tbl1", -1);
+        List<String> result = metadata.listPartitionNames("db1", "tbl1", TableVersionRange.empty());
         Assert.assertEquals(2, result.size());
         List<String> expections = Lists.newArrayList("year=2020/month=1", "year=2020/month=2");
         Assertions.assertThat(result).hasSameElementsAs(expections);
@@ -279,7 +280,8 @@ public class PaimonMetadataTest {
         };
         PaimonTable paimonTable = (PaimonTable) metadata.getTable("db1", "tbl1");
         List<String> requiredNames = Lists.newArrayList("f2", "dt");
-        List<RemoteFileInfo> result = metadata.getRemoteFileInfos(paimonTable, null, -1, null, requiredNames, -1);
+        List<RemoteFileInfo> result = metadata.getRemoteFileInfos(paimonTable, null,
+                TableVersionRange.empty(), null, requiredNames, -1);
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result.get(0).getFiles().size());
         PaimonRemoteFileDesc desc = (PaimonRemoteFileDesc) result.get(0).getFiles().get(0);
@@ -408,8 +410,8 @@ public class PaimonMetadataTest {
         new MockUp<MetadataMgr>() {
             @Mock
             public List<RemoteFileInfo> getRemoteFileInfos(String catalogName, Table table, List<PartitionKey> partitionKeys,
-                                                           long snapshotId, ScalarOperator predicate, List<String> fieldNames,
-                                                           long limit) {
+                                                           TableVersionRange versionRange, ScalarOperator predicate,
+                                                           List<String> fieldNames, long limit) {
                 return Lists.newArrayList(RemoteFileInfo.builder()
                         .setFiles(Lists.newArrayList(PaimonRemoteFileDesc.createPamonRemoteFileDesc(
                                 new PaimonSplitsInfo(null, Lists.newArrayList((Split) splits.get(0))))))

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -29,6 +29,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.delta.DeltaLakeMetadata;
 import com.starrocks.connector.hive.HiveMetadata;
 import com.starrocks.connector.hudi.HudiMetadata;
@@ -141,7 +142,7 @@ public class UnifiedMetadataTest {
                 minTimes = 1;
             }
             {
-                hiveMetadata.listPartitionNames("test_db", "test_tbl", -1);
+                hiveMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -151,7 +152,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                hiveMetadata.getRemoteFileInfos(hiveTable, ImmutableList.of(), -1, null, null, -1);
+                hiveMetadata.getRemoteFileInfos(hiveTable, ImmutableList.of(), TableVersionRange.empty(), null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -177,12 +178,12 @@ public class UnifiedMetadataTest {
 
         Table table = unifiedMetadata.getTable("test_db", "test_tbl");
         assertTrue(table instanceof HiveTable);
-        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", -1);
+        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(
-                hiveTable, ImmutableList.of(), -1, null, null, -1);
+                hiveTable, ImmutableList.of(), TableVersionRange.empty(), null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(hiveTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
@@ -213,7 +214,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                icebergMetadata.listPartitionNames("test_db", "test_tbl", -1);
+                icebergMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -223,7 +224,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                icebergMetadata.getRemoteFileInfos(icebergTable, ImmutableList.of(), -1, null, null, -1);
+                icebergMetadata.getRemoteFileInfos(icebergTable, ImmutableList.of(), TableVersionRange.empty(), null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -251,7 +252,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                icebergMetadata.getPrunedPartitions(icebergTable, null, -1);
+                icebergMetadata.getPrunedPartitions(icebergTable, null, -1, TableVersionRange.empty());
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -264,12 +265,12 @@ public class UnifiedMetadataTest {
 
         Table table = unifiedMetadata.getTable("test_db", "test_tbl");
         assertTrue(table instanceof IcebergTable);
-        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", -1);
+        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(icebergTable, ImmutableList.of(),
-                -1, null, null, -1);
+                TableVersionRange.empty(), null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(icebergTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
@@ -277,8 +278,9 @@ public class UnifiedMetadataTest {
         unifiedMetadata.finishSink("test_db", "test_tbl", ImmutableList.of());
         createTableStmt.setEngineName("iceberg");
         assertTrue(unifiedMetadata.createTable(createTableStmt));
-        Assert.assertTrue(unifiedMetadata.getPrunedPartitions(table, null, -1).isEmpty());
-        Assert.assertTrue(unifiedMetadata.prepareMetadata(new MetaPreparationItem(icebergTable, null, -1), null, null));
+        Assert.assertTrue(unifiedMetadata.getPrunedPartitions(table, null, -1, TableVersionRange.empty()).isEmpty());
+        Assert.assertTrue(unifiedMetadata.prepareMetadata(new MetaPreparationItem(icebergTable, null,
+                -1, TableVersionRange.empty()), null, null));
         Assert.assertNotNull(unifiedMetadata.getSerializedMetaSpec("test_db", "test_tbl", -1, null));
     }
 
@@ -298,7 +300,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                hudiMetadata.listPartitionNames("test_db", "test_tbl", -1);
+                hudiMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -308,7 +310,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                hudiMetadata.getRemoteFileInfos(hudiTable, ImmutableList.of(), -1, null, null, -1);
+                hudiMetadata.getRemoteFileInfos(hudiTable, ImmutableList.of(), TableVersionRange.empty(), null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -334,12 +336,12 @@ public class UnifiedMetadataTest {
 
         Table table = unifiedMetadata.getTable("test_db", "test_tbl");
         assertTrue(table instanceof HudiTable);
-        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", -1);
+        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(
-                hudiTable, ImmutableList.of(), -1, null, null, -1);
+                hudiTable, ImmutableList.of(), TableVersionRange.empty(), null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(hudiTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
@@ -370,7 +372,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                deltaLakeMetadata.listPartitionNames("test_db", "test_tbl", -1);
+                deltaLakeMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -380,7 +382,8 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                deltaLakeMetadata.getRemoteFileInfos(deltaLakeTable, ImmutableList.of(), -1, null, null, -1);
+                deltaLakeMetadata.getRemoteFileInfos(deltaLakeTable, ImmutableList.of(), TableVersionRange.empty(),
+                        null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -406,12 +409,12 @@ public class UnifiedMetadataTest {
 
         Table table = unifiedMetadata.getTable("test_db", "test_tbl");
         assertTrue(table instanceof DeltaLakeTable);
-        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", -1);
+        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(deltaLakeTable, ImmutableList.of(),
-                -1, null, null, -1);
+                TableVersionRange.empty(), null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(deltaLakeTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
@@ -437,7 +440,7 @@ public class UnifiedMetadataTest {
                 minTimes = 1;
             }
             {
-                kuduMetadata.listPartitionNames("test_db", "test_tbl", -1);
+                kuduMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -447,7 +450,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                kuduMetadata.getRemoteFileInfos(kuduTable, ImmutableList.of(), -1, null, null, -1);
+                kuduMetadata.getRemoteFileInfos(kuduTable, ImmutableList.of(), TableVersionRange.empty(), null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -460,12 +463,12 @@ public class UnifiedMetadataTest {
 
         Table table = unifiedMetadata.getTable("test_db", "test_tbl");
         assertTrue(table instanceof KuduTable);
-        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", -1);
+        List<String> partitionNames = unifiedMetadata.listPartitionNames("test_db", "test_tbl", TableVersionRange.empty());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(kuduTable, ImmutableList.of(),
-                -1, null, null, -1);
+                TableVersionRange.empty(), null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(kuduTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.starrocks.catalog.Type.INT;
 import static com.starrocks.catalog.Type.STRING;
@@ -79,6 +80,7 @@ public class IcebergScanNodeTest extends TableTestBase {
         mockedNativeTableC.newRowDelta().addRows(FILE_B_1).addDeletes(FILE_C_1).commit();
         mockedNativeTableC.refresh();
 
+        scanNode.setSnapshotId(Optional.of(mockedNativeTableC.currentSnapshot().snapshotId()));
         scanNode.setupScanRangeLocations(descTable);
 
         List<TScanRangeLocations> result = scanNode.getScanRangeLocations(1);
@@ -108,8 +110,9 @@ public class IcebergScanNodeTest extends TableTestBase {
         mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
         // FILE_A_DELETES = positionalDelete / FILE_A2_DELETES = equalityDelete
         mockedNativeTableA.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_A2_DELETES).commit();
-        mockedNativeTableC.refresh();
+        mockedNativeTableA.refresh();
 
+        scanNode.setSnapshotId(Optional.of(mockedNativeTableA.currentSnapshot().snapshotId()));
         scanNode.setupScanRangeLocations(descTable);
 
         List<TScanRangeLocations> result = scanNode.getScanRangeLocations(1);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
@@ -359,7 +360,7 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
         mockedJDBCMetadata.initPartitions();
 
         // get base table partitions
-        List<String> baseParNames = mockedJDBCMetadata.listPartitionNames("partitioned_db0", "tbl1", -1);
+        List<String> baseParNames = mockedJDBCMetadata.listPartitionNames("partitioned_db0", "tbl1", TableVersionRange.empty());
         Assert.assertEquals(4, baseParNames.size());
 
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -24,6 +24,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetastoreApiConverter;
 import com.starrocks.connector.hive.MockedHiveMetadata;
@@ -421,7 +422,7 @@ public class MetadataMgrTest {
     @Test(expected = StarRocksConnectorException.class)
     public void testGetPrunedPartition() {
         MetadataMgr metadataMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
-        metadataMgr.getPrunedPartitions("hive_catalog", null, null, -1);
+        metadataMgr.getPrunedPartitions("hive_catalog", null, null, -1, TableVersionRange.empty());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OdpsTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -76,7 +77,7 @@ public class PruneHDFSScanColumnRuleTest {
                         scanColumnMap, Maps.newHashMap(), -1,
                         new BinaryPredicateOperator(BinaryType.EQ,
                                 new ColumnRefOperator(1, Type.INT, "id", true),
-                                ConstantOperator.createInt(1))));
+                                ConstantOperator.createInt(1)), TableVersionRange.empty()));
 
         List<TaskContext> taskContextList = new ArrayList<>();
         taskContextList.add(taskContext);
@@ -93,7 +94,7 @@ public class PruneHDFSScanColumnRuleTest {
                                                  @Mocked TaskContext taskContext) {
         OptExpression scan = new OptExpression(
                 new LogicalIcebergScanOperator(table,
-                        scanColumnMap, Maps.newHashMap(), -1, null));
+                        scanColumnMap, Maps.newHashMap(), -1, null, TableVersionRange.empty()));
 
         List<TaskContext> taskContextList = new ArrayList<>();
         taskContextList.add(taskContext);
@@ -214,7 +215,7 @@ public class PruneHDFSScanColumnRuleTest {
                                                         @Mocked TaskContext taskContext) {
         OptExpression scan = new OptExpression(
                 new LogicalIcebergScanOperator(table,
-                        scanColumnMap, Maps.newHashMap(), -1, null));
+                        scanColumnMap, Maps.newHashMap(), -1, null, TableVersionRange.empty()));
 
         List<TaskContext> taskContextList = new ArrayList<>();
         taskContextList.add(taskContext);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PushDownMinMaxConjunctsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PushDownMinMaxConjunctsRuleTest.java
@@ -21,6 +21,7 @@ import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.iceberg.TableTestBase;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.optimizer.Memo;
@@ -41,6 +42,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.starrocks.catalog.Type.INT;
 import static com.starrocks.catalog.Type.STRING;
@@ -74,7 +76,7 @@ public class PushDownMinMaxConjunctsRuleTest extends TableTestBase {
         columnMetaToColRefMap.put(col, colRef);
         OptExpression scan =
                 new OptExpression(new LogicalIcebergScanOperator(table, colRefToColumnMetaMap, columnMetaToColRefMap,
-                        -1, binaryPredicateOperator));
+                        -1, binaryPredicateOperator, TableVersionRange.empty()));
 
         assertEquals(0, ((LogicalIcebergScanOperator) scan.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
 
@@ -87,7 +89,7 @@ public class PushDownMinMaxConjunctsRuleTest extends TableTestBase {
 
         OptExpression scanNoPushDown =
                 new OptExpression(new LogicalIcebergScanOperator(table, colRefToColumnMetaMap, columnMetaToColRefMap,
-                        -1, binaryPredicateOperatorNoPushDown));
+                        -1, binaryPredicateOperatorNoPushDown, TableVersionRange.empty()));
 
         assertEquals(0,
                 ((LogicalIcebergScanOperator) scanNoPushDown.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
@@ -117,9 +119,11 @@ public class PushDownMinMaxConjunctsRuleTest extends TableTestBase {
         Map<Column, ColumnRefOperator> columnMetaToColRefMap = new HashMap<>();
         colRefToColumnMetaMap.put(colRef1, col1);
         columnMetaToColRefMap.put(col2, colRef2);
+        TableVersionRange version = TableVersionRange.withEnd(Optional.of(
+                mockedNativeTableA.currentSnapshot().snapshotId()));
         OptExpression scan =
                 new OptExpression(new LogicalIcebergScanOperator(icebergTable, colRefToColumnMetaMap, columnMetaToColRefMap,
-                        -1, null));
+                        -1, null, version));
 
         rule0.transform(scan, new OptimizerContext(new Memo(), new ColumnRefFactory()));
         assertEquals(1, ((LogicalIcebergScanOperator) scan.getOp()).getScanOperatorPredicates()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
+import com.starrocks.connector.TableVersionRange;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -307,7 +308,7 @@ public class StatisticsCalculatorTest {
         BinaryPredicateOperator predicateOperator = new BinaryPredicateOperator(BinaryType.LT,
                 partitionColumn, ConstantOperator.createInt(50));
         LogicalIcebergScanOperator icebergScanOperator = new LogicalIcebergScanOperator(icebergTable, refToColumn,
-                columnToRef, -1, predicateOperator);
+                columnToRef, -1, predicateOperator, TableVersionRange.empty());
 
         GroupExpression groupExpression = new GroupExpression(icebergScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));


### PR DESCRIPTION
## Why I'm doing:
Snapshot should not be recorded in the table, which is not semantic. It should be a query options.

## What I'm doing:
1. remove `snapshot` field and `getSnapshot()` method in the IcebergTable
2. add TableVersionRange to `LogicalScanOperator` and `PhysicalScanOperator` for passing.
3. add `getTableVersionRange` interface to ConnectorMetadata
4. add `TableVersionRange` to ConnectorMetadata interface such as listPartitionNames/getTableStatistics/getRemoteFiles/getPrunedPartitions

TODO:
support timetravel in the next patch

Fixes #issue
https://github.com/StarRocks/starrocks/issues/47846

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
