### PR TITLE
[BugFix] Avoid hdfs fs manager interrupting the thread when exception occurs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -49,6 +49,7 @@ import software.amazon.awssdk.regions.Region;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -1200,6 +1201,10 @@ public class HdfsFsManager {
         } catch (FileNotFoundException e) {
             LOG.info("file not found: " + path, e);
             throw new UserException("file not found: " + path, e);
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while get file status: " + path, e);
+            throw new UserException("Failed to get file status: " + path, e); // throw unified user exception
         } catch (Exception e) {
             LOG.error("errors while get file status ", e);
             throw new UserException("Fail to get file status: " + e.getMessage(), e);
@@ -1246,6 +1251,10 @@ public class HdfsFsManager {
                     "the arguments like region, IAM, instance profile and so on.");
             throw new UserException("The arguments of blob store(S3/Azure) may be wrong. " +
                     "You can check the arguments like region, IAM, instance profile and so on.", e);
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while list path: " + path, e);
+            throw new UserException("Failed to list path: " + path, e); // throw unified user exception
         } catch (Exception e) {
             LOG.error("errors while get file status ", e);
             throw new UserException("Fail to get file status: " + e.getMessage(), e);
@@ -1259,6 +1268,10 @@ public class HdfsFsManager {
         Path filePath = new Path(pathUri.getPath());
         try {
             fileSystem.getDFSFileSystem().delete(filePath, true);
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while delete path: " + path, e);
+            throw new UserException("Failed to delete path: " + path, e); // throw unified user exception
         } catch (IOException e) {
             LOG.error("errors while delete path " + path, e);
             throw new UserException("delete path " + path + "error", e);
@@ -1288,6 +1301,11 @@ public class HdfsFsManager {
             if (!isRenameSuccess) {
                 throw new UserException("failed to rename path from " + srcPath + " to " + destPath);
             }
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while rename path from " + srcPath + " to " + destPath, e);
+            // throw unified user exception
+            throw new UserException("Failed to rename path from " + srcPath + " to " + destPath, e);
         } catch (IOException e) {
             LOG.error("errors while rename path from " + srcPath + " to " + destPath, e);
             throw new UserException("errors while rename " + srcPath + "to " + destPath, e);
@@ -1300,6 +1318,10 @@ public class HdfsFsManager {
         Path filePath = new Path(pathUri.getPath());
         try {
             return fileSystem.getDFSFileSystem().exists(filePath);
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while check path exist: " + path, e);
+            throw new UserException("Failed to check path exist: " + path, e); // throw unified user exception
         } catch (IOException e) {
             LOG.error("errors while check path exist: " + path, e);
             throw new UserException("errors while check if path " + path + " exist", e);
@@ -1317,6 +1339,10 @@ public class HdfsFsManager {
             TBrokerFD fd = parseUUIDToFD(uuid);
             ioStreamManager.putNewInputStream(fd, fsDataInputStream, fileSystem);
             return fd;
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while open file " + path, e);
+            throw new UserException("Failed to open file " + path, e); // throw unified user exception
         } catch (IOException e) {
             LOG.error("errors while open path", e);
             throw new UserException("could not open file " + path, e);
@@ -1329,6 +1355,11 @@ public class HdfsFsManager {
             long currentStreamOffset;
             try {
                 currentStreamOffset = fsDataInputStream.getPos();
+            } catch (InterruptedIOException e) {
+                Thread.interrupted(); // clear interrupted flag
+                LOG.error("Interrupted while get file pos from output stream", e);
+                // throw unified user exception
+                throw new UserException("Failed to get file pos from output stream", e);
             } catch (IOException e) {
                 LOG.error("errors while get file pos from output stream", e);
                 throw new UserException("errors while get file pos from output stream");
@@ -1340,6 +1371,11 @@ public class HdfsFsManager {
                         + offset + " seek to it");
                 try {
                     fsDataInputStream.seek(offset);
+                } catch (InterruptedIOException e) {
+                    Thread.interrupted(); // clear interrupted flag
+                    LOG.error("Interrupted while seek file pos from output stream", e);
+                    // throw unified user exception
+                    throw new UserException("Failed to seek file pos from output stream", e);
                 } catch (IOException e) {
                     throw new UserException("current read offset " + currentStreamOffset + " is not equal to "
                             + offset + ", and could not seek to it");
@@ -1367,6 +1403,10 @@ public class HdfsFsManager {
                     System.arraycopy(buf, 0, smallerBuf, 0, readLength);
                     return smallerBuf;
                 }
+            } catch (InterruptedIOException e) {
+                Thread.interrupted(); // clear interrupted flag
+                LOG.error("Interrupted while read data from stream", e);
+                throw new UserException("Failed to read data from stream", e); // throw unified user exception
             } catch (IOException e) {
                 LOG.error("errors while read data from stream", e);
                 throw new UserException("errors while read data from stream", e);
@@ -1383,6 +1423,10 @@ public class HdfsFsManager {
         synchronized (fsDataInputStream) {
             try {
                 fsDataInputStream.close();
+            } catch (InterruptedIOException e) {
+                Thread.interrupted(); // clear interrupted flag
+                LOG.error("Interrupted while close file input stream", e);
+                throw new UserException("Failed to close file input stream", e); // throw unified user exception
             } catch (IOException e) {
                 LOG.error("errors while close file input stream", e);
                 throw new UserException("errors while close file input stream", e);
@@ -1404,6 +1448,10 @@ public class HdfsFsManager {
             LOG.info("finish a open writer request. fd: " + fd);
             ioStreamManager.putNewOutputStream(fd, fsDataOutputStream, fileSystem);
             return fd;
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while open file " + path, e);
+            throw new UserException("Failed to open file " + path, e); // throw unified user exception
         } catch (IOException e) {
             LOG.error("errors while open path", e);
             throw new UserException("could not open file " + path, e);
@@ -1420,6 +1468,11 @@ public class HdfsFsManager {
             }
             try {
                 fsDataOutputStream.write(data);
+            } catch (InterruptedIOException e) {
+                Thread.interrupted(); // clear interrupted flag
+                LOG.error("Interrupted while write file " + fd + " to output stream", e);
+                // throw unified user exception
+                throw new UserException("Failed to write file " + fd + " to output stream", e);
             } catch (IOException e) {
                 LOG.error("errors while write file " + fd + " to output stream", e);
                 throw new UserException("errors while write data to output stream", e);
@@ -1433,6 +1486,11 @@ public class HdfsFsManager {
             try {
                 fsDataOutputStream.hsync();
                 fsDataOutputStream.close();
+            } catch (InterruptedIOException e) {
+                Thread.interrupted(); // clear interrupted flag
+                LOG.error("Interrupted while close file " + fd + " output stream", e);
+                // throw unified user exception
+                throw new UserException("Failed to close file " + fd + " output stream", e);
             } catch (IOException e) {
                 LOG.error("errors while close file " + fd + " output stream", e);
                 throw new UserException("errors while close file output stream", e);


### PR DESCRIPTION
## Why I'm doing:
When exception occurs in hdfs fs manager, the current thread will be interrupted, causing `InterruptedException` or `ClosedByInterruptException` in subsequent code execution. 

This may cause the following problem: 
User backup data to a HDFS repository, and then releases the HDFS cluster. When FE starts, it will access the released HDFS cluster. If the access fails,  the current thread will be interrupted, an `InterruptedIOException` or `ClosedByInterruptException` is thrown and the startup fails.

## What I'm doing:
Avoid hdfs fs manager interrupting the thread by clearing the interrupted flag when exception occurs.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
