### PR TITLE
[Enhancement] support strict segment count restriction in lake compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1438,4 +1438,10 @@ CONF_mInt32(thrift_max_frame_size, "16384000");
 // allows for structures nested up to 64 levels deep.
 CONF_mInt32(thrift_max_recursion_depth, "64");
 
+// if turned on, each compaction will use at most `max_cumulative_compaction_num_singleton_deltas` segments,
+// for now, only support non-pk LAKE compaction in size tierd compaction.
+CONF_mBool(enable_lake_compaction_use_partial_segments, "false");
+// chunk size used by lake compaction
+CONF_mInt32(lake_compaction_chunk_size, "4096");
+
 } // namespace starrocks::config

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -26,11 +26,13 @@
 
 namespace starrocks {
 class TxnLogPB;
-}
+class TxnLogPB_OpCompaction;
+} // namespace starrocks
 
 namespace starrocks::lake {
 
 class Rowset;
+class TabletWriter;
 
 class CompactionTask {
 public:
@@ -48,6 +50,8 @@ public:
 
     inline static const CancelFunc kNoCancelFn = []() { return Status::OK(); };
     inline static const CancelFunc kCancelledFn = []() { return Status::Aborted(""); };
+
+    Status fill_compaction_segment_info(TxnLogPB_OpCompaction* op_compaction, TabletWriter* writer);
 
 protected:
     int64_t _txn_id;

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -122,19 +122,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     auto op_compaction = txn_log->mutable_op_compaction();
     txn_log->set_tablet_id(_tablet.id());
     txn_log->set_txn_id(_txn_id);
-    for (auto& rowset : _input_rowsets) {
-        op_compaction->add_input_rowsets(rowset->id());
-    }
-
-    for (auto& file : writer->files()) {
-        op_compaction->mutable_output_rowset()->add_segments(file.path);
-        op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
-        op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
-    }
-
-    op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
-    op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
-    op_compaction->mutable_output_rowset()->set_overlapped(false);
+    RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
     op_compaction->set_compact_version(_tablet.metadata()->version());
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
@@ -151,6 +139,12 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
 }
 
 StatusOr<int32_t> HorizontalCompactionTask::calculate_chunk_size() {
+    if (_input_rowsets.size() > 0 && _input_rowsets.back()->partial_segments_compaction()) {
+        // can not call `get_read_chunk_size`, for example, if `total_input_segs` is shrinked to half,
+        // read_chunk_size might be doubled, in this case, this optimization will not take effect
+        return config::lake_compaction_chunk_size;
+    }
+
     int64_t total_num_rows = 0;
     int64_t total_input_segs = 0;
     int64_t total_mem_footprint = 0;
@@ -172,8 +166,10 @@ StatusOr<int32_t> HorizontalCompactionTask::calculate_chunk_size() {
             }
         }
     }
-    return CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker, config::vector_chunk_size,
-                                                total_num_rows, total_mem_footprint, total_input_segs);
+
+    return CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker,
+                                                config::lake_compaction_chunk_size, total_num_rows, total_mem_footprint,
+                                                total_input_segs);
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -209,6 +209,47 @@ void MetaFileBuilder::_collect_del_files_above_rebuild_point(RowsetMetadataPB* r
     }
 }
 
+// check the last input rowset to determine whether this is partial compaction,
+// if is, modify last intput rowset `segments` info, for example, following
+// `e` and `f` will be removed from last input rowset.
+// before(last rowset input segments): x y a b c d e f
+// segments in compaction: a b c d
+// output segments:                    x y m n e f
+// after (last rowset input segments): a b c d
+void trim_partial_compaction_last_input_rowset(const MutableTabletMetadataPtr& metadata,
+                                               const TxnLogPB_OpCompaction& op_compaction,
+                                               RowsetMetadataPB& last_input_rowset) {
+    if (op_compaction.input_rowsets_size() < 1) {
+        return;
+    }
+    if (op_compaction.input_rowsets(op_compaction.input_rowsets_size() - 1) != last_input_rowset.id()) {
+        return;
+    }
+    if (op_compaction.has_output_rowset() && op_compaction.output_rowset().segments_size() > 0 &&
+        last_input_rowset.segments_size() > 0) {
+        // iterate all segments in last input rowset, find if any of them exists in
+        // compaction output rowset, if is, erase them from last input rowset
+        size_t before = last_input_rowset.segments_size();
+        auto iter = last_input_rowset.mutable_segments()->begin();
+        while (iter != last_input_rowset.mutable_segments()->end()) {
+            auto it = std::find_if(op_compaction.output_rowset().segments().begin(),
+                                   op_compaction.output_rowset().segments().end(),
+                                   [iter](const std::string& segment) { return *iter == segment; });
+            if (it != op_compaction.output_rowset().segments().end()) {
+                iter = last_input_rowset.mutable_segments()->erase(iter);
+            } else {
+                ++iter;
+            }
+        }
+        size_t after = last_input_rowset.segments_size();
+        if (after - before > 0) {
+            LOG(INFO) << "find partial compaction, tablet: " << metadata->id() << ", version: " << metadata->version()
+                      << ", last input rowset id: " << last_input_rowset.id()
+                      << ", uncompacted segment count: " << (before - after);
+        }
+    }
+}
+
 void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction,
                                          uint32_t max_compact_input_rowset_id, int64_t output_rowset_schema_id) {
     // delete input rowsets

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -93,5 +93,9 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, ui
 bool is_primary_key(TabletMetadata* metadata);
 bool is_primary_key(const TabletMetadata& metadata);
 
+void trim_partial_compaction_last_input_rowset(const MutableTabletMetadataPtr& metadata,
+                                               const TxnLogPB_OpCompaction& op_compaction,
+                                               RowsetMetadataPB& last_input_rowset);
+
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -158,7 +158,8 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(
     ASSIGN_OR_RETURN(auto rowset_indexes, pick_rowset_indexes(tablet_metadata, calc_score, has_dels));
     input_rowsets.reserve(rowset_indexes.size());
     for (auto rowset_index : rowset_indexes) {
-        input_rowsets.emplace_back(std::make_shared<Rowset>(_tablet_mgr, tablet_metadata, rowset_index));
+        input_rowsets.emplace_back(
+                std::make_shared<Rowset>(_tablet_mgr, tablet_metadata, rowset_index, 0 /* compaction_segment_limit */));
     }
     VLOG(2) << strings::Substitute(
             "lake PrimaryCompactionPolicy pick_rowsets tabletid:$0 version:$1 inputs:$2", tablet_metadata->id(),

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -20,6 +20,7 @@
 #include "storage/delete_predicates.h"
 #include "storage/lake/column_mode_partial_update_handler.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
 #include "storage/projection_iterator.h"
 #include "storage/rowset/rowid_range_option.h"
@@ -29,6 +30,7 @@
 #include "storage/rowset/short_key_range_option.h"
 #include "storage/tablet_schema_map.h"
 #include "storage/union_iterator.h"
+#include "types/logical_type.h"
 
 namespace starrocks::lake {
 
@@ -38,14 +40,19 @@ Rowset::Rowset(TabletManager* tablet_mgr, int64_t tablet_id, const RowsetMetadat
           _tablet_id(tablet_id),
           _metadata(metadata),
           _index(index),
-          _tablet_schema(std::move(tablet_schema)) {}
+          _tablet_schema(std::move(tablet_schema)),
+          _parallel_load(config::enable_load_segment_parallel),
+          _compaction_segment_limit(0) {}
 
-Rowset::Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int rowset_index)
+Rowset::Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int rowset_index,
+               size_t compaction_segment_limit)
         : _tablet_mgr(tablet_mgr),
           _tablet_id(tablet_metadata->id()),
           _metadata(&tablet_metadata->rowsets(rowset_index)),
           _index(rowset_index),
-          _tablet_metadata(std::move(tablet_metadata)) {
+          _tablet_metadata(std::move(tablet_metadata)),
+          _parallel_load(config::enable_load_segment_parallel),
+          _compaction_segment_limit(0) {
     auto rowset_id = _tablet_metadata->rowsets(rowset_index).id();
     if (_tablet_metadata->rowset_to_schema().empty() ||
         _tablet_metadata->rowset_to_schema().find(rowset_id) == _tablet_metadata->rowset_to_schema().end()) {
@@ -56,6 +63,23 @@ Rowset::Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int
         _tablet_schema =
                 GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->historical_schemas().at(schema_id)).first;
     }
+
+    // if segments are loaded in parallel, can not perform partial compaction, since
+    // loaded segments might not be in the same sequence than that in rowset metadata
+    if (is_overlapped() && compaction_segment_limit > 0 && !_parallel_load) {
+        // check if ouput schema has `struct` column, if is, do not perform partial compaction
+        bool skip_limit = false;
+        for (const auto& column : _tablet_schema->columns()) {
+            if (column.type() == LogicalType::TYPE_STRUCT) {
+                skip_limit = true;
+                break;
+            }
+        }
+        _compaction_segment_limit = skip_limit ? 0 : compaction_segment_limit;
+    } else {
+        // every segment will be used
+        _compaction_segment_limit = 0;
+    }
 }
 
 Rowset::~Rowset() {
@@ -65,6 +89,83 @@ Rowset::~Rowset() {
         DCHECK_EQ(_metadata, &_tablet_metadata->rowsets(_index))
                 << "tablet metadata been modified during rowset been destroyed";
     }
+}
+
+Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_compaction, TabletWriter* writer,
+                                                    uint64_t& uncompacted_num_rows, uint64_t& uncompacted_data_size) {
+    DCHECK(partial_segments_compaction());
+
+    std::vector<SegmentPtr> segments;
+    std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>> not_used_segments;
+    LakeIOOptions lake_io_opts{.fill_data_cache = true};
+    RETURN_IF_ERROR(load_segments(&segments, lake_io_opts, true /* fill_metadata_cache */, &not_used_segments));
+
+    bool clear_file_size_info = false;
+    bool clear_encryption_meta = (metadata().segments_size() != metadata().segment_encryption_metas_size());
+
+    // 1. add already compacted segments first
+    auto& already_compacted_segments = not_used_segments.first;
+    for (size_t i = 0; i < metadata().next_compaction_offset(); ++i) {
+        op_compaction->mutable_output_rowset()->add_segments(metadata().segments(i));
+        StatusOr<int64_t> size_or = already_compacted_segments[i]->get_data_size();
+        int64_t file_size = 0;
+        if (size_or.ok()) {
+            file_size = *size_or;
+            op_compaction->mutable_output_rowset()->add_segment_size(file_size);
+        } else {
+            clear_file_size_info = true;
+            LOG(WARNING) << "unable to get file size for segment " << metadata().segments(i) << " for tablet "
+                         << _tablet_id << " when collecting uncompacted segment info, error: " << size_or.status();
+        }
+        if (!clear_encryption_meta) {
+            op_compaction->mutable_output_rowset()->add_segment_encryption_metas(
+                    metadata().segment_encryption_metas(i));
+        }
+
+        uncompacted_num_rows += already_compacted_segments[i]->num_rows();
+        uncompacted_data_size += file_size;
+    }
+
+    // 2. add compacted segments in this round
+    for (auto& file : writer->files()) {
+        op_compaction->mutable_output_rowset()->add_segments(file.path);
+        op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
+        op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
+    }
+
+    // 3. set next compaction offset
+    op_compaction->mutable_output_rowset()->set_next_compaction_offset(op_compaction->output_rowset().segments_size());
+
+    // 4. add uncompacted segments
+    auto& uncompacted_segments = not_used_segments.second;
+    for (size_t i = metadata().next_compaction_offset() + _compaction_segment_limit, idx = 0;
+         i < metadata().segments_size(); ++i, ++idx) {
+        op_compaction->mutable_output_rowset()->add_segments(metadata().segments(i));
+        StatusOr<int64_t> size_or = uncompacted_segments[idx]->get_data_size();
+        int64_t file_size = 0;
+        if (size_or.ok()) {
+            file_size = *size_or;
+            op_compaction->mutable_output_rowset()->add_segment_size(file_size);
+        } else {
+            clear_file_size_info = true;
+            LOG(WARNING) << "unable to get file size for segment " << metadata().segments(i) << " for tablet "
+                         << _tablet_id << " when collecting uncompacted segment info, error: " << size_or.status();
+        }
+        if (!clear_encryption_meta) {
+            op_compaction->mutable_output_rowset()->add_segment_encryption_metas(
+                    metadata().segment_encryption_metas(i));
+        }
+
+        uncompacted_num_rows += uncompacted_segments[idx]->num_rows();
+        uncompacted_data_size += file_size;
+    }
+    if (clear_file_size_info) {
+        op_compaction->mutable_output_rowset()->mutable_segment_size()->Clear();
+    }
+    if (clear_encryption_meta) {
+        op_compaction->mutable_output_rowset()->mutable_segment_encryption_metas()->Clear();
+    }
+    return Status::OK();
 }
 
 StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const RowsetReadOptions& options) {
@@ -123,7 +224,6 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     }
 
     std::vector<ChunkIteratorPtr> segment_iterators;
-    segment_iterators.reserve(num_segments());
     if (options.stats) {
         options.stats->segments_read_count += num_segments();
     }
@@ -271,17 +371,18 @@ StatusOr<std::vector<SegmentPtr>> Rowset::segments(bool fill_cache) {
 
 StatusOr<std::vector<SegmentPtr>> Rowset::segments(const LakeIOOptions& lake_io_opts, bool fill_metadata_cache) {
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(load_segments(&segments, lake_io_opts, fill_metadata_cache));
+    RETURN_IF_ERROR(load_segments(&segments, lake_io_opts, fill_metadata_cache, nullptr));
     return segments;
 }
 
 Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_cache, int64_t buffer_size) {
     LakeIOOptions lake_io_opts{.fill_data_cache = fill_cache, .buffer_size = buffer_size};
-    return load_segments(segments, lake_io_opts, fill_cache);
+    return load_segments(segments, lake_io_opts, fill_cache, nullptr);
 }
 
 Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOptions& lake_io_opts,
-                             bool fill_metadata_cache) {
+                             bool fill_metadata_cache,
+                             std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>>* not_used_segments) {
 #ifndef BE_TEST
     RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("LoadSegments"));
 #endif
@@ -333,7 +434,7 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
         }
         index++;
 
-        if (config::enable_load_segment_parallel) {
+        if (_parallel_load) {
             auto task = std::make_shared<std::packaged_task<std::pair<StatusOr<SegmentPtr>, std::string>()>>([=]() {
                 auto result = _tablet_mgr->load_segment(segment_info, seg_id, lake_io_opts, fill_metadata_cache,
                                                         _tablet_schema);
@@ -370,6 +471,29 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
             return status;
         }
     }
+
+    // if this is for partial compaction, erase segments that are alreagy compacted and segments
+    // that are not compacted but exceeds compaction limit
+    if (partial_segments_compaction()) {
+        if (not_used_segments) {
+            not_used_segments->first.insert(not_used_segments->first.begin(), segments->begin(),
+                                            segments->begin() + metadata().next_compaction_offset());
+            not_used_segments->second.insert(
+                    not_used_segments->second.begin(),
+                    segments->begin() + metadata().next_compaction_offset() + _compaction_segment_limit,
+                    segments->end());
+            LOG(INFO) << "tablet: " << tablet_id() << ", version: " << version() << ", rowset: " << metadata().id()
+                      << ", total segments: " << metadata().segments_size()
+                      << ", compacted segments: " << not_used_segments->first.size()
+                      << ", uncompacted segments: " << not_used_segments->second.size();
+        }
+
+        // trim compacted segments
+        segments->erase(segments->begin(), segments->begin() + metadata().next_compaction_offset());
+        // trim uncompacted segments
+        segments->resize(_compaction_segment_limit);
+    }
+
     return Status::OK();
 }
 

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -26,6 +26,7 @@ namespace starrocks::lake {
 
 class MetaFileBuilder;
 class TabletManager;
+class TabletWriter;
 
 class Rowset : public BaseRowset {
 public:
@@ -44,7 +45,8 @@ public:
     // Requires:
     //  - |tablet_mgr| and |tablet_metadata| is not nullptr
     //  - 0 <= |rowset_index| && |rowset_index| < tablet_metadata->rowsets_size()
-    explicit Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int rowset_index);
+    explicit Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int rowset_index,
+                    size_t compaction_segment_limit);
 
     virtual ~Rowset();
 
@@ -76,7 +78,17 @@ public:
 
     [[nodiscard]] bool is_overlapped() const override { return metadata().overlapped(); }
 
-    [[nodiscard]] int64_t num_segments() const { return metadata().segments_size(); }
+    // if _compaction_segment_limit is set > 0, it means only partial segments will be used
+    [[nodiscard]] int64_t num_segments() const {
+        return _compaction_segment_limit > 0 ? _compaction_segment_limit : metadata().segments_size();
+    }
+
+    // only used in compaction
+    [[nodiscard]] bool partial_segments_compaction() const { return _compaction_segment_limit > 0; }
+    // only used in compaction
+    [[nodiscard]] Status add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_compaction,
+                                                              TabletWriter* writer, uint64_t& uncompacted_num_rows,
+                                                              uint64_t& uncompacted_data_size);
 
     [[nodiscard]] int64_t num_rows() const override { return metadata().num_rows(); }
 
@@ -101,8 +113,8 @@ public:
     // `fill_cache` controls `fill_data_cache` and `fill_meta_cache`
     Status load_segments(std::vector<SegmentPtr>* segments, bool fill_cache, int64_t buffer_size = -1);
 
-    Status load_segments(std::vector<SegmentPtr>* segments, const LakeIOOptions& lake_io_opts,
-                         bool fill_metadata_cache);
+    Status load_segments(std::vector<SegmentPtr>* segments, const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
+                         std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>>* not_used_segments);
 
     int64_t tablet_id() const { return _tablet_id; }
 
@@ -116,13 +128,18 @@ private:
     TabletSchemaPtr _tablet_schema;
     TabletMetadataPtr _tablet_metadata;
     std::vector<SegmentSharedPtr> _segments;
+    bool _parallel_load;
+    // only takes effect when rowset is overlapped, tells how many segments will be used in compaction,
+    // default is 0 means every segment will be used.
+    // only used for compaction
+    size_t _compaction_segment_limit;
 };
 
 inline std::vector<RowsetPtr> Rowset::get_rowsets(TabletManager* tablet_mgr, const TabletMetadataPtr& tablet_metadata) {
     std::vector<RowsetPtr> rowsets;
     rowsets.reserve(tablet_metadata->rowsets_size());
     for (int i = 0, size = tablet_metadata->rowsets_size(); i < size; ++i) {
-        auto rowset = std::make_shared<Rowset>(tablet_mgr, tablet_metadata, i);
+        auto rowset = std::make_shared<Rowset>(tablet_mgr, tablet_metadata, i, 0 /* compaction_segment_limit */);
         rowsets.emplace_back(std::move(rowset));
     }
     return rowsets;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -745,6 +745,10 @@ StatusOr<VersionedTablet> TabletManager::get_tablet(int64_t tablet_id, int64_t v
 StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
                                                  const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
                                                  TabletSchemaPtr tablet_schema) {
+    // NOTE: if partial compaction is turned on, `segment_id` might not be the same as cached segment id
+    //       for example, in tablet X, segment `a` has segment id 10, if partial compaction happens,
+    //                    in tablet X+1, segment `a` might still exists, but its actual id will not be 10.
+    //       but in meta cache, segment `a` still has segment id 10, it is not changed.
     auto segment = metacache()->lookup_segment(segment_info.path);
     if (segment == nullptr) {
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_info.path));

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -434,10 +434,18 @@ private:
                                                      input_rowsets_id, _metadata.get()));
         int64_t output_rowset_schema_id = tablet_schema->id();
 
-        const auto end_input_pos = pre_input_pos + 1;
+        auto last_input_pos = pre_input_pos;
+        RowsetMetadataPB last_input_rowset = *last_input_pos;
+        trim_partial_compaction_last_input_rowset(_metadata, op_compaction, last_input_rowset);
 
+        const auto end_input_pos = pre_input_pos + 1;
         for (auto iter = first_input_pos; iter != end_input_pos; ++iter) {
-            _metadata->mutable_compaction_inputs()->Add(std::move(*iter));
+            if (iter != last_input_pos) {
+                _metadata->mutable_compaction_inputs()->Add(std::move(*iter));
+            } else {
+                // might be a partial compaction, use real last input rowset
+                _metadata->mutable_compaction_inputs()->Add(std::move(last_input_rowset));
+            }
         }
 
         auto first_idx = static_cast<uint32_t>(first_input_pos - _metadata->mutable_rowsets()->begin());

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -88,18 +88,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     auto op_compaction = txn_log->mutable_op_compaction();
     txn_log->set_tablet_id(_tablet.id());
     txn_log->set_txn_id(_txn_id);
-    for (auto& rowset : _input_rowsets) {
-        op_compaction->add_input_rowsets(rowset->id());
-    }
-    for (auto& file : writer->files()) {
-        op_compaction->mutable_output_rowset()->add_segments(std::move(file.path));
-        op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
-        op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
-    }
-
-    op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
-    op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
-    op_compaction->mutable_output_rowset()->set_overlapped(false);
+    RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
     op_compaction->set_compact_version(_tablet.metadata()->version());
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
@@ -117,6 +106,12 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
 
 StatusOr<int32_t> VerticalCompactionTask::calculate_chunk_size_for_column_group(
         const std::vector<uint32_t>& column_group) {
+    if (_input_rowsets.size() > 0 && _input_rowsets.back()->partial_segments_compaction()) {
+        // can not call `get_read_chunk_size`, for example, if `_total_input_segs` is shrinked to half,
+        // read_chunk_size might be doubled, in this case, this optimization will not take effect
+        return config::lake_compaction_chunk_size;
+    }
+
     int64_t total_mem_footprint = 0;
     for (auto& rowset : _input_rowsets) {
         // in vertical compaction, there may be a lot of column groups, it will waste a lot of time to
@@ -139,8 +134,9 @@ StatusOr<int32_t> VerticalCompactionTask::calculate_chunk_size_for_column_group(
             }
         }
     }
-    return CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker, config::vector_chunk_size,
-                                                _total_num_rows, total_mem_footprint, _total_input_segs);
+    return CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker,
+                                                config::lake_compaction_chunk_size, _total_num_rows,
+                                                total_mem_footprint, _total_input_segs);
 }
 
 Status VerticalCompactionTask::compact_column_group(bool is_key, int column_group_index, size_t column_group_size,

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -200,4 +200,44 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
     }
 }
 
+TEST_F(LakeRowsetTest, test_add_partial_compaction_segments_info) {
+    create_rowsets_for_testing();
+
+    auto rs = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 1 /* compaction_segment_limit */);
+    ASSERT_TRUE(rs->partial_segments_compaction());
+
+    ASSIGN_OR_ABORT(auto segments, rs->segments(false));
+
+    TxnLogPB_OpCompaction op_compaction;
+    uint64_t num_rows = 0;
+    uint64_t data_size = 0;
+    EXPECT_EQ(op_compaction.output_rowset().segments_size(), 0);
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+
+    // prepare writer
+    {
+        std::vector<int> k1{40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
+        std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(k1.data(), k1.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        Chunk chunk0({c0, c1}, _schema);
+
+        ASSERT_OK(writer->open());
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->finish());
+        ASSERT_EQ(1, writer->files().size());
+    }
+
+    EXPECT_TRUE(rs->add_partial_compaction_segments_info(&op_compaction, writer.get(), num_rows, data_size).ok());
+    EXPECT_EQ(op_compaction.output_rowset().segments_size(), 2);
+    EXPECT_TRUE(num_rows > 0);
+    EXPECT_TRUE(data_size > 0);
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -777,11 +777,11 @@ TEST_F(LakeTabletManagerTest, test_get_output_rorwset_schema) {
         }
     }
 
-    auto rs1 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 0);
-    auto rs2 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 1);
-    auto rs3 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 2);
-    auto rs4 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 3);
-    auto rs5 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 4);
+    auto rs1 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 0, 0 /* compaction_segment_limit */);
+    auto rs2 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 1, 0 /* compaction_segment_limit */);
+    auto rs3 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 2, 0 /* compaction_segment_limit */);
+    auto rs4 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 3, 0 /* compaction_segment_limit */);
+    auto rs5 = std::make_shared<lake::Rowset>(_tablet_manager, tablet_metadata, 4, 0 /* compaction_segment_limit */);
 
     {
         std::vector<uint32_t> input_rowsets;

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -682,7 +682,7 @@ TEST_F(LakeTabletReaderSpit, test_reader_split) {
 
         // construct rowid_range_option
         auto rowid_range_option = std::make_shared<RowidRangeOption>();
-        Rowset rowset(_tablet_mgr.get(), _tablet_metadata, 1);
+        Rowset rowset(_tablet_mgr.get(), _tablet_metadata, 1, 0 /* compaction_segment_limit */);
         auto segment = rowset.get_segments().back();
         auto sparse_range = std::make_shared<SparseRange<rowid_t>>(1, 21);
         rowid_range_option->add(&rowset, segment.get(), sparse_range, true);

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -104,6 +104,9 @@ message RowsetMetadataPB {
     // del_files are generated when pk table handle delete operation.
     repeated DelfileWithRowsetId del_files = 11;
     repeated bytes segment_encryption_metas = 12;
+    // set in partial compaction, indicate which segment index next compaction should start from
+    // only be set > 0 if `overlapped` is true
+    optional uint32 next_compaction_offset = 13;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. add  be config`enable_lake_compaction_use_partial_segments`, if set to `true`, each compaction will use at most `max_cumulative_compaction_num_singleton_deltas` segments. PK is not supported for now
2. add be config `lake_compaction_chunk_size` to control compaction chunk size independently

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
