### PR TITLE
[Enhancement] Add exception stacktrace in orc reader to track exception

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -16,7 +16,6 @@
 
 #include <glog/logging.h>
 
-#include <boost/stacktrace.hpp>
 #include <exception>
 #include <set>
 #include <unordered_map>
@@ -36,6 +35,7 @@
 #include "orc_schema_builder.h"
 #include "simd/simd.h"
 #include "types/logical_type.h"
+#include "util/stack_util.cpp"
 #include "util/timezone_utils.h"
 
 namespace starrocks {
@@ -451,7 +451,7 @@ Status OrcChunkReader::read_next(orc::RowReader::ReadPosition* pos) {
             return Status::EndOfFile("");
         }
     } catch (std::exception& e) {
-        LOG(WARNING) << boost::stacktrace::stacktrace();
+        LOG(WARNING) << get_stack_trace();
         auto s = strings::Substitute("ORC reader read file $0 failed. Reason is $1.", _current_file_name, e.what());
         LOG(WARNING) << s;
         return Status::InternalError(s);

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -16,6 +16,7 @@
 
 #include <glog/logging.h>
 
+#include <boost/stacktrace.hpp>
 #include <exception>
 #include <set>
 #include <unordered_map>
@@ -450,6 +451,7 @@ Status OrcChunkReader::read_next(orc::RowReader::ReadPosition* pos) {
             return Status::EndOfFile("");
         }
     } catch (std::exception& e) {
+        LOG(WARNING) << boost::stacktrace::stacktrace();
         auto s = strings::Substitute("ORC reader read file $0 failed. Reason is $1.", _current_file_name, e.what());
         LOG(WARNING) << s;
         return Status::InternalError(s);


### PR DESCRIPTION
## Why I'm doing:
Can't locate the bug about `Reason is vector::_M_range_check: __n (which is 0) >= this->size() (which is 0).')`;

## What I'm doing:
add stack trace to locate the root cause.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
