### PR TITLE
[BugFix] fix deserialization not initialize field

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
@@ -65,6 +65,10 @@ public class ExpressionRangePartitionInfoV2 extends RangePartitionInfo
     @SerializedName(value = "sourcePartitionTypes")
     private List<Type> sourcePartitionTypes;
 
+    public ExpressionRangePartitionInfoV2() {
+        this.type = PartitionType.EXPR_RANGE_V2;
+    }
+
     public ExpressionRangePartitionInfoV2(List<Expr> partitionExprs, List<Column> columns) {
         super(columns);
         this.type = PartitionType.EXPR_RANGE_V2;


### PR DESCRIPTION
## Why I'm doing:
Without a no-args constructor, the gson deserialization would use reflection to build a obejct which may not initialize some field (such as `idToTabletType` which only exist in memory ). This may cause NPE in further process.
https://github.com/StarRocks/starrocks/pull/47542 modify the clone process which may lead a NPE in `p.idToTabletType = new HashMap<>(this.idToTabletType);`.
https://github.com/StarRocks/starrocks/pull/45215 fix this problem in main and 3.3.

## What I'm doing:
Add a default no-args constructor.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

