### PR TITLE
[BugFix] Fix jdbc predicate on LargeStringLiteral

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.common.UserException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TJDBCScanNode;
 import com.starrocks.thrift.TPlanNode;
@@ -139,7 +140,7 @@ public class JDBCScanNode extends ScanNode {
 
         ArrayList<Expr> jdbcConjuncts = Expr.cloneList(conjuncts, sMap);
         for (Expr p : jdbcConjuncts) {
-            filters.add(p.toJDBCSQL());
+            filters.add(AstToStringBuilder.toString(p));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1165,6 +1165,8 @@ public class AstToStringBuilder {
         public String visitSlot(SlotRef node, Void context) {
             if (node.getTblNameWithoutAnalyzed() != null) {
                 return node.getTblNameWithoutAnalyzed().toString() + "." + node.getColumnName();
+            } else if (node.getLabel() != null) {
+                return node.getLabel();
             } else {
                 return node.getColumnName();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
@@ -14,6 +14,15 @@
 
 package com.starrocks.connector.jdbc;
 
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.LargeStringLiteral;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.TableName;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
+import com.starrocks.sql.parser.NodePosition;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -46,6 +55,26 @@ public class JDBCTableTest {
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();
+        }
+    }
+
+    @Test
+    public void testJDBCPredicateRewrite() {
+        {
+            Expr left = new SlotRef(new TableName("db", "tbl"), "k1");
+            Expr right = new LargeStringLiteral("main_interface_of_live#all_module#null#write_real_time_start#0",
+                    NodePosition.ZERO);
+            Expr expr = new BinaryPredicate(BinaryType.EQ, left, right);
+            String str = AstToStringBuilder.toString(expr);
+            Assert.assertEquals(str, "db.tbl.k1 = 'main_interface_of_live#all_module#null#write_real_time_start#0'");
+        }
+
+        {
+            Expr left = new SlotRef(new TableName("db", "tbl"), "k1");
+            Expr right = new StringLiteral("123", NodePosition.ZERO);
+            Expr expr = new BinaryPredicate(BinaryType.LE, left, right);
+            String str = AstToStringBuilder.toString(expr);
+            Assert.assertEquals(str, "db.tbl.k1 <= '123'");
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

After https://github.com/StarRocks/starrocks/pull/46957, large string(len > 50) in the predicate used by JDBC Scan node on will be truncated before sending to BE. This leads to an incorrect result set. 

<img width="733" alt="image" src="https://github.com/user-attachments/assets/f5f845d3-3624-458e-ab3c-7c894a7b4c06">
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/b3c85aff-ef95-4e97-bf7c-b4a3fed0a00e">



## What I'm doing:

Fix jdbc predicate on LargeStringLiteral

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
