### PR TITLE
[BugFix] Fix statistics agg functions to return NULL incorrectly (backport #47904)

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -37,6 +37,40 @@
 
 namespace starrocks {
 
+static const std::unordered_set<std::string> ALWAYS_NULLABLE_RESULT_AGG_FUNCS = {"variance_samp", "var_samp",
+                                                                                 "stddev_samp", "covar_samp", "corr"};
+
+template <bool UseIntermediateAsOutput>
+bool AggFunctionTypes::is_result_nullable() const {
+    if constexpr (UseIntermediateAsOutput) {
+        // If using intermediate results as output, no output will be generated and only the input will be serialized.
+        // Therefore, only judge whether the input is nullable to decide whether to serialize null data.
+        return has_nullable_child;
+    } else {
+        // `is_nullable` means whether the output MAY be nullable. It will be false only when the output is always non-nullable.
+        // Therefore, we need to decide whether the output is really nullable case by case:
+        // 1. Same as input: `has_nullable_child` = `has_nullable_child && is_nullable(true)`.
+        // 2. Always non-nullable: `false` = `has_nullable_child && is_nullable(false)`, eg. count, count distinct, and bitmap_union_int.
+        // 3. Always nullable: `is_always_nullable_result`.
+        return (has_nullable_child && is_nullable) || is_always_nullable_result;
+    }
+}
+
+bool AggFunctionTypes::use_nullable_fn(bool use_intermediate_as_output) const {
+    // The non-nullable version functions assume that both the input and output are non-nullable, while the nullable version
+    // functions support nullable input or nullable output, which will judge whether the input and output are nullable.
+    //
+    // NOTE that for the case of `is_always_nullable_result=true`, the function created with `use_intermediate_as_output=true`
+    // also needs to use `is_result_nullable<true>` when getting the finalize result.
+    // Because for the case of `is_always_nullable_result=true and has_nullable_child=false`, the function is the non-nullable version,
+    // which causes only non-nullable output can be created.
+    if (use_intermediate_as_output) {
+        return has_nullable_child || is_result_nullable<true>();
+    } else {
+        return has_nullable_child || is_result_nullable<false>();
+    }
+}
+
 std::string AggrAutoContext::get_auto_state_string(const AggrAutoState& state) {
     switch (state) {
     case INIT_PREAGG:
@@ -127,8 +161,10 @@ void AggregatorParams::init() {
                 arg_typedescs.push_back(AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_thrift(type)));
             }
 
-            bool is_input_nullable = has_outer_join_child || desc.nodes[0].has_nullable_child;
+            const bool is_input_nullable = has_outer_join_child || desc.nodes[0].has_nullable_child;
             agg_fn_types[i] = {return_type, serde_type, arg_typedescs, is_input_nullable, desc.nodes[0].is_nullable};
+            agg_fn_types[i].is_always_nullable_result =
+                    ALWAYS_NULLABLE_RESULT_AGG_FUNCS.contains(fn.name.function_name);
             if (fn.name.function_name == "array_agg" || fn.name.function_name == "group_concat") {
                 // set order by info
                 if (fn.aggregate_fn.__isset.is_asc_order && fn.aggregate_fn.__isset.nulls_first &&
@@ -156,35 +192,6 @@ void AggregatorParams::init() {
     }
 
     VLOG_ROW << "has_nullable_key " << has_nullable_key;
-}
-
-ChunkUniquePtr AggregatorParams::create_result_chunk(bool is_serialize_fmt, const TupleDescriptor& desc) {
-    auto result_chunk = std::make_unique<Chunk>();
-
-    const auto& slots = desc.slots();
-    size_t append_offset = 0;
-
-    for (auto& group_by_type : group_by_types) {
-        auto col = ColumnHelper::create_column(group_by_type.result_type, group_by_type.is_nullable);
-        result_chunk->append_column(std::move(col), slots[append_offset++]->id());
-    }
-
-    if (!is_serialize_fmt) {
-        for (auto& agg_fn_type : agg_fn_types) {
-            // For count, count distinct, bitmap_union_int such as never return null function,
-            // we need to create a not-nullable column.
-            auto col = ColumnHelper::create_column(agg_fn_type.result_type,
-                                                   agg_fn_type.has_nullable_child && agg_fn_type.is_nullable);
-            result_chunk->append_column(std::move(col), slots[append_offset++]->id());
-        }
-    } else {
-        for (auto& agg_fn_type : agg_fn_types) {
-            auto col = ColumnHelper::create_column(agg_fn_type.serde_type, agg_fn_type.has_nullable_child);
-            result_chunk->append_column(std::move(col), slots[append_offset++]->id());
-        }
-    }
-
-    return result_chunk;
 }
 
 #define ALIGN_TO(size, align) ((size + align - 1) / align * align)
@@ -357,6 +364,7 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
     for (int i = 0; i < agg_size; ++i) {
         const TExpr& desc = aggregate_functions[i];
         const TFunction& fn = desc.nodes[0].fn;
+        const auto& agg_fn_type = _agg_fn_types[i];
         _is_merge_funcs[i] = aggregate_functions[i].nodes[0].agg_expr.is_merge_agg;
         // get function
         if (fn.name.function_name == "count") {
@@ -393,14 +401,14 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
                 arg_type = TypeDescriptor(TYPE_BIGINT);
             }
 
-            bool is_input_nullable = has_outer_join_child || desc.nodes[0].has_nullable_child;
-            auto* func = get_aggregate_function(fn.name.function_name, arg_type.type, return_type.type,
-                                                is_input_nullable, fn.binary_type, state->func_version());
+            const bool use_nullable_fn = agg_fn_type.use_nullable_fn(_use_intermediate_as_output());
+            auto* func = get_aggregate_function(fn.name.function_name, arg_type.type, return_type.type, use_nullable_fn,
+                                                fn.binary_type, state->func_version());
             if (func == nullptr) {
                 return Status::InternalError(strings::Substitute(
                         "Invalid agg function plan: $0 with (arg type $1, serde type $2, result type $3, nullable $4)",
                         fn.name.function_name, type_to_string(arg_type.type), type_to_string(serde_type.type),
-                        type_to_string(return_type.type), is_input_nullable ? "true" : "false"));
+                        type_to_string(return_type.type), use_nullable_fn ? "true" : "false"));
             }
             VLOG_ROW << "get agg function " << func->get_name() << " serde_type " << serde_type << " return_type "
                      << return_type;
@@ -1019,14 +1027,14 @@ Columns Aggregator::_create_agg_result_columns(size_t num_rows, bool use_interme
         for (size_t i = 0; i < _agg_fn_types.size(); ++i) {
             // For count, count distinct, bitmap_union_int such as never return null function,
             // we need to create a not-nullable column.
-            agg_result_columns[i] = ColumnHelper::create_column(
-                    _agg_fn_types[i].result_type, _agg_fn_types[i].has_nullable_child && _agg_fn_types[i].is_nullable);
+            agg_result_columns[i] = ColumnHelper::create_column(_agg_fn_types[i].result_type,
+                                                                _agg_fn_types[i].is_result_nullable<false>());
             agg_result_columns[i]->reserve(num_rows);
         }
     } else {
         for (size_t i = 0; i < _agg_fn_types.size(); ++i) {
-            agg_result_columns[i] =
-                    ColumnHelper::create_column(_agg_fn_types[i].serde_type, _agg_fn_types[i].has_nullable_child);
+            agg_result_columns[i] = ColumnHelper::create_column(_agg_fn_types[i].serde_type,
+                                                                _agg_fn_types[i].is_result_nullable<true>());
             agg_result_columns[i]->reserve(num_rows);
         }
     }
@@ -1322,7 +1330,8 @@ void Aggregator::build_hash_map_with_selection_and_allocation(size_t chunk_size,
     });
 }
 
-Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk, bool* use_intermediate_as_output) {
+Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk,
+                                             bool force_use_intermediate_as_output) {
     SCOPED_TIMER(_agg_stat->get_results_timer);
 
     RETURN_IF_ERROR(_hash_map_variant.visit([&](auto& variant_value) {
@@ -1334,8 +1343,7 @@ Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk
 
         const auto hash_map_size = _hash_map_variant.size();
         auto num_rows = std::min<size_t>(hash_map_size - _num_rows_processed, chunk_size);
-        auto use_intermediate =
-                use_intermediate_as_output != nullptr ? *use_intermediate_as_output : _use_intermediate_as_output();
+        auto use_intermediate = force_use_intermediate_as_output || _use_intermediate_as_output();
         Columns group_by_columns = _create_group_by_columns(num_rows);
         Columns agg_result_columns = _create_agg_result_columns(num_rows, use_intermediate);
 

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -163,8 +163,7 @@ void AggregatorParams::init() {
 
             const bool is_input_nullable = has_outer_join_child || desc.nodes[0].has_nullable_child;
             agg_fn_types[i] = {return_type, serde_type, arg_typedescs, is_input_nullable, desc.nodes[0].is_nullable};
-            agg_fn_types[i].is_always_nullable_result =
-                    ALWAYS_NULLABLE_RESULT_AGG_FUNCS.contains(fn.name.function_name);
+            agg_fn_types[i].is_always_nullable_result = ALWAYS_NULLABLE_RESULT_AGG_FUNCS.count(fn.name.function_name);
             if (fn.name.function_name == "array_agg" || fn.name.function_name == "group_concat") {
                 // set order by info
                 if (fn.aggregate_fn.__isset.is_asc_order && fn.aggregate_fn.__isset.nulls_first &&

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -136,6 +136,11 @@ struct AggFunctionTypes {
     std::vector<bool> nulls_first;
 
     bool is_distinct = false;
+    bool is_always_nullable_result = false;
+
+    template <bool UseIntermediateAsOutput>
+    bool is_result_nullable() const;
+    bool use_nullable_fn(bool use_intermediate_as_output) const;
 };
 
 struct ColumnType {
@@ -238,8 +243,6 @@ struct AggregatorParams {
     bool has_nullable_key;
 
     void init();
-
-    ChunkUniquePtr create_result_chunk(bool is_serialize_fmt, const TupleDescriptor& desc);
 };
 using AggregatorParamsPtr = std::shared_ptr<AggregatorParams>;
 AggregatorParamsPtr convert_to_aggregator_params(const TPlanNode& tnode);
@@ -502,7 +505,8 @@ public:
     void build_hash_map(size_t chunk_size, bool agg_group_by_with_limit = false);
     void build_hash_map_with_selection(size_t chunk_size);
     void build_hash_map_with_selection_and_allocation(size_t chunk_size, bool agg_group_by_with_limit = false);
-    Status convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk, bool* use_intermediate_as_output = nullptr);
+    Status convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk,
+                                     bool force_use_intermediate_as_output = false);
 
     void build_hash_set(size_t chunk_size);
     void build_hash_set_with_selection(size_t chunk_size);

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -253,11 +253,9 @@ std::function<StatusOr<ChunkPtr>()> SpillableAggregateBlockingSinkOperator::_bui
             return chunk;
         }
         if (should_spill_hash_table) {
-            bool use_intermediate_as_output = true;
             if (!_aggregator->is_ht_eos()) {
                 auto chunk = std::make_shared<Chunk>();
-                RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), &chunk,
-                                                                       &use_intermediate_as_output));
+                RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), &chunk, true));
                 return chunk;
             }
             COUNTER_UPDATE(_aggregator->input_row_count(), _aggregator->num_input_rows());

--- a/be/src/exprs/agg/covariance.h
+++ b/be/src/exprs/agg/covariance.h
@@ -113,11 +113,12 @@ public:
         double deltaY = this->data(state).meanY - meanY;
 
         double sum_count = this->data(state).count + count;
-        double factor = (this->data(state).count / sum_count);
 
-        this->data(state).meanX = meanX + deltaX * factor;
-        this->data(state).meanY = meanY + deltaY * factor;
+        double factor_for_mean = (this->data(state).count / sum_count);
+        this->data(state).meanX = meanX + deltaX * factor_for_mean;
+        this->data(state).meanY = meanY + deltaY * factor_for_mean;
 
+        double factor = (this->data(state).count * count / sum_count);
         this->data(state).c2 = c2 + this->data(state).c2 + (deltaX * deltaY) * factor;
         this->data(state).count = sum_count;
 
@@ -200,9 +201,24 @@ public:
 
 template <LogicalType LT, bool isSample, typename T = RunTimeCppType<LT>>
 class CorVarianceAggregateFunction final : public CorVarianceBaseAggregateFunction<LT, false> {
+public:
     using InputColumnType = RunTimeColumnType<LT>;
     using InputCppType = T;
     using ResultColumnType = RunTimeColumnType<TYPE_DOUBLE>;
+
+    struct AggNullPred {
+        bool operator()(const CovarianceCorelationAggregateState<false>& state) const {
+            if constexpr (isSample) {
+                return state.count <= 1;
+            } else {
+                // The non-sample case will return null only when `state.count` is 0, where
+                // `NullableAggregateFunctionState::is_null` also true.
+                // Therefore, we don't need to check `state.count` here.
+                return false;
+            }
+        }
+    };
+
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
 
@@ -257,6 +273,10 @@ public:
     using InputColumnType = RunTimeColumnType<LT>;
     using InputCppType = T;
     using ResultColumnType = RunTimeColumnType<TYPE_DOUBLE>;
+
+    struct AggNullPred {
+        bool operator()(const CovarianceCorelationAggregateState<true>& state) const { return state.count <= 1; }
+    };
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -135,11 +135,14 @@ public:
     static AggregateFunctionPtr MakeAnyValueAggregateFunction();
 
     template <typename NestedState, bool IsWindowFunc, bool IgnoreNull = true,
-              typename NestedFunctionPtr = AggregateFunctionPtr>
-    static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function);
+              typename NestedFunctionPtr = AggregateFunctionPtr,
+              IsAggNullPred<NestedState> AggNullPred = AggNonNullPred<NestedState>>
+    static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
+                                                                   AggNullPred null_pred = AggNullPred());
 
-    template <typename NestedState>
-    static AggregateFunctionPtr MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function);
+    template <typename NestedState, IsAggNullPred<NestedState> AggNullPred = AggNonNullPred<NestedState>>
+    static AggregateFunctionPtr MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
+                                                                      AggNullPred null_pred = AggNullPred());
 
     template <LogicalType LT>
     static auto MakeSumAggregateFunction();
@@ -148,16 +151,16 @@ public:
     static auto MakeDecimalSumAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static AggregateFunctionPtr MakeVarianceAggregateFunction();
+    static auto MakeVarianceAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static AggregateFunctionPtr MakeStddevAggregateFunction();
+    static auto MakeStddevAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static AggregateFunctionPtr MakeCovarianceAggregateFunction();
+    static auto MakeCovarianceAggregateFunction();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeCorelationAggregateFunction();
+    static auto MakeCorelationAggregateFunction();
 
     template <LogicalType LT>
     static auto MakeSumDistinctAggregateFunction();
@@ -301,18 +304,22 @@ AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
             AnyValueAggregateFunction<LT, AnyValueAggregateData<LT>, AnyValueElement<LT, AnyValueAggregateData<LT>>>>();
 }
 
-template <typename NestedState, bool IsWindowFunc, bool IgnoreNull, typename NestedFunctionPtr>
-AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function) {
+template <typename NestedState, bool IsWindowFunc, bool IgnoreNull, typename NestedFunctionPtr,
+          IsAggNullPred<NestedState> AggNullPred>
+AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
+                                                                          AggNullPred null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, IsWindowFunc>;
-    return std::make_shared<
-            NullableAggregateFunctionUnary<NestedFunctionPtr, AggregateDataType, IsWindowFunc, IgnoreNull>>(
-            nested_function);
+    return std::make_shared<NullableAggregateFunctionUnary<NestedFunctionPtr, AggregateDataType, IsWindowFunc,
+                                                           IgnoreNull, AggNullPred>>(nested_function,
+                                                                                     std::move(null_pred));
 }
 
-template <typename NestedState>
-AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function) {
+template <typename NestedState, IsAggNullPred<NestedState> AggNullPred>
+AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
+                                                                             AggNullPred null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, false>;
-    return std::make_shared<NullableAggregateFunctionVariadic<AggregateDataType>>(nested_function);
+    return std::make_shared<NullableAggregateFunctionVariadic<AggregateDataType, AggNullPred>>(nested_function,
+                                                                                               std::move(null_pred));
 }
 
 template <LogicalType LT>
@@ -326,22 +333,22 @@ auto AggregateFactory::MakeDecimalSumAggregateFunction() {
 }
 
 template <LogicalType LT, bool is_sample>
-AggregateFunctionPtr AggregateFactory::MakeVarianceAggregateFunction() {
+auto AggregateFactory::MakeVarianceAggregateFunction() {
     return std::make_shared<VarianceAggregateFunction<LT, is_sample>>();
 }
 
 template <LogicalType LT, bool is_sample>
-AggregateFunctionPtr AggregateFactory::MakeStddevAggregateFunction() {
+auto AggregateFactory::MakeStddevAggregateFunction() {
     return std::make_shared<StddevAggregateFunction<LT, is_sample>>();
 }
 
 template <LogicalType LT, bool is_sample>
-AggregateFunctionPtr AggregateFactory::MakeCovarianceAggregateFunction() {
+auto AggregateFactory::MakeCovarianceAggregateFunction() {
     return std::make_shared<CorVarianceAggregateFunction<LT, is_sample>>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeCorelationAggregateFunction() {
+auto AggregateFactory::MakeCorelationAggregateFunction() {
     return std::make_shared<CorelationAggregateFunction<LT>>();
 }
 

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -135,12 +135,11 @@ public:
     static AggregateFunctionPtr MakeAnyValueAggregateFunction();
 
     template <typename NestedState, bool IsWindowFunc, bool IgnoreNull = true,
-              typename NestedFunctionPtr = AggregateFunctionPtr,
-              IsAggNullPred<NestedState> AggNullPred = AggNonNullPred<NestedState>>
+              typename NestedFunctionPtr = AggregateFunctionPtr, typename AggNullPred = AggNonNullPred<NestedState>>
     static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
                                                                    AggNullPred null_pred = AggNullPred());
 
-    template <typename NestedState, IsAggNullPred<NestedState> AggNullPred = AggNonNullPred<NestedState>>
+    template <typename NestedState, typename AggNullPred = AggNonNullPred<NestedState>>
     static AggregateFunctionPtr MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
                                                                       AggNullPred null_pred = AggNullPred());
 
@@ -304,8 +303,7 @@ AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
             AnyValueAggregateFunction<LT, AnyValueAggregateData<LT>, AnyValueElement<LT, AnyValueAggregateData<LT>>>>();
 }
 
-template <typename NestedState, bool IsWindowFunc, bool IgnoreNull, typename NestedFunctionPtr,
-          IsAggNullPred<NestedState> AggNullPred>
+template <typename NestedState, bool IsWindowFunc, bool IgnoreNull, typename NestedFunctionPtr, typename AggNullPred>
 AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
                                                                           AggNullPred null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, IsWindowFunc>;
@@ -314,7 +312,7 @@ AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(Nested
                                                                                      std::move(null_pred));
 }
 
-template <typename NestedState, IsAggNullPred<NestedState> AggNullPred>
+template <typename NestedState, typename AggNullPred>
 AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
                                                                              AggNullPred null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, false>;

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -117,29 +117,36 @@ public:
     }
 
     template <LogicalType ArgType, LogicalType RetType, class StateType,
-              typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true>
-    void add_aggregate_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true,
+              IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
+    void add_aggregate_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun,
+                               AggNullPred null_pred = AggNullPred()) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
-        auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, false, IgnoreNull>(fun);
+        auto nullable_agg =
+                AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, false, IgnoreNull>(fun, null_pred);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, true), nullable_agg);
 
         if (is_window) {
             _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, true, false), fun);
-            auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, true, IgnoreNull>(fun);
+            auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, true, IgnoreNull>(
+                    fun, std::move(null_pred));
             _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, true, true), nullable_agg);
         }
     }
 
     template <LogicalType ArgType, LogicalType RetType, class StateType,
-              typename SpecificAggFunctionPtr = AggregateFunctionPtr>
-    void add_aggregate_mapping_variadic(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr,
+              IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
+    void add_aggregate_mapping_variadic(const std::string& name, bool is_window, SpecificAggFunctionPtr fun,
+                                        AggNullPred null_pred = AggNullPred()) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
-        auto variadic_agg = AggregateFactory::MakeNullableAggregateFunctionVariadic<StateType>(fun);
+        auto variadic_agg = AggregateFactory::MakeNullableAggregateFunctionVariadic<StateType>(fun, null_pred);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, true), variadic_agg);
 
         if (is_window) {
             _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, true, false), fun);
-            auto variadic_agg = AggregateFactory::MakeNullableAggregateFunctionVariadic<StateType>(fun);
+            auto variadic_agg =
+                    AggregateFactory::MakeNullableAggregateFunctionVariadic<StateType>(fun, std::move(null_pred));
             _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, true, true), variadic_agg);
         }
     }

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -118,7 +118,7 @@ public:
 
     template <LogicalType ArgType, LogicalType RetType, class StateType,
               typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true,
-              IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
+              typename AggNullPred = AggNonNullPred<StateType>>
     void add_aggregate_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun,
                                AggNullPred null_pred = AggNullPred()) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
@@ -135,8 +135,7 @@ public:
     }
 
     template <LogicalType ArgType, LogicalType RetType, class StateType,
-              typename SpecificAggFunctionPtr = AggregateFunctionPtr,
-              IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr, typename AggNullPred = AggNonNullPred<StateType>>
     void add_aggregate_mapping_variadic(const std::string& name, bool is_window, SpecificAggFunctionPtr fun,
                                         AggNullPred null_pred = AggNullPred()) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);

--- a/be/src/exprs/agg/factory/aggregate_resolver_variance.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_variance.cpp
@@ -34,9 +34,11 @@ struct StdDispatcher {
                     "var_pop", true, AggregateFactory::MakeVarianceAggregateFunction<lt, false>());
 
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
-                    "variance_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>());
+                    "variance_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>(),
+                    typename VarianceAggregateFunction<lt, true>::AggNullPred());
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
-                    "var_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>());
+                    "var_samp", true, AggregateFactory::MakeVarianceAggregateFunction<lt, true>(),
+                    typename VarianceAggregateFunction<lt, true>::AggNullPred());
 
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
                     "stddev", true, AggregateFactory::MakeStddevAggregateFunction<lt, false>());
@@ -45,7 +47,8 @@ struct StdDispatcher {
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
                     "stddev_pop", true, AggregateFactory::MakeStddevAggregateFunction<lt, false>());
             resolver->add_aggregate_mapping<lt, DevFromAveResultLT<lt>, VarState>(
-                    "stddev_samp", true, AggregateFactory::MakeStddevAggregateFunction<lt, true>());
+                    "stddev_samp", true, AggregateFactory::MakeStddevAggregateFunction<lt, true>(),
+                    typename StddevAggregateFunction<lt, true>::AggNullPred());
         }
     }
 };
@@ -59,11 +62,13 @@ struct CorVarDispatcher {
                     "covar_pop", true, AggregateFactory::MakeCovarianceAggregateFunction<lt, false>());
 
             resolver->add_aggregate_mapping_variadic<lt, TYPE_DOUBLE, VarState>(
-                    "covar_samp", true, AggregateFactory::MakeCovarianceAggregateFunction<lt, true>());
+                    "covar_samp", true, AggregateFactory::MakeCovarianceAggregateFunction<lt, true>(),
+                    typename CorVarianceAggregateFunction<lt, true>::AggNullPred());
 
             using CorrState = CovarianceCorelationAggregateState<true>;
             resolver->add_aggregate_mapping_variadic<lt, TYPE_DOUBLE, CorrState>(
-                    "corr", true, AggregateFactory::MakeCorelationAggregateFunction<lt>());
+                    "corr", true, AggregateFactory::MakeCorelationAggregateFunction<lt>(),
+                    typename CorelationAggregateFunction<lt>::AggNullPred());
         }
     }
 };

--- a/be/src/exprs/agg/variance.h
+++ b/be/src/exprs/agg/variance.h
@@ -196,6 +196,19 @@ public:
     using ResultColumnType =
             typename DevFromAveAggregateFunction<LT, is_sample, T, ResultLT, TResult>::ResultColumnType;
 
+    struct AggNullPred {
+        bool operator()(const DevFromAveAggregateState<TResult>& state) const {
+            if constexpr (is_sample) {
+                return state.count <= 1;
+            } else {
+                // The non-sample case will return null only when `state.count` is 0, where
+                // `NullableAggregateFunctionState::is_null` also true.
+                // Therefore, we don't need to check `state.count` here.
+                return false;
+            }
+        }
+    };
+
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
 
@@ -312,6 +325,19 @@ class StddevAggregateFunction final : public DevFromAveAggregateFunction<LT, is_
 public:
     using ResultColumnType =
             typename DevFromAveAggregateFunction<LT, is_sample, T, ResultLT, TResult>::ResultColumnType;
+
+    struct AggNullPred {
+        bool operator()(const DevFromAveAggregateState<TResult>& state) const {
+            if constexpr (is_sample) {
+                return state.count <= 1;
+            } else {
+                // The non-sample case will return null only when `state.count` is 0, where
+                // `NullableAggregateFunctionState::is_null` also true.
+                // Therefore, we don't need to check `state.count` here.
+                return false;
+            }
+        }
+    };
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());

--- a/test/sql/test_agg_function/R/test_always_null_statistic_funcs
+++ b/test/sql/test_agg_function/R/test_always_null_statistic_funcs
@@ -1,0 +1,1161 @@
+-- name: test_always_null_statistic_funcs
+CREATE TABLE t1 (
+    idx BIGINT, 
+    k BIGINT NULL, 
+    val1 BIGINT NULL,
+    val2 BIGINT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE t1_nonnull (
+    idx BIGINT, 
+    k BIGINT NOT NULL, 
+    val1 BIGINT NOT NULL,
+    val2 BIGINT NOT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (NULL, 4,4,8),
+    (50, NULL,5,10),
+    (NULL, NULL,6,12),
+    (70, NULL,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+-- result:
+-- !result
+INSERT INTO t1_nonnull (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (40, 4,4,8),
+    (50, 5,5,10),
+    (60, 6,6,12),
+    (70, 7,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+-- result:
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(var_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(var_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(variance_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(variance_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	None	0.707
+6	None	None
+7	None	None
+8	8	None
+9	9	0.707
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull;
+-- result:
+3.028
+-- !result
+select round(stddev_samp(val1), 3) from t1;
+-- result:
+3.638
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	None	5.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	5.0
+10	10	100	10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	40	10.0
+5	5	50	10.0
+6	6	60	10.0
+7	7	70	10.0
+8	8	80	10.0
+9	9	90	10.0
+10	10	100	10.0
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+-- result:
+91.667
+-- !result
+select round(covar_samp(val1, val2), 3) from t1;
+-- result:
+155.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	None	1.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	40	1.0
+5	5	50	1.0
+6	6	60	1.0
+7	7	70	1.0
+8	8	80	1.0
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+select round(corr(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull;
+-- result:
+1.0
+-- !result
+select round(corr(val1, val2), 3) from t1;
+-- result:
+1.0
+-- !result
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(var_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(var_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(var_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	None	0.5
+6	None	None
+7	None	None
+8	8	None
+9	9	0.5
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.5
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(variance_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(variance_samp(val1), 3) from t1_nonnull;
+-- result:
+9.167
+-- !result
+select round(variance_samp(val1), 3) from t1;
+-- result:
+13.238
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	None	0.707
+6	None	None
+7	None	None
+8	8	None
+9	9	0.707
+10	10	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	None
+2	2	0.707
+3	3	1.0
+4	4	1.0
+5	5	1.0
+6	6	1.0
+7	7	1.0
+8	8	1.0
+9	9	1.0
+10	10	1.0
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(stddev_samp(val1), 3) from t1_nonnull;
+-- result:
+3.028
+-- !result
+select round(stddev_samp(val1), 3) from t1;
+-- result:
+3.638
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- result:
+10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	None	5.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	5.0
+10	10	100	10.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	5.0
+3	3	30	10.0
+4	4	40	10.0
+5	5	50	10.0
+6	6	60	10.0
+7	7	70	10.0
+8	8	80	10.0
+9	9	90	10.0
+10	10	100	10.0
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+-- result:
+91.667
+-- !result
+select round(covar_samp(val1, val2), 3) from t1;
+-- result:
+155.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+None
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+-- result:
+1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	None	1.0
+5	None	50	None
+6	None	None	None
+7	None	70	None
+8	8	80	None
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+-- result:
+1	1	10	None
+2	2	20	1.0
+3	3	30	1.0
+4	4	40	1.0
+5	5	50	1.0
+6	6	60	1.0
+7	7	70	1.0
+8	8	80	1.0
+9	9	90	1.0
+10	10	100	1.0
+-- !result
+select round(corr(val1, val2), 3) from t1 where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- result:
+None
+-- !result
+select round(corr(val1, val2), 3) from t1_nonnull;
+-- result:
+1.0
+-- !result
+select round(corr(val1, val2), 3) from t1;
+-- result:
+1.0
+-- !result

--- a/test/sql/test_agg_function/T/test_always_null_statistic_funcs
+++ b/test/sql/test_agg_function/T/test_always_null_statistic_funcs
@@ -1,0 +1,647 @@
+
+-- name: test_always_null_statistic_funcs
+CREATE TABLE t1 (
+    idx BIGINT, 
+    k BIGINT NULL, 
+    val1 BIGINT NULL,
+    val2 BIGINT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE t1_nonnull (
+    idx BIGINT, 
+    k BIGINT NOT NULL, 
+    val1 BIGINT NOT NULL,
+    val2 BIGINT NOT NULL
+) PRIMARY KEY(idx) 
+DISTRIBUTED BY HASH (idx) BUCKETS 32
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO t1 (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (NULL, 4,4,8),
+    (50, NULL,5,10),
+    (NULL, NULL,6,12),
+    (70, NULL,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+
+INSERT INTO t1_nonnull (val2, val1, k, idx) values
+    (10, 1,1,2),
+    (20, 2,2,4),
+    (30, 3,3,6),
+    (40, 4,4,8),
+    (50, 5,5,10),
+    (60, 6,6,12),
+    (70, 7,7,14),
+    (80, 8,8,16),
+    (90, 9,9,18),
+    (100, 10,10,20);
+
+-- var_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- One non-null row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(var_samp(val1), 3) from t1 where k > 100;
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(var_samp(val1), 3) from t1 where k = 2;
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(var_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(var_samp(val1), 3) from t1;
+
+
+-- variance_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(variance_samp(val1), 3) from t1 where k > 100;
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(variance_samp(val1), 3) from t1 where k = 2;
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(variance_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(variance_samp(val1), 3) from t1;
+
+
+-- stddev_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(stddev_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(stddev_samp(val1), 3) from t1;
+
+
+-- covar_samp
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+
+
+-- Two phase agg.
+-- Empty
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(covar_samp(val1, val2), 3) from t1;
+
+
+-- corr
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+
+-- Two phase agg.
+-- Empty
+select round(corr(val1, val2), 3) from t1 where k > 100;
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(corr(val1, val2), 3) from t1 where k = 2;
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(corr(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(corr(val1, val2), 3) from t1;
+
+
+
+-- set force spill and repeat the above cases.
+set enable_spill=true;
+set spill_mode="force";
+
+
+
+-- var_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1 where c1 > 10;
+-- One non-null row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(var_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(var_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(var_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(var_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(VAR_SAMP(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS var_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(var_samp(val1), 3) from t1 where k > 100;
+select round(var_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(var_samp(val1), 3) from t1 where k = 2;
+select round(var_samp(val1), 3) from t1_nonnull where k = 2;
+select round(var_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(var_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(var_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(var_samp(val1), 3) from t1;
+
+
+-- variance_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(variance_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(variance_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(variance_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(variance_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS variance_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(variance_samp(val1), 3) from t1 where k > 100;
+select round(variance_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(variance_samp(val1), 3) from t1 where k = 2;
+select round(variance_samp(val1), 3) from t1_nonnull where k = 2;
+select round(variance_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(variance_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(variance_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(variance_samp(val1), 3) from t1;
+
+
+-- stddev_samp
+-- Empty
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1 from ( values (1) )t)
+select round(stddev_samp(c1), 3) from w1;
+with w1 as (select column_0 as c1 from ( values (1), (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1 from ( values (null), (null) )t)
+select round(stddev_samp(c1), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1 from ( values (1), (2), (null), (3) )t)
+select round(stddev_samp(c1), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    round(stddev_samp(val1) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS stddev_samp_val1
+FROM t1_nonnull
+order by k;
+-- Two phase agg.
+-- Empty
+select round(stddev_samp(val1), 3) from t1 where k > 100;
+select round(stddev_samp(val1), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(stddev_samp(val1), 3) from t1 where k = 2;
+select round(stddev_samp(val1), 3) from t1_nonnull where k = 2;
+select round(stddev_samp(val1), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(stddev_samp(val1), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(stddev_samp(val1), 3) from t1_nonnull;
+--   Input is nullable.
+select round(stddev_samp(val1), 3) from t1;
+
+
+-- covar_samp
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(covar_samp(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(covar_samp(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS covar_samp_val1
+FROM t1_nonnull
+order by k;
+
+
+-- Two phase agg.
+-- Empty
+select round(covar_samp(val1, val2), 3) from t1 where k > 100;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(covar_samp(val1, val2), 3) from t1 where k = 2;
+select round(covar_samp(val1, val2), 3) from t1_nonnull where k = 2;
+select round(covar_samp(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(covar_samp(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(covar_samp(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(covar_samp(val1, val2), 3) from t1;
+
+
+-- corr
+-- Empty
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1 where c1 > 10;
+-- One row.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (null, 20), (3, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Only NULL rows.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (null, null), (null, null) )t)
+select round(corr(c1, c2), 3) from w1;
+-- Normal
+--   Input is non-nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+--   Input is nullable.
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (null, null), (3, 30) )t)
+select round(corr(c1, c2), 3) from w1;
+with w1 as (select column_0 as c1, column_1 as c2 from ( values (1, 10), (2, 20), (4, null), (3, 30), (null, 50) )t)
+select round(corr(c1, c2), 3) from w1;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1
+order by k;
+
+SELECT
+    k,
+    val1,
+    val2,
+    round(corr(val1, val2) over (
+        ORDER BY k ASC 
+        ROWS BETWEEN 2 PRECEDING and CURRENT ROW
+    ), 3) AS corr_val1
+FROM t1_nonnull
+order by k;
+
+-- Two phase agg.
+-- Empty
+select round(corr(val1, val2), 3) from t1 where k > 100;
+select round(corr(val1, val2), 3) from t1_nonnull where k > 100;
+-- One non-null row.
+select round(corr(val1, val2), 3) from t1 where k = 2;
+select round(corr(val1, val2), 3) from t1_nonnull where k = 2;
+select round(corr(val1, val2), 3) from t1 where k in (2, 5, 6);
+-- Only NULL rows.
+select round(corr(val1, val2), 3) from t1 where k in (5, 6);
+-- Normal
+--   Input is non-nullable.
+select round(corr(val1, val2), 3) from t1_nonnull;
+--   Input is nullable.
+select round(corr(val1, val2), 3) from t1;


### PR DESCRIPTION
CP from #47904

## Why I'm doing:

### Return NULL incorrectly

For now, the result nullable property of aggregation functions contains two cases:
1. **Always non-nullable**
    - FE pass `is_output_nullable` with `false` value to BE, such as such as count, count distinct, and bitmap_union_int.
2. **Nullable the same as input**
    - FE pass `is_output_nullable` with `true` value to BE. (**NOTE that BE need determine whether the result is nullable by itself!**)
    - The result is `NULl` only when all the input rows are `NULL`.

This is OK, until the statistics aggregations occur. The reason is that the output of statistics aggregations is **always nullable** no matter what the input is, because they will return `NULL` when the number of input non-null rows is less than 2.

### COVARIANCE
According to [Wikipedia](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online), when merging two COVARIANCE states $C_A$ and $C_B$, the formula should be as follows:

$$
C_X = C_A + C_B + (\overline{x}_A - \overline{x}_B)(\overline{y}_A - \overline{y}_B) \cdot \frac{n_A n_B}{n_X},
$$

but we use a wrong one as follows:

$$
C_X = C_A + C_B + (\overline{x}_A - \overline{x}_B)(\overline{y}_A - \overline{y}_B) \cdot \frac{n_A}{n_X},
$$

where $C_n$ is defined as follows:
 $$C_n = \sum_{i=1}^{n} (x_i - \overline{x}_n)(y_i - \overline{y}_n)$$

## What I'm doing:


1. Pass `AggNullPred(State)` to `NullableAggregate`.
   For now, `NullableAggregate` only returns null when the input is null, but the statistics function will return `NULL` when the number of input non-null rows is less than 2.
   Therefore, we need to add a new parameter `AggNullPred` to determine whether the output is nullable.
   And this is zero overhead when it is passed as a constexpr functor `AggNonNullPred` by default, since the compiler will eliminate this always false predicate.
2. Jusge `is_result_nullable` and `use_nullable_fn` according to `use_intermediate_as_output`, `is_input_nullable`, `is_output_nullable` and `is_always_nullable_result`.





Fixes #47762.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5


