### PR TITLE
[BugFix] fix the race condition of addPartition operation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -18,6 +18,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.common.AnalysisException;
@@ -33,6 +34,7 @@ import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.sql.ast.SinglePartitionDesc;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageMedium;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -144,6 +146,21 @@ public class ListPartitionInfo extends PartitionInfo {
 
     public Map<Long, List<LiteralExpr>> getLiteralExprValues() {
         return this.idToLiteralExprValues;
+    }
+
+    /**
+     * Return all unique values for specified partitionIds
+     */
+    public Set<LiteralExpr> getValuesSet(Set<Long> partitionIds) {
+        if (MapUtils.isEmpty(idToLiteralExprValues)) {
+            return Sets.newHashSet();
+        }
+        return idToLiteralExprValues
+                .entrySet()
+                .stream()
+                .filter(x -> partitionIds.contains(x.getKey()))
+                .flatMap(x -> x.getValue().stream())
+                .collect(Collectors.toSet());
     }
 
     public void setMultiValues(long partitionId, List<List<String>> multiValues) {


### PR DESCRIPTION
## Why I'm doing:
- `analyzeAddPartitionProperties` actually modify the state of `ListPartitionInfo`, but it's under ReadLock, so it would introduce a race condition on the `ListPartitionInfo`

## What I'm doing:
- Remove the modification by `setBatchLiteralExprValues`
    - it's totally unnecessary to change the LiteralValues since the `idToValues` is always consistent with `idToLiteralExprValues` 
- Simplify the code

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
