### PR TITLE
[Enhancement] avoid use dict_mapping function in lookup_string

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -20,11 +20,14 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -419,8 +422,22 @@ public class MetaFunctions {
                                                  ConstantOperator lookupKey,
                                                  ConstantOperator returnColumn) {
         TableName tableNameValue = TableName.fromString(tableName.getVarchar());
-        String sql = String.format("select cast(dict_mapping('%s', '%s', '%s') as string)",
-                tableNameValue.toString(), lookupKey.getVarchar(), returnColumn.getVarchar());
+        Optional<Table> maybeTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableNameValue);
+        maybeTable.orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tableNameValue));
+        if (!(maybeTable.get() instanceof OlapTable)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, "must be OLAP_TABLE");
+        }
+        OlapTable table = (OlapTable) maybeTable.get();
+        if (table.getKeysType() != KeysType.PRIMARY_KEYS) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, "must be PRIMARY_KEY");
+        }
+        if (table.getKeysNum() > 1) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, "too many key columns");
+        }
+        Column keyColumn = table.getKeyColumns().get(0);
+
+        String sql = String.format("select cast(`%s` as string) from %s where `%s` = '%s' limit 1",
+                returnColumn.getVarchar(), tableNameValue.toString(), keyColumn.getName(), lookupKey.getVarchar());
         try {
             List<TResultBatch> result = RepoExecutor.getInstance().executeDQL(sql);
             return deserializeLookupResult(result);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -178,8 +178,8 @@ public class MetaFunctionsTest {
             Exception e = Assert.assertThrows(SemanticException.class, () ->
                     lookupString("t1", "v1", "c1")
             );
-            Assert.assertEquals("Getting analyzing error. Detail message: lookup failed: " +
-                    "Getting analyzing error. Detail message: dict table t1 is not found..", e.getMessage());
+            Assert.assertEquals("Getting analyzing error. Detail message: Unknown table 'test.t1'.",
+                    e.getMessage());
         }
         {
             starRocksAssert.withTable("create table t1(c1 string, c2 bigint) duplicate key(c1) " +
@@ -187,9 +187,8 @@ public class MetaFunctionsTest {
             Exception e = Assert.assertThrows(SemanticException.class, () ->
                     lookupString("t1", "v1", "c1")
             );
-            Assert.assertEquals("Getting analyzing error. Detail message: lookup failed: " +
-                            "Getting analyzing error. Detail message: dict table test.t1 should be primary key table..",
-                    e.getMessage());
+            Assert.assertEquals("Getting analyzing error. Detail message: " +
+                            "Invalid parameter must be PRIMARY_KEY.", e.getMessage());
             starRocksAssert.dropTable("t1");
         }
         {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- The `dict_mapping` is not efficient under high-concurrency, so here we use a vanilla sql to perform lookup
- The problem of `dict_mapping` is, at BE it would call FE to resolve the tablet address, which introduce extra overhead on FE, and may even get error when FE is overloaded

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
