### PR TITLE
[UT] Fix unstable FE UT QueryDumpActionTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/http/QueryDumpActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/QueryDumpActionTest.java
@@ -16,19 +16,30 @@ package com.starrocks.http;
 
 import com.starrocks.http.rest.QueryDumpAction;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.awaitility.Awaitility;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryDumpActionTest extends StarRocksHttpTestCase {
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        setUpWithCatalog();
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME) != null);
+    }
 
     @Override
     protected void doSetUp() {
@@ -38,10 +49,8 @@ public class QueryDumpActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testSuccess() throws Exception {
-        setUpWithCatalog();
-
         try (Response response = postQueryDump(DB_NAME, true, "select * from testTbl")) {
-            assertThat(response.isSuccessful()).isTrue();
+            assertThat(response.isSuccessful()).describedAs(response.toString()).isTrue();
             String body = response.body().string();
             assertThat(body)
                     .contains("\"statement\":\"SELECT *\\nFROM db_mock_000.tbl_mock_001\"")
@@ -76,8 +85,6 @@ public class QueryDumpActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testInvalidQuery() throws Exception {
-        setUpWithCatalog();
-
         try (Response response = postQueryDump(DB_NAME, false, "")) {
             String body = response.body().string();
             assertThat(response.code()).isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
@@ -93,8 +100,6 @@ public class QueryDumpActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testInvalidDatabase() throws Exception {
-        setUpWithCatalog();
-
         try (Response response = postQueryDump("default_catalog.no_db", false, "select * from testTbl")) {
             String body = response.body().string();
             assertThat(response.code()).isEqualTo(HttpResponseStatus.NOT_FOUND.code());


### PR DESCRIPTION
## Why I'm doing:

```
Missing 1 invocation to:
com.starrocks.server.GlobalStateMgr#isLeader()
   on mock instance: com.starrocks.server.GlobalStateMgr@5de4b284
Caused by: Missing invocations
	at com.starrocks.metric.MetricRepo$13.getValue(MetricRepo.java:603)
	at com.starrocks.metric.MetricRepo$13.getValue(MetricRepo.java:600)
	at com.starrocks.metric.MetricCalculator.update(MetricCalculator.java:105)
	at com.starrocks.metric.MetricCalculator.run(MetricCalculator.java:61)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

The reason is that `@Before setUp()` mock `GlobalStateMgr` firstly, and then `setupWithCatalog` mock `GlobalStateMgr` again.

`@Before setUp()` mocks `GlobalStateMgr#isLeader`, but `setupWithCatalog` doesn't.

## What I'm doing:

Extract the common logic of `@Before setUp()` and `setupWithCatalog`, to avoid repeating the same codes and forgetting some mocks in one of them.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
