### PR TITLE
[BugFix] Fix load boolean from json

### DIFF
--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -153,6 +153,7 @@ static TypeDescriptor construct_json_type(const TypeDescriptor& src_type) {
     case TYPE_INT:
     case TYPE_SMALLINT:
     case TYPE_TINYINT:
+    case TYPE_BOOLEAN:
     case TYPE_CHAR:
     case TYPE_VARCHAR:
     case TYPE_JSON: {

--- a/be/test/exec/json_scanner_test.cpp
+++ b/be/test/exec/json_scanner_test.cpp
@@ -483,7 +483,7 @@ TEST_F(JsonScannerTest, test_invalid_column_in_array) {
     EXPECT_EQ(1, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 
-    EXPECT_EQ("[NULL]", chunk->debug_row(0));
+    EXPECT_EQ("[[[NULL,20],[30,40]]]", chunk->debug_row(0));
 }
 
 TEST_F(JsonScannerTest, test_invalid_nested_level1) {
@@ -516,7 +516,7 @@ TEST_F(JsonScannerTest, test_invalid_nested_level1) {
     EXPECT_EQ(1, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 
-    EXPECT_EQ("[NULL]", chunk->debug_row(0));
+    EXPECT_EQ("[[NULL,NULL,NULL,NULL]]", chunk->debug_row(0));
 }
 
 TEST_F(JsonScannerTest, test_invalid_nested_level2) {

--- a/be/test/formats/json/nullable_column_test.cpp
+++ b/be/test/formats/json/nullable_column_test.cpp
@@ -110,6 +110,22 @@ TEST_F(AddNullableColumnTest, test_add_boolean) {
     ASSERT_TRUE(st.ok());
     ASSERT_EQ("[1]", column->debug_string());
 
+    column->reset_column();
+    json = R"(  { "f_boolean": 9223372036854775808}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": 18446744073709551616}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
     // string
     column->reset_column();
     json = R"(  { "f_boolean": "TrUe"}  )"_padded;
@@ -121,6 +137,22 @@ TEST_F(AddNullableColumnTest, test_add_boolean) {
 
     column->reset_column();
     json = R"(  { "f_boolean": "1"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": "-1"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": "10"}  )"_padded;
     doc = parser.iterate(json);
     val = doc.find_field("f_boolean");
     st = add_nullable_column(column.get(), t, "f_boolean", &val, false);

--- a/be/test/formats/json/nullable_column_test.cpp
+++ b/be/test/formats/json/nullable_column_test.cpp
@@ -57,18 +57,113 @@ TEST_F(AddNullableColumnTest, test_add_binary) {
 }
 
 TEST_F(AddNullableColumnTest, test_add_boolean) {
-    TypeDescriptor t = TypeDescriptor::create_char_type(20);
+    TypeDescriptor t(TYPE_BOOLEAN);
     auto column = ColumnHelper::create_column(t, true);
 
+    // boolean
     simdjson::ondemand::parser parser;
     auto json = R"(  { "f_boolean": true}  )"_padded;
     auto doc = parser.iterate(json);
     simdjson::ondemand::value val = doc.find_field("f_boolean");
-
     auto st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
     ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
 
-    ASSERT_EQ("['1']", column->debug_string());
+    column->reset_column();
+    json = R"(  { "f_boolean": false}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[0]", column->debug_string());
+
+    // number
+    column->reset_column();
+    json = R"(  { "f_boolean": 1}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": 0}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[0]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": -1}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": 0.1}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    // string
+    column->reset_column();
+    json = R"(  { "f_boolean": "TrUe"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": "1"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[1]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": "FaLse"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[0]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": "0"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[0]", column->debug_string());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": "FaLs"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.is_invalid_argument());
+
+    column->reset_column();
+    json = R"(  { "f_boolean": "0.1"}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.is_invalid_argument());
+
+    // array
+    column->reset_column();
+    json = R"(  { "f_boolean": [1]}  )"_padded;
+    doc = parser.iterate(json);
+    val = doc.find_field("f_boolean");
+    st = add_nullable_column(column.get(), t, "f_boolean", &val, false);
+    ASSERT_TRUE(st.is_invalid_argument());
 }
 
 TEST_F(AddNullableColumnTest, test_add_invalid_as_null) {
@@ -113,6 +208,20 @@ TEST_F(AddNullableColumnTest, add_null_numeric_array) {
     column->check_or_die();
 }
 
+TEST_F(AddNullableColumnTest, add_boolean_array) {
+    auto desc = TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_BOOLEAN));
+    auto column = ColumnHelper::create_column(desc, true);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_array": [null, 0.1, -0.1, 1, -1, 0, "TRUE", "false", "1"]}  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_array");
+
+    auto st = add_nullable_column(column.get(), desc, "f_array", &val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("[[NULL,1,1,1,1,0,1,0,1]]", column->debug_string());
+}
+
 TEST_F(AddNullableColumnTest, test_add_struct) {
     TypeDescriptor type_desc = TypeDescriptor::create_struct_type(
             {"key1", "key2"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(10)});
@@ -126,6 +235,21 @@ TEST_F(AddNullableColumnTest, test_add_struct) {
     ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
 
     ASSERT_EQ("[{key1:'foo',key2:'bar'}]", column->debug_string());
+}
+
+TEST_F(AddNullableColumnTest, test_add_struct_null) {
+    TypeDescriptor type_desc = TypeDescriptor::create_struct_type(
+            {"key1", "key2"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(10)});
+    auto column = ColumnHelper::create_column(type_desc, true);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "key0": null}  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field_unordered("key0");
+
+    ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
+
+    ASSERT_EQ("[NULL]", column->debug_string());
 }
 
 TEST_F(AddNullableColumnTest, test_add_map) {
@@ -142,6 +266,22 @@ TEST_F(AddNullableColumnTest, test_add_map) {
     ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
 
     ASSERT_EQ("[{'key1':'foo','key2':'bar','key3':'baz'}]", column->debug_string());
+}
+
+TEST_F(AddNullableColumnTest, test_add_map_null) {
+    TypeDescriptor type_desc = TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(10),
+                                                               TypeDescriptor::create_varchar_type(10));
+
+    auto column = ColumnHelper::create_column(type_desc, true);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "key0": null}  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field_unordered("key0");
+
+    ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
+
+    ASSERT_EQ("[NULL]", column->debug_string());
 }
 
 TEST_F(AddNullableColumnTest, test_invalid_json_convert) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
according to json type
1. boolean: true or false
2. number: !=0 is true else false
3. string: int32_t string, "true"(case insensitive) is true; "0", "false" is false, others is invalid
4. other type: invalid

Fixes https://github.com/StarRocks/StarRocksTest/issues/8095

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
