### PR TITLE
[BugFix] Fix several glue & s3 integration issues

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -22,6 +22,7 @@ import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
 import com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -161,7 +162,8 @@ public class HiveMetaClient {
             return (T) method.invoke(client.hiveClient, args);
         } catch (Throwable e) {
             LOG.error(messageIfError, e);
-            connectionException = new StarRocksConnectorException(messageIfError + ", msg: " + e.getMessage(), e.getCause());
+            connectionException = new StarRocksConnectorException(messageIfError + ", msg: " +
+                    ExceptionUtils.getRootCauseMessage(e), e);
             throw connectionException;
         } finally {
             if (client == null && connectionException != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/GlueMetastoreClientDelegate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/GlueMetastoreClientDelegate.java
@@ -496,7 +496,9 @@ public class GlueMetastoreClientDelegate {
             try {
                 wh.deleteDir(tblPath, true, ifPurge, getDatabase(dbName));
             } catch (Exception e) {
-                LOGGER.error("Unable to remove table directory " + tblPath, e);
+                String msg = "Unable to remove table directory " + tblPath;
+                LOGGER.error(msg, e);
+                throw new MetaException(msg + e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/ExpressionHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/ExpressionHelper.java
@@ -206,7 +206,7 @@ public final class ExpressionHelper {
     }
 
     private static boolean isQuotedType(String type) {
-        return QUOTED_TYPES.contains(type);
+        return QUOTED_TYPES.contains(type) || type.startsWith("varchar");
     }
 
     public static String replaceDoubleQuoteWithSingleQuotes(String s) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -103,7 +103,7 @@ public class HiveMetaClientTest {
         try {
             client.getAllDatabaseNames();
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Unable to instantiate"));
+            Assert.assertTrue(e.getMessage().contains("Invalid port 90303"));
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Retrieve the root excpetion message from a chain of exceptions. 
2. Fix hive sink (using glue) with partition column of string.
3. Fix dropping hive table does not report an error when deleteObject operation is not privileged. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
