### PR TITLE
[BugFix] Ensure to refresh base table for cached mv partition mappings

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -840,6 +840,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         mv.refBaseTablePartitionExprsOpt = this.refBaseTablePartitionExprsOpt;
         mv.refBaseTablePartitionSlotsOpt = this.refBaseTablePartitionSlotsOpt;
         mv.refBaseTablePartitionColumnsOpt = this.refBaseTablePartitionColumnsOpt;
+        mv.tableToBaseTableInfoCache = this.tableToBaseTableInfoCache;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1537,13 +1537,15 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     for (BaseTableInfo baseTableInfo : baseTableInfos) {
                         Table table = MvUtils.getTableChecked(baseTableInfo);
                         if (partitionSlotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
-                            refBaseTableColumnOpt = Optional.of(Pair.create(table, table.getColumn(partitionSlotRef.getColumnName())));
+                            refBaseTableColumnOpt =
+                                    Optional.of(Pair.create(table, table.getColumn(partitionSlotRef.getColumnName())));
                             break;
                         }
                     }
                     if (refBaseTableColumnOpt.isEmpty()) {
                         String baseTableNames = baseTableInfos.stream()
-                                .map(tableInfo -> MvUtils.getTableChecked(tableInfo).getName()).collect(Collectors.joining(","));
+                                .map(tableInfo -> MvUtils.getTableChecked(tableInfo).getName())
+                                .collect(Collectors.joining(","));
                         throw new RuntimeException(
                                 String.format("can not find partition info for mv:%s on base tables:%s", name, baseTableNames));
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -414,7 +414,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @Deprecated
     private List<Expr> partitionRefTableExprs;
     @Deprecated
-    private transient Optional<Pair<Table, Column>> refBaseTableColumnOpt = Optional.empty();
+    private transient volatile Optional<Pair<Table, Column>> refBaseTableColumnOpt = Optional.empty();
 
     // Maintenance plan for this MV
     private transient ExecPlan maintenancePlan;
@@ -434,13 +434,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     private Map<ExpressionSerializedObject, ExpressionSerializedObject> serializedPartitionExprMaps;
     private Map<Expr, SlotRef> partitionExprMaps;
     // ref base table to partition expression
-    private transient Optional<Map<Table, Expr>> refBaseTablePartitionExprsOpt = Optional.empty();
+    private transient volatile Optional<Map<Table, Expr>> refBaseTablePartitionExprsOpt = Optional.empty();
     // ref bae table to partition column slot ref
-    private transient Optional<Map<Table, SlotRef>> refBaseTablePartitionSlotsOpt = Optional.empty();
+    private transient volatile Optional<Map<Table, SlotRef>> refBaseTablePartitionSlotsOpt = Optional.empty();
     // ref bae table to partition column
-    private transient Optional<Map<Table, Column>> refBaseTablePartitionColumnsOpt = Optional.empty();
+    private transient volatile Optional<Map<Table, Column>> refBaseTablePartitionColumnsOpt = Optional.empty();
     // cache table to base table info's mapping to refresh table
-    private transient Map<Table, BaseTableInfo> tableToBaseTableInfoCache = Maps.newHashMap();
+    private transient volatile Map<Table, BaseTableInfo> tableToBaseTableInfoCache = Maps.newConcurrentMap();
 
     // Materialized view's output columns may be different from defined query's output columns.
     // Record the indexes based on materialized view's column output.
@@ -1383,24 +1383,27 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public Map<Table, Expr> getRefBaseTablePartitionExprs() {
         if (refBaseTablePartitionExprsOpt.isEmpty()) {
-            Map<Table, Expr> refBaseTablePartitionExprMap = Maps.newHashMap();
-            for (BaseTableInfo tableInfo : baseTableInfos) {
-                Table table = MvUtils.getTableChecked(tableInfo);
-                Optional<MVPartitionExpr> mvPartitionExpr = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
-                if (mvPartitionExpr.isEmpty()) {
-                    LOG.info("Base table {} contains no partition expr, skip", table.getName());
-                    continue;
+            synchronized (this) {
+                if (refBaseTablePartitionExprsOpt.isEmpty()) {
+                    Map<Table, Expr> refBaseTablePartitionExprMap = Maps.newHashMap();
+                    for (BaseTableInfo tableInfo : baseTableInfos) {
+                        Table table = MvUtils.getTableChecked(tableInfo);
+                        Optional<MVPartitionExpr> mvPartitionExpr = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
+                        if (mvPartitionExpr.isEmpty()) {
+                            LOG.info("Base table {} contains no partition expr, skip", table.getName());
+                            continue;
+                        }
+                        tableToBaseTableInfoCache.put(table, tableInfo);
+                        refBaseTablePartitionExprMap.put(table, mvPartitionExpr.get().getExpr());
+                    }
+                    LOG.info("The refBaseTablePartitionExprMap of mv {} is {}", getName(), refBaseTablePartitionExprMap);
+                    refBaseTablePartitionExprsOpt = Optional.of(refBaseTablePartitionExprMap);
+                    return refBaseTablePartitionExprMap;
                 }
-                tableToBaseTableInfoCache.put(table, tableInfo);
-                refBaseTablePartitionExprMap.put(table, mvPartitionExpr.get().getExpr());
             }
-            LOG.info("The refBaseTablePartitionExprMap of mv {} is {}", getName(), refBaseTablePartitionExprMap);
-            refBaseTablePartitionExprsOpt = Optional.of(refBaseTablePartitionExprMap);
-            return refBaseTablePartitionExprMap;
-        } else {
-            Preconditions.checkState(refBaseTablePartitionExprsOpt.isPresent());
-            return refBaseTablePartitionExprsOpt.map(this::refreshBaseTable).get();
         }
+        Preconditions.checkState(refBaseTablePartitionExprsOpt.isPresent());
+        return refBaseTablePartitionExprsOpt.map(this::refreshBaseTable).get();
     }
 
     /**
@@ -1410,24 +1413,27 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public Map<Table, SlotRef> getRefBaseTablePartitionSlots() {
         if (refBaseTablePartitionSlotsOpt.isEmpty()) {
-            Map<Table, SlotRef> refBaseTablePartitionSlotMap = new HashMap<>();
-            for (BaseTableInfo tableInfo : baseTableInfos) {
-                Table table = MvUtils.getTableChecked(tableInfo);
-                Optional<MVPartitionExpr> mvPartitionExpr = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
-                if (mvPartitionExpr.isEmpty()) {
-                    LOG.info("Base table {} contains no partition expr, skip", table.getName());
-                    continue;
+            synchronized (this) {
+                if (refBaseTablePartitionSlotsOpt.isEmpty()) {
+                    Map<Table, SlotRef> refBaseTablePartitionSlotMap = new HashMap<>();
+                    for (BaseTableInfo tableInfo : baseTableInfos) {
+                        Table table = MvUtils.getTableChecked(tableInfo);
+                        Optional<MVPartitionExpr> mvPartitionExpr = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
+                        if (mvPartitionExpr.isEmpty()) {
+                            LOG.info("Base table {} contains no partition expr, skip", table.getName());
+                            continue;
+                        }
+                        tableToBaseTableInfoCache.put(table, tableInfo);
+                        refBaseTablePartitionSlotMap.put(table, mvPartitionExpr.get().getSlotRef());
+                    }
+                    LOG.info("The refBaseTablePartitionSlotMap of mv {} is {}", getName(), refBaseTablePartitionSlotMap);
+                    refBaseTablePartitionSlotsOpt = Optional.of(refBaseTablePartitionSlotMap);
+                    return refBaseTablePartitionSlotMap;
                 }
-                tableToBaseTableInfoCache.put(table, tableInfo);
-                refBaseTablePartitionSlotMap.put(table, mvPartitionExpr.get().getSlotRef());
             }
-            LOG.info("The refBaseTablePartitionSlotMap of mv {} is {}", getName(), refBaseTablePartitionSlotMap);
-            refBaseTablePartitionSlotsOpt = Optional.of(refBaseTablePartitionSlotMap);
-            return refBaseTablePartitionSlotMap;
-        } else {
-            Preconditions.checkState(refBaseTablePartitionSlotsOpt.isPresent());
-            return refBaseTablePartitionSlotsOpt.map(this::refreshBaseTable).get();
         }
+        Preconditions.checkState(refBaseTablePartitionSlotsOpt.isPresent());
+        return refBaseTablePartitionSlotsOpt.map(this::refreshBaseTable).get();
     }
 
     /**
@@ -1521,23 +1527,27 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return null;
         }
         if (refBaseTableColumnOpt.isEmpty()) {
-            Expr partitionExpr = getPartitionRefTableExprs().get(0);
-            List<SlotRef> slotRefs = Lists.newArrayList();
-            partitionExpr.collect(SlotRef.class, slotRefs);
-            Preconditions.checkState(slotRefs.size() == 1);
-            SlotRef partitionSlotRef = slotRefs.get(0);
-            for (BaseTableInfo baseTableInfo : baseTableInfos) {
-                Table table = MvUtils.getTableChecked(baseTableInfo);
-                if (partitionSlotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
-                    refBaseTableColumnOpt = Optional.of(Pair.create(table, table.getColumn(partitionSlotRef.getColumnName())));
-                    break;
+            synchronized (this) {
+                if (refBaseTableColumnOpt.isEmpty()) {
+                    Expr partitionExpr = getPartitionRefTableExprs().get(0);
+                    List<SlotRef> slotRefs = Lists.newArrayList();
+                    partitionExpr.collect(SlotRef.class, slotRefs);
+                    Preconditions.checkState(slotRefs.size() == 1);
+                    SlotRef partitionSlotRef = slotRefs.get(0);
+                    for (BaseTableInfo baseTableInfo : baseTableInfos) {
+                        Table table = MvUtils.getTableChecked(baseTableInfo);
+                        if (partitionSlotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
+                            refBaseTableColumnOpt = Optional.of(Pair.create(table, table.getColumn(partitionSlotRef.getColumnName())));
+                            break;
+                        }
+                    }
+                    if (refBaseTableColumnOpt.isEmpty()) {
+                        String baseTableNames = baseTableInfos.stream()
+                                .map(tableInfo -> MvUtils.getTableChecked(tableInfo).getName()).collect(Collectors.joining(","));
+                        throw new RuntimeException(
+                                String.format("can not find partition info for mv:%s on base tables:%s", name, baseTableNames));
+                    }
                 }
-            }
-            if (refBaseTableColumnOpt.isEmpty()) {
-                String baseTableNames = baseTableInfos.stream()
-                        .map(tableInfo -> MvUtils.getTableChecked(tableInfo).getName()).collect(Collectors.joining(","));
-                throw new RuntimeException(
-                        String.format("can not find partition info for mv:%s on base tables:%s", name, baseTableNames));
             }
         }
         Preconditions.checkState(refBaseTableColumnOpt.isPresent());
@@ -1550,13 +1560,16 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public Map<Table, Column> getRefBaseTablePartitionColumns() {
         if (refBaseTablePartitionColumnsOpt.isEmpty()) {
-            Map<Table, Column> result = getBaseTablePartitionColumnMapImpl();
-            refBaseTablePartitionColumnsOpt = Optional.of(result);
-            return result;
-        } else {
-            Preconditions.checkState(refBaseTablePartitionColumnsOpt.isPresent());
-            return refBaseTablePartitionColumnsOpt.map(this::refreshBaseTable).get();
+            synchronized (this) {
+                if (refBaseTablePartitionColumnsOpt.isEmpty()) {
+                    Map<Table, Column> result = getBaseTablePartitionColumnMapImpl();
+                    refBaseTablePartitionColumnsOpt = Optional.of(result);
+                    return result;
+                }
+            }
         }
+        Preconditions.checkState(refBaseTablePartitionColumnsOpt.isPresent());
+        return refBaseTablePartitionColumnsOpt.map(this::refreshBaseTable).get();
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Use double-check to initialize cached singletons to avoid concurrent bugs;
- Refresh table object for cached objects;

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

