### PR TITLE
[BugFix] fix not parsing prepare parameter in order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2067,6 +2067,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitUpdateStatement(StarRocksParser.UpdateStatementContext context) {
+        List<CTERelation> ctes = null;
+        if (context.withClause() != null) {
+            ctes = visit(context.withClause().commonTableExpression(), CTERelation.class);
+        }
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         TableName targetTableName = qualifiedNameToTableName(qualifiedName);
         List<ColumnAssignment> assignments = visit(context.assignmentList().assignment(), ColumnAssignment.class);
@@ -2081,10 +2085,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
         }
         Expr where = context.where != null ? (Expr) visit(context.where) : null;
-        List<CTERelation> ctes = null;
-        if (context.withClause() != null) {
-            ctes = visit(context.withClause().commonTableExpression(), CTERelation.class);
-        }
         UpdateStmt ret = new UpdateStmt(targetTableName, assignments, fromRelations, where, ctes, createPos(context));
         if (context.explainDesc() != null) {
             ret.setIsExplain(true, getExplainType(context.explainDesc()));
@@ -2098,6 +2098,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitDeleteStatement(StarRocksParser.DeleteStatementContext context) {
+        List<CTERelation> ctes = null;
+        if (context.withClause() != null) {
+            ctes = visit(context.withClause().commonTableExpression(), CTERelation.class);
+        }
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         TableName targetTableName = qualifiedNameToTableName(qualifiedName);
         PartitionNames partitionNames = null;
@@ -2106,10 +2110,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
         List<Relation> usingRelations = context.using != null ? visit(context.using.relation(), Relation.class) : null;
         Expr where = context.where != null ? (Expr) visit(context.where) : null;
-        List<CTERelation> ctes = null;
-        if (context.withClause() != null) {
-            ctes = visit(context.withClause().commonTableExpression(), CTERelation.class);
-        }
         DeleteStmt ret =
                 new DeleteStmt(targetTableName, partitionNames, usingRelations, where, ctes, createPos(context));
         if (context.explainDesc() != null) {
@@ -4578,14 +4578,12 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitQueryRelation(StarRocksParser.QueryRelationContext context) {
-        QueryRelation queryRelation = (QueryRelation) visit(context.queryNoWith());
-
         List<CTERelation> withQuery = new ArrayList<>();
         if (context.withClause() != null) {
             withQuery = visit(context.withClause().commonTableExpression(), CTERelation.class);
         }
+        QueryRelation queryRelation = (QueryRelation) visit(context.queryNoWith());
         withQuery.forEach(queryRelation::addCTERelation);
-
         return queryRelation;
     }
 

--- a/test/sql/test_preparestatement/R/test_preprare_statement
+++ b/test/sql/test_preparestatement/R/test_preprare_statement
@@ -14,55 +14,48 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
     PRIMARY KEY (k1, k2, k3, k4, k5)
     DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
 -- result:
-[]
 -- !result
 insert into prepare_stmt values (1, 2, 3, 4, '2', true, '2021-02-01', '1', '2021-02-01 00:00:12', '1', 2);
 -- result:
-[]
 -- !result
 insert into prepare_stmt values (3, 2, 3, 4, '2', true, '2021-02-01', '1', '2021-02-01 00:00:12', '1', 2);
 -- result:
-[]
 -- !result
 PREPARE stmt1 FROM select * from prepare_stmt where k1 = ? and k2 = ?;
 -- result:
-[]
 -- !result
 PREPARE stmt2 FROM 'select * from prepare_stmt order by k1';
 -- result:
-[]
 -- !result
 PREPARE stmt3 FROM select * from prepare_stmt order by k1;
 -- result:
-[]
+-- !result
+PREPARE cte_stmt_1 FROM with cte as (select * from prepare_stmt where k1 = ?) select * from cte where v9 = ?;
+-- result:
+-- !result
+PREPARE cte_stmt_2 FROM  select *, ? from (with cte as (select * from prepare_stmt where k1 = ?) select * from cte) t where v9 = ?;
+-- result:
 -- !result
 set @i = 1;
 -- result:
-[]
 -- !result
 set @i2 = 2;
 -- result:
-[]
 -- !result
 set @i3 = 3;
 -- result:
-[]
 -- !result
 set @v = '1';
 -- result:
-[]
 -- !result
 set @v2 = '2';
 -- result:
-[]
 -- !result
 set @b = true;
 -- result:
-[]
 -- !result
 set @t = '2021-02-01 00:00:12';
 -- result:
-[]
 -- !result
 execute stmt1 using @i, @i2;
 -- result:
@@ -77,20 +70,31 @@ execute stmt2;
 1	2	3	4	2	1	2021-02-01	1	2021-02-01 00:00:12	1	2.00
 3	2	3	4	2	1	2021-02-01	1	2021-02-01 00:00:12	1	2.00
 -- !result
+execute cte_stmt_1 using @i, @t;
+-- result:
+1	2	3	4	2	1	2021-02-01	1	2021-02-01 00:00:12	1	2.00
+-- !result
+execute cte_stmt_2 using @i3, @i, @t;
+-- result:
+1	2	3	4	2	1	2021-02-01	1	2021-02-01 00:00:12	1	2.00	3
+-- !result
 drop prepare stmt1;
 -- result:
-[]
 -- !result
 deallocate prepare stmt2; -- deallocate is alias
 drop prepare stmt3;
 -- result:
-[]
+-- !result
+drop prepare cte_stmt_1;
+-- result:
+-- !result
+drop prepare cte_stmt_2;
+-- result:
 -- !result
 DROP TABLE prepare_stmt FORCE;
 -- result:
-[]
 -- !result
-CREATE TABLE `customer_row` (
+CREATE TABLE IF NOT EXISTS `customer_row` (
   `customer_key` bigint(20) NOT NULL COMMENT "",
   `customer_row_value_0` varchar(65533) NULL COMMENT "",
   `customer_row_value_1` varchar(65533) NULL COMMENT "",

--- a/test/sql/test_preparestatement/T/test_preprare_statement
+++ b/test/sql/test_preparestatement/T/test_preprare_statement
@@ -19,6 +19,8 @@ insert into prepare_stmt values (3, 2, 3, 4, '2', true, '2021-02-01', '1', '2021
 PREPARE stmt1 FROM select * from prepare_stmt where k1 = ? and k2 = ?;
 PREPARE stmt2 FROM 'select * from prepare_stmt order by k1';
 PREPARE stmt3 FROM select * from prepare_stmt order by k1;
+PREPARE cte_stmt_1 FROM with cte as (select * from prepare_stmt where k1 = ?) select * from cte where v9 = ?;
+PREPARE cte_stmt_2 FROM  select *, ? from (with cte as (select * from prepare_stmt where k1 = ?) select * from cte) t where v9 = ?;
 
 set @i = 1;
 set @i2 = 2;
@@ -34,9 +36,14 @@ execute stmt1 using @i3, @i2;
 
 execute stmt2;
 
+execute cte_stmt_1 using @i, @t;
+execute cte_stmt_2 using @i3, @i, @t;
+
 drop prepare stmt1;
 deallocate prepare stmt2; -- deallocate is alias
 drop prepare stmt3;
+drop prepare cte_stmt_1;
+drop prepare cte_stmt_2;
 
 DROP TABLE prepare_stmt FORCE;
 


### PR DESCRIPTION
## Why I'm doing:
Parser parsed sql with relation first and cte second. This would cause parameter in prepare stmt not being parsed in the right order.

## What I'm doing:
Parse cte first as it defined in the parser rule.
```
queryRelation
    : withClause? queryNoWith
    ;
```

Fixes #48276

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
