### PR TITLE
[Enhancement] check window function of MV in subquery/cte

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionSlotRefResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionSlotRefResolver.java
@@ -13,14 +13,17 @@
 // limitations under the License.
 package com.starrocks.mv.analyzer;
 
+import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryStatement;
@@ -40,7 +43,16 @@ import java.util.List;
  * join/sub-query/view/set operator fo find the slot ref which it comes from.
  */
 public class MVPartitionSlotRefResolver {
-    private  static final AstVisitor<Expr, Relation> EXPR_SHUTTLE = new AstVisitor<Expr, Relation>() {
+
+    static class ExprShuttle implements AstVisitor<Expr, Relation> {
+
+        private final AstVisitor<Expr, SlotRef> slotRefResolver;
+
+        // Use customized SlotRefResolver
+        public ExprShuttle(AstVisitor<Expr, SlotRef> slotRefResolver) {
+            this.slotRefResolver = slotRefResolver;
+        }
+
         @Override
         public Expr visit(ParseNode node) {
             throw new SemanticException("Cannot resolve materialized view's partition slot ref, " +
@@ -63,13 +75,13 @@ public class MVPartitionSlotRefResolver {
         @Override
         public Expr visitSlot(SlotRef slotRef, Relation node) {
             if (slotRef.getTblNameWithoutAnalyzed() == null) {
-                return node.accept(SLOT_REF_RESOLVER, slotRef);
+                return node.accept(slotRefResolver, slotRef);
             }
             String tableName = slotRef.getTblNameWithoutAnalyzed().getTbl();
             if (node.getAlias() != null && !node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
                 return null;
             }
-            return node.accept(SLOT_REF_RESOLVER, slotRef);
+            return node.accept(slotRefResolver, slotRef);
         }
 
         @Override
@@ -78,11 +90,12 @@ public class MVPartitionSlotRefResolver {
                     .getFieldByIndex(fieldReference.getFieldIndex());
             SlotRef slotRef = new SlotRef(field.getRelationAlias(), field.getName(), field.getName());
             slotRef.setType(field.getType());
-            return node.accept(SLOT_REF_RESOLVER, slotRef);
+            return node.accept(slotRefResolver, slotRef);
         }
-    };
+    }
 
     private static final AstVisitor<Expr, SlotRef> SLOT_REF_RESOLVER = new AstVisitor<Expr, SlotRef>() {
+
         @Override
         public Expr visit(ParseNode node) {
             throw new SemanticException("Cannot resolve materialized view's partition expression, " +
@@ -200,12 +213,85 @@ public class MVPartitionSlotRefResolver {
         }
     };
 
+    private static final AstVisitor<Expr, Relation> EXPR_SHUTTLE = new ExprShuttle(SLOT_REF_RESOLVER);
+
+    /**
+     * Recursive check if the query contains an unsupported window function
+     */
+    private static class WindowFunctionChecker extends AstTraverser<Expr, SlotRef> {
+
+        private CreateMaterializedViewStatement statement;
+        private Expr partitionByExpr;
+        private final ExprShuttle exprShuttle = new ExprShuttle(this);
+
+        public static void check(CreateMaterializedViewStatement statement, Expr partitionByExpr) {
+            WindowFunctionChecker checker = new WindowFunctionChecker();
+            checker.statement = statement;
+            checker.partitionByExpr = partitionByExpr;
+            partitionByExpr.accept(checker.exprShuttle, statement.getQueryStatement().getQueryRelation());
+        }
+
+        private void checkWindowFunction(SelectRelation node) {
+            for (SelectListItem item : node.getSelectList().getItems()) {
+                Expr expr = item.getExpr();
+                if (expr instanceof AnalyticExpr) {
+                    AnalyticExpr analyticExpr = expr.cast();
+                    if (analyticExpr.getPartitionExprs() == null
+                            || !analyticExpr.getPartitionExprs().contains(partitionByExpr)) {
+                        String name = partitionByExpr instanceof SlotRef ?
+                                ((SlotRef) partitionByExpr).getColumnName() : partitionByExpr.toSql();
+                        throw new SemanticException("window function %s ’s partition expressions" +
+                                " should contain the partition column %s of materialized view",
+                                analyticExpr.getFnCall().getFnName().getFunction(),
+                                name
+                        );
+                    }
+                }
+            }
+        }
+
+        @Override
+        public Expr visitSelect(SelectRelation node, SlotRef slot) {
+            // Only check the window function at the relation that SlotRef exists
+            // E.g. The Partition-By refs to c1, so we only check this relation
+            // SELECT * FROM (
+            //      SELECT c1, row_number() over (partition by ...)
+            //      FROM t1
+            // )r;
+            for (SelectListItem selectListItem : node.getSelectList().getItems()) {
+                TableName tableName = slot.getTblNameWithoutAnalyzed();
+                if (selectListItem.getAlias() == null) {
+                    if (selectListItem.getExpr() instanceof SlotRef) {
+                        SlotRef result = (SlotRef) selectListItem.getExpr();
+                        if (result.getColumnName().equalsIgnoreCase(slot.getColumnName())
+                                && (tableName == null || tableName.equals(result.getTblNameWithoutAnalyzed()))) {
+                            checkWindowFunction(node);
+                        }
+                    }
+                } else {
+                    if (tableName != null && tableName.isFullyQualified()) {
+                        continue;
+                    }
+                    if (selectListItem.getAlias().equalsIgnoreCase(slot.getColumnName())) {
+                        checkWindowFunction(node);
+                    }
+                }
+            }
+            return super.visitSelect(node, slot);
+        }
+
+    }
+
     /**
      * Resolve the expression through join/sub-query/view/set operator fo find the slot ref
      * which it comes from.
      */
     public static Expr resolveExpr(Expr expr, QueryStatement queryStatement) {
         return expr.accept(EXPR_SHUTTLE, queryStatement.getQueryRelation());
+    }
+
+    public static void checkWindowFunction(CreateMaterializedViewStatement statement, Expr partitionByExpr) {
+        WindowFunctionChecker.check(statement, partitionByExpr);
     }
 
     public static Expr resolveExpr(Expr expr, Relation relation) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -34,7 +34,7 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     @Override
     public R visitInsertStatement(InsertStmt statement, C context) {
         if (statement.getQueryStatement() != null) {
-            visit(statement.getQueryStatement());
+            visit(statement.getQueryStatement(), context);
         }
         return null;
     }
@@ -43,7 +43,7 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     public R visitUpdateStatement(UpdateStmt statement, C context) {
         //Update Statement after analyze, all information will be used to build QueryStatement, so it is enough to traverse Query
         if (statement.getQueryStatement() != null) {
-            visit(statement.getQueryStatement());
+            visit(statement.getQueryStatement(), context);
         }
         return null;
     }
@@ -52,7 +52,7 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     public R visitDeleteStatement(DeleteStmt statement, C context) {
         //Delete Statement after analyze, all information will be used to build QueryStatement, so it is enough to traverse Query
         if (statement.getQueryStatement() != null) {
-            visit(statement.getQueryStatement());
+            visit(statement.getQueryStatement(), context);
         }
         return null;
     }
@@ -60,10 +60,10 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     @Override
     public R visitSubmitTaskStatement(SubmitTaskStmt statement, C context) {
         if (statement.getInsertStmt() != null) {
-            visit(statement.getInsertStmt());
+            visit(statement.getInsertStmt(), context);
         }
         if (statement.getCreateTableAsSelectStmt() != null) {
-            visit(statement.getCreateTableAsSelectStmt());
+            visit(statement.getCreateTableAsSelectStmt(), context);
         }
         return null;
     }
@@ -71,7 +71,7 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     @Override
     public R visitCreatePipeStatement(CreatePipeStmt statement, C context) {
         if (statement.getInsertStmt() != null) {
-            visit(statement.getInsertStmt());
+            visit(statement.getInsertStmt(), context);
         }
         return null;
     }
@@ -79,10 +79,10 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     @Override
     public R visitCreateTableAsSelectStatement(CreateTableAsSelectStmt statement, C context) {
         if (statement.getQueryStatement() != null) {
-            visit(statement.getQueryStatement());
+            visit(statement.getQueryStatement(), context);
         }
         if (statement.getInsertStmt() != null) {
-            visit(statement.getInsertStmt());
+            visit(statement.getInsertStmt(), context);
         }
         return null;
     }
@@ -92,66 +92,66 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     @Override
     public R visitSelect(SelectRelation node, C context) {
         if (node.hasWithClause()) {
-            node.getCteRelations().forEach(this::visit);
+            node.getCteRelations().forEach(x -> visit(x, context));
         }
 
         if (node.getOrderBy() != null) {
             for (OrderByElement orderByElement : node.getOrderBy()) {
-                visit(orderByElement.getExpr());
+                visit(orderByElement.getExpr(), context);
             }
         }
 
         if (node.getOutputExpression() != null) {
-            node.getOutputExpression().forEach(this::visit);
+            node.getOutputExpression().forEach(x -> visit(x, context));
         }
 
         if (node.getPredicate() != null) {
-            visit(node.getPredicate());
+            visit(node.getPredicate(), context);
         }
 
         if (node.getGroupBy() != null) {
-            node.getGroupBy().forEach(this::visit);
+            node.getGroupBy().forEach(x -> visit(x, context));
         }
 
         if (node.getAggregate() != null) {
-            node.getAggregate().forEach(this::visit);
+            node.getAggregate().forEach(x -> visit(x, context));
         }
 
         if (node.getHaving() != null) {
-            visit(node.getHaving());
+            visit(node.getHaving(), context);
         }
 
-        return visit(node.getRelation());
+        return visit(node.getRelation(), context);
     }
 
     @Override
     public R visitJoin(JoinRelation node, C context) {
         if (node.getOnPredicate() != null) {
-            visit(node.getOnPredicate());
+            visit(node.getOnPredicate(), context);
         }
 
-        visit(node.getLeft());
-        visit(node.getRight());
+        visit(node.getLeft(), context);
+        visit(node.getRight(), context);
         return null;
     }
 
     @Override
     public R visitSubquery(SubqueryRelation node, C context) {
-        return visit(node.getQueryStatement());
+        return visit(node.getQueryStatement(), context);
     }
 
     @Override
     public R visitSetOp(SetOperationRelation node, C context) {
         if (node.hasWithClause()) {
-            node.getCteRelations().forEach(this::visit);
+            node.getCteRelations().forEach(x -> visit(x, context));
         }
-        node.getRelations().forEach(this::visit);
+        node.getRelations().forEach(x -> visit(x, context));
         return null;
     }
 
     @Override
     public R visitCTE(CTERelation node, C context) {
-        return visit(node.getCteQueryStatement());
+        return visit(node.getCteQueryStatement(), context);
     }
 
     @Override
@@ -163,12 +163,12 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
 
     @Override
     public R visitExpression(Expr node, C context) {
-        node.getChildren().forEach(this::visit);
+        node.getChildren().forEach(x -> visit(x, context));
         return null;
     }
 
     @Override
     public R visitSubquery(Subquery node, C context) {
-        return visit(node.getQueryStatement());
+        return visit(node.getQueryStatement(), context);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -358,8 +358,6 @@ public class AnalyzeTestUtil {
             if (!exceptMessage.equals("")) {
                 Assert.assertTrue(e.getMessage(), e.getMessage().contains(exceptMessage));
             }
-        } catch (Exception e) {
-            Assert.fail("analyze exception: " + e);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -338,6 +338,7 @@ public class MaterializedViewAnalyzerTest {
         }
 
         {
+            // Not supported
             String mvSql = "create materialized view window_mv_3\n" +
                     "partition by k1\n" +
                     "distributed by hash(k2)\n" +
@@ -348,6 +349,48 @@ public class MaterializedViewAnalyzerTest {
                     "from tbl1 \n";
             analyzeFail(mvSql, "Detail message: window function row_number ’s partition expressions" +
                     " should contain the partition column k1 of materialized view");
+        }
+
+        {
+            starRocksAssert.withTable("CREATE TABLE t1_event(\n" +
+                    "    order_root_id VARCHAR(255),\n" +
+                    "    event_type VARCHAR(255),\n" +
+                    "    sequence_timestamp datetime\n" + ")\n" +
+                    "PARTITION BY date_trunc('day', sequence_timestamp)\n" +
+                    "PROPERTIES(\"replication_num\"=\"1\");");
+
+            // Not supported
+            String mvSql = "CREATE MATERIALIZED VIEW denorm_mv_root_order\n" +
+                    "REFRESH ASYNC " +
+                    "PARTITION BY date_trunc('day', sequence_timestamp)\n" +
+                    "PROPERTIES(\n" +
+                    "  \"partition_refresh_number\" = \"4\")\n" +
+                    "AS\n" +
+                    "  SELECT\n" +
+                    "    order_root_id, event_type, sequence_timestamp,\n" +
+                    "    ROW_NUMBER() OVER (" +
+                    "       PARTITION BY order_root_id " +
+                    "       ORDER BY sequence_timestamp DESC) AS row_num\n" +
+                    "  FROM t1_event";
+            analyzeFail(mvSql, "Detail message: window function row_number ’s partition expressions " +
+                    "should contain the partition column sequence_timestamp of materialized view.");
+
+            // Not supported
+            mvSql = "CREATE MATERIALIZED VIEW denorm_mv_root_order\n" +
+                    "REFRESH ASYNC \n" +
+                    "PARTITION BY date_trunc('day', sequence_timestamp)\n" +
+                    "PROPERTIES(\n" + "  \"partition_refresh_number\" = \"4\")\n" +
+                    "AS\n" +
+                    "SELECT * from  (\n" +
+                    "  SELECT\n" +
+                    "    order_root_id, event_type, sequence_timestamp,\n" +
+                    "    ROW_NUMBER() OVER (" +
+                    "       PARTITION BY order_root_id " +
+                    "       ORDER BY sequence_timestamp DESC) AS row_num\n" +
+                    "  FROM t1_event) t\n" +
+                    "ORDER BY sequence_timestamp;\n";
+            analyzeFail(mvSql, "Detail message: window function row_number ’s partition expressions " +
+                    "should contain the partition column sequence_timestamp of materialized view.");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Previously we only check the window function in the top scope of a query, but actually we need to check all window function is the cte/subquery
- If the window function is not supported, we need to report an error for it 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
