### PR TITLE
[Enhancement] Initialize olap_reader without copying tablet schema

### DIFF
--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -246,6 +246,14 @@ FieldPtr Schema::get_field_by_name(const std::string& name) const {
     return idx == -1 ? nullptr : _fields[idx];
 }
 
+void Schema::set_field_by_name(FieldPtr field, const std::string& name) {
+    size_t idx = get_field_index_by_name(name);
+    if (idx == -1) {
+        return;
+    }
+    _fields[idx] = std::move(field);
+}
+
 void Schema::_build_index_map(const Fields& fields) {
     _name_to_index.reset(new std::unordered_map<std::string_view, size_t>());
     for (size_t i = 0; i < fields.size(); i++) {

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -88,6 +88,8 @@ public:
     // return null if name not found
     FieldPtr get_field_by_name(const std::string& name) const;
 
+    void set_field_by_name(FieldPtr field, const std::string& name);
+
     size_t get_field_index_by_name(const std::string& name) const;
 
     std::vector<ColumnId> field_column_ids(bool use_rowstore = false) const;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -391,7 +391,9 @@ Status OlapChunkSource::_prune_schema_by_access_paths(Schema* schema) {
             LOG(WARNING) << "failed to find column in schema: " << root;
             continue;
         }
-        RETURN_IF_ERROR(prune_field_by_access_paths(field.get(), path.get()));
+        auto new_field = std::make_shared<Field>(*field);
+        schema->set_field_by_name(new_field, root);
+        RETURN_IF_ERROR(prune_field_by_access_paths(new_field.get(), path.get()));
     }
 
     return Status::OK();
@@ -408,15 +410,21 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
 
     auto scope = IOProfiler::scope(IOProfiler::TAG_QUERY, _scan_range->tablet_id);
 
-    // if column_desc come from fe, reset tablet schema
-    if (_scan_node->thrift_olap_scan_node().__isset.columns_desc &&
-        !_scan_node->thrift_olap_scan_node().columns_desc.empty() &&
-        _scan_node->thrift_olap_scan_node().columns_desc[0].col_unique_id >= 0) {
-        _tablet_schema =
-                TabletSchema::copy(*_tablet->tablet_schema(), _scan_node->thrift_olap_scan_node().columns_desc);
-    } else {
-        // struct column prune will modify fields, so deep copy a new schema
-        _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema());
+    if (_scan_node->thrift_olap_scan_node().__isset.schema_id) {
+        _tablet_schema = GlobalTabletSchemaMap::Instance()->get(_scan_node->thrift_olap_scan_node().schema_id);
+    }
+
+    if (_tablet_schema == nullptr) {
+        // if column_desc come from fe, reset tablet schema
+        if (_scan_node->thrift_olap_scan_node().__isset.columns_desc &&
+            !_scan_node->thrift_olap_scan_node().columns_desc.empty() &&
+            _scan_node->thrift_olap_scan_node().columns_desc[0].col_unique_id >= 0) {
+            _tablet_schema =
+                    TabletSchema::copy(*_tablet->tablet_schema(), _scan_node->thrift_olap_scan_node().columns_desc);
+        } else {
+            // struct column prune will modify fields, so deep copy a new schema
+            _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema());
+        }
     }
 
     RETURN_IF_ERROR(_init_global_dicts(&_params));

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -391,6 +391,7 @@ Status OlapChunkSource::_prune_schema_by_access_paths(Schema* schema) {
             LOG(WARNING) << "failed to find column in schema: " << root;
             continue;
         }
+        // field maybe modified, so we need to deep copy
         auto new_field = std::make_shared<Field>(*field);
         schema->set_field_by_name(new_field, root);
         RETURN_IF_ERROR(prune_field_by_access_paths(new_field.get(), path.get()));
@@ -422,8 +423,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
             _tablet_schema =
                     TabletSchema::copy(*_tablet->tablet_schema(), _scan_node->thrift_olap_scan_node().columns_desc);
         } else {
-            // struct column prune will modify fields, so deep copy a new schema
-            _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema());
+            _tablet_schema = _tablet->tablet_schema();
         }
     }
 

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -49,12 +49,17 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
     RETURN_IF_ERROR(Expr::clone_if_not_exists(runtime_state, &_pool, *params.conjunct_ctxs, &_conjunct_ctxs));
     RETURN_IF_ERROR(_get_tablet(params.scan_range));
 
-    // if column_desc come from fe, reset tablet schema
-    if (_parent->_olap_scan_node.__isset.columns_desc && !_parent->_olap_scan_node.columns_desc.empty() &&
-        _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
-        _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), _parent->_olap_scan_node.columns_desc);
-    } else {
-        _tablet_schema = _tablet->tablet_schema();
+    if (_parent->_olap_scan_node.__isset_schema_id) {
+        _tablet_schema = GlobalTabletSchemaMap::Instance()->get(_parent->_olap_scan_node.schema_id);
+    }
+    if (_tablet_schema == nullptr) {
+        // if column_desc come from fe, reset tablet schema
+        if (_parent->_olap_scan_node.__isset.columns_desc && !_parent->_olap_scan_node.columns_desc.empty() &&
+            _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
+            _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), _parent->_olap_scan_node.columns_desc);
+        } else {
+            _tablet_schema = _tablet->tablet_schema();
+        }
     }
 
     RETURN_IF_ERROR(_init_unused_output_columns(*params.unused_output_columns));

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -49,17 +49,12 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
     RETURN_IF_ERROR(Expr::clone_if_not_exists(runtime_state, &_pool, *params.conjunct_ctxs, &_conjunct_ctxs));
     RETURN_IF_ERROR(_get_tablet(params.scan_range));
 
-    if (_parent->_olap_scan_node.__isset.schema_id) {
-        _tablet_schema = GlobalTabletSchemaMap::Instance()->get(_parent->_olap_scan_node.schema_id);
-    }
-    if (_tablet_schema == nullptr) {
-        // if column_desc come from fe, reset tablet schema
-        if (_parent->_olap_scan_node.__isset.columns_desc && !_parent->_olap_scan_node.columns_desc.empty() &&
-            _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
-            _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), _parent->_olap_scan_node.columns_desc);
-        } else {
-            _tablet_schema = _tablet->tablet_schema();
-        }
+    // if column_desc come from fe, reset tablet schema
+    if (_parent->_olap_scan_node.__isset.columns_desc && !_parent->_olap_scan_node.columns_desc.empty() &&
+        _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
+        _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), _parent->_olap_scan_node.columns_desc);
+    } else {
+        _tablet_schema = _tablet->tablet_schema();
     }
 
     RETURN_IF_ERROR(_init_unused_output_columns(*params.unused_output_columns));

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -49,7 +49,7 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
     RETURN_IF_ERROR(Expr::clone_if_not_exists(runtime_state, &_pool, *params.conjunct_ctxs, &_conjunct_ctxs));
     RETURN_IF_ERROR(_get_tablet(params.scan_range));
 
-    if (_parent->_olap_scan_node.__isset_schema_id) {
+    if (_parent->_olap_scan_node.__isset.schema_id) {
         _tablet_schema = GlobalTabletSchemaMap::Instance()->get(_parent->_olap_scan_node.schema_id);
     }
     if (_tablet_schema == nullptr) {

--- a/be/src/storage/tablet_schema_map.cpp
+++ b/be/src/storage/tablet_schema_map.cpp
@@ -180,15 +180,14 @@ void TabletSchemaMap::erase(SchemaId id) {
     }
 }
 
-TabletSchemaPtr TabletSchemaMap::get(SchemaId id) {
+TabletSchemaMap::TabletSchemaPtr TabletSchemaMap::get(SchemaId id) {
     MapShard* shard = get_shard(id);
     TabletSchemaPtr result = nullptr;
-    TabletSchemaPtr ptr = nullptr;
     {
         std::lock_guard l(shard->mtx);
         auto iter = shard->map.find(id);
         if (iter != shard->map.end()) {
-            result = it->second.tablet_schema.lock();
+            result = iter->second.tablet_schema.lock();
         }
     }
     return result;

--- a/be/src/storage/tablet_schema_map.cpp
+++ b/be/src/storage/tablet_schema_map.cpp
@@ -180,6 +180,20 @@ void TabletSchemaMap::erase(SchemaId id) {
     }
 }
 
+TabletSchemaPtr TabletSchemaMap::get(SchemaId id) {
+    MapShard* shard = get_shard(id);
+    TabletSchemaPtr result = nullptr;
+    TabletSchemaPtr ptr = nullptr;
+    {
+        std::lock_guard l(shard->mtx);
+        auto iter = shard->map.find(id);
+        if (iter != shard->map.end()) {
+            result = it->second.tablet_schema.lock();
+        }
+    }
+    return result;
+}
+
 bool TabletSchemaMap::contains(SchemaId id) const {
     const MapShard* shard = get_shard(id);
     std::lock_guard l(shard->mtx);

--- a/be/src/storage/tablet_schema_map.h
+++ b/be/src/storage/tablet_schema_map.h
@@ -60,6 +60,8 @@ public:
     // [thread-safe]
     void erase(SchemaId id);
 
+    TabletSchemaPtr get(SchemaId id);
+
     // Checks if there is an element with unique id equivalent to id in the container.
     //
     // Returns true if there is such an element, otherwise false.

--- a/be/test/storage/tablet_schema_map_test.cpp
+++ b/be/test/storage/tablet_schema_map_test.cpp
@@ -239,4 +239,25 @@ TEST_F(TabletSchemaMapTest, test_emplace_schema) {
     ASSERT_EQ(0, stats8.memory_usage);
 }
 
+TEST_F(TabletSchemaMapTest, test_get_erase) {
+    TabletSchemaMap schema_map;
+    auto src_schema_1 = _gen_schema(&schema_map, 1, 1);
+    auto src_schema_2 = _gen_schema(&schema_map, 2, 1);
+
+    auto get_schema_1 = schema_map.get(1);
+    ASSERT_TRUE(get_schema_1 == nullptr);
+
+    schema_map.emplace(src_schema_1);
+    get_schema_1 = schema_map.get(1);
+    ASSERT_TRUE(get_schema_1 != nullptr);
+    ASSERT_TRUE(get_schema_1->id() == 1);
+
+    auto get_schema_2 = schema_map.get(2);
+    ASSERT_TRUE(get_schema_2 == nullptr);
+
+    schema_map.erase(1);
+    auto get_schema_3 = schema_map.get(1);
+    ASSERT_TRUE(get_schema_3 == nullptr);
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -908,10 +908,12 @@ public class OlapScanNode extends ScanNode {
         List<TPrimitiveType> keyColumnTypes = new ArrayList<TPrimitiveType>();
         List<TColumn> columnsDesc = new ArrayList<TColumn>();
         Set<ColumnId> bfColumns = olapTable.getBfColumnIds();
+        long schemaId = -1;
 
         if (selectedIndexId != -1) {
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);
             if (indexMeta != null) {
+                schemaId = indexMeta.getSchemaId();
                 for (Column col : olapTable.getSchemaByIndexId(selectedIndexId)) {
                     TColumn tColumn = col.toThrift();
                     tColumn.setColumn_name(col.getColumnId().getId());
@@ -980,6 +982,7 @@ public class OlapScanNode extends ScanNode {
             msg.olap_scan_node =
                     new TOlapScanNode(desc.getId().asInt(), keyColumnNames, keyColumnTypes, isPreAggregation);
             msg.olap_scan_node.setColumns_desc(columnsDesc);
+            msg.olap_scan_node.setSchema_id(schemaId);
             msg.olap_scan_node.setSort_key_column_names(keyColumnNames);
             msg.olap_scan_node.setRollup_name(olapTable.getIndexNameById(selectedIndexId));
             if (!conjuncts.isEmpty()) {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -552,6 +552,7 @@ struct TOlapScanNode {
   34: optional bool partition_order_hint
   35: optional bool enable_prune_column_after_index_filter
   36: optional bool enable_gin_filter
+  37: optional i64 schema_id
 }
 
 struct TJDBCScanNode {


### PR DESCRIPTION
## Why I'm doing:
We will regenerate a new tablet schema according to column description and it will deep copy tablet schema. However, if we can find the specified tablet schema in BE, we do not need to deep copy the tablet schema. But here's a special case, when the read column include struct column and we enable prune for struct fields. We may modify the `field` during query which will modify the tablet schema. So we still need to deep copy the struct fields. 

When the query has a lot of tablet, deep copy tablet schema may take a lot of time.

## What I'm doing:
This pr does the following:
1. Add a schema id when we init `OlapScanNode` in FE.
2. Try to find the tablet schema with specified schema id and skip deep copy if find the specified tablet schema.
3. Only deep copy the struct field if needed.

In my test, create the following table and the time cost of init olap_reader can reduce 2x~3x
```
CREATE TABLE IF NOT EXISTS activity(
    account_id BIGINT,
    activity_date DATETIME,
    tenant_id BIGINT NOT NULL,
    activity_date_month DATETIME NOT NULL,
    id BIGINT,
    person_profile_id BIGINT,
    person_id BIGINT,
    program_id BIGINT,
    activity_type_id BIGINT,
    _dsp_demandbase_fee_micros_usd BIGINT,
    _dsp_media_cost_micros_usd BIGINT,
    _dsp_vendor_fee_micros_usd BIGINT,
    _dsp_pub_domain VARCHAR(1048576),
    _dsp_segment_tier VARCHAR(1048576),
    _dsp_user_id VARCHAR(1048576)
)
DUPLICATE KEY (account_id)
PARTITION by (tenant_id, activity_date_month)
DISTRIBUTED BY HASH(tenant_id, account_id) BUCKETS 25000
PROPERTIES (
    "replication_num" = "1"
);

// ingestion

 select account_id from activity where activity_date = "2024-03-01 12:00:00"  and account_id = 3;
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
