### PR TITLE
[Enhancement]  support memory estimation of array_agg and group_concat state

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -463,6 +463,7 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
         }
         state->obj_pool()->add(_agg_fn_ctxs[i]);
         _agg_fn_ctxs[i]->set_mem_usage_counter(&_agg_state_mem_usage);
+        _agg_fn_ctxs[i]->set_agg_state_column_allocator(_allocator.get());
     }
 
     // save TFunction object

--- a/be/src/exprs/agg/aggregate_state_allocator.h
+++ b/be/src/exprs/agg/aggregate_state_allocator.h
@@ -17,6 +17,7 @@
 #include "column/hash_set.h"
 #include "common/config.h"
 #include "runtime/memory/allocator.h"
+#include "runtime/memory/column_allocator.h"
 #include "runtime/memory/roaring_hook.h"
 
 namespace starrocks {

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -23,6 +23,8 @@
 #include "exprs/agg/aggregate.h"
 #include "exprs/function_context.h"
 #include "runtime/mem_pool.h"
+#include "runtime/memory/column_allocator.h"
+#include "runtime/memory/counting_allocator.h"
 #include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 #include "util/defer_op.h"
@@ -180,10 +182,14 @@ public:
 // input columns result in intermediate result: struct{array[col0], array[col1], array[col2]... array[coln]}
 // return ordered array[col0']
 struct ArrayAggAggregateStateV2 {
-    void update(const Column& column, size_t index, size_t offset, size_t count) {
+    void update(FunctionContext* ctx, const Column& column, size_t index, size_t offset, size_t count) {
+        SCOPED_THREAD_LOCAL_COLUMN_ALLOCATOR_SETTER(ctx->agg_state_column_allocator());
         data_columns[index]->append(column, offset, count);
     }
-    void update_nulls(size_t index, size_t count) { data_columns[index]->append_nulls(count); }
+    void update_nulls(FunctionContext* ctx, size_t index, size_t count) {
+        SCOPED_THREAD_LOCAL_COLUMN_ALLOCATOR_SETTER(ctx->agg_state_column_allocator());
+        data_columns[index]->append_nulls(count);
+    }
 
     bool check_overflow(FunctionContext* ctx) const {
         std::string err_msg;
@@ -207,14 +213,34 @@ struct ArrayAggAggregateStateV2 {
     }
 
     // release the trailing N-1 order-by columns
-    void release_order_by_columns() {
+    void release_order_by_columns(FunctionContext* ctx) {
         if (data_columns.empty()) {
             return;
         }
+        SCOPED_THREAD_LOCAL_COLUMN_ALLOCATOR_SETTER(ctx->agg_state_column_allocator());
         for (auto i = 1; i < data_columns.size(); ++i) {
             data_columns[i].reset();
         }
         data_columns.resize(1);
+    }
+
+    void reset(FunctionContext* ctx) {
+        if (data_columns.empty()) {
+            return;
+        }
+
+        SCOPED_THREAD_LOCAL_COLUMN_ALLOCATOR_SETTER(ctx->agg_state_column_allocator());
+        for (auto& col : data_columns) {
+            col->resize(0);
+        }
+    }
+
+    void release(FunctionContext* ctx) {
+        SCOPED_THREAD_LOCAL_COLUMN_ALLOCATOR_SETTER(ctx->agg_state_column_allocator());
+        for (auto& col : data_columns) {
+            col.reset();
+        }
+        data_columns.clear();
     }
 
     // using pointer rather than vector to avoid variadic size
@@ -236,11 +262,7 @@ public:
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         auto& state_impl = this->data(state);
-        if (!state_impl.data_columns.empty()) {
-            for (auto& col : state_impl.data_columns) {
-                col->resize(0);
-            }
-        }
+        state_impl.reset(ctx);
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
@@ -252,7 +274,7 @@ public:
             }
             // TODO: update is random access, so we could not pre-reserve memory for State, which is the bottleneck
             if ((columns[i]->is_nullable() && columns[i]->is_null(row_num)) || columns[i]->only_null()) {
-                this->data(state).update_nulls(i, 1);
+                this->data(state).update_nulls(ctx, i, 1);
                 continue;
             }
             auto* data_col = columns[i];
@@ -262,7 +284,7 @@ public:
                 data_col = down_cast<const ConstColumn*>(columns[i])->data_column().get();
                 tmp_row_num = 0;
             }
-            this->data(state).update(*data_col, i, tmp_row_num, 1);
+            this->data(state).update(ctx, *data_col, i, tmp_row_num, 1);
         }
     }
 
@@ -272,7 +294,7 @@ public:
         for (auto i = 0; i < input_columns.size(); ++i) {
             auto array_column = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(input_columns[i].get()));
             auto& offsets = array_column->offsets().get_data();
-            this->data(state).update(array_column->elements(), i, offsets[row_num],
+            this->data(state).update(ctx, array_column->elements(), i, offsets[row_num],
                                      offsets[row_num + 1] - offsets[row_num]);
         }
     }
@@ -304,9 +326,8 @@ public:
             }
             auto& offsets = array_col->offsets_column()->get_data();
             offsets.push_back(offsets.back() + elem_size);
-            state_impl.data_columns[i].reset();
         }
-        state_impl.data_columns.clear();
+        state_impl.release(ctx);
 
         // should check overflow after append, otherwise the result column with multi row will be overflow.
         if (UNLIKELY(state_impl.check_overflow(*to, ctx))) {
@@ -348,7 +369,7 @@ public:
             Status st = sort_and_tie_columns(ctx->state()->cancelled_ref(), order_by_columns, sort_desc, &perm);
             // release order-by columns early
             order_by_columns.clear();
-            state_impl.release_order_by_columns();
+            state_impl.release_order_by_columns(ctx);
             if (UNLIKELY(ctx->state()->cancelled_ref())) {
                 ctx->set_error("array_agg detects cancelled.", false);
                 return;
@@ -410,7 +431,7 @@ public:
         } else {
             array_col->elements_column()->append_selective(*res, index);
         }
-        state_impl.data_columns.clear(); // early release memory
+        state_impl.release(ctx);
         auto& offsets = array_col->offsets_column()->get_data();
         offsets.push_back(offsets.back() + elem_size);
         // should check overflow after append, otherwise the result column with multi row will be overflow.

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -23,6 +23,9 @@
 #include <vector>
 
 #include "common/status.h"
+#include "runtime/memory/allocator.h"
+#include "runtime/memory/column_allocator.h"
+#include "runtime/memory/counting_allocator.h"
 #include "runtime/types.h"
 #include "types/logical_type.h"
 
@@ -151,6 +154,9 @@ public:
 
     void set_mem_usage_counter(int64_t* mem_usage_counter) { _mem_usage_counter = mem_usage_counter; }
 
+    void set_agg_state_column_allocator(Allocator* allocator) { _agg_state_column_allocator = allocator; }
+    Allocator* agg_state_column_allocator() { return _agg_state_column_allocator; }
+
     int64_t mem_usage() const {
         DCHECK(_mem_usage_counter);
         return *_mem_usage_counter;
@@ -216,6 +222,8 @@ private:
     // If it is not explicitly set externally (e.g. AggFuncBasedValueAggregator),
     // it will point to the internal _mem_usage
     int64_t* _mem_usage_counter = &_mem_usage;
+
+    Allocator* _agg_state_column_allocator = &kDefaultColumnAllocator;
 
     // UDAF Context
     std::unique_ptr<JavaUDAFContext> _jvm_udaf_ctxs;

--- a/be/src/runtime/memory/column_allocator.h
+++ b/be/src/runtime/memory/column_allocator.h
@@ -79,4 +79,10 @@ public:
 private:
     Allocator* _prev = nullptr;
 };
+
+#define SCOPED_THREAD_LOCAL_COLUMN_ALLOCATOR_SETTER(allocator) \
+    auto VARNAME_LINENUM(alloc_setter) = ThreadLocalColumnAllocatorSetter(allocator)
+
+;
+
 } // namespace starrocks

--- a/be/src/runtime/memory/counting_allocator.h
+++ b/be/src/runtime/memory/counting_allocator.h
@@ -18,7 +18,7 @@
 #include <memory>
 
 #include "common/compiler_util.h"
-#include "exprs/expr_context.h"
+#include "glog/logging.h"
 #include "runtime/memory/allocator.h"
 #include "runtime/memory/mem_hook_allocator.h"
 

--- a/be/src/types/hll_sketch.h
+++ b/be/src/types/hll_sketch.h
@@ -24,6 +24,7 @@
 #include "runtime/memory/counting_allocator.h"
 #include "runtime/memory/mem_chunk.h"
 #include "runtime/memory/mem_chunk_allocator.h"
+#include "types/constexpr.h"
 
 namespace starrocks {
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This is a part of #48195 follow-up work,
In this PR,  I support memory estimation of array_agg and group_concat.
These two states are somewhat similar, as they maintain their state internally through Columns.

Currently, the cost of obtaining the memory usage of a certain Column is very high, and we need to balance performance and memory statistics accuracy.

considering that these two functions just aggregates data into Column, does not perform deduplication operations, I directly use the size of the input column to estimate memory changes.

In the future, if our Column becomes an allocator aware structure, we can obtain memory usage at a very low cost.



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5