### PR TITLE
[BugFix] Fix statistics agg functions to return NULL incorrectly (backport #47904)

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -136,6 +136,11 @@ struct AggFunctionTypes {
     std::vector<bool> nulls_first;
 
     bool is_distinct = false;
+    bool is_always_nullable_result = false;
+
+    template <bool UseIntermediateAsOutput>
+    bool is_result_nullable() const;
+    bool use_nullable_fn(bool use_intermediate_as_output) const;
 };
 
 struct ColumnType {
@@ -239,8 +244,6 @@ struct AggregatorParams {
     bool has_nullable_key;
 
     void init();
-
-    ChunkUniquePtr create_result_chunk(bool is_serialize_fmt, const TupleDescriptor& desc);
 };
 using AggregatorParamsPtr = std::shared_ptr<AggregatorParams>;
 AggregatorParamsPtr convert_to_aggregator_params(const TPlanNode& tnode);
@@ -504,7 +507,8 @@ public:
     void build_hash_map(size_t chunk_size, std::atomic<int64_t>& shared_limit_countdown, bool agg_group_by_with_limit);
     void build_hash_map_with_selection(size_t chunk_size);
     void build_hash_map_with_selection_and_allocation(size_t chunk_size, bool agg_group_by_with_limit = false);
-    Status convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk, bool* use_intermediate_as_output = nullptr);
+    Status convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk,
+                                     bool force_use_intermediate_as_output = false);
 
     void build_hash_set(size_t chunk_size);
     void build_hash_set_with_selection(size_t chunk_size);

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -262,11 +262,9 @@ std::function<StatusOr<ChunkPtr>()> SpillableAggregateBlockingSinkOperator::_bui
             return chunk;
         }
         if (should_spill_hash_table) {
-            bool use_intermediate_as_output = true;
             if (!_aggregator->is_ht_eos()) {
                 auto chunk = std::make_shared<Chunk>();
-                RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), &chunk,
-                                                                       &use_intermediate_as_output));
+                RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), &chunk, true));
                 return chunk;
             }
             COUNTER_UPDATE(_aggregator->input_row_count(), _aggregator->num_input_rows());

--- a/be/src/exprs/agg/covariance.h
+++ b/be/src/exprs/agg/covariance.h
@@ -113,11 +113,12 @@ public:
         double deltaY = this->data(state).meanY - meanY;
 
         double sum_count = this->data(state).count + count;
-        double factor = (this->data(state).count / sum_count);
 
-        this->data(state).meanX = meanX + deltaX * factor;
-        this->data(state).meanY = meanY + deltaY * factor;
+        double factor_for_mean = (this->data(state).count / sum_count);
+        this->data(state).meanX = meanX + deltaX * factor_for_mean;
+        this->data(state).meanY = meanY + deltaY * factor_for_mean;
 
+        double factor = (this->data(state).count * count / sum_count);
         this->data(state).c2 = c2 + this->data(state).c2 + (deltaX * deltaY) * factor;
         this->data(state).count = sum_count;
 
@@ -200,9 +201,24 @@ public:
 
 template <LogicalType LT, bool isSample, typename T = RunTimeCppType<LT>>
 class CorVarianceAggregateFunction final : public CorVarianceBaseAggregateFunction<LT, false> {
+public:
     using InputColumnType = RunTimeColumnType<LT>;
     using InputCppType = T;
     using ResultColumnType = RunTimeColumnType<TYPE_DOUBLE>;
+
+    struct AggNullPred {
+        bool operator()(const CovarianceCorelationAggregateState<false>& state) const {
+            if constexpr (isSample) {
+                return state.count <= 1;
+            } else {
+                // The non-sample case will return null only when `state.count` is 0, where
+                // `NullableAggregateFunctionState::is_null` also true.
+                // Therefore, we don't need to check `state.count` here.
+                return false;
+            }
+        }
+    };
+
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
 
@@ -257,6 +273,10 @@ public:
     using InputColumnType = RunTimeColumnType<LT>;
     using InputCppType = T;
     using ResultColumnType = RunTimeColumnType<TYPE_DOUBLE>;
+
+    struct AggNullPred {
+        bool operator()(const CovarianceCorelationAggregateState<true>& state) const { return state.count <= 1; }
+    };
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());

--- a/be/src/exprs/agg/factory/aggregate_resolver_variance.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_variance.cpp
@@ -34,9 +34,11 @@ struct StdDispatcher {
                     "var_pop", true, AggregateFactory::MakeVarianceAggregateFunction<lt, false>());
 
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
-                    "variance_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>());
+                    "variance_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>(),
+                    typename VarianceAggregateFunction<lt, true>::AggNullPred());
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
-                    "var_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>());
+                    "var_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>(),
+                    typename VarianceAggregateFunction<lt, true>::AggNullPred());
 
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
                     "stddev", true, AggregateFactory::MakeStddevAggregateFunction<lt, false>());
@@ -45,7 +47,8 @@ struct StdDispatcher {
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
                     "stddev_pop", true, AggregateFactory::MakeStddevAggregateFunction<lt, false>());
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
-                    "stddev_samp", true, AggregateFactory::MakeStddevAggregateFunction<lt, true>());
+                    "stddev_samp", true, AggregateFactory::MakeStddevAggregateFunction<lt, true>(),
+                    typename StddevAggregateFunction<lt, true>::AggNullPred());
         }
     }
 };
@@ -59,11 +62,13 @@ struct CorVarDispatcher {
                     "covar_pop", true, AggregateFactory::MakeCovarianceAggregateFunction<lt, false>());
 
             resolver->add_aggregate_mapping_variadic<lt, TYPE_DOUBLE, VarState>(
-                    "covar_samp", true, AggregateFactory::MakeCovarianceAggregateFunction<lt, true>());
+                    "covar_samp", true, AggregateFactory::MakeCovarianceAggregateFunction<lt, true>(),
+                    typename CorVarianceAggregateFunction<lt, true>::AggNullPred());
 
             using CorrState = CovarianceCorelationAggregateState<true>;
             resolver->add_aggregate_mapping_variadic<lt, TYPE_DOUBLE, CorrState>(
-                    "corr", true, AggregateFactory::MakeCorelationAggregateFunction<lt>());
+                    "corr", true, AggregateFactory::MakeCorelationAggregateFunction<lt>(),
+                    typename CorelationAggregateFunction<lt>::AggNullPred());
         }
     }
 };

--- a/be/src/exprs/agg/variance.h
+++ b/be/src/exprs/agg/variance.h
@@ -196,6 +196,19 @@ public:
     using ResultColumnType =
             typename DevFromAveAggregateFunction<LT, is_sample, T, ResultLT, TResult>::ResultColumnType;
 
+    struct AggNullPred {
+        bool operator()(const DevFromAveAggregateState<TResult>& state) const {
+            if constexpr (is_sample) {
+                return state.count <= 1;
+            } else {
+                // The non-sample case will return null only when `state.count` is 0, where
+                // `NullableAggregateFunctionState::is_null` also true.
+                // Therefore, we don't need to check `state.count` here.
+                return false;
+            }
+        }
+    };
+
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
 
@@ -312,6 +325,19 @@ class StddevAggregateFunction final : public DevFromAveAggregateFunction<LT, is_
 public:
     using ResultColumnType =
             typename DevFromAveAggregateFunction<LT, is_sample, T, ResultLT, TResult>::ResultColumnType;
+
+    struct AggNullPred {
+        bool operator()(const DevFromAveAggregateState<TResult>& state) const {
+            if constexpr (is_sample) {
+                return state.count <= 1;
+            } else {
+                // The non-sample case will return null only when `state.count` is 0, where
+                // `NullableAggregateFunctionState::is_null` also true.
+                // Therefore, we don't need to check `state.count` here.
+                return false;
+            }
+        }
+    };
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());

--- a/test/sql/test_agg_function/R/test_always_null_statistic_funcs
+++ b/test/sql/test_agg_function/R/test_always_null_statistic_funcs
@@ -1,0 +1,1161 @@
+-- name: test_always_null_statistic_funcs
+CREATE TABLE t1 (
+    idx BIGINT, 
+    k BIGINT NULL, 
+    val1 BIGINT NULL,
+    val2 BIGINT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE t1_nonnull (
+    idx BIGINT, 
+    k BIGINT NOT NULL, 
+    val1 BIGINT NOT NULL,
+    val2 BIGINT NOT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (NULL, 4,4,8),
+    (50, NULL,5,10),
+    (NULL, NULL,6,12),
+    (70, NULL,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+-- result:
+-- !result
+INSERT INTO t1_nonnull (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (40, 4,4,8),
+    (50, 5,5,10),
+    (60, 6,6,12),
+    (70, 7,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+-- result:
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(var_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(var_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(variance_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(variance_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	None	0.707
+6	None	None
+7	None	None
+8	8	None
+9	9	0.707
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull;
+-- result:
+3.028
+-- !result
+select round(stddev_samp(val1), 3) from t1;
+-- result:
+3.638
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	None	5.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	5.0
+10	10	100	10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	40	10.0
+5	5	50	10.0
+6	6	60	10.0
+7	7	70	10.0
+8	8	80	10.0
+9	9	90	10.0
+10	10	100	10.0
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+-- result:
+91.667
+-- !result
+select round(covar_samp(val1, val2), 3) from t1;
+-- result:
+155.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	None	1.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	40	1.0
+5	5	50	1.0
+6	6	60	1.0
+7	7	70	1.0
+8	8	80	1.0
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+select round(corr(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull;
+-- result:
+1.0
+-- !result
+select round(corr(val1, val2), 3) from t1;
+-- result:
+1.0
+-- !result
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(var_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(var_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(variance_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(variance_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	None	0.707
+6	None	None
+7	None	None
+8	8	None
+9	9	0.707
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull;
+-- result:
+3.028
+-- !result
+select round(stddev_samp(val1), 3) from t1;
+-- result:
+3.638
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	None	5.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	5.0
+10	10	100	10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	40	10.0
+5	5	50	10.0
+6	6	60	10.0
+7	7	70	10.0
+8	8	80	10.0
+9	9	90	10.0
+10	10	100	10.0
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+-- result:
+91.667
+-- !result
+select round(covar_samp(val1, val2), 3) from t1;
+-- result:
+155.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	None	1.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	40	1.0
+5	5	50	1.0
+6	6	60	1.0
+7	7	70	1.0
+8	8	80	1.0
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+select round(corr(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull;
+-- result:
+1.0
+-- !result
+select round(corr(val1, val2), 3) from t1;
+-- result:
+1.0
+-- !result

--- a/test/sql/test_agg_function/T/test_always_null_statistic_funcs
+++ b/test/sql/test_agg_function/T/test_always_null_statistic_funcs
@@ -1,0 +1,647 @@
+
+-- name: test_always_null_statistic_funcs
+CREATE TABLE t1 (
+    idx BIGINT, 
+    k BIGINT NULL, 
+    val1 BIGINT NULL,
+    val2 BIGINT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE t1_nonnull (
+    idx BIGINT, 
+    k BIGINT NOT NULL, 
+    val1 BIGINT NOT NULL,
+    val2 BIGINT NOT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO t1 (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (NULL, 4,4,8),
+    (50, NULL,5,10),
+    (NULL, NULL,6,12),
+    (70, NULL,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+
+INSERT INTO t1_nonnull (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (40, 4,4,8),
+    (50, 5,5,10),
+    (60, 6,6,12),
+    (70, 7,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+
+-- var_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- One non-null row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(var_samp(val1), 3) from t1 where k > 100;
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(var_samp(val1), 3) from t1 where k = 2;
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(var_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(var_samp(val1), 3) from t1;
+
+
+-- variance_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(variance_samp(val1), 3) from t1 where k > 100;
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(variance_samp(val1), 3) from t1 where k = 2;
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(variance_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(variance_samp(val1), 3) from t1;
+
+
+-- stddev_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(stddev_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(stddev_samp(val1), 3) from t1;
+
+
+-- covar_samp
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+
+
+-- Two phase agg.
+-- Empty
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(covar_samp(val1, val2), 3) from t1;
+
+
+-- corr
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+
+-- Two phase agg.
+-- Empty
+select round(corr(val1, val2), 3) from t1 where k > 100;
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(corr(val1, val2), 3) from t1 where k = 2;
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(corr(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(corr(val1, val2), 3) from t1;
+
+
+
+-- set force spill and repeat the above cases.
+set enable_spill=true;
+set spill_mode="force";
+
+
+
+-- var_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- One non-null row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(var_samp(val1), 3) from t1 where k > 100;
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(var_samp(val1), 3) from t1 where k = 2;
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(var_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(var_samp(val1), 3) from t1;
+
+
+-- variance_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(variance_samp(val1), 3) from t1 where k > 100;
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(variance_samp(val1), 3) from t1 where k = 2;
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(variance_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(variance_samp(val1), 3) from t1;
+
+
+-- stddev_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(stddev_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(stddev_samp(val1), 3) from t1;
+
+
+-- covar_samp
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+
+
+-- Two phase agg.
+-- Empty
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(covar_samp(val1, val2), 3) from t1;
+
+
+-- corr
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+
+-- Two phase agg.
+-- Empty
+select round(corr(val1, val2), 3) from t1 where k > 100;
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(corr(val1, val2), 3) from t1 where k = 2;
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(corr(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(corr(val1, val2), 3) from t1;


### PR DESCRIPTION
CP from #47904

## Why I'm doing:

### Return NULL incorrectly

For now, the result nullable property of aggregation functions contains two cases:
1. **Always non-nullable**
    - FE pass `is_output_nullable` with `false` value to BE, such as such as count, count distinct, and bitmap_union_int.
2. **Nullable the same as input**
    - FE pass `is_output_nullable` with `true` value to BE. (**NOTE that BE need determine whether the result is nullable by itself!**)
    - The result is `NULl` only when all the input rows are `NULL`.

This is OK, until the statistics aggregations occur. The reason is that the output of statistics aggregations is **always nullable** no matter what the input is, because they will return `NULL` when the number of input non-null rows is less than 2.

### COVARIANCE
According to [Wikipedia](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online), when merging two COVARIANCE states $C_A$ and $C_B$, the formula should be as follows:

$$
C_X = C_A + C_B + (\overline{x}_A - \overline{x}_B)(\overline{y}_A - \overline{y}_B) \cdot \frac{n_A n_B}{n_X},
$$

but we use a wrong one as follows:

$$
C_X = C_A + C_B + (\overline{x}_A - \overline{x}_B)(\overline{y}_A - \overline{y}_B) \cdot \frac{n_A}{n_X},
$$

where $C_n$ is defined as follows:
 $$C_n = \sum_{i=1}^{n} (x_i - \overline{x}_n)(y_i - \overline{y}_n)$$

## What I'm doing:


1. Pass `AggNullPred(State)` to `NullableAggregate`.
   For now, `NullableAggregate` only returns null when the input is null, but the statistics function will return `NULL` when the number of input non-null rows is less than 2.
   Therefore, we need to add a new parameter `AggNullPred` to determine whether the output is nullable.
   And this is zero overhead when it is passed as a constexpr functor `AggNonNullPred` by default, since the compiler will eliminate this always false predicate.
2. Jusge `is_result_nullable` and `use_nullable_fn` according to `use_intermediate_as_output`, `is_input_nullable`, `is_output_nullable` and `is_always_nullable_result`.





Fixes #47762.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5

