### PR TITLE
[BugFix] Fix race condition between optimize table and archive task history

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -337,6 +337,15 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         int progress = 0;
         TaskRunManager taskRunManager = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager();
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
+
+        // prepare for the history task info
+        Set<String> taskNames = Sets.newHashSet();
+        for (OptimizeTask rewriteTask : rewriteTasks) {
+            taskNames.add(rewriteTask.getName());
+        }
+        List<TaskRunStatus> resStatus = GlobalStateMgr.getCurrentState().getTaskManager()
+                    .getTaskRunManager().getTaskRunHistory().lookupHistoryByTaskNames(dbName, taskNames);
+
         for (OptimizeTask rewriteTask : rewriteTasks) {
             if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.FAILED
                     || rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.SUCCESS) {
@@ -353,16 +362,18 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 continue;
             }
 
-            Set<String> taskName = Sets.newHashSet();
-            taskName.add(rewriteTask.getName());
-            List<TaskRunStatus> resStatus = GlobalStateMgr.getCurrentState().getTaskManager()
-                    .getTaskRunManager().getTaskRunHistory().lookupHistoryByTaskNames(dbName, taskName);
             if (resStatus == null || resStatus.isEmpty()) {
                 allFinished = false;
                 continue;
             }
-            Preconditions.checkState(resStatus.size() == 1);
-            TaskRunStatus status = resStatus.get(0);
+            List<TaskRunStatus> filteredTask = resStatus.stream()
+                                .filter(x -> rewriteTask.getName().equals(x.getTaskName())).collect(Collectors.toList());
+            if (filteredTask.isEmpty()) {
+                allFinished = false;
+                continue;
+            }
+            Preconditions.checkState(filteredTask.size() == 1);
+            TaskRunStatus status = filteredTask.get(0);
 
             if (status.getState() == Constants.TaskRunState.FAILED) {
                 LOG.warn("optimize task {} failed", rewriteTask.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -352,12 +352,17 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 allFinished = false;
                 continue;
             }
-            TaskRunStatus status = GlobalStateMgr.getCurrentState().getTaskManager()
-                    .getTaskRunManager().getTaskRunHistory().getTaskByName(rewriteTask.getName());
-            if (status == null) {
+
+            Set<String> taskName = Sets.newHashSet();
+            taskName.add(rewriteTask.getName());
+            List<TaskRunStatus> resStatus = GlobalStateMgr.getCurrentState().getTaskManager()
+                    .getTaskRunManager().getTaskRunHistory().lookupHistoryByTaskNames(dbName, taskName);
+            if (resStatus == null || resStatus.isEmpty()) {
                 allFinished = false;
                 continue;
             }
+            Preconditions.checkState(resStatus.size() == 1);
+            TaskRunStatus status = resStatus.get(0);
 
             if (status.getState() == Constants.TaskRunState.FAILED) {
                 LOG.warn("optimize task {} failed", rewriteTask.getName());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -178,8 +179,18 @@ public class OptimizeJobV2Test extends DDLTestBase {
 
         // runRunningJob
         List<OptimizeTask> optimizeTasks = optimizeJob.getOptimizeTasks();
-        for (OptimizeTask optimizeTask : optimizeTasks) {
-            optimizeTask.setOptimizeTaskState(Constants.TaskRunState.SUCCESS);
+        for (int i = 0; i < optimizeTasks.size(); ++i) {
+            OptimizeTask optimizeTask = optimizeTasks.get(i);
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
+                        .getTaskRunScheduler().removeRunningTask(optimizeTask.getId());
+            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
+                        .getTaskRunScheduler().removePendingTask(optimizeTask);
+            TaskRunStatus taskRunStatus = new TaskRunStatus();
+            taskRunStatus.setTaskName(optimizeTask.getName());
+            taskRunStatus.setState(Constants.TaskRunState.SUCCESS);
+            taskRunStatus.setDbName(db.getFullName());
+            GlobalStateMgr.getCurrentState().getTaskManager()
+                        .getTaskRunManager().getTaskRunHistory().addHistory(taskRunStatus);
         }
         optimizeJob.runRunningJob();
 


### PR DESCRIPTION
## Why I'm doing:
This problem caused by the uncompatibility between optimize table and archive for task history. In pr(#47742) we introduce archive for task history. This feature will dump the task history info into disk and save more memory. But in optimize table, we depend the task history info to finish the whole progress. If we archive the history info, the memory side will be deleted and optimize table task will never be able to obtain history info until timeout reached.

## What I'm doing:
Use new interface to retrieval the history info.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/8115

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
