### PR TITLE
[Enhancement] create star mgr dir on startup in shared-data cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -250,6 +250,19 @@ public class NodeMgr {
 
         Storage storage = new Storage(this.imageDir);
 
+        // prepare starmgr dir
+        if (RunMode.isSharedDataMode()) {
+            String subDir = this.imageDir + StarMgrServer.IMAGE_SUBDIR;
+            File dir = new File(subDir);
+            if (!dir.exists()) { // subDir might not exist
+                LOG.info("create image dir for star mgr, {}.", dir.getAbsolutePath());
+                if (!dir.mkdir()) {
+                    LOG.error("create image dir for star mgr failed! exit now.");
+                    System.exit(-1);
+                }
+            }
+        }
+
         // if helper node is point to self, or there is ROLE and VERSION file in local.
         // get the node type from local
         if (isMyself() || (roleFile.exists() && versionFile.exists())) {
@@ -434,16 +447,6 @@ public class NodeMgr {
             }
             getNewImageOnStartup(rightHelperNode, "");
             if (RunMode.isSharedDataMode()) { // get star mgr image
-                // subdir might not exist
-                String subDir = this.imageDir + StarMgrServer.IMAGE_SUBDIR;
-                File dir = new File(subDir);
-                if (!dir.exists()) { // subDir might not exist
-                    LOG.info("create image dir for {}.", dir.getAbsolutePath());
-                    if (!dir.mkdir()) {
-                        LOG.error("create image dir for star mgr failed! exit now.");
-                        System.exit(-1);
-                    }
-                }
                 getNewImageOnStartup(rightHelperNode, StarMgrServer.IMAGE_SUBDIR);
             }
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
create starmgr dir when FE first starts up

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
