### PR TITLE
[BugFix] strip quotes before date parse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -166,9 +166,12 @@ public class StatisticAutoCollector extends FrontendDaemon {
     }
 
     private static boolean checkoutAnalyzeTime(LocalTime now) {
+        String startTimeStr = stripQuotes(Config.statistic_auto_analyze_start_time);
+        String endTimeStr = stripQuotes(Config.statistic_auto_analyze_end_time);
+
         try {
-            LocalTime start = LocalTime.parse(Config.statistic_auto_analyze_start_time, DateUtils.TIME_FORMATTER);
-            LocalTime end = LocalTime.parse(Config.statistic_auto_analyze_end_time, DateUtils.TIME_FORMATTER);
+            LocalTime start = LocalTime.parse(startTimeStr, DateUtils.TIME_FORMATTER);
+            LocalTime end = LocalTime.parse(endTimeStr, DateUtils.TIME_FORMATTER);
 
             if (start.isAfter(end) && (now.isAfter(start) || now.isBefore(end))) {
                 return true;
@@ -179,10 +182,13 @@ public class StatisticAutoCollector extends FrontendDaemon {
             }
         } catch (DateTimeParseException e) {
             LOG.warn("Parse analyze start/end time format fail : " + e.getMessage());
-
             // If the time format configuration is incorrect,
             // processing can be run at any time without affecting the normal process
             return true;
         }
+    }
+
+    private static String stripQuotes(String str) {
+        return str != null ? str.replaceAll("[\"']", "") : str;
     }
 }


### PR DESCRIPTION
## Why I'm doing:
We fail to respect analyze interval because of quoted value

## What I'm doing:
Stripping quotes before parsing date

Fixes #73241

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

