### PR TITLE
[Enhancement] simplify case-when true expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
@@ -82,6 +82,7 @@ public class CaseWhenOperator extends CallOperator {
      */
     public void removeElseClause() {
         Preconditions.checkState(hasElse);
+        hasElse = false;
         arguments.remove(arguments.size() - 1);
     }
 
@@ -89,6 +90,12 @@ public class CaseWhenOperator extends CallOperator {
     public void setElseClause(ScalarOperator elseClause) {
         Preconditions.checkState(hasElse);
         arguments.set(arguments.size() - 1, elseClause);
+    }
+
+    public void addElseClause(ScalarOperator elseClause) {
+        Preconditions.checkState(!hasElse);
+        hasElse = true;
+        arguments.add(elseClause);
     }
 
     // must after call hasCase

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
@@ -77,6 +77,14 @@ public class CaseWhenOperator extends CallOperator {
         return hasElse;
     }
 
+    /**
+     * Remove the ELSE-clause, but not set the hasElse state
+     */
+    public void removeElseClause() {
+        Preconditions.checkState(hasElse);
+        arguments.remove(arguments.size() - 1);
+    }
+
     // must after call hasElse
     public void setElseClause(ScalarOperator elseClause) {
         Preconditions.checkState(hasElse);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -171,6 +171,23 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             }
         }
 
+        // If the operator has constant WHEN TRUE, the following WHEN/ELSE is meaningless
+        // E.g. CASE WHEN random() > 1 THEN 1 WHEN TRUE THEN 2 ELSE 10 END
+        // ---> CASE WHEN random() > 1 THEN 1 ELSE 2 END
+        for (int i = 0; i < operator.getWhenClauseSize(); ++i) {
+            if (operator.getWhenClause(i).isConstantTrue()) {
+                for (int j = i + 1; j < operator.getWhenClauseSize(); j++) {
+                    removeArgumentsSet.add(2 * j + whenStart);
+                    removeArgumentsSet.add(2 * j + whenStart + 1);
+                }
+                if (operator.hasElse()) {
+                    operator.removeElseClause();
+                }
+                operator.setElseClause(operator.getThenClause(i));
+                break;
+            }
+        }
+
         for (int i = 0; i < operator.getWhenClauseSize(); ++i) {
             if (operator.getWhenClause(i).isConstantRef()) {
                 ConstantOperator when = (ConstantOperator) operator.getWhenClause(i);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1061,7 +1061,7 @@ public class ExpressionTest extends PlanTestBase {
         // 1.8 test when true in the middle not return directly
         String sql18 = "select case when substr(k7,2,1) then 3 when true then 1 else 2 end as col16 from test.baseall;";
         Assert.assertTrue(StringUtils.containsIgnoreCase(getFragmentPlan(sql18),
-                "CASE WHEN CAST(substr(9: k7, 2, 1) AS BOOLEAN) THEN 3 WHEN TRUE THEN 1 ELSE 2 END"));
+                "if(CAST(substr(9: k7, 2, 1) AS BOOLEAN), 3, 1)"));
 
         // 1.9 test remove when clause when is false/null
         String sql19 = "select case when substr(k7,2,1) then 3 " +


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Simplify the `case when xxx then xx when true then xxx end` expression
- Since `WHEN TRUE` is always true, we can remove the `WHEN` after that 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
