### PR TITLE
[BugFix] [UT] Ensure to refresh base table for cached mv partition mappings

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -457,7 +457,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @Deprecated
     private List<Expr> partitionRefTableExprs;
     @Deprecated
-    private transient Optional<Pair<Table, Column>> refBaseTableColumnOpt = Optional.empty();
+    private transient volatile Optional<Pair<Table, Column>> refBaseTableColumnOpt = Optional.empty();
 
     // Maintenance plan for this MV
     private transient ExecPlan maintenancePlan;
@@ -477,11 +477,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     private Map<ExpressionSerializedObject, ExpressionSerializedObject> serializedPartitionExprMaps;
     private Map<Expr, SlotRef> partitionExprMaps;
     // ref base table to partition expression
-    private transient Optional<Map<Table, Expr>> refBaseTablePartitionExprsOpt = Optional.empty();
+    private transient volatile Optional<Map<Table, Expr>> refBaseTablePartitionExprsOpt = Optional.empty();
     // ref bae table to partition column slot ref
-    private transient Optional<Map<Table, SlotRef>> refBaseTablePartitionSlotsOpt = Optional.empty();
+    private transient volatile Optional<Map<Table, SlotRef>> refBaseTablePartitionSlotsOpt = Optional.empty();
     // ref bae table to partition column
-    private transient Optional<Map<Table, Column>> refBaseTablePartitionColumnsOpt = Optional.empty();
+    private transient volatile Optional<Map<Table, Column>> refBaseTablePartitionColumnsOpt = Optional.empty();
+    // cache table to base table info's mapping to refresh table
+    private transient volatile Map<Table, BaseTableInfo> tableToBaseTableInfoCache = Maps.newConcurrentMap();
 
     // Materialized view's output columns may be different from defined query's output columns.
     // Record the indexes based on materialized view's column output.
@@ -581,13 +583,20 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         LOG.warn("set {} to inactive because of {}", name, reason);
         this.active = false;
         this.inactiveReason = reason;
-        CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this, false);
-
         // reset cached variables
+        resetMetadataCache();
+        CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this, false);
+    }
+
+    /**
+     * Reset cached metadata when mv's meta has changed.
+     */
+    public void resetMetadataCache() {
         refBaseTableColumnOpt = Optional.empty();
         refBaseTablePartitionExprsOpt = Optional.empty();
         refBaseTablePartitionSlotsOpt = Optional.empty();
         refBaseTablePartitionColumnsOpt = Optional.empty();
+        tableToBaseTableInfoCache.clear();
     }
 
     public String getInactiveReason() {
@@ -882,6 +891,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         mv.refBaseTablePartitionExprsOpt = this.refBaseTablePartitionExprsOpt;
         mv.refBaseTablePartitionSlotsOpt = this.refBaseTablePartitionSlotsOpt;
         mv.refBaseTablePartitionColumnsOpt = this.refBaseTablePartitionColumnsOpt;
+        mv.tableToBaseTableInfoCache = this.tableToBaseTableInfoCache;
     }
 
     @Override
@@ -1433,13 +1443,19 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     LOG.info("Base table {} contains no partition expr, skip", table.getName());
                     continue;
                 }
+                tableToBaseTableInfoCache.put(table, tableInfo);
                 refBaseTablePartitionExprMap.put(table, mvPartitionExpr.get().getExpr());
             }
             LOG.info("The refBaseTablePartitionExprMap of mv {} is {}", getName(), refBaseTablePartitionExprMap);
-            refBaseTablePartitionExprsOpt = Optional.of(refBaseTablePartitionExprMap);
+            synchronized (this) {
+                if (refBaseTablePartitionExprsOpt.isEmpty()) {
+                    refBaseTablePartitionExprsOpt = Optional.of(refBaseTablePartitionExprMap);
+                    return refBaseTablePartitionExprMap;
+                }
+            }
         }
         Preconditions.checkState(refBaseTablePartitionExprsOpt.isPresent());
-        return refBaseTablePartitionExprsOpt.get();
+        return refBaseTablePartitionExprsOpt.map(this::refreshBaseTable).get();
     }
 
     /**
@@ -1457,13 +1473,19 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     LOG.info("Base table {} contains no partition expr, skip", table.getName());
                     continue;
                 }
+                tableToBaseTableInfoCache.put(table, tableInfo);
                 refBaseTablePartitionSlotMap.put(table, mvPartitionExpr.get().getSlotRef());
             }
             LOG.info("The refBaseTablePartitionSlotMap of mv {} is {}", getName(), refBaseTablePartitionSlotMap);
-            refBaseTablePartitionSlotsOpt = Optional.of(refBaseTablePartitionSlotMap);
+            synchronized (this) {
+                if (refBaseTablePartitionSlotsOpt.isEmpty()) {
+                    refBaseTablePartitionSlotsOpt = Optional.of(refBaseTablePartitionSlotMap);
+                    return refBaseTablePartitionSlotMap;
+                }
+            }
         }
         Preconditions.checkState(refBaseTablePartitionSlotsOpt.isPresent());
-        return refBaseTablePartitionSlotsOpt.get();
+        return refBaseTablePartitionSlotsOpt.map(this::refreshBaseTable).get();
     }
 
     /**
@@ -1557,27 +1579,35 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return null;
         }
         if (refBaseTableColumnOpt.isEmpty()) {
-            Expr partitionExpr = getPartitionRefTableExprs().get(0);
-            List<SlotRef> slotRefs = Lists.newArrayList();
-            partitionExpr.collect(SlotRef.class, slotRefs);
-            Preconditions.checkState(slotRefs.size() == 1);
-            SlotRef partitionSlotRef = slotRefs.get(0);
-            for (BaseTableInfo baseTableInfo : baseTableInfos) {
-                Table table = MvUtils.getTableChecked(baseTableInfo);
-                if (partitionSlotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
-                    refBaseTableColumnOpt = Optional.of(Pair.create(table, table.getColumn(partitionSlotRef.getColumnName())));
-                    break;
+            Pair<Table, Column> refBaseTableColumn = getRefBaseTablePartitionColumnImpl();
+            synchronized (this) {
+                if (refBaseTableColumnOpt.isEmpty()) {
+                    refBaseTableColumnOpt = Optional.of(refBaseTableColumn);
+                    return refBaseTableColumn;
                 }
-            }
-            if (refBaseTableColumnOpt.isEmpty()) {
-                String baseTableNames = baseTableInfos.stream()
-                        .map(tableInfo -> MvUtils.getTableChecked(tableInfo).getName()).collect(Collectors.joining(","));
-                throw new RuntimeException(
-                        String.format("can not find partition info for mv:%s on base tables:%s", name, baseTableNames));
             }
         }
         Preconditions.checkState(refBaseTableColumnOpt.isPresent());
         return refBaseTableColumnOpt.get();
+    }
+
+    private Pair<Table, Column> getRefBaseTablePartitionColumnImpl() {
+        Expr partitionExpr = getPartitionRefTableExprs().get(0);
+        List<SlotRef> slotRefs = Lists.newArrayList();
+        partitionExpr.collect(SlotRef.class, slotRefs);
+        Preconditions.checkState(slotRefs.size() == 1);
+        SlotRef partitionSlotRef = slotRefs.get(0);
+        for (BaseTableInfo baseTableInfo : baseTableInfos) {
+            Table table = MvUtils.getTableChecked(baseTableInfo);
+            if (partitionSlotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
+                return Pair.create(table, table.getColumn(partitionSlotRef.getColumnName()));
+            }
+        }
+        String baseTableNames = baseTableInfos.stream()
+                .map(tableInfo -> MvUtils.getTableChecked(tableInfo).getName())
+                .collect(Collectors.joining(","));
+        throw new RuntimeException(
+                String.format("can not find partition info for mv:%s on base tables:%s", name, baseTableNames));
     }
 
     /**
@@ -1586,10 +1616,30 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public Map<Table, Column> getRefBaseTablePartitionColumns() {
         if (refBaseTablePartitionColumnsOpt.isEmpty()) {
-            refBaseTablePartitionColumnsOpt = Optional.of(getBaseTablePartitionColumnMapImpl());
+            Map<Table, Column> result = getBaseTablePartitionColumnMapImpl();
+            synchronized (this) {
+                if (refBaseTablePartitionColumnsOpt.isEmpty()) {
+                    refBaseTablePartitionColumnsOpt = Optional.of(result);
+                    return result;
+                }
+            }
         }
         Preconditions.checkState(refBaseTablePartitionColumnsOpt.isPresent());
-        return refBaseTablePartitionColumnsOpt.get();
+        return refBaseTablePartitionColumnsOpt.map(this::refreshBaseTable).get();
+    }
+
+    /**
+     * Since the table is cached in the Optional, needs to refresh it again for each query.
+     * TODO: optimize cases which not care table's refresh-ness.
+     */
+    private <K> Map<Table, K> refreshBaseTable(Map<Table, K> cached) {
+        Map<Table, K> result = Maps.newHashMap();
+        for (Map.Entry<Table, K> e : cached.entrySet()) {
+            Preconditions.checkState(tableToBaseTableInfoCache.containsKey(e.getKey()));
+            Table refreshedTable = MvUtils.getTableChecked(tableToBaseTableInfoCache.get(e.getKey()));
+            result.put(refreshedTable, e.getValue());
+        }
+        return result;
     }
 
     private Map<Table, Column> getBaseTablePartitionColumnMapImpl() {
@@ -1619,6 +1669,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                         table.getName(), baseTablePartitionSlotMap);
                 continue;
             }
+            tableToBaseTableInfoCache.put(table, baseTableInfo);
             result.put(table, partitionColumnOpt.get());
         }
         if (result.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -179,6 +179,8 @@ public class MVPCTMetaRepairer {
             List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
             baseTableInfos.remove(oldBaseTableInfo);
             baseTableInfos.add(newBaseTableInfo);
+            // reset mv's state after repair
+            mv.resetMetadataCache();
 
             ConnectorTableInfo connectorTableInfo = GlobalStateMgr.getCurrentState().getConnectorTblMetaInfoMgr()
                     .getConnectorTableInfo(oldBaseTableInfo.getCatalogName(), oldBaseTableInfo.getDbName(),


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Use double-check to initialize cached singletons to avoid concurrent bugs;
- Refresh table object for cached objects;

Backport from https://github.com/StarRocks/starrocks/pull/48508

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
