### PR TITLE
[Enhancement] support colocate restore in share nothing mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -687,7 +687,6 @@ public class RestoreJob extends AbstractJob {
                     // Table does not exist
                     OlapTable remoteOlapTbl = (OlapTable) remoteTbl;
 
-                    boolean isColocate = enableColocateRestore;
                     // Retain only expected restore partitions in this table;
                     Set<String> allPartNames = remoteOlapTbl.getPartitionNames();
                     for (String partName : allPartNames) {
@@ -696,7 +695,7 @@ public class RestoreJob extends AbstractJob {
                         }
                     }
 
-                    if (!isColocate) {
+                    if (!enableColocateRestore) {
                         remoteOlapTbl.setColocateGroup(null);
                     }
 
@@ -709,7 +708,7 @@ public class RestoreJob extends AbstractJob {
                     }
 
                     ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-                    if (isColocate && colocateTableIndex.isColocateTable(remoteOlapTbl.getId())) {
+                    if (enableColocateRestore && colocateTableIndex.isColocateTable(remoteOlapTbl.getId())) {
                         ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(remoteOlapTbl.getId());
                         List<List<Long>> backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
                         ColocatePersistInfo colocatePersistInfo = ColocatePersistInfo

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -55,6 +55,7 @@ import com.starrocks.backup.BackupJobInfo.BackupTabletInfo;
 import com.starrocks.backup.RestoreFileMapping.IdChain;
 import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.backup.mv.MvRestoreContext;
+import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DataProperty;
@@ -88,6 +89,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.fs.HdfsUtil;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.task.AgentBatchTask;
@@ -183,6 +185,9 @@ public class RestoreJob extends AbstractJob {
     @SerializedName(value = "snapshotInfos")
     protected com.google.common.collect.Table<Long, Long, SnapshotInfo> snapshotInfos = HashBasedTable.create();
 
+    @SerializedName(value = "colocatePersistInfos")
+    private List<ColocatePersistInfo> colocatePersistInfos = Lists.newArrayList();
+
     protected Map<Long, Long> unfinishedSignatureToId = Maps.newConcurrentMap();
 
     // store some remote table ids that is skipped to restore, eg: mv is active in local db
@@ -191,6 +196,8 @@ public class RestoreJob extends AbstractJob {
     private MvRestoreContext mvRestoreContext;
 
     private AgentBatchTask batchTask;
+
+    boolean enableColocateRestore = Config.enable_colocate_restore;
 
     public RestoreJob() {
         super(JobType.RESTORE);
@@ -546,6 +553,9 @@ public class RestoreJob extends AbstractJob {
                     OlapTable localOlapTbl = (OlapTable) localTbl;
                     OlapTable remoteOlapTbl = (OlapTable) remoteTbl;
 
+                    // disable colocate restore if the restored table has been existed
+                    remoteOlapTbl.setColocateGroup(null);
+
                     List<String> intersectPartNames = Lists.newArrayList();
                     Status st = localOlapTbl.getIntersectPartNamesWith(remoteOlapTbl, intersectPartNames);
                     if (!st.ok()) {
@@ -677,6 +687,7 @@ public class RestoreJob extends AbstractJob {
                     // Table does not exist
                     OlapTable remoteOlapTbl = (OlapTable) remoteTbl;
 
+                    boolean isColocate = enableColocateRestore;
                     // Retain only expected restore partitions in this table;
                     Set<String> allPartNames = remoteOlapTbl.getPartitionNames();
                     for (String partName : allPartNames) {
@@ -685,12 +696,25 @@ public class RestoreJob extends AbstractJob {
                         }
                     }
 
+                    if (!isColocate) {
+                        remoteOlapTbl.setColocateGroup(null);
+                    }
+
                     // reset all ids in this table
                     Status st = resetTableForRestore(remoteOlapTbl, db);
                     // TODO: delete the shards for lake table if it fails.
                     if (!st.ok()) {
                         status = st;
                         return;
+                    }
+
+                    ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+                    if (isColocate && colocateTableIndex.isColocateTable(remoteOlapTbl.getId())) {
+                        ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(remoteOlapTbl.getId());
+                        List<List<Long>> backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
+                        ColocatePersistInfo colocatePersistInfo = ColocatePersistInfo
+                                    .createForAddTable(groupId, remoteOlapTbl.getId(), backendsPerBucketSeq);
+                        colocatePersistInfos.add(colocatePersistInfo);
                     }
 
                     tblInfo.checkAndRecoverAutoIncrementId((Table) remoteOlapTbl);
@@ -997,7 +1021,7 @@ public class RestoreJob extends AbstractJob {
                 remoteIdx.clearTabletsForRestore();
                 // generate new table
                 status = remoteTbl.createTabletsForRestore(remotetabletSize, remoteIdx, globalStateMgr, restoreReplicationNum,
-                        visibleVersion, schemaHash, physicalPartition.getId(), physicalPartition.getShardGroupId());
+                        visibleVersion, schemaHash, physicalPartition.getId(), physicalPartition.getShardGroupId(), null);
                 if (!status.ok()) {
                     return null;
                 }
@@ -1139,6 +1163,9 @@ public class RestoreJob extends AbstractJob {
             state = RestoreJobState.DOWNLOAD;
 
             globalStateMgr.getEditLog().logRestoreJob(this);
+            for (ColocatePersistInfo colocatePersistInfo : colocatePersistInfos) {
+                GlobalStateMgr.getCurrentState().getEditLog().logColocateAddTable(colocatePersistInfo);
+            }
             LOG.info("finished making snapshots. {}", this);
             return;
         }
@@ -1650,6 +1677,15 @@ public class RestoreJob extends AbstractJob {
                 }
             } finally {
                 locker.unLockDatabase(db, LockType.WRITE);
+            }
+        }
+
+        for (ColocatePersistInfo colocatePersistInfo : colocatePersistInfos) {
+            for (Table restoreTbl : restoredTbls) {
+                if (restoreTbl instanceof OlapTable && restoreTbl.getId() == colocatePersistInfo.getTableId()) {
+                    GlobalStateMgr.getCurrentState().getColocateTableIndex()
+                                        .removeTable(restoreTbl.getId(), (OlapTable) restoreTbl, isReplay);
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -59,6 +59,7 @@ import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.backup.mv.MvBackupInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.binlog.BinlogConfig;
+import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.catalog.LocalTablet.TabletHealthStatus;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -836,6 +837,9 @@ public class OlapTable extends Table {
             }
         }
 
+        // reset replication number for olaptable
+        setReplicationNum((short) restoreReplicationNum);
+
         // for each partition, reset rollup index map
         for (Map.Entry<Long, Partition> entry : idToPartition.entrySet()) {
             Partition partition = entry.getValue();
@@ -858,7 +862,7 @@ public class OlapTable extends Table {
                     idx.clearTabletsForRestore();
                     Status status = createTabletsForRestore(tabletNum, idx, globalStateMgr,
                             partitionInfo.getReplicationNum(entry.getKey()), physicalPartition.getVisibleVersion(),
-                            schemaHash, physicalPartition.getId(), physicalPartition.getShardGroupId());
+                            schemaHash, physicalPartition.getId(), physicalPartition.getShardGroupId(), db);
                     if (!status.ok()) {
                         return status;
                     }
@@ -866,33 +870,93 @@ public class OlapTable extends Table {
             }
         }
 
-        // reset replication number for olaptable
-        setReplicationNum((short) restoreReplicationNum);
-
         return Status.OK;
     }
 
     public Status createTabletsForRestore(int tabletNum, MaterializedIndex index, GlobalStateMgr globalStateMgr,
                                           int replicationNum, long version, int schemaHash,
-                                          long partitionId, long shardGroupId) {
-        for (int i = 0; i < tabletNum; i++) {
-            long newTabletId = globalStateMgr.getNextId();
-            LocalTablet newTablet = new LocalTablet(newTabletId);
-            index.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
+                                          long partitionId, long shardGroupId, Database db) {
+        Preconditions.checkArgument(replicationNum > 0);
+        boolean isColocate = (this.colocateGroup != null && !this.colocateGroup.isEmpty() && db != null);
 
-            // replicas
-            List<Long> beIds = GlobalStateMgr.getCurrentState().getNodeMgr()
-                    .getClusterInfo().getNodeSelector().seqChooseBackendIds(replicationNum, true, true, getLocation());
-            if (CollectionUtils.isEmpty(beIds)) {
-                return new Status(ErrCode.COMMON_ERROR, "failed to find "
-                        + replicationNum
-                        + " different hosts to create table: " + name);
+        if (isColocate) {
+            try {
+                isColocate = GlobalStateMgr.getCurrentState().getColocateTableIndex()
+                                            .addTableToGroup(db, this, this.colocateGroup, false);
+            } catch (Exception e) {
+                return new Status(ErrCode.COMMON_ERROR,
+                    "check colocate restore failed, errmsg: " + e.getMessage() +
+                    ", you can disable colocate restore by turn off Config.enable_colocate_restore");
             }
-            for (Long beId : beIds) {
-                long newReplicaId = globalStateMgr.getNextId();
-                Replica replica = new Replica(newReplicaId, beId, ReplicaState.NORMAL,
-                        version, schemaHash);
-                newTablet.addReplica(replica, false/* update inverted index */);
+        }
+
+        if (isColocate) {
+            ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+            ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(this.id);
+            List<List<Long>> backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
+            boolean chooseBackendsArbitrary = backendsPerBucketSeq == null || backendsPerBucketSeq.isEmpty();
+    
+            if (chooseBackendsArbitrary) {
+                backendsPerBucketSeq = Lists.newArrayList();
+            }
+
+            for (int i = 0; i < tabletNum; ++i) {
+                long newTabletId = globalStateMgr.getNextId();
+                LocalTablet newTablet = new LocalTablet(newTabletId);
+                index.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
+    
+                // replicas
+                List<Long> beIds;
+                if (chooseBackendsArbitrary) {
+                    // This is the first colocate table in the group, or just a normal table,
+                    // randomly choose backends
+                    beIds = GlobalStateMgr.getCurrentState().getNodeMgr()
+                        .getClusterInfo().getNodeSelector().seqChooseBackendIds(replicationNum, true, true, getLocation());
+                    backendsPerBucketSeq.add(beIds);
+                } else {
+                    // get backends from existing backend sequence
+                    beIds = backendsPerBucketSeq.get(i);
+                }
+
+                if (CollectionUtils.isEmpty(beIds)) {
+                    return new Status(ErrCode.COMMON_ERROR, "failed to find "
+                            + replicationNum
+                            + " different hosts to create table: " + name);
+                }
+                for (Long beId : beIds) {
+                    long newReplicaId = globalStateMgr.getNextId();
+                    Replica replica = new Replica(newReplicaId, beId, ReplicaState.NORMAL,
+                            version, schemaHash);
+                    newTablet.addReplica(replica, false/* update inverted index */);
+                }
+                Preconditions.checkState(beIds.size() == replicationNum,
+                                         beIds.size() + " vs. " + replicationNum);
+            }
+
+            // first colocate table in CG
+            if (groupId != null && chooseBackendsArbitrary) {
+                colocateTableIndex.addBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
+            }
+        } else {
+            for (int i = 0; i < tabletNum; i++) {
+                long newTabletId = globalStateMgr.getNextId();
+                LocalTablet newTablet = new LocalTablet(newTabletId);
+                index.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
+    
+                // replicas
+                List<Long> beIds = GlobalStateMgr.getCurrentState().getNodeMgr()
+                        .getClusterInfo().getNodeSelector().seqChooseBackendIds(replicationNum, true, true, getLocation());
+                if (CollectionUtils.isEmpty(beIds)) {
+                    return new Status(ErrCode.COMMON_ERROR, "failed to find "
+                            + replicationNum
+                            + " different hosts to create table: " + name);
+                }
+                for (Long beId : beIds) {
+                    long newReplicaId = globalStateMgr.getNextId();
+                    Replica replica = new Replica(newReplicaId, beId, ReplicaState.NORMAL,
+                            version, schemaHash);
+                    newTablet.addReplica(replica, false/* update inverted index */);
+                }
             }
         }
         return Status.OK;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3066,4 +3066,9 @@ public class Config extends ConfigBase {
 
     @ConfField
     public static boolean enable_parser_context_cache = true;
+
+    // Whether restore tables into colocate group if the
+    // backuped table is colocated
+    @ConfField(mutable = true)
+    public static boolean enable_colocate_restore = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -24,6 +24,7 @@ import com.starrocks.alter.AlterJobV2Builder;
 import com.starrocks.backup.Status;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
@@ -172,7 +173,7 @@ public class LakeTable extends OlapTable {
     @Override
     public Status createTabletsForRestore(int tabletNum, MaterializedIndex index, GlobalStateMgr globalStateMgr,
                                           int replicationNum, long version, int schemaHash,
-                                          long partitionId, long shardGroupId) {
+                                          long partitionId, long shardGroupId, Database db) {
         FilePathInfo fsInfo = getPartitionFilePathInfo(partitionId);
         FileCacheInfo cacheInfo = getPartitionFileCacheInfo(partitionId);
         Map<String, String> properties = new HashMap<>();

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -568,54 +568,23 @@ public class RestoreJobTest {
             locker.unLockDatabase(db, LockType.READ);
         }
 
-        jobInfo = new BackupJobInfo();
-        jobInfo.backupTime = System.currentTimeMillis();
-        jobInfo.dbId = db.getId();
-        jobInfo.dbName = db.getFullName();
-        jobInfo.success = true;
+        expectedRestoreTbl.resetIdsForRestore(globalStateMgr, db, 3, null);
 
-        OlapTable tbl1 = new OlapTable(expectedRestoreTbl.getId(), expectedRestoreTbl.getName(),
-                expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
-                expectedRestoreTbl.getDefaultDistributionInfo());
-        tbl1.setColocateGroup("test_group");
+        new Expectations() {
+            {
+                try {
+                    GlobalStateMgr.getCurrentState().getColocateTableIndex()
+                            .addTableToGroup((Database) any, (OlapTable) any, (String) any, false);
+                } catch (Exception e) {
+                }
+                result = true;
+            }
+        };
+        expectedRestoreTbl.setColocateGroup("test_group");
+        expectedRestoreTbl.resetIdsForRestore(globalStateMgr, db, 3, null);
+        expectedRestoreTbl.resetIdsForRestore(globalStateMgr, db, 3, null);
 
-        OlapTable tbl2 = new OlapTable(expectedRestoreTbl.getId() + 1, expectedRestoreTbl.getName() + "x",
-                expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
-                expectedRestoreTbl.getDefaultDistributionInfo());
-        tbl1.setColocateGroup("test_group");
-
-        OlapTable tbl3 = new OlapTable(expectedRestoreTbl.getId() + 2, expectedRestoreTbl.getName() + "xx",
-                expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
-                expectedRestoreTbl.getDefaultDistributionInfo());
-        tbl1.setColocateGroup("");
-
-        BackupTableInfo tblInfo1 = new BackupTableInfo();
-        tblInfo1.id = tbl1.getId();
-        tblInfo1.name = tbl1.getName();
-        jobInfo.tables.put(tblInfo1.name, tblInfo1);
-
-    
-        BackupTableInfo tblInfo2 = new BackupTableInfo();
-        tblInfo2.id = tbl2.getId();
-        tblInfo2.name = tbl2.getName();
-        jobInfo.tables.put(tblInfo2.name, tblInfo2);
-
-        BackupTableInfo tblInfo3 = new BackupTableInfo();
-        tblInfo3.id = tbl3.getId();
-        tblInfo3.name = tbl3.getName();
-        jobInfo.tables.put(tblInfo3.name, tblInfo3);
-
-        List<Table> tbls = Lists.newArrayList();
-        tbls.add(tbl1);
-        tbls.add(tbl2);
-        tbls.add(tbl3);
-        backupMeta = new BackupMeta(tbls);
-
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
-        job.setRepo(repo);
-        job.run();
+        Config.enable_colocate_restore = false;
     }
 }
 


### PR DESCRIPTION
Support colocate restore in shared nothing mode as following:
1. If "colocate_with" is defined in table property for the snapshot table, StarRocks can
    restore the tablet following the distribution rule by the colocate group.
2. Use enable_colocate_restore(mutable) to control whether restore in colocate mode.
3. If enable_colocate_restore == true, StarRocks can only restore the tables in colocate mode
   if the table does not exist before restore

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
