### PR TITLE
[UT] Fix unstable FE UT QueryDumpActionTest (backport #48413)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -449,6 +449,43 @@ public abstract class StarRocksHttpTestCase {
     @Before
     public void setUp() {
         GlobalStateMgr globalStateMgr = newDelegateCatalog();
+        setUpWithGlobalStateMgr(globalStateMgr);
+    }
+
+    public void setUpWithCatalog() {
+        GlobalStateMgr globalStateMgr = newDelegateGlobalStateMgr();
+        setUpWithGlobalStateMgr(globalStateMgr);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            SchemaChangeHandler getSchemaChangeHandler() {
+                return new SchemaChangeHandler();
+            }
+
+            @Mock
+            MaterializedViewHandler getRollupHandler() {
+                return new MaterializedViewHandler();
+            }
+
+            @Mock
+            GlobalTransactionMgr getGlobalTransactionMgr() {
+                new MockUp<GlobalTransactionMgr>() {
+                    @Mock
+                    TransactionStatus getLabelState(long dbId, String label) {
+                        if (label == "a") {
+                            return TransactionStatus.PREPARED;
+                        } else {
+                            return TransactionStatus.PREPARE;
+                        }
+                    }
+                };
+
+                return new GlobalTransactionMgr(null);
+            }
+        };
+    }
+
+    private void setUpWithGlobalStateMgr(GlobalStateMgr globalStateMgr) {
         SystemInfoService systemInfoService = new SystemInfoService();
         TabletInvertedIndex tabletInvertedIndex = new TabletInvertedIndex();
         NodeMgr nodeMgr = new NodeMgr();
@@ -490,72 +527,6 @@ public abstract class StarRocksHttpTestCase {
                 globalStateMgr.isSafeMode();
                 minTimes = 0;
                 result = true;
-            }
-        };
-
-        new Expectations(nodeMgr) {
-            {
-                nodeMgr.getClusterInfo();
-                minTimes = 0;
-                result = systemInfoService;
-            }
-        };
-
-        assignBackends();
-        doSetUp();
-    }
-
-    public void setUpWithCatalog() {
-        GlobalStateMgr globalStateMgr = newDelegateGlobalStateMgr();
-        SystemInfoService systemInfoService = new SystemInfoService();
-        TabletInvertedIndex tabletInvertedIndex = new TabletInvertedIndex();
-        NodeMgr nodeMgr = new NodeMgr();
-
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            SchemaChangeHandler getSchemaChangeHandler() {
-                return new SchemaChangeHandler();
-            }
-
-            @Mock
-            MaterializedViewHandler getRollupHandler() {
-                return new MaterializedViewHandler();
-            }
-
-            @Mock
-            GlobalTransactionMgr getGlobalTransactionMgr() {
-                new MockUp<GlobalTransactionMgr>() {
-                    @Mock
-                    TransactionStatus getLabelState(long dbId, String label) {
-                        if (label == "a") {
-                            return TransactionStatus.PREPARED;
-                        } else {
-                            return TransactionStatus.PREPARE;
-                        }
-                    }
-                };
-
-                return new GlobalTransactionMgr(null);
-            }
-        };
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-            }
-        };
-
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getNodeMgr();
-                minTimes = 0;
-                result = nodeMgr;
-
-                globalStateMgr.getTabletInvertedIndex();
-                minTimes = 0;
-                result = tabletInvertedIndex;
             }
         };
 


### PR DESCRIPTION
CP from #48413.

## Why I'm doing:

```
Missing 1 invocation to:
com.starrocks.server.GlobalStateMgr#isLeader()
   on mock instance: com.starrocks.server.GlobalStateMgr@5de4b284
Caused by: Missing invocations
	at com.starrocks.metric.MetricRepo$13.getValue(MetricRepo.java:603)
	at com.starrocks.metric.MetricRepo$13.getValue(MetricRepo.java:600)
	at com.starrocks.metric.MetricCalculator.update(MetricCalculator.java:105)
	at com.starrocks.metric.MetricCalculator.run(MetricCalculator.java:61)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

The reason is that `@Before setUp()` mock `GlobalStateMgr` firstly, and then `setupWithCatalog` mock `GlobalStateMgr` again.

`@Before setUp()` mocks `GlobalStateMgr#isLeader`, but `setupWithCatalog` doesn't.

## What I'm doing:

Extract the common logic of `@Before setUp()` and `setupWithCatalog`, to avoid repeating the same codes and forgetting some mocks in one of them.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

