### PR TITLE
[BugFix] Make Broadcast Join generate deterministic GRF

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -318,13 +318,13 @@ int FragmentExecutor::_calc_query_expired_seconds(const UnifiedExecPlanFragmentP
     return QueryContext::DEFAULT_EXPIRE_SECONDS;
 }
 
-static void collect_shuffle_hash_bucket_rf_ids(const ExecNode* node, std::unordered_set<int32_t>& filter_ids) {
+static void collect_non_broadcast_rf_ids(const ExecNode* node, std::unordered_set<int32_t>& filter_ids) {
     for (const auto* child : node->children()) {
-        collect_shuffle_hash_bucket_rf_ids(child, filter_ids);
+        collect_non_broadcast_rf_ids(child, filter_ids);
     }
     if (node->type() == TPlanNodeType::HASH_JOIN_NODE) {
         const auto* join_node = down_cast<const HashJoinNode*>(node);
-        if (join_node->distribution_mode() == TJoinDistributionMode::SHUFFLE_HASH_BUCKET) {
+        if (join_node->distribution_mode() != TJoinDistributionMode::BROADCAST) {
             for (const auto* rf : join_node->build_runtime_filters()) {
                 filter_ids.insert(rf->filter_id());
             }
@@ -385,8 +385,8 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
             ExecNode::create_tree(runtime_state, obj_pool, _fragment_ctx->tplan(), desc_tbl, &_fragment_ctx->plan()));
     ExecNode* plan = _fragment_ctx->plan();
     std::unordered_set<int32_t> filter_ids;
-    collect_shuffle_hash_bucket_rf_ids(plan, filter_ids);
-    runtime_state->set_shuffle_hash_bucket_rf_ids(std::move(filter_ids));
+    collect_non_broadcast_rf_ids(plan, filter_ids);
+    runtime_state->set_non_broadcast_rf_ids(std::move(filter_ids));
     BroadcastJoinRightOffsprings broadcast_join_right_offsprings_map;
     collect_broadcast_join_right_offsprings(plan, broadcast_join_right_offsprings_map);
     runtime_state->set_broadcast_join_right_offsprings(std::move(broadcast_join_right_offsprings_map));

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -631,7 +631,7 @@ void RuntimeFilterProbeCollector::push_down(const RuntimeState* state, TPlanNode
             continue;
         }
         if (desc->is_bound(tuple_ids) && !(state->broadcast_join_right_offsprings().contains(target_plan_node_id) &&
-                                           state->shuffle_hash_bucket_rf_ids().contains(desc->filter_id()))) {
+                                           state->non_broadcast_rf_ids().contains(desc->filter_id()))) {
             add_descriptor(desc);
             if (desc->is_local()) {
                 local_rf_waiting_set.insert(desc->build_plan_node_id());

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -511,11 +511,11 @@ public:
 
     std::string_view get_sql_dialect() const { return _query_options.sql_dialect; }
 
-    void set_shuffle_hash_bucket_rf_ids(std::unordered_set<int32_t>&& filter_ids) {
-        this->_shuffle_hash_bucket_rf_ids = std::move(filter_ids);
+    void set_non_broadcast_rf_ids(std::unordered_set<int32_t>&& filter_ids) {
+        this->_non_broadcast_rf_ids = std::move(filter_ids);
     }
 
-    const std::unordered_set<int32_t>& shuffle_hash_bucket_rf_ids() const { return this->_shuffle_hash_bucket_rf_ids; }
+    const std::unordered_set<int32_t>& non_broadcast_rf_ids() const { return this->_non_broadcast_rf_ids; }
 
     void set_broadcast_join_right_offsprings(BroadcastJoinRightOffsprings&& broadcast_join_right_offsprings) {
         this->_broadcast_join_right_offsprings = std::move(broadcast_join_right_offsprings);
@@ -665,7 +665,7 @@ private:
 
     bool _enable_pipeline_engine = false;
 
-    std::unordered_set<int32_t> _shuffle_hash_bucket_rf_ids;
+    std::unordered_set<int32_t> _non_broadcast_rf_ids;
     BroadcastJoinRightOffsprings _broadcast_join_right_offsprings;
 
     std::optional<TSpillOptions> _spill_options;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -901,21 +901,31 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         }
     }
 
-
-    private RoaringBitmap collectShuffleHashBucketRfIds(PlanNode root) {
+    private RoaringBitmap collectNonBroadcastRfIds(PlanNode root) {
         RoaringBitmap filterIds = root.getChildren().stream()
                 .filter(child -> child.getFragmentId().equals(root.getFragmentId()))
-                .map(this::collectShuffleHashBucketRfIds)
+                .map(this::collectNonBroadcastRfIds)
                 .reduce(RoaringBitmap.bitmapOf(), (a, b) -> RoaringBitmap.or(a, b));
         if (root instanceof HashJoinNode) {
             HashJoinNode joinNode = (HashJoinNode) root;
-            if (joinNode.getDistrMode().equals(JoinNode.DistributionMode.SHUFFLE_HASH_BUCKET)) {
+            if (!joinNode.isBroadcast()) {
                 joinNode.getBuildRuntimeFilters().forEach(rf -> filterIds.add(rf.getFilterId()));
             }
         }
         return filterIds;
     }
 
+    /**
+     * In the same fragment, collect all nodes of the right subtree of BroadcastJoinNode that will build global RFs
+     * For example, the following plan will add 3 and 4 to {@code localRightOffsprings}.
+     * <pre>{@code
+     *       Broadcast Join#1
+     *        /        \
+     *      Node#2  ProjectNode#3
+     *                 |
+     *          ExchangeSourceNode#4
+     * }</pre>
+     */
     private RoaringBitmap collectLocalRightOffspringsOfBroadcastJoin(PlanNode root,
                                                                      RoaringBitmap localRightOffsprings) {
         List<RoaringBitmap> localOffspringsPerChild = root.getChildren().stream()
@@ -954,10 +964,12 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     public void removeRfOnRightOffspringsOfBroadcastJoin() {
         RoaringBitmap localRightOffsprings = RoaringBitmap.bitmapOf();
         collectLocalRightOffspringsOfBroadcastJoin(getPlanRoot(), localRightOffsprings);
-        RoaringBitmap filterIds = collectShuffleHashBucketRfIds(getPlanRoot());
+
+        RoaringBitmap filterIds = collectNonBroadcastRfIds(getPlanRoot());
         if (localRightOffsprings.isEmpty() || filterIds.isEmpty()) {
             return;
         }
+
         removeRfOfRightOffspring(getPlanRoot(), localRightOffsprings, filterIds);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RuntimeFilterTest.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RuntimeFilterTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+        connectContext.getSessionVariable().setGlobalRuntimeFilterProbeMinSize(0);
+    }
+
+    @Test
+    public void testDeterministicBroadcastJoinForColocateJoin() throws Exception {
+        String sql = "select * from \n" +
+                "  t0 vt1 join [bucket] t0 vt2 on vt1.v1 = vt2.v1\n" +
+                "  join [broadcast] t1 vt3 on vt1.v1 = vt3.v4\n" +
+                "  join [colocate] t0 vt4 on vt1.v1 = vt4.v1";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  6:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  equal join conjunct: [1: v1, BIGINT, true] = [7: v4, BIGINT, true]\n" +
+                "  |  build runtime filters:\n" +
+                "  |  - filter_id = 1, build_expr = (7: v4), remote = true\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  |----5:EXCHANGE\n" +
+                "  |       distribution type: BROADCAST\n" +
+                "  |       cardinality: 1");
+
+    }
+
+    @Test
+    public void testDeterministicBroadcastJoinForBroadcastJoin() throws Exception {
+        String sql = "select * from \n" +
+                "  t0 vt1 join [bucket] t0 vt2 on vt1.v1 = vt2.v1\n" +
+                "  join [broadcast] t1 vt3 on vt1.v1 = vt3.v4\n" +
+                "  join [broadcast] t0 vt4 on vt1.v1 = vt4.v1";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  |----5:EXCHANGE\n" +
+                "  |       distribution type: BROADCAST\n" +
+                "  |       cardinality: 1\n" +
+                "  |       probe runtime filters:\n" +
+                "  |       - filter_id = 2, probe_expr = (7: v4)");
+    }
+}

--- a/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/R/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
+++ b/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/R/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
@@ -46,3 +46,16 @@ order by k1;
 10
 20
 -- !result
+with 
+    w1 as (select vt1.k1, vt1.c1 from t1 vt1 join [bucket] t1 vt2 on vt1.k1 = vt2.k1),
+    w2 as (select vt1.k1 from w1 vt1 join [broadcast] t2 vt2 on vt1.k1 =vt2.k1 ),
+    w3_right as (select * from t1 where c1 in (1, 4, 10, 20)),
+    w3 as (select vt1.k1 from w2 vt1 join [broadcast] w3_right vt2 on vt1.k1 = vt2.k1)
+select * from w3
+order by k1;
+-- result:
+1
+4
+10
+20
+-- !result

--- a/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/R/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
+++ b/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/R/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
@@ -1,0 +1,48 @@
+-- name: test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE t2 (
+  k1 bigint NULL,
+  c1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from TABLE(generate_series(0, 100 - 1));
+-- result:
+-- !result
+insert into t2 select * from t1;
+-- result:
+-- !result
+set global_runtime_filter_probe_min_size = 0;
+-- result:
+-- !result
+set enable_group_execution = false;
+-- result:
+-- !result
+with 
+    w1 as (select vt1.k1, vt1.c1 from t1 vt1 join [bucket] t1 vt2 on vt1.k1 = vt2.k1),
+    w2 as (select vt1.k1 from w1 vt1 join [broadcast] t2 vt2 on vt1.k1 =vt2.k1 ),
+    w3_right as (select * from t1 where c1 in (1, 4, 10, 20)),
+    w3 as (select vt1.k1 from w2 vt1 join [colocate] w3_right vt2 on vt1.k1 = vt2.k1)
+select * from w3
+order by k1;
+-- result:
+1
+4
+10
+20
+-- !result

--- a/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/T/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
+++ b/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/T/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
@@ -1,0 +1,36 @@
+
+-- name: test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
+
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+CREATE TABLE t2 (
+  k1 bigint NULL,
+  c1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 select generate_series, generate_series from TABLE(generate_series(0, 100 - 1));
+insert into t2 select * from t1;
+
+set global_runtime_filter_probe_min_size = 0;
+set enable_group_execution = false;
+
+with 
+    w1 as (select vt1.k1, vt1.c1 from t1 vt1 join [bucket] t1 vt2 on vt1.k1 = vt2.k1),
+    w2 as (select vt1.k1 from w1 vt1 join [broadcast] t2 vt2 on vt1.k1 =vt2.k1 ),
+    w3_right as (select * from t1 where c1 in (1, 4, 10, 20)),
+    w3 as (select vt1.k1 from w2 vt1 join [colocate] w3_right vt2 on vt1.k1 = vt2.k1)
+select * from w3
+order by k1;

--- a/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/T/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
+++ b/test/sql/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf/T/test_runtime_filter_push_down_on_local_right_offsprings_of_broadcast_join_with_grf_for_colocate
@@ -34,3 +34,11 @@ with
     w3 as (select vt1.k1 from w2 vt1 join [colocate] w3_right vt2 on vt1.k1 = vt2.k1)
 select * from w3
 order by k1;
+
+with 
+    w1 as (select vt1.k1, vt1.c1 from t1 vt1 join [bucket] t1 vt2 on vt1.k1 = vt2.k1),
+    w2 as (select vt1.k1 from w1 vt1 join [broadcast] t2 vt2 on vt1.k1 =vt2.k1 ),
+    w3_right as (select * from t1 where c1 in (1, 4, 10, 20)),
+    w3 as (select vt1.k1 from w2 vt1 join [broadcast] w3_right vt2 on vt1.k1 = vt2.k1)
+select * from w3
+order by k1;


### PR DESCRIPTION
## Why I'm doing:

Broadcast join that produces global runtime filters must build the same hash table in each instance. Otherwise, they will produce different global RFs, which will cause the probe side node to incorrectly filter out data.

This constraint always holds until the ancestor node of the broadcast join is another join. In this case, the right table (exchange source) of the broadcast join will be filtered by the local RF generated by this join, resulting in different right tables of the broadcast join in each instance. The following figure show this case:

<img src="https://github.com/user-attachments/assets/d098c376-7740-4b1e-a0c4-6cc8f5916cdd" width="50%">

Typically, there are two cases that can cause this problem, as shown in the following two figures.

fig1:
<img src="https://github.com/user-attachments/assets/0211758e-608a-4234-8bac-ac060490a909" width="50%">

fig2:
<img src="https://github.com/user-attachments/assets/e40b23d1-09ef-4db3-8df2-1c0bdf894557" width="50%">


## What I'm doing:

When the broadcast join produces a global runtime filter, clear all runtime filters of the right subtree of the broadcast join in the same fragment.
In fact, we already have this logic, but it was previously limited to clearing only when the ancestor join of the broadcast join is `BUCKET SHUFFLE JOIN`. Now it is changed to clear when the ancestor join is not `BROADCAST JOIN`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
