### PR TITLE
[Enhancement] add enable_experimental_temporary_table configuration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2786,7 +2786,7 @@ public class Config extends ConfigBase {
      * Enable the experimental temporary table feature
      */
     @ConfField(mutable = true)
-    public static boolean enable_experimental_temporary_table = false;
+    public static boolean enable_experimental_temporary_table = true;
 
     @ConfField(mutable = true)
     public static long max_per_node_grep_log_limit = 500000;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -735,6 +735,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             columnDefs = getColumnDefs(context.columnDesc());
         }
         if (context.TEMPORARY() != null) {
+            if (!Config.enable_experimental_temporary_table) {
+                throw new ParsingException(
+                        PARSER_ERROR_MSG.feConfigDisable("enable_experimental_temporary_table"), NodePosition.ZERO);
+            }
             return new CreateTemporaryTableStmt(
                     context.IF() != null,
                     false,
@@ -1032,6 +1036,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
 
         if (context.TEMPORARY() != null) {
+            if (!Config.enable_experimental_temporary_table) {
+                throw new ParsingException(
+                        PARSER_ERROR_MSG.feConfigDisable("enable_experimental_temporary_table"), NodePosition.ZERO);
+            }
             CreateTemporaryTableStmt createTemporaryTableStmt = new CreateTemporaryTableStmt(
                     context.IF() != null,
                     false,
@@ -1099,6 +1107,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         Map<String, String> properties = getProperties(context.properties());
 
         if (context.TEMPORARY() != null) {
+            if (!Config.enable_experimental_temporary_table) {
+                throw new ParsingException(
+                        PARSER_ERROR_MSG.feConfigDisable("enable_experimental_temporary_table"), NodePosition.ZERO);
+            }
             return new CreateTemporaryTableLikeStmt(context.IF() != null,
                     qualifiedNameToTableName(getQualifiedName(context.qualifiedName(0))),
                     qualifiedNameToTableName(getQualifiedName(context.qualifiedName(1))),

--- a/test/sql/test_temporary_table/R/temporary_table
+++ b/test/sql/test_temporary_table/R/temporary_table
@@ -451,3 +451,46 @@ create analyze table t;
 -- result:
 E: (1064, "Getting analyzing error. Detail message: Don't support create analyze job for temporary table.")
 -- !result
+-- name: test_dynamic_temp_table_config @sequential
+create table `t` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+admin set frontend config("enable_experimental_temporary_table"="false");
+-- result:
+-- !result
+create temporary table `tbl1` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+E: (1064, "Getting syntax error. Detail message: FE config 'enable_experimental_temporary_table' is disabled.")
+-- !result
+create temporary table `tbl2` like `t`;
+-- result:
+E: (1064, "Getting syntax error. Detail message: FE config 'enable_experimental_temporary_table' is disabled.")
+-- !result
+create temporary table `tbl3` as select * from `t`;
+-- result:
+E: (1064, "Getting syntax error. Detail message: FE config 'enable_experimental_temporary_table' is disabled.")
+-- !result
+admin set frontend config("enable_experimental_temporary_table"="true");
+-- result:
+-- !result
+create temporary table `tbl1` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+create temporary table `tbl2` like `t`;
+-- result:
+-- !result
+create temporary table `tbl3` as select * from `t`;
+-- result:
+-- !result

--- a/test/sql/test_temporary_table/T/temporary_table
+++ b/test/sql/test_temporary_table/T/temporary_table
@@ -196,3 +196,26 @@ create temporary table `t` (
     `c3` int
 ) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
 create analyze table t;
+
+-- name: test_dynamic_temp_table_config @sequential
+create table `t` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+admin set frontend config("enable_experimental_temporary_table"="false");
+create temporary table `tbl1` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+create temporary table `tbl2` like `t`;
+create temporary table `tbl3` as select * from `t`;
+admin set frontend config("enable_experimental_temporary_table"="true");
+create temporary table `tbl1` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+create temporary table `tbl2` like `t`;
+create temporary table `tbl3` as select * from `t`;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

After introducing the temporary table, the metadata of the table has changed. If the old version of FE directly loads the new version of metadata, the temporary table will be treated as a regular table, causing errors.

Before rolling back, we need to clean up all temporary tables and generate a metadata image that does not contain temporary tables. 

So in this process, we need to have a way to prohibit the creation of temporary tables.  I have added a dynamic configuration for FE, `enable_experimental_temporary_table`, with a default value of true. When `enable_experimental_temporary_table`=false, creating temporary table will return an error.

With this configuration, during rollback, admin can first modify the configuration to false to prevent incremental temporary tables from being created, and then use the clean temporary table stmt to clean up the existing temporary tables.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
