### PR TITLE
[Enhancement] Add mv repair handler interface

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -39,6 +39,7 @@ import com.starrocks.lake.Utils;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MVRepairHandler.PartitionRepairInfo;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -211,6 +212,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.WRITE);
         }
 
+        handleMVRepair(db, table);
         LOG.info("update meta job finished: {}", jobId);
     }
 
@@ -520,5 +522,35 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     @Override
     public Optional<Long> getTransactionId() {
         return watershedTxnId < 0 ? Optional.empty() : Optional.of(watershedTxnId);
+    }
+
+    private void handleMVRepair(Database db, LakeTable table) {
+        List<PartitionRepairInfo> partitionRepairInfos = Lists.newArrayListWithCapacity(commitVersionMap.size());
+
+        Locker locker = new Locker();
+        locker.lockDatabase(db, LockType.READ);
+        try {
+            for (Map.Entry<Long, Long> partitionVersion : commitVersionMap.entrySet()) {
+                long partitionId = partitionVersion.getKey();
+                Partition partition = table.getPartition(partitionId);
+                if (partition == null || table.isTempPartition(partitionId)) {
+                    continue;
+                }
+                PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo();
+                partitionRepairInfo.setPartitionId(partitionId);
+                partitionRepairInfo.setPartitionName(partition.getName());
+                partitionRepairInfo.setVersion(partitionVersion.getValue());
+                partitionRepairInfo.setVersionTime(finishedTimeMs);
+                partitionRepairInfos.add(partitionRepairInfo);
+            }
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
+
+        if (partitionRepairInfos.isEmpty()) {
+            return;
+        }
+
+        GlobalStateMgr.getCurrentState().getLocalMetastore().handleMVRepair(db, table, partitionRepairInfos);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -525,6 +525,10 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     }
 
     private void handleMVRepair(Database db, LakeTable table) {
+        if (table.getRelatedMaterializedViews().isEmpty()) {
+            return;
+        }
+
         List<PartitionRepairInfo> partitionRepairInfos = Lists.newArrayListWithCapacity(commitVersionMap.size());
 
         Locker locker = new Locker();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -275,7 +275,7 @@ import javax.validation.constraints.NotNull;
 import static com.starrocks.server.GlobalStateMgr.NEXT_ID_INIT_VALUE;
 import static com.starrocks.server.GlobalStateMgr.isCheckpointThread;
 
-public class LocalMetastore implements ConnectorMetadata {
+public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
     private static final Logger LOG = LogManager.getLogger(LocalMetastore.class);
 
     private final ConcurrentHashMap<Long, Database> idToDb = new ConcurrentHashMap<>();
@@ -5149,4 +5149,8 @@ public class LocalMetastore implements ConnectorMetadata {
         GlobalStateMgr.getCurrentState().getEsRepository().loadTableFromCatalog();
     }
 
+    @Override
+    public void handleMVRepair(Database db, Table table, List<MVRepairHandler.PartitionRepairInfo> partitionRepairInfos) {
+        // TODO
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MVRepairHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MVRepairHandler.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.transaction.PartitionCommitInfo;
+import com.starrocks.transaction.TableCommitInfo;
+import com.starrocks.transaction.TransactionState;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MVRepairHandler {
+
+    public class PartitionRepairInfo {
+        private long partitionId; // partition id
+        private String partitionName; // partition name
+        private long version; // partition visible version
+        private long versionTime; // partition visible version time
+
+        public long getPartitionId() {
+            return partitionId;
+        }
+
+        public void setPartitionId(long partitionId) {
+            this.partitionId = partitionId;
+        }
+
+        public String getPartitionName() {
+            return partitionName;
+        }
+
+        public void setPartitionName(String partitionName) {
+            this.partitionName = partitionName;
+        }
+
+        public long getVersion() {
+            return version;
+        }
+
+        public void setVersion(long version) {
+            this.version = version;
+        }
+
+        public long getVersionTime() {
+            return versionTime;
+        }
+
+        public void setVersionTime(long versionTime) {
+            this.versionTime = versionTime;
+        }
+    }
+
+    // Only called in fe leader
+    // Caller should ensure that this interface is not called in the db lock
+    void handleMVRepair(Database db, Table table, List<PartitionRepairInfo> partitionRepairInfos);
+
+    // Only called in fe leader
+    // Caller should ensure that this interface is not called in the db lock
+    default void handleMVRepair(TransactionState transactionState) {
+        if (transactionState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
+            return;
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(transactionState.getDbId());
+        if (db == null) {
+            return;
+        }
+
+        for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
+            Table table = db.getTable(tableCommitInfo.getTableId());
+            if (table == null || !(table instanceof OlapTable) || table.getRelatedMaterializedViews().isEmpty()) {
+                continue;
+            }
+
+            OlapTable olapTable = (OlapTable) table;
+            Map<Long, PartitionCommitInfo> partitionCommitInfos = tableCommitInfo.getIdToPartitionCommitInfo();
+            List<PartitionRepairInfo> partitionRepairInfos = Lists.newArrayListWithCapacity(partitionCommitInfos.size());
+
+            Locker locker = new Locker();
+            locker.lockDatabase(db, LockType.READ);
+            try {
+                for (PartitionCommitInfo partitionCommitInfo : partitionCommitInfos.values()) {
+                    long partitionId = partitionCommitInfo.getPartitionId();
+                    Partition partition = olapTable.getPartition(partitionId);
+                    if (partition == null || olapTable.isTempPartition(partitionId)) {
+                        continue;
+                    }
+                    PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo();
+                    partitionRepairInfo.setPartitionId(partitionId);
+                    partitionRepairInfo.setPartitionName(partition.getName());
+                    partitionRepairInfo.setVersion(partitionCommitInfo.getVersion());
+                    partitionRepairInfo.setVersionTime(partitionCommitInfo.getVersionTime());
+                    partitionRepairInfos.add(partitionRepairInfo);
+                }
+            } finally {
+                locker.unLockDatabase(db, LockType.READ);
+            }
+
+            if (partitionRepairInfos.isEmpty()) {
+                continue;
+            }
+
+            handleMVRepair(db, table, partitionRepairInfos);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1208,6 +1208,7 @@ public class DatabaseTransactionMgr {
         transactionState.notifyVisible();
         // do after transaction finish
         GlobalStateMgr.getCurrentState().getOperationListenerBus().onStreamJobTransactionFinish(transactionState);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().handleMVRepair(transactionState);
         LOG.info("finish transaction {} successfully", transactionState);
     }
 
@@ -1875,6 +1876,7 @@ public class DatabaseTransactionMgr {
 
         // do after transaction finish
         GlobalStateMgr.getCurrentState().getOperationListenerBus().onStreamJobTransactionFinish(transactionState);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().handleMVRepair(transactionState);
         LOG.info("finish transaction {} successfully", transactionState);
     }
 
@@ -1941,6 +1943,7 @@ public class DatabaseTransactionMgr {
         // do after transaction finish in batch
         for (TransactionState transactionState : stateBatch.getTransactionStates()) {
             GlobalStateMgr.getCurrentState().getOperationListenerBus().onStreamJobTransactionFinish(transactionState);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().handleMVRepair(transactionState);
         }
 
         LOG.info("finish transaction {} batch successfully", stateBatch);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -17,6 +17,7 @@ package com.starrocks.alter;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PrimitiveType;
@@ -57,7 +58,9 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
         Database db = GlobalStateMgr.getCurrentState().getDb(createTableStmt.getDbName());
-        return (LakeTable) db.getTable(createTableStmt.getTableName());
+        LakeTable table = (LakeTable) db.getTable(createTableStmt.getTableName());
+        table.addRelatedMaterializedView(new MvId(db.getId(), GlobalStateMgr.getCurrentState().getNextId()));
+        return table;
     }
 
     private static void alterTable(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.transaction.PartitionCommitInfo;
+import com.starrocks.transaction.TableCommitInfo;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class MVRepairHandlerTest {
+    private static Database database;
+    private static Table table;
+    private static Partition partition;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable(
+                        "CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+
+        database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        table = database.getTable("t1");
+        Assert.assertTrue(table instanceof OlapTable);
+        OlapTable olapTable = (OlapTable) table;
+        partition = olapTable.getPartition("t1");
+    }
+
+    @Test
+    public void testMVRepairHandler() {
+        TransactionState txnState = new TransactionState(database.getId(), Lists.newArrayList(table.getId()), 100,
+                "test_label", null, TransactionState.LoadJobSourceType.LAKE_COMPACTION, null, 0, 100);
+        PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(partition.getId(), 100, 100);
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(table.getId());
+        tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
+        txnState.putIdToTableCommitInfo(table.getId(), tableCommitInfo);
+
+        MVRepairHandler mvRepairHandler = new MVRepairHandler() {
+            @Override
+            public void handleMVRepair(Database db, Table table, List<PartitionRepairInfo> partitionRepairInfos) {
+                Assert.assertEquals(1, partitionRepairInfos.size());
+                PartitionRepairInfo partitionRepairInfo = partitionRepairInfos.get(0);
+                Assert.assertEquals(partition.getId(), partitionRepairInfo.getPartitionId());
+                Assert.assertEquals(partition.getName(), partitionRepairInfo.getPartitionName());
+                Assert.assertEquals(100, partitionRepairInfo.getVersion());
+                Assert.assertEquals(100, partitionRepairInfo.getVersionTime());
+            }
+        };
+
+        mvRepairHandler.handleMVRepair(txnState);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
@@ -46,9 +46,10 @@ public class MVRepairHandlerTest {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable(
-                        "CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
-                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+                .withTable("CREATE TABLE test.t1(k1 int, k2 int, k3 int) " +
+                        "distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
+                .withMaterializedView("CREATE MATERIALIZED VIEW test.mv1 " +
+                        "distributed by hash(k1) buckets 3 refresh async as select k1 from test.t1");
 
         database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         table = database.getTable("t1");


### PR DESCRIPTION
## Why I'm doing:
In shared-data mode, the background task such as compaction and schema change will increase the visible version of the partition. The associated mv will think that the data has been updated, which will trigger the refresh of the mv. But compaction and schema change  do not update the data, but only reorganize the data. The associated mv does not need to be refreshed. The useless mv refresh will occupy a lot of resources, resulting in resource waste, which needs to be avoided.

## What I'm doing:
Add mv repair handler interface, which can be called to avoid upcoming useless mv refresh.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
