### PR TITLE
[Enhancement] Support large json in image

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -61,6 +61,7 @@ import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -698,11 +699,11 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         return checksum;
     }
 
-    public void saveBackupHandlerV2(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos,
+    public void saveBackupHandlerV2(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(
                 SRMetaBlockID.BACKUP_MGR, 2 + dbIdToBackupOrRestoreJob.size());
         writer.writeJson(this);
-        writer.writeJson(dbIdToBackupOrRestoreJob.size());
+        writer.writeInt(dbIdToBackupOrRestoreJob.size());
         for (AbstractJob job : dbIdToBackupOrRestoreJob.values()) {
             writer.writeJson(job);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -52,6 +52,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.persist.ColocatePersistInfo;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.TablePropertyInfo;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -816,8 +817,8 @@ public class ColocateTableIndex implements Writable {
         return checksum;
     }
 
-    public void saveColocateTableIndexV2(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.COLOCATE_TABLE_INDEX, 1);
+    public void saveColocateTableIndexV2(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.COLOCATE_TABLE_INDEX, 1);
         writer.writeJson(this);
         writer.close();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -34,6 +34,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.persist.DictionaryMgrInfo;
 import com.starrocks.persist.DropDictionaryInfo;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -74,7 +75,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.DataOutput;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -506,8 +506,8 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
         }
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.DICTIONARY_MGR, 1);
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.DICTIONARY_MGR, 1);
         writer.writeJson(this);
         writer.close();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/GlobalFunctionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/GlobalFunctionMgr.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.common.UserException;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -192,12 +193,12 @@ public class GlobalFunctionMgr {
         return checksum;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         List<Function> functions = getFunctions();
 
         int numJson = 1 + functions.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.GLOBAL_FUNCTION_MGR, numJson);
-        writer.writeJson(functions.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.GLOBAL_FUNCTION_MGR, numJson);
+        writer.writeInt(functions.size());
         for (Function function : functions) {
             writer.writeJson(function);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -21,6 +21,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.ResourceGroupOpEntry;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -604,10 +605,10 @@ public class ResourceGroupMgr implements Writable {
         public List<ResourceGroup> resourceGroups;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         int numJson = 1 + resourceGroupMap.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.RESOURCE_GROUP_MGR, numJson);
-        writer.writeJson(resourceGroupMap.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.RESOURCE_GROUP_MGR, numJson);
+        writer.writeInt(resourceGroupMap.size());
         for (ResourceGroup resourceGroup : resourceGroupMap.values()) {
             writer.writeJson(resourceGroup);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -44,6 +44,7 @@ import com.starrocks.common.proc.BaseProcResult;
 import com.starrocks.common.proc.ProcNodeInterface;
 import com.starrocks.common.proc.ProcResult;
 import com.starrocks.persist.DropResourceOperationLog;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -354,8 +355,8 @@ public class ResourceMgr implements Writable {
         return checksum;
     }
 
-    public void saveResourcesV2(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.RESOURCE_MGR, 1);
+    public void saveResourcesV2(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.RESOURCE_MGR, 1);
         writer.writeJson(this);
         writer.close();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SmallFileMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SmallFileMgr.java
@@ -45,6 +45,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -578,9 +579,9 @@ public class SmallFileMgr implements Writable {
         return checksum;
     }
 
-    public void saveSmallFilesV2(DataOutputStream out) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(out, SRMetaBlockID.SMALL_FILE_MGR, 1 + idToFiles.size());
-        writer.writeJson(idToFiles.size());
+    public void saveSmallFilesV2(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.SMALL_FILE_MGR, 1 + idToFiles.size());
+        writer.writeInt(idToFiles.size());
         for (SmallFile file : idToFiles.values()) {
             writer.writeJson(file);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/encryption/KeyMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/encryption/KeyMgr.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -32,7 +33,6 @@ import com.starrocks.thrift.TGetKeysResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -204,13 +204,13 @@ public class KeyMgr {
         }
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         keysLock.readLock().lock();
         try {
             final int cnt = 1 + idToKey.size();
-            SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.KEY_MGR, cnt);
+            SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.KEY_MGR, cnt);
             // write keys
-            writer.writeJson(idToKey.size());
+            writer.writeInt(idToKey.size());
             for (EncryptionKey key : idToKey.values()) {
                 EncryptionKeyPB pb = new EncryptionKeyPB();
                 key.toPB(pb, this);

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaBaseAction.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http.meta;
 
+import com.google.common.base.Strings;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -88,7 +89,7 @@ public class MetaBaseAction extends WebBaseAction {
         return true;
     }
 
-    protected void writeFileResponse(BaseRequest request, BaseResponse response, File file) {
+    protected void writeFileResponse(BaseRequest request, BaseResponse response, File file, String checksum) {
         if (file == null || !file.exists()) {
             response.appendContent("File does not exist.");
             writeResponse(request, response, HttpResponseStatus.NOT_FOUND);
@@ -98,6 +99,9 @@ public class MetaBaseAction extends WebBaseAction {
         // add custom header
         response.updateHeader(CONTENT_DISPOSITION, "attachment; filename=" + file.getName());
         response.updateHeader(MetaHelper.X_IMAGE_SIZE, String.valueOf(file.length()));
+        if (!Strings.isNullOrEmpty(checksum)) {
+            response.updateHeader(MetaHelper.X_IMAGE_CHECKSUM, checksum);
+        }
 
         writeObjectResponse(request, response, HttpResponseStatus.OK, file, file.getName(), true);
         return;

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -43,6 +43,8 @@ import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import com.starrocks.leader.MetaHelper;
+import com.starrocks.persist.ImageFormatVersion;
+import com.starrocks.persist.ImageLoader;
 import com.starrocks.persist.MetaCleaner;
 import com.starrocks.persist.Storage;
 import com.starrocks.persist.StorageInfo;
@@ -58,17 +60,21 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class MetaService {
+    private static final Logger LOG = LogManager.getLogger(MetaService.class);
+
     private static final int TIMEOUT_SECOND = 10;
 
     public static class ImageAction extends MetaBaseAction {
         private static final String VERSION = "version";
         private static final String SUBDIR = "subdir";
+        private static final String IMAGE_FORMAT_VERSION = "image_format_version";
 
         public ImageAction(ActionController controller, File imageDir) {
             super(controller, imageDir);
@@ -89,12 +95,17 @@ public class MetaService {
             }
 
             String subDirStr = request.getSingleParameter(SUBDIR);
-            File realDir = null;
             if (Strings.isNullOrEmpty(subDirStr)) {
-                realDir = imageDir;
-            } else {
-                realDir = new File(imageDir.getAbsolutePath() + subDirStr);
+                subDirStr = "";
             }
+
+            ImageFormatVersion imageFormatVersion = ImageFormatVersion.v1;
+            String imageFormatStr = request.getSingleParameter(IMAGE_FORMAT_VERSION);
+            if (!Strings.isNullOrEmpty(imageFormatStr)) {
+                imageFormatVersion = ImageFormatVersion.valueOf(imageFormatStr);
+            }
+
+            File realDir = new File(getRealImageDir(imageDir.getAbsolutePath(), subDirStr, imageFormatVersion));
 
             long version = checkLongParam(versionStr);
             if (version < 0) {
@@ -108,7 +119,18 @@ public class MetaService {
                 return;
             }
 
-            writeFileResponse(request, response, imageFile);
+            String checksum = null;
+            if (imageFormatVersion == ImageFormatVersion.v2) {
+                File checksumFile = Storage.getChecksumFile(realDir, version);
+                if (checksumFile.exists()) {
+                    try {
+                        checksum = new String(Files.readAllBytes(Path.of(checksumFile.getAbsolutePath())));
+                    } catch (IOException e) {
+                        LOG.warn("get checksum from file {} failed", checksumFile.getAbsoluteFile(), e);
+                    }
+                }
+            }
+            writeFileResponse(request, response, imageFile, checksum);
         }
     }
 
@@ -136,8 +158,9 @@ public class MetaService {
             }
 
             try {
-                Storage currentStorageInfo = new Storage(realDir.getAbsolutePath());
-                StorageInfo storageInfo = new StorageInfo(currentStorageInfo.getImageJournalId());
+                ImageLoader imageLoader = new ImageLoader(realDir.getAbsolutePath());
+                StorageInfo storageInfo = new StorageInfo(imageLoader.getImageJournalId(),
+                        imageLoader.getImageFormatVersion());
 
                 response.setContentType("application/json");
                 Gson gson = new Gson();
@@ -166,7 +189,7 @@ public class MetaService {
         @Override
         public void executeGet(BaseRequest request, BaseResponse response) {
             File versionFile = new File(imageDir, Storage.VERSION_FILE);
-            writeFileResponse(request, response, versionFile);
+            writeFileResponse(request, response, versionFile, null);
         }
     }
 
@@ -177,6 +200,7 @@ public class MetaService {
         private static final String PORT = "port";
         private static final String SUBDIR = "subdir";
         private static final String FOR_GLOBAL_STATE = "for_global_state";
+        private static final String IMAGE_FORMAT_VERSION = "image_format_version";
 
         public PutAction(ActionController controller, File imageDir) {
             super(controller, imageDir);
@@ -240,16 +264,27 @@ public class MetaService {
                 return;
             }
 
-            String url = "http://" + NetUtils.getHostPortInAccessibleFormat(machine, Integer.parseInt(portStr)) +
-                    "/image?version=" + versionStr + "&subdir=" + subDirStr;
+            String formatStr = request.getSingleParameter(IMAGE_FORMAT_VERSION);
+            ImageFormatVersion imageFormatVersion = ImageFormatVersion.v1;
+            if (!Strings.isNullOrEmpty(formatStr)) {
+                imageFormatVersion = ImageFormatVersion.valueOf(formatStr);
+            }
+
+            String url = "http://" + NetUtils.getHostPortInAccessibleFormat(machine, Integer.parseInt(portStr)) + 
+                    "/image?version=" + versionStr
+                    + "&subdir=" + subDirStr
+                    + "&image_format_version=" + imageFormatVersion;
             String filename = Storage.IMAGE + "." + versionStr;
 
-            String realDir = GlobalStateMgr.getCurrentState().getImageDir() + subDirStr;
+            String realDir = getRealImageDir(GlobalStateMgr.getCurrentState().getImageDir(),
+                    subDirStr, imageFormatVersion);
             File dir = new File(realDir);
             try {
-                OutputStream out = MetaHelper.getOutputStream(filename, dir);
-                MetaHelper.getRemoteFile(url, TIMEOUT_SECOND * 1000, out);
-                MetaHelper.complete(filename, dir);
+                if (Files.exists(Path.of(realDir + "/" + filename))) {
+                    LOG.info("image file : {} version: {} already exists, ignore", filename, imageFormatVersion);
+                } else {
+                    MetaHelper.downloadImageFile(url, TIMEOUT_SECOND * 1000, versionStr, dir);
+                }
                 writeResponse(request, response);
             } catch (FileNotFoundException e) {
                 LOG.warn("file not found. file: {}", filename, e);
@@ -273,6 +308,14 @@ public class MetaService {
             } catch (IOException e) {
                 LOG.error("Follower/Observer delete old image file fail.", e);
             }
+        }
+    }
+
+    private static String getRealImageDir(String imageMetaDir, String subDir, ImageFormatVersion imageFormatVersion) {
+        if (imageFormatVersion == ImageFormatVersion.v1) {
+            return imageMetaDir + subDir;
+        } else {
+            return imageMetaDir + subDir + "/" + imageFormatVersion;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -20,7 +20,6 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Config;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.ImageWriter;
-import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -31,8 +30,6 @@ import com.starrocks.sql.common.MetaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataOutputStream;
-import java.io.DataInput;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;

--- a/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.leader;
 
+import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
@@ -41,6 +42,7 @@ import com.starrocks.common.util.NetUtils;
 import com.starrocks.journal.Journal;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ImageFormatVersion;
 import com.starrocks.persist.MetaCleaner;
 import com.starrocks.persist.Storage;
 import com.starrocks.server.GlobalStateMgr;
@@ -53,8 +55,12 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -136,11 +142,17 @@ public class Checkpoint extends FrontendDaemon {
 
         // Step4: Delete old image files from local storage.
         if (newImageCreated) {
-            MetaCleaner cleaner = new MetaCleaner(imageDir);
-            try {
-                cleaner.clean();
-            } catch (IOException e) {
-                LOG.error("Leader delete old image file fail.", e);
+            List<String> dirsToClean = Lists.newArrayList(imageDir);
+            if (belongToGlobalStateMgr) {
+                dirsToClean.add(imageDir + "/v2");
+            }
+            for (String dirToClean : dirsToClean) {
+                MetaCleaner cleaner = new MetaCleaner(dirToClean);
+                try {
+                    cleaner.clean();
+                } catch (IOException e) {
+                    LOG.error("Leader delete old image file from dir {} fail.", dirsToClean, e);
+                }
             }
         }
     }
@@ -169,24 +181,48 @@ public class Checkpoint extends FrontendDaemon {
                 continue;
             }
 
-            String url = "http://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Config.http_port)
-                    + "/put?version=" + imageVersion + "&port=" + Config.http_port + "&subdir=" + subDir
-                    + "&for_global_state=" + belongToGlobalStateMgr;
-            try {
-                MetaHelper.getRemoteFile(url, PUT_TIMEOUT_SECOND * 1000, new NullOutputStream());
-                successPushedCnt++;
-                iterator.remove();
-                LOG.info("push image successfully, url = {}", url);
-                if (MetricRepo.hasInit) {
-                    MetricRepo.COUNTER_IMAGE_PUSH.increase(1L);
+            boolean allFormatSuccess = true;
+            for (ImageFormatVersion formatVersion : getImageFormatVersionToPush(imageVersion)) {
+                String url = "http://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Config.http_port)
+                        + "/put?version=" + imageVersion
+                        + "&port=" + Config.http_port
+                        + "&subdir=" + subDir
+                        + "&for_global_state=" + belongToGlobalStateMgr
+                        + "&image_format_version=" + formatVersion.toString();
+                try {
+                    MetaHelper.getRemoteFile(url, PUT_TIMEOUT_SECOND * 1000, new NullOutputStream());
+                    LOG.info("push image successfully, url = {}", url);
+                    if (MetricRepo.hasInit) {
+                        MetricRepo.COUNTER_IMAGE_PUSH.increase(1L);
+                    }
+                } catch (IOException e) {
+                    allFormatSuccess = false;
+                    LOG.error("Exception when pushing image file. url = {}", url, e);
                 }
-            } catch (IOException e) {
-                LOG.error("Exception when pushing image file. url = {}", url, e);
+            }
+            if (allFormatSuccess) {
+                iterator.remove();
+                successPushedCnt++;
             }
         }
 
         LOG.info("push image.{} from subdir [{}] to other nodes. totally {} nodes, push succeeded {} nodes",
                 imageVersion, subDir, needToPushCnt, successPushedCnt);
+    }
+
+    private List<ImageFormatVersion> getImageFormatVersionToPush(long imageVersion) {
+        List<ImageFormatVersion> result = new ArrayList<>();
+        if (belongToGlobalStateMgr) {
+            // for global state mgr, the creation of v1 format image may fail, so check the existence of image file
+            if (Files.exists(Path.of(imageDir + "/image." + imageVersion))) {
+                result.add(ImageFormatVersion.v1);
+            }
+            result.add(ImageFormatVersion.v2);
+        } else {
+            // for staros mgr, there is only v1 format image.
+            result.add(ImageFormatVersion.v1);
+        }
+        return result;
     }
 
     private boolean createImage(long logVersion) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -50,6 +50,7 @@ import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.OrderByPair;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -451,10 +452,10 @@ public class ExportMgr implements MemoryTrackable {
         return checksum;
     }
 
-    public void saveExportJobV2(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void saveExportJobV2(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         int numJson = 1 + idToJob.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.EXPORT_MGR, numJson);
-        writer.writeJson(idToJob.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.EXPORT_MGR, numJson);
+        writer.writeInt(idToJob.size());
         for (ExportJob job : idToJob.values()) {
             writer.writeJson(job);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobMgr.java
@@ -23,6 +23,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.CreateInsertOverwriteJobLog;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.InsertOverwriteStateChangeInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -40,7 +41,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -255,8 +255,8 @@ public class InsertOverwriteJobMgr implements Writable, GsonPostProcessable, Mem
         }
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.INSERT_OVERWRITE_JOB_MGR, 1);
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.INSERT_OVERWRITE_JOB_MGR, 1);
         writer.writeJson(this);
         writer.close();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -57,6 +57,7 @@ import com.starrocks.load.FailMsg.CancelType;
 import com.starrocks.load.Load;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.AlterLoadJobOperationLog;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -806,12 +807,12 @@ public class LoadMgr implements Writable, MemoryTrackable {
         }
     }
 
-    public void saveLoadJobsV2JsonFormat(DataOutputStream out) throws IOException, SRMetaBlockException {
+    public void saveLoadJobsV2JsonFormat(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         List<LoadJob> loadJobs = idToLoadJob.values().stream().filter(this::needSave).collect(Collectors.toList());
         // 1 json for number of jobs, size of idToLoadJob for jobs
         final int cnt = 1 + loadJobs.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(out, SRMetaBlockID.LOAD_MGR, cnt);
-        writer.writeJson(loadJobs.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.LOAD_MGR, cnt);
+        writer.writeInt(loadJobs.size());
         for (LoadJob loadJob : loadJobs) {
             writer.writeJson(loadJob);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
@@ -20,6 +20,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -36,7 +37,6 @@ import com.starrocks.sql.ast.pipe.PipeName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -309,12 +309,12 @@ public class PipeManager {
         }
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         try {
             lock.readLock().lock();
             final int cnt = 1 + pipeMap.size();
-            SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.PIPE_MGR, cnt);
-            writer.writeJson(pipeMap.size());
+            SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.PIPE_MGR, cnt);
+            writer.writeInt(pipeMap.size());
             for (Pipe pipe : pipeMap.values()) {
                 writer.writeJson(pipe);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeRepo.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.load.pipe;
 
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.PipeOpEntry;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -22,7 +23,6 @@ import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
@@ -68,8 +68,8 @@ public class PipeRepo {
         LOG.info("loaded {} pipes", cnt);
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        pipeManager.save(dos);
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        pipeManager.save(imageWriter);
     }
 
     public void replay(PipeOpEntry entry) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -53,6 +53,7 @@ import com.starrocks.common.util.LogKey;
 import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -785,10 +786,10 @@ public class RoutineLoadMgr implements Writable, MemoryTrackable {
         return checksum;
     }
 
-    public void saveRoutineLoadJobsV2(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void saveRoutineLoadJobsV2(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         final int cnt = 1 + idToRoutineLoadJob.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.ROUTINE_LOAD_MGR, cnt);
-        writer.writeJson(idToRoutineLoadJob.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.ROUTINE_LOAD_MGR, cnt);
+        writer.writeInt(idToRoutineLoadJob.size());
         for (RoutineLoadJob loadJob : idToRoutineLoadJob.values()) {
             writer.writeJson(loadJob);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -33,6 +33,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -637,10 +638,10 @@ public class StreamLoadMgr implements MemoryTrackable {
         return streamLoadManager;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         int numJson = 1 + idToStreamLoadTask.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.STREAM_LOAD_MGR, numJson);
-        writer.writeJson(idToStreamLoadTask.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.STREAM_LOAD_MGR, numJson);
+        writer.writeInt(idToStreamLoadTask.size());
         for (StreamLoadTask streamLoadTask : idToStreamLoadTask.values()) {
             writer.writeJson(streamLoadTask);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ImageFormatVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ImageFormatVersion.java
@@ -12,17 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package com.starrocks.persist;
 
-package com.starrocks.persist.metablock;
-
-import java.io.IOException;
-
-public interface SRMetaBlockWriter {
-    void writeJson(Object object) throws IOException, SRMetaBlockException;
-
-    void writeInt(int value) throws IOException, SRMetaBlockException;
-
-    void writeLong(long value) throws IOException, SRMetaBlockException;
-
-    void close() throws IOException, SRMetaBlockException;
+public enum ImageFormatVersion {
+    v1,
+    v2
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ImageLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ImageLoader.java
@@ -22,9 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedInputStream;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ImageLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ImageLoader.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.stream.JsonReader;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV1;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
+
+public class ImageLoader {
+    private static final Logger LOG = LogManager.getLogger(ImageLoader.class);
+
+    private final String imageDir;
+    private final ImageFormatVersion imageFormatVersion;
+    private final File imageFile;
+    private final long imageJournalId;
+    private JsonReader jsonReader;
+    private CheckedInputStream checkedInputStream;
+    private BufferedInputStream bufferedInputStream;
+
+    public ImageLoader(String imageDir) throws IOException {
+        this.imageDir = imageDir;
+        Storage storageV1 = new Storage(imageDir);
+        Storage storageV2 = new Storage(imageDir + "/v2");
+        if (storageV1.getImageJournalId() > storageV2.getImageJournalId()) {
+            imageFile = storageV1.getCurrentImageFile();
+            imageFormatVersion = ImageFormatVersion.v1;
+            imageJournalId = storageV1.getImageJournalId();
+        } else {
+            imageFile = storageV2.getCurrentImageFile();
+            imageFormatVersion = ImageFormatVersion.v2;
+            imageJournalId = storageV2.getImageJournalId();
+        }
+    }
+
+    public File getImageFile() {
+        return imageFile;
+    }
+
+    public long getImageJournalId() {
+        return imageJournalId;
+    }
+
+    public ImageFormatVersion getImageFormatVersion() {
+        return imageFormatVersion;
+    }
+
+    public void setInputStream(InputStream inputStream) {
+        this.bufferedInputStream = new BufferedInputStream(inputStream);
+        this.checkedInputStream = new CheckedInputStream(inputStream, new CRC32());
+        if (imageFormatVersion == ImageFormatVersion.v2) {
+            this.jsonReader = new JsonReader(new InputStreamReader(this.checkedInputStream));
+        }
+    }
+
+    public CheckedInputStream getCheckedInputStream() {
+        return checkedInputStream;
+    }
+
+    public SRMetaBlockReader getBlockReader() throws IOException {
+        if (imageFormatVersion == ImageFormatVersion.v1) {
+            return new SRMetaBlockReaderV1(bufferedInputStream);
+        } else {
+            return new SRMetaBlockReaderV2(jsonReader);
+        }
+    }
+
+    public void readTheRemainingBytes() {
+        if (imageFormatVersion == ImageFormatVersion.v2) {
+            byte[] bytes = new byte[8192];
+            try {
+                while (checkedInputStream.read(bytes) != -1) {
+                }
+            } catch (IOException e) {
+                LOG.warn("read the remaining bytes failed", e);
+            }
+        }
+    }
+
+    public void checkCheckSum() throws IOException {
+        if (imageFormatVersion == ImageFormatVersion.v2) {
+            Path checksumPath = Path.of(imageDir, "v2", Storage.CHECKSUM + "." + imageJournalId);
+            long expectedCheckSum = Long.parseLong(Files.readString(checksumPath));
+            long realCheckSum = checkedInputStream.getChecksum().getValue();
+            if (expectedCheckSum != realCheckSum) {
+                throw new IOException(String.format("checksum mismatch! expect %d actual %d",
+                        expectedCheckSum, realCheckSum));
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ImageWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ImageWriter.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.stream.JsonWriter;
+import com.starrocks.persist.metablock.SRMetaBlockException;
+import com.starrocks.persist.metablock.SRMetaBlockID;
+import com.starrocks.persist.metablock.SRMetaBlockWriter;
+import com.starrocks.persist.metablock.SRMetaBlockWriterV1;
+import com.starrocks.persist.metablock.SRMetaBlockWriterV2;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedOutputStream;
+
+public class ImageWriter {
+    private final ImageFormatVersion imageFormatVersion;
+    private final String imageDir;
+    private final long imageJournalId;
+
+    private OutputStream outputStream;
+    private CheckedOutputStream checkedOutputStream;
+    private JsonWriter jsonWriter;
+    private DataOutputStream dataOutputStream;
+
+    public ImageWriter(String imageDir, ImageFormatVersion imageFormatVersion, long imageJournalId) {
+        this.imageDir = imageDir;
+        this.imageFormatVersion = imageFormatVersion;
+        this.imageJournalId = imageJournalId;
+    }
+
+    public void setOutputStream(OutputStream outputStream) {
+        this.outputStream = outputStream;
+        this.checkedOutputStream = new CheckedOutputStream(outputStream, new CRC32());
+        this.dataOutputStream = new DataOutputStream(checkedOutputStream);
+        this.jsonWriter = new JsonWriter(new OutputStreamWriter(checkedOutputStream, StandardCharsets.UTF_8));
+    }
+
+    public SRMetaBlockWriter getBlockWriter(SRMetaBlockID id, int numJson) throws SRMetaBlockException {
+        if (imageFormatVersion == ImageFormatVersion.v1) {
+            return new SRMetaBlockWriterV1(outputStream, id, numJson);
+        } else {
+            return new SRMetaBlockWriterV2(jsonWriter, id, numJson);
+        }
+    }
+
+    public DataOutputStream getDataOutputStream() {
+        return dataOutputStream;
+    }
+
+    public void saveChecksum() throws IOException {
+        if (imageFormatVersion == ImageFormatVersion.v2) {
+            Path path = Path.of(imageDir, Storage.CHECKSUM + "." + imageJournalId);
+            String checksum = String.valueOf(checkedOutputStream.getChecksum().getValue());
+            Files.writeString(path, checksum);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/MetaCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/MetaCleaner.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.persist;
 
+import com.starrocks.leader.MetaHelper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,9 +68,9 @@ public class MetaCleaner {
                 }
                 String filename = file.getName();
                 // Delete all image whose version is less than imageVersionDelete
-                if (type.equalsIgnoreCase(Storage.IMAGE)) {
-                    if (filename.endsWith(".part")) {
-                        filename = filename.substring(0, filename.length() - ".part".length());
+                if (type.equalsIgnoreCase(Storage.IMAGE) || type.equalsIgnoreCase(Storage.CHECKSUM)) {
+                    if (filename.endsWith(MetaHelper.PART_SUFFIX)) {
+                        filename = filename.substring(0, filename.length() - MetaHelper.PART_SUFFIX.length());
                     }
                     long version = Long.parseLong(filename.substring(filename.lastIndexOf('.') + 1));
 
@@ -85,20 +86,23 @@ public class MetaCleaner {
         }
     }
 
-    private String fileType(File file) throws IOException {
+    private String fileType(File file) {
         String type = null;
         String filename = file.getName();
 
         if (filename.equals(Storage.IMAGE_NEW)) {
             type = Storage.IMAGE_NEW;
         } else {
-            if (filename.endsWith(".part")) {
-                filename = filename.substring(0, filename.length() - ".part".length());
+            if (filename.endsWith(MetaHelper.PART_SUFFIX)) {
+                filename = filename.substring(0, filename.length() - MetaHelper.PART_SUFFIX.length());
             }
 
             if (filename.contains(".")) {
                 if (filename.startsWith(Storage.IMAGE)) {
                     type = Storage.IMAGE;
+                }
+                if (filename.startsWith(Storage.CHECKSUM)) {
+                    type = Storage.CHECKSUM;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
@@ -61,6 +61,7 @@ public class Storage {
 
     public static final String IMAGE_NEW = "image.ckpt";
     public static final String IMAGE = "image";
+    public static final String CHECKSUM = "checksum";
     public static final String VERSION_FILE = "VERSION";
     public static final String ROLE_FILE = "ROLE";
 
@@ -172,14 +173,6 @@ public class Storage {
         return nodeName;
     }
 
-    public String getMetaDir() {
-        return metaDir;
-    }
-
-    public void setMetaDir(String metaDir) {
-        this.metaDir = metaDir;
-    }
-
     public long getImageJournalId() {
         return imageJournalId;
     }
@@ -246,28 +239,6 @@ public class Storage {
         }
     }
 
-    public void clear() throws IOException {
-        File metaFile = new File(metaDir);
-        if (metaFile.exists()) {
-            String[] children = metaFile.list();
-            if (children != null) {
-                for (String child : children) {
-                    File file = new File(metaFile, child);
-                    if (!file.delete()) {
-                        LOG.warn("Failed to delete file, filepath={}", file.getAbsolutePath());
-                    }
-                }
-            }
-            if (!metaFile.delete()) {
-                LOG.warn("Failed to delete file, filepath={}", metaFile.getAbsolutePath());
-            }
-        }
-
-        if (!metaFile.mkdirs()) {
-            throw new IOException("Cannot create directory " + metaFile);
-        }
-    }
-
     public static void rename(File from, File to) throws IOException {
         if (!from.renameTo(to)) {
             throw new IOException("Failed to rename  " + from.getCanonicalPath()
@@ -287,6 +258,10 @@ public class Storage {
         return new File(dir, IMAGE + "." + version);
     }
 
+    public static File getChecksumFile(File dir, long version) {
+        return new File(dir, CHECKSUM + "." + version);
+    }
+
     public final File getVersionFile() {
         return new File(metaDir, VERSION_FILE);
     }
@@ -294,5 +269,5 @@ public class Storage {
     public final File getRoleFile() {
         return new File(metaDir, ROLE_FILE);
     }
-}
 
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/StorageInfo.java
@@ -44,19 +44,23 @@ public class StorageInfo {
     @SerializedName("imageJournalId")
     private long imageJournalId;
 
+    @SerializedName("imageFormatVersion")
+    private ImageFormatVersion imageFormatVersion;
+
     public StorageInfo() {
-        this(0);
+        this(0, ImageFormatVersion.v1);
     }
 
-    public StorageInfo(long imageJournalId) {
+    public StorageInfo(long imageJournalId, ImageFormatVersion imageFormatVersion) {
         this.imageJournalId = imageJournalId;
+        this.imageFormatVersion = imageFormatVersion;
     }
 
     public long getImageJournalId() {
         return imageJournalId;
     }
 
-    public void setImageJournalId(long imageJournalId) {
-        this.imageJournalId = imageJournalId;
+    public ImageFormatVersion getImageFormatVersion() {
+        return imageFormatVersion;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/IntObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/IntObject.java
@@ -12,17 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.persist.metablock;
 
-import java.io.IOException;
+import com.google.gson.annotations.SerializedName;
 
-public interface SRMetaBlockWriter {
-    void writeJson(Object object) throws IOException, SRMetaBlockException;
+public class IntObject {
 
-    void writeInt(int value) throws IOException, SRMetaBlockException;
+    @SerializedName("v")
+    private int value;
 
-    void writeLong(long value) throws IOException, SRMetaBlockException;
+    public IntObject(int value) {
+        this.value = value;
+    }
 
-    void close() throws IOException, SRMetaBlockException;
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/LongObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/LongObject.java
@@ -12,17 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.persist.metablock;
 
-import java.io.IOException;
+import com.google.gson.annotations.SerializedName;
 
-public interface SRMetaBlockWriter {
-    void writeJson(Object object) throws IOException, SRMetaBlockException;
+public class LongObject {
+    @SerializedName("v")
+    private long value;
 
-    void writeInt(int value) throws IOException, SRMetaBlockException;
+    public LongObject(long value) {
+        this.value = value;
+    }
 
-    void writeLong(long value) throws IOException, SRMetaBlockException;
+    public long getValue() {
+        return value;
+    }
 
-    void close() throws IOException, SRMetaBlockException;
+    public void setValue(long value) {
+        this.value = value;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReader.java
@@ -15,108 +15,20 @@
 
 package com.starrocks.persist.metablock;
 
-import com.starrocks.common.io.Text;
-import com.starrocks.persist.gson.GsonUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.zip.CRC32;
-import java.util.zip.CheckedInputStream;
 
-/**
- * Load object from input stream as the following format.
- * <p>
- * +------------------+
- * |     header       | {"numJson": 10, "name": "AuthenticationManager"}
- * +------------------+
- * |     Json 1       |
- * +------------------+
- * |     Json 2       |
- * +------------------+
- * |      ...         |
- * +------------------+
- * |     Json 10      |
- * +------------------+
- * |      footer      | {"checksum": xxx}
- * +------------------+
- * <p>
- * Usage see com.starrocks.persist.metablock.SRMetaBlockTest#testSimple()
- */
-public class SRMetaBlockReader {
-    private static final Logger LOG = LogManager.getLogger(SRMetaBlockReader.class);
-    private static final int MAX_JSON_PRINT_LENGTH = 1000;
-    private final CheckedInputStream checkedInputStream;
-    private SRMetaBlockHeader header;
-    private int numJsonRead;
-    // For backward compatibility reason
-    private final String oldManagerClassName = "com.starrocks.privilege.PrivilegeManager";
+public interface SRMetaBlockReader {
 
-    public SRMetaBlockReader(DataInputStream dis) throws IOException {
-        this.checkedInputStream = new CheckedInputStream(dis, new CRC32());
-        this.header = null;
-        this.numJsonRead = 0;
+    SRMetaBlockHeader getHeader();
 
-        String s = Text.readStringWithChecksum(checkedInputStream);
-        header = GsonUtils.GSON.fromJson(s, SRMetaBlockHeader.class);
-    }
+    <T> T readJson(Class<T> returnClass) throws IOException, SRMetaBlockEOFException;
 
-    public SRMetaBlockHeader getHeader() {
-        return header;
-    }
+    int readInt() throws IOException, SRMetaBlockEOFException;
 
-    private String readJsonText() throws IOException, SRMetaBlockEOFException {
-        if (numJsonRead >= header.getNumJson()) {
-            throw new SRMetaBlockEOFException(String.format(
-                    "Read json more than expect: %d >= %d", numJsonRead, header.getNumJson()));
-        }
-        String s = Text.readStringWithChecksum(checkedInputStream);
-        numJsonRead += 1;
-        return s;
-    }
+    long readLong() throws IOException, SRMetaBlockEOFException;
 
-    public <T> T readJson(Class<T> returnClass) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
-        return GsonUtils.GSON.fromJson(readJsonText(), returnClass);
-    }
+    Object readJson(Type returnType) throws IOException, SRMetaBlockEOFException;
 
-    public int readInt() throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
-        return readJson(int.class);
-    }
-
-    public Object readJson(Type returnType) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
-        return GsonUtils.GSON.fromJson(readJsonText(), returnType);
-    }
-
-    public void close() throws IOException, SRMetaBlockException {
-        if (header == null) {
-            LOG.warn("do nothing and quit.");
-            return;
-        }
-        if (numJsonRead < header.getNumJson()) {
-            // discard the rest of data for compatibility
-            // normally it's because this FE has just rollback from a higher version that would produce more metadata
-            int rest = header.getNumJson() - numJsonRead;
-            LOG.warn("Meta block for {} read {} json < total {} json, will skip the rest {} json",
-                    header.getSrMetaBlockID(), numJsonRead, header.getNumJson(), rest);
-            for (int i = 0; i != rest; ++i) {
-                String text = Text.readStringWithChecksum(checkedInputStream);
-                LOG.warn("skip {}th json: {}", i,
-                        text.substring(0, Math.min(MAX_JSON_PRINT_LENGTH, text.length())));
-            }
-        }
-
-        // 1. calculate checksum
-        // 2. read footer
-        // 3. compare checksum
-        // step 1 must before step 2 as the writer goes
-        long checksum = checkedInputStream.getChecksum().getValue();
-        String s = Text.readStringWithChecksum(checkedInputStream);
-        SRMetaBlockFooter footer = GsonUtils.GSON.fromJson(s, SRMetaBlockFooter.class);
-        if (checksum != footer.getChecksum()) {
-            throw new SRMetaBlockException(String.format(
-                    "Invalid meta block, checksum mismatch! expect %d actual %d", footer.getChecksum(), checksum));
-        }
-    }
+    void close() throws IOException, SRMetaBlockException;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReaderV1.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReaderV1.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReaderV1.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReaderV1.java
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.metablock;
+
+import com.google.gson.stream.JsonReader;
+import com.starrocks.common.io.Text;
+import com.starrocks.persist.gson.GsonUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
+
+/**
+ * Load object from input stream as the following format.
+ * <p>
+ * +------------------+
+ * |     header       | {"numJson": 10, "id": "1"}
+ * +------------------+
+ * |     Json 1       |
+ * +------------------+
+ * |     Json 2       |
+ * +------------------+
+ * |      ...         |
+ * +------------------+
+ * |     Json 10      |
+ * +------------------+
+ * |      footer      | {"checksum": xxx}
+ * +------------------+
+ * <p>
+ *
+ * the storage format of one json object is length:bytes,
+ * `length` is a 4-byte int that stores the following byte size,
+ * and `bytes` is the json str UTF8 encoded bytes.
+ *
+ * Usage see com.starrocks.persist.metablock.SRMetaBlockTest#testSimple()
+ */
+public class SRMetaBlockReaderV1 implements SRMetaBlockReader {
+    private static final Logger LOG = LogManager.getLogger(SRMetaBlockReaderV1.class);
+    private static final int MAX_JSON_PRINT_LENGTH = 1000;
+    private final CheckedInputStream checkedInputStream;
+    private SRMetaBlockHeader header;
+    private int numJsonRead;
+
+    public SRMetaBlockReaderV1(InputStream in) throws IOException {
+        this.checkedInputStream = new CheckedInputStream(in, new CRC32());
+        this.header = null;
+        this.numJsonRead = 0;
+
+        String s = Text.readStringWithChecksum(checkedInputStream);
+        header = GsonUtils.GSON.fromJson(s, SRMetaBlockHeader.class);
+    }
+
+    @Override
+    public SRMetaBlockHeader getHeader() {
+        return header;
+    }
+
+    private byte[] readJsonBytes() throws IOException, SRMetaBlockEOFException {
+        if (numJsonRead >= header.getNumJson()) {
+            throw new SRMetaBlockEOFException(String.format(
+                    "Read json more than expect: %d >= %d", numJsonRead, header.getNumJson()));
+        }
+        byte[] bytes = new byte[4];
+        readAndCheckEof(checkedInputStream, bytes, 4);
+        int length = ByteBuffer.wrap(bytes).getInt();
+        bytes = new byte[length];
+        readAndCheckEof(checkedInputStream, bytes, length);
+        numJsonRead += 1;
+        return bytes;
+    }
+
+    private void readAndCheckEof(CheckedInputStream in, byte[] bytes, int expectLength) throws IOException {
+        int readRet = in.read(bytes, 0, expectLength);
+        if (readRet != expectLength) {
+            throw new EOFException(String.format("reach EOF: read expect %d actual %d!", expectLength, readRet));
+        }
+    }
+
+    @Override
+    public <T> T readJson(Class<T> returnClass) throws IOException, SRMetaBlockEOFException {
+        byte[] bytes = readJsonBytes();
+        try (JsonReader jsonReader = new JsonReader(new InputStreamReader(new ByteArrayInputStream(bytes),
+                StandardCharsets.UTF_8))) {
+            return GsonUtils.GSON.fromJson(jsonReader, returnClass);
+        }
+    }
+
+    @Override
+    public int readInt() throws IOException, SRMetaBlockEOFException {
+        return readJson(int.class);
+    }
+
+    @Override
+    public long readLong() throws IOException, SRMetaBlockEOFException {
+        return readJson(long.class);
+    }
+
+    @Override
+    public Object readJson(Type returnType) throws IOException, SRMetaBlockEOFException {
+        byte[] bytes = readJsonBytes();
+        try (JsonReader jsonReader = new JsonReader(new InputStreamReader(new ByteArrayInputStream(bytes),
+                StandardCharsets.UTF_8))) {
+            return GsonUtils.GSON.fromJson(jsonReader, returnType);
+        }
+    }
+
+    @Override
+    public void close() throws IOException, SRMetaBlockException {
+        if (header == null) {
+            LOG.warn("do nothing and quit.");
+            return;
+        }
+        if (numJsonRead < header.getNumJson()) {
+            // discard the rest of data for compatibility
+            // normally it's because this FE has just rollback from a higher version that would produce more metadata
+            int rest = header.getNumJson() - numJsonRead;
+            LOG.warn("Meta block for {} read {} json < total {} json, will skip the rest {} json",
+                    header.getSrMetaBlockID(), numJsonRead, header.getNumJson(), rest);
+            for (int i = 0; i != rest; ++i) {
+                String text = Text.readStringWithChecksum(checkedInputStream);
+                LOG.warn("skip {}th json: {}", i,
+                        text.substring(0, Math.min(MAX_JSON_PRINT_LENGTH, text.length())));
+            }
+        }
+
+        // 1. calculate checksum
+        // 2. read footer
+        // 3. compare checksum
+        // step 1 must before step 2 as the writer goes
+        long checksum = checkedInputStream.getChecksum().getValue();
+        String s = Text.readStringWithChecksum(checkedInputStream);
+        SRMetaBlockFooter footer = GsonUtils.GSON.fromJson(s, SRMetaBlockFooter.class);
+        if (checksum != footer.getChecksum()) {
+            throw new SRMetaBlockException(String.format(
+                    "Invalid meta block, checksum mismatch! expect %d actual %d", footer.getChecksum(), checksum));
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReaderV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockReaderV2.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.metablock;
+
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.starrocks.persist.gson.GsonUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+/**
+ * Load object from input stream as the following format.
+ * <p>
+ * +------------------+
+ * |     header       | {"numJson": 10, "id": "1"}
+ * +------------------+
+ * |     Json 1       |
+ * +------------------+
+ * |     Json 2       |
+ * +------------------+
+ * |      ...         |
+ * +------------------+
+ * |     Json 10      |
+ * +------------------+
+ *
+ * The format of json is json str, starting with "{" and ending with "}
+ *
+ */
+public class SRMetaBlockReaderV2 implements SRMetaBlockReader {
+    private static final Logger LOG = LogManager.getLogger(SRMetaBlockReaderV1.class);
+
+    private final JsonReader jsonReader;
+    private int numJsonRead;
+    private SRMetaBlockHeader header;
+
+    public SRMetaBlockReaderV2(JsonReader jsonReader) throws IOException {
+        this.numJsonRead = 0;
+        this.jsonReader = jsonReader;
+        try {
+            header = GsonUtils.GSON.fromJson(jsonReader, SRMetaBlockHeader.class);
+        } catch (JsonSyntaxException e) {
+            handleJsonSyntaxException(e);
+        }
+    }
+
+    @Override
+    public SRMetaBlockHeader getHeader() {
+        return header;
+    }
+
+    @Override
+    public <T> T readJson(Class<T> returnClass) throws IOException, SRMetaBlockEOFException {
+        checkEOF();
+        try {
+            T t = GsonUtils.GSON.fromJson(jsonReader, returnClass);
+            numJsonRead++;
+            return t;
+        } catch (JsonSyntaxException e) {
+            handleJsonSyntaxException(e);
+        }
+        return null;
+    }
+
+    @Override
+    public int readInt() throws IOException, SRMetaBlockEOFException {
+        return readJson(IntObject.class).getValue();
+    }
+
+    @Override
+    public long readLong() throws IOException, SRMetaBlockEOFException {
+        return readJson(LongObject.class).getValue();
+    }
+
+    @Override
+    public Object readJson(Type returnType) throws IOException, SRMetaBlockEOFException {
+        checkEOF();
+        try {
+            Object obj = GsonUtils.GSON.fromJson(jsonReader, returnType);
+            numJsonRead++;
+            return obj;
+        } catch (JsonSyntaxException e) {
+            handleJsonSyntaxException(e);
+        }
+        return null;
+    }
+
+    private void checkEOF() throws SRMetaBlockEOFException {
+        if (numJsonRead >= header.getNumJson()) {
+            throw new SRMetaBlockEOFException(String.format(
+                    "Read json more than expect: %d >= %d", numJsonRead, header.getNumJson()));
+        }
+    }
+
+
+    @Override
+    public void close() throws IOException {
+        if (numJsonRead < header.getNumJson()) {
+            // discard the rest of data for compatibility
+            // normally it's because this FE has just rollback from a higher version that would produce more metadata
+            int rest = header.getNumJson() - numJsonRead;
+            LOG.warn("Meta block for {} read {} json < total {} json, will skip the rest {} json",
+                    header.getSrMetaBlockID(), numJsonRead, header.getNumJson(), rest);
+            jsonReader.setLenient(true);
+            for (int i = 0; i != rest; ++i) {
+                jsonReader.skipValue();
+                LOG.warn("skip {}th json", i);
+            }
+        }
+    }
+
+    private void handleJsonSyntaxException(JsonSyntaxException e) throws IOException, JsonSyntaxException {
+        if (jsonReader.peek() == JsonToken.END_DOCUMENT) {
+            throw new EOFException(e.getMessage());
+        } else {
+            throw e;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockWriterV1.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockWriterV1.java
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.metablock;
+
+
+import com.starrocks.common.io.Text;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedOutputStream;
+
+/**
+ * Save object to output stream as the following format.
+ * <p>
+ * +------------------+
+ * |     header       | {"numJson": 10, "name": "AuthenticationManager"}
+ * +------------------+
+ * |     Json 1       |
+ * +------------------+
+ * |     Json 2       |
+ * +------------------+
+ * |      ...         |
+ * +------------------+
+ * |     Json 10      |
+ * +------------------+
+ * |      footer      | {"checksum": xxx}
+ * +------------------+
+ * <p>
+ * Usage see com.starrocks.persist.metablock.SRMetaBlockTest#testSimple()
+ */
+
+public class SRMetaBlockWriterV1 implements SRMetaBlockWriter {
+    private final CheckedOutputStream checkedOutputStream;
+    private final SRMetaBlockHeader header;
+    private int numJsonWritten;
+
+    @Deprecated
+    public SRMetaBlockWriterV1(DataOutputStream dos, String name, int numJson) throws SRMetaBlockException {
+        if (numJson <= 0) {
+            throw new SRMetaBlockException(String.format("invalid numJson: %d", numJson));
+        }
+        this.checkedOutputStream = new CheckedOutputStream(dos, new CRC32());
+        this.header = new SRMetaBlockHeader(name, numJson);
+        this.numJsonWritten = 0;
+    }
+
+    public SRMetaBlockWriterV1(OutputStream out, SRMetaBlockID id, int numJson) throws SRMetaBlockException {
+        if (numJson <= 0) {
+            throw new SRMetaBlockException(String.format("invalid numJson: %d", numJson));
+        }
+        this.checkedOutputStream = new CheckedOutputStream(out, new CRC32());
+        this.header = new SRMetaBlockHeader(id, numJson);
+        this.numJsonWritten = 0;
+    }
+
+    @Override
+    public void writeJson(Object object) throws IOException, SRMetaBlockException {
+        // always check if write more than expect
+        if (numJsonWritten >= header.getNumJson()) {
+            throw new SRMetaBlockException(String.format(
+                    "About to write json more than expect %d, actual %d", header.getNumJson(), numJsonWritten));
+        }
+        if (numJsonWritten == 0) {
+            // write header
+            Text.writeStringWithChecksum(checkedOutputStream, GsonUtils.GSON.toJson(header));
+        }
+        Text.writeStringWithChecksum(checkedOutputStream, GsonUtils.GSON.toJson(object));
+        numJsonWritten += 1;
+    }
+
+    @Override
+    public void writeInt(int value) throws IOException, SRMetaBlockException {
+        writeJson(value);
+    }
+
+    @Override
+    public void writeLong(long value) throws IOException, SRMetaBlockException {
+        writeJson(value);
+    }
+
+    @Override
+    public void close() throws IOException, SRMetaBlockException {
+        // check if write as many json string as expect
+        if (numJsonWritten != header.getNumJson()) {
+            throw new SRMetaBlockException(String.format(
+                    "Block json number mismatch: expect %d actual %d", header.getNumJson(), numJsonWritten));
+        }
+        // write footer, especially checksum
+        SRMetaBlockFooter footer = new SRMetaBlockFooter(checkedOutputStream.getChecksum().getValue());
+        Text.writeStringWithChecksum(checkedOutputStream, GsonUtils.GSON.toJson(footer));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockWriterV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockWriterV2.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.metablock;
+
+import com.google.gson.stream.JsonWriter;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.IOException;
+
+public class SRMetaBlockWriterV2 implements SRMetaBlockWriter {
+    private final SRMetaBlockHeader header;
+    private final JsonWriter jsonWriter;
+    private int numJsonWritten;
+
+    public SRMetaBlockWriterV2(JsonWriter jsonWriter, SRMetaBlockID id, int numJson) throws SRMetaBlockException {
+        if (numJson <= 0) {
+            throw new SRMetaBlockException(String.format("invalid numJson: %d", numJson));
+        }
+        this.header = new SRMetaBlockHeader(id, numJson);
+        this.jsonWriter = jsonWriter;
+        this.numJsonWritten = 0;
+    }
+
+    @Override
+    public void writeJson(Object object) throws IOException, SRMetaBlockException {
+        if (isBasicType(object)) {
+            throw new SRMetaBlockException("can not write primitive type");
+        }
+
+        // always check if write more than expect
+        if (numJsonWritten >= header.getNumJson()) {
+            throw new SRMetaBlockException(String.format(
+                    "About to write json more than expect %d, actual %d", header.getNumJson(), numJsonWritten));
+        }
+        if (numJsonWritten == 0) {
+            // write header
+            GsonUtils.GSON.toJson(header, header.getClass(), jsonWriter);
+        }
+        GsonUtils.GSON.toJson(object, object.getClass(), jsonWriter);
+        numJsonWritten++;
+    }
+
+    @Override
+    public void writeInt(int value) throws IOException, SRMetaBlockException {
+        writeJson(new IntObject(value));
+    }
+
+    @Override
+    public void writeLong(long value) throws IOException, SRMetaBlockException {
+        writeJson(new LongObject(value));
+    }
+
+    @Override
+    public void close() throws IOException, SRMetaBlockException {
+        // check if write as many json string as expect
+        if (numJsonWritten != header.getNumJson()) {
+            throw new SRMetaBlockException(String.format(
+                    "Block json number mismatch: expect %d actual %d", header.getNumJson(), numJsonWritten));
+        }
+        jsonWriter.flush();
+    }
+
+    private boolean isBasicType(Object object) {
+        return object instanceof Byte || object instanceof Short || object instanceof Integer || object instanceof Long
+                || object instanceof Double || object instanceof Float
+                || object instanceof String || object instanceof Character
+                || object instanceof Boolean;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
@@ -43,6 +43,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.PrintableMap;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -360,12 +361,12 @@ public class PluginMgr implements Writable {
         return checksum;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         List<PluginInfo> pluginInfos = getAllDynamicPluginInfo();
 
         int numJson = 1 + pluginInfos.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.PLUGIN_MGR, numJson);
-        writer.writeJson(pluginInfos.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.PLUGIN_MGR, numJson);
+        writer.writeInt(pluginInfos.size());
         for (PluginInfo pluginInfo : pluginInfos) {
             writer.writeJson(pluginInfo);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
@@ -28,6 +28,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.RolePrivilegeCollectionInfo;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -50,7 +51,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1696,7 +1696,7 @@ public class AuthorizationMgr {
             ret.initBuiltinRolesAndUsers();
 
             // 1 json for num user
-            int numUser = reader.readJson(int.class);
+            int numUser = reader.readInt();
             LOG.info("loading {} users", numUser);
             for (int i = 0; i != numUser; ++i) {
                 // 2 json for each user(kv)
@@ -1714,11 +1714,11 @@ public class AuthorizationMgr {
                 ret.userToPrivilegeCollection.put(userIdentity, collection);
             }
             // 1 json for num roles
-            int numRole = reader.readJson(int.class);
+            int numRole = reader.readInt();
             LOG.info("loading {} roles", numRole);
             for (int i = 0; i != numRole; ++i) {
                 // 2 json for each role(kv)
-                Long roleId = reader.readJson(Long.class);
+                Long roleId = reader.readLong();
                 RolePrivilegeCollectionV2 collection = reader.readJson(RolePrivilegeCollectionV2.class);
 
                 // Use hard-code PrivilegeCollection in the memory as the built-in role permission.
@@ -1751,23 +1751,23 @@ public class AuthorizationMgr {
         }
     }
 
-    public void saveV2(DataOutputStream dos) throws IOException {
+    public void saveV2(ImageWriter imageWriter) throws IOException {
         try {
             // 1 json for myself,1 json for number of users, 2 json for each user(kv)
             // 1 json for number of roles, 2 json for each role(kv)
             final int cnt = 1 + 1 + userToPrivilegeCollection.size() * 2
                     + 1 + roleIdToPrivilegeCollection.size() * 2;
-            SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.AUTHORIZATION_MGR, cnt);
+            SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.AUTHORIZATION_MGR, cnt);
             // 1 json for myself
             writer.writeJson(this);
             // 1 json for num user
-            writer.writeJson(userToPrivilegeCollection.size());
+            writer.writeInt(userToPrivilegeCollection.size());
             for (Map.Entry<UserIdentity, UserPrivilegeCollectionV2> entry : userToPrivilegeCollection.entrySet()) {
                 writer.writeJson(entry.getKey());
                 writer.writeJson(entry.getValue());
             }
             // 1 json for num roles
-            writer.writeJson(roleIdToPrivilegeCollection.size());
+            writer.writeInt(roleIdToPrivilegeCollection.size());
             for (Map.Entry<Long, RolePrivilegeCollectionV2> entry : roleIdToPrivilegeCollection.entrySet()) {
                 RolePrivilegeCollectionV2 value = entry.getValue();
                 // Avoid newly added PEntryObject type corrupt forward compatibility,
@@ -1780,7 +1780,7 @@ public class AuthorizationMgr {
                     clone.typeToPrivilegeEntryList = new HashMap<>();
                     value = clone;
                 }
-                writer.writeJson(entry.getKey());
+                writer.writeLong(entry.getKey());
                 writer.writeJson(value);
             }
             writer.close();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -47,6 +47,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.GlobalVarPersistInfo;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -61,7 +62,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -353,7 +353,7 @@ public class VariableMgr {
         setValue(sessionVariable, ctx.getField(), value);
     }
 
-    public static void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public static void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         Map<String, String> m = new HashMap<>();
         Map<String, String> g = new HashMap<>();
         try {
@@ -403,14 +403,14 @@ public class VariableMgr {
             throw new IOException("failed to write session variable: " + e.getMessage());
         }
 
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.VARIABLE_MGR, 1 + m.size() + 1 + g.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.VARIABLE_MGR, 1 + m.size() + 1 + g.size());
 
-        writer.writeJson(m.size());
+        writer.writeInt(m.size());
         for (Map.Entry<String, String> e : m.entrySet()) {
             writer.writeJson(new VariableInfo(e.getKey(), e.getValue()));
         }
 
-        writer.writeJson(g.size());
+        writer.writeInt(g.size());
         for (Map.Entry<String, String> e : g.entrySet()) {
             writer.writeJson(new VariableInfo(e.getKey(), e.getValue()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
@@ -21,6 +21,7 @@ import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -34,7 +35,6 @@ import com.starrocks.thrift.TTableReplicationRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -203,8 +203,8 @@ public class ReplicationMgr extends FrontendDaemon {
         return replicatingDataSize;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.REPLICATION_MGR, 1);
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.REPLICATION_MGR, 1);
         writer.writeJson(this);
         writer.close();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -30,6 +30,7 @@ import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.QueryableReentrantLock;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
@@ -54,7 +55,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.util.SizeEstimator;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -586,18 +586,18 @@ public class TaskManager implements MemoryTrackable {
         }
     }
 
-    public void saveTasksV2(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void saveTasksV2(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         taskRunManager.getTaskRunHistory().forceGC();
         List<TaskRunStatus> runStatusList = getMatchedTaskRunStatus(null);
         LOG.info("saveTasksV2, nameToTaskMap size:{}, runStatusList size: {}", nameToTaskMap.size(), runStatusList.size());
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.TASK_MGR,
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.TASK_MGR,
                 2 + nameToTaskMap.size() + runStatusList.size());
-        writer.writeJson(nameToTaskMap.size());
+        writer.writeInt(nameToTaskMap.size());
         for (Task task : nameToTaskMap.values()) {
             writer.writeJson(task);
         }
 
-        writer.writeJson(runStatusList.size());
+        writer.writeInt(runStatusList.size());
         for (TaskRunStatus status : runStatusList) {
             writer.writeJson(status);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MaterializedViewMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MaterializedViewMgr.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -287,10 +288,10 @@ public class MaterializedViewMgr {
         List<MVMaintenanceJob> jobList;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         int numJson = 1 + jobMap.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.MATERIALIZED_VIEW_MGR, numJson);
-        writer.writeJson(jobMap.size());
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.MATERIALIZED_VIEW_MGR, numJson);
+        writer.writeInt(jobMap.size());
         for (MVMaintenanceJob mvMaintenanceJob : jobMap.values()) {
             writer.writeJson(mvMaintenanceJob);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -44,6 +44,7 @@ import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.persist.AlterCatalogLog;
 import com.starrocks.persist.DropCatalogLog;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -532,15 +533,15 @@ public class CatalogMgr {
         }
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         Map<String, Catalog> serializedCatalogs = catalogs.entrySet().stream()
                 .filter(entry -> !isResourceMappingCatalog(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         int numJson = 1 + serializedCatalogs.size();
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.CATALOG_MGR, numJson);
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.CATALOG_MGR, numJson);
 
-        writer.writeJson(serializedCatalogs.size());
+        writer.writeInt(serializedCatalogs.size());
         for (Catalog catalog : serializedCatalogs.values()) {
             writer.writeJson(catalog);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -158,7 +158,10 @@ import com.starrocks.meta.MetaContext;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ImageFormatVersion;
 import com.starrocks.persist.ImageHeader;
+import com.starrocks.persist.ImageLoader;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.Storage;
 import com.starrocks.persist.gson.GsonUtils;
@@ -237,6 +240,8 @@ import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -1075,6 +1080,10 @@ public class GlobalStateMgr {
                 if (!imageDir.exists()) {
                     imageDir.mkdirs();
                 }
+                File imageV2Dir = new File(this.imageDir + "/v2");
+                if (!imageV2Dir.exists()) {
+                    imageV2Dir.mkdirs();
+                }
             } else {
                 LOG.error("Invalid edit log type: {}", Config.edit_log_type);
                 System.exit(-1);
@@ -1444,14 +1453,14 @@ public class GlobalStateMgr {
     // The manager that loads meta from image must be a member of GlobalStateMgr and cannot be SINGLETON,
     // since Checkpoint uses a separate memory.
     public void loadImage(String imageDir) throws IOException {
-        Storage storage = new Storage(imageDir);
-        File curFile = storage.getCurrentImageFile();
+        ImageLoader imageLoader = new ImageLoader(imageDir);
+        File curFile = imageLoader.getImageFile();
         if (!curFile.exists()) {
             // image.0 may not exist
             LOG.info("image does not exist: {}", curFile.getAbsolutePath());
             return;
         }
-        replayedJournalId.set(storage.getImageJournalId());
+        replayedJournalId.set(imageLoader.getImageJournalId());
         LOG.info("start load image from {}. is ckpt: {}", curFile.getAbsolutePath(),
                 GlobalStateMgr.isCheckpointThread());
         long loadImageStartTime = System.currentTimeMillis();
@@ -1491,15 +1500,17 @@ public class GlobalStateMgr {
                 .build();
 
         Set<SRMetaBlockID> metaMgrMustExists = new HashSet<>(loadImages.keySet());
-        try (DataInputStream dis = new DataInputStream(new BufferedInputStream(Files.newInputStream(curFile.toPath())))) {
-            loadHeader(dis);
+        InputStream in = Files.newInputStream(curFile.toPath());
+        try {
+            imageLoader.setInputStream(in);
+            loadHeader(new DataInputStream(imageLoader.getCheckedInputStream()));
             while (true) {
-                SRMetaBlockReader reader = new SRMetaBlockReader(dis);
+                SRMetaBlockReader reader = imageLoader.getBlockReader();
                 SRMetaBlockID srMetaBlockID = reader.getHeader().getSrMetaBlockID();
 
                 try {
-                    SRMetaBlockLoader imageLoader = loadImages.get(srMetaBlockID);
-                    if (imageLoader == null) {
+                    SRMetaBlockLoader metaBlockLoader = loadImages.get(srMetaBlockID);
+                    if (metaBlockLoader == null) {
                         /*
                          * The expected read module does not match the module stored in the image,
                          * and the json chunk is skipped directly. This usually occurs in several situations.
@@ -1512,7 +1523,7 @@ public class GlobalStateMgr {
                         continue;
                     }
 
-                    imageLoader.apply(reader);
+                    metaBlockLoader.apply(reader);
                     metaMgrMustExists.remove(srMetaBlockID);
                     LOG.info("Success load StarRocks meta block " + srMetaBlockID + " from image");
                 } catch (SRMetaBlockEOFException srMetaBlockEOFException) {
@@ -1540,7 +1551,12 @@ public class GlobalStateMgr {
         } catch (SRMetaBlockException e) {
             LOG.error("load meta block failed ", e);
             throw new IOException("load meta block failed ", e);
+        } finally {
+            imageLoader.readTheRemainingBytes();
+            in.close();
         }
+
+        imageLoader.checkCheckSum();
 
         try {
             postLoadImage();
@@ -1549,7 +1565,7 @@ public class GlobalStateMgr {
         }
 
         long loadImageEndTime = System.currentTimeMillis();
-        this.imageJournalId = storage.getImageJournalId();
+        this.imageJournalId = imageLoader.getImageJournalId();
         LOG.info("finished to load image in " + (loadImageEndTime - loadImageStartTime) + " ms");
     }
 
@@ -1600,11 +1616,27 @@ public class GlobalStateMgr {
 
     // Only called by checkpoint thread
     public void saveImage() throws IOException {
+        try {
+            saveImage(ImageFormatVersion.v1);
+        } catch (Throwable t) {
+            // image v1 may fail because of byte[] size overflow, ignore
+            LOG.warn("save image v1 failed, ignore", t);
+        }
+        saveImage(ImageFormatVersion.v2);
+    }
+
+    public void saveImage(ImageFormatVersion formatVersion) throws IOException {
+        String destDir;
+        if (formatVersion == ImageFormatVersion.v1) {
+            destDir = this.imageDir;
+        } else {
+            destDir = this.imageDir + "/v2";
+        }
         // Write image.ckpt
-        Storage storage = new Storage(this.imageDir);
+        Storage storage = new Storage(destDir);
         File curFile = storage.getImageFile(replayedJournalId.get());
-        File ckpt = new File(this.imageDir, Storage.IMAGE_NEW);
-        saveImage(ckpt, replayedJournalId.get());
+        File ckpt = new File(destDir, Storage.IMAGE_NEW);
+        saveImage(new ImageWriter(destDir, formatVersion, replayedJournalId.get()), ckpt);
 
         // Move image.ckpt to image.dataVersion
         LOG.info("Move " + ckpt.getAbsolutePath() + " to " + curFile.getAbsolutePath());
@@ -1618,7 +1650,7 @@ public class GlobalStateMgr {
 
     // The manager that saves meta to image must be a member of GlobalStateMgr and cannot be SINGLETON,
     // since Checkpoint uses a separate memory.
-    public void saveImage(File curFile, long replayedJournalId) throws IOException {
+    public void saveImage(ImageWriter imageWriter, File curFile) throws IOException {
         if (!curFile.exists()) {
             if (!curFile.createNewFile()) {
                 LOG.warn("Failed to create file, filepath={}", curFile.getAbsolutePath());
@@ -1629,44 +1661,46 @@ public class GlobalStateMgr {
         LOG.info("start save image to {}. is ckpt: {}", curFile.getAbsolutePath(), GlobalStateMgr.isCheckpointThread());
 
         long saveImageStartTime = System.currentTimeMillis();
-        try (DataOutputStream dos = new DataOutputStream(Files.newOutputStream(curFile.toPath()))) {
+        try (OutputStream outputStream = Files.newOutputStream(curFile.toPath())) {
+            imageWriter.setOutputStream(outputStream);
             try {
-                saveHeader(dos);
-                nodeMgr.save(dos);
-                localMetastore.save(dos);
-                alterJobMgr.save(dos);
-                recycleBin.save(dos);
-                VariableMgr.save(dos);
-                resourceMgr.saveResourcesV2(dos);
-                exportMgr.saveExportJobV2(dos);
-                backupHandler.saveBackupHandlerV2(dos);
-                globalTransactionMgr.saveTransactionStateV2(dos);
-                colocateTableIndex.saveColocateTableIndexV2(dos);
-                routineLoadMgr.saveRoutineLoadJobsV2(dos);
-                loadMgr.saveLoadJobsV2JsonFormat(dos);
-                smallFileMgr.saveSmallFilesV2(dos);
-                pluginMgr.save(dos);
-                deleteMgr.save(dos);
-                analyzeMgr.save(dos);
-                resourceGroupMgr.save(dos);
-                authenticationMgr.saveV2(dos);
-                authorizationMgr.saveV2(dos);
-                taskManager.saveTasksV2(dos);
-                catalogMgr.save(dos);
-                insertOverwriteJobMgr.save(dos);
-                compactionMgr.save(dos);
-                streamLoadMgr.save(dos);
-                materializedViewMgr.save(dos);
-                globalFunctionMgr.save(dos);
-                storageVolumeMgr.save(dos);
-                dictionaryMgr.save(dos);
-                replicationMgr.save(dos);
-                keyMgr.save(dos);
-                pipeManager.getRepo().save(dos);
+                saveHeader(imageWriter.getDataOutputStream());
+                nodeMgr.save(imageWriter);
+                localMetastore.save(imageWriter);
+                alterJobMgr.save(imageWriter);
+                recycleBin.save(imageWriter);
+                VariableMgr.save(imageWriter);
+                resourceMgr.saveResourcesV2(imageWriter);
+                exportMgr.saveExportJobV2(imageWriter);
+                backupHandler.saveBackupHandlerV2(imageWriter);
+                globalTransactionMgr.saveTransactionStateV2(imageWriter);
+                colocateTableIndex.saveColocateTableIndexV2(imageWriter);
+                routineLoadMgr.saveRoutineLoadJobsV2(imageWriter);
+                loadMgr.saveLoadJobsV2JsonFormat(imageWriter);
+                smallFileMgr.saveSmallFilesV2(imageWriter);
+                pluginMgr.save(imageWriter);
+                deleteMgr.save(imageWriter);
+                analyzeMgr.save(imageWriter);
+                resourceGroupMgr.save(imageWriter);
+                authenticationMgr.saveV2(imageWriter);
+                authorizationMgr.saveV2(imageWriter);
+                taskManager.saveTasksV2(imageWriter);
+                catalogMgr.save(imageWriter);
+                insertOverwriteJobMgr.save(imageWriter);
+                compactionMgr.save(imageWriter);
+                streamLoadMgr.save(imageWriter);
+                materializedViewMgr.save(imageWriter);
+                globalFunctionMgr.save(imageWriter);
+                storageVolumeMgr.save(imageWriter);
+                dictionaryMgr.save(imageWriter);
+                replicationMgr.save(imageWriter);
+                keyMgr.save(imageWriter);
             } catch (SRMetaBlockException e) {
                 LOG.error("Save meta block failed ", e);
                 throw new IOException("Save meta block failed ", e);
             }
+
+            imageWriter.saveChecksum();
 
             long saveImageEndTime = System.currentTimeMillis();
             LOG.info("Finished save meta block {} in {} ms.",
@@ -2431,7 +2465,7 @@ public class GlobalStateMgr {
             dumpFilePath = dumpFile.getAbsolutePath();
             try {
                 LOG.info("begin to dump {}", dumpFilePath);
-                saveImage(dumpFile, journalId);
+                saveImage(new ImageWriter(Config.meta_dir, ImageFormatVersion.v2, journalId), dumpFile);
             } catch (IOException e) {
                 LOG.error("failed to dump image to {}", dumpFilePath, e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -234,7 +234,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
@@ -1695,6 +1694,7 @@ public class GlobalStateMgr {
                 dictionaryMgr.save(imageWriter);
                 replicationMgr.save(imageWriter);
                 keyMgr.save(imageWriter);
+                pipeManager.getRepo().save(imageWriter);
             } catch (SRMetaBlockException e) {
                 LOG.error("Save meta block failed ", e);
                 throw new IOException("Save meta block failed ", e);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -152,6 +152,7 @@ import com.starrocks.persist.DropDbInfo;
 import com.starrocks.persist.DropPartitionInfo;
 import com.starrocks.persist.DropPartitionsInfo;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.ListPartitionPersistInfo;
 import com.starrocks.persist.ModifyPartitionInfo;
 import com.starrocks.persist.ModifyTableColumnOperationLog;
@@ -262,7 +263,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -5201,7 +5201,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
         }
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         // Don't write system db meta
         Map<Long, Database> idToDbNormal =
                 idToDb.entrySet().stream().filter(entry -> entry.getKey() > NEXT_ID_INIT_VALUE)
@@ -5211,13 +5211,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
             totalTableNum += database.getTableNumber();
         }
         int cnt = 1 + idToDbNormal.size() + idToDbNormal.size() /* record database table size */ + totalTableNum + 1;
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.LOCAL_META_STORE, cnt);
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.LOCAL_META_STORE, cnt);
 
-        writer.writeJson(idToDbNormal.size());
+        writer.writeInt(idToDbNormal.size());
         for (Database database : idToDbNormal.values()) {
             writer.writeJson(database);
             int totalTableNumber = database.getTables().size();
-            writer.writeJson(totalTableNumber);
+            writer.writeInt(totalTableNumber);
             List<Table> tables = database.getTables();
             for (Table table : tables) {
                 writer.writeJson(table);
@@ -5231,7 +5231,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
     }
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
-        int dbSize = reader.readJson(int.class);
+        int dbSize = reader.readInt();
         for (int i = 0; i < dbSize; ++i) {
             Database db = reader.readJson(Database.class);
             int tableSize = reader.readInt();

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -52,6 +52,9 @@ import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.LeaderInfo;
 import com.starrocks.http.meta.MetaBaseAction;
 import com.starrocks.leader.MetaHelper;
+import com.starrocks.persist.ImageFormatVersion;
+import com.starrocks.persist.ImageLoader;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.Storage;
 import com.starrocks.persist.StorageInfo;
 import com.starrocks.persist.gson.GsonUtils;
@@ -81,7 +84,6 @@ import com.starrocks.thrift.TStatusCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -699,25 +701,31 @@ public class NodeMgr {
      * Exception are free to raise on initialized phase
      */
     private void getNewImageOnStartup(Pair<String, Integer> helperNode, String subDir) throws IOException {
-        long localImageVersion = 0;
         String dirStr = this.imageDir + subDir;
-        Storage storage = new Storage(dirStr);
-        localImageVersion = storage.getImageJournalId();
+        ImageLoader imageLoader = new ImageLoader(dirStr);
+        long localImageVersion = imageLoader.getImageJournalId();
 
         String accessibleHostPort = NetUtils.getHostPortInAccessibleFormat(helperNode.first, Config.http_port);
         URL infoUrl = new URL("http://" + accessibleHostPort + "/info?subdir=" + subDir);
-        StorageInfo info = getStorageInfo(infoUrl);
-        long version = info.getImageJournalId();
-        if (version > localImageVersion) {
-            String url = "http://" + accessibleHostPort + "/image?version=" + version + "&subdir=" + subDir;
-            LOG.info("start to download image.{} from {}", version, url);
-            String filename = Storage.IMAGE + "." + version;
-            File dir = new File(dirStr);
-            MetaHelper.getRemoteFile(url, HTTP_TIMEOUT_SECOND * 1000, MetaHelper.getOutputStream(filename, dir));
-            MetaHelper.complete(filename, dir);
+        StorageInfo remoteStorageInfo = getStorageInfo(infoUrl);
+        long remoteImageVersion = remoteStorageInfo.getImageJournalId();
+        if (remoteImageVersion > localImageVersion) {
+            String url = "http://" + accessibleHostPort + "/image?"
+                    + "version=" + remoteImageVersion
+                    + "&subdir=" + subDir
+                    + "&image_format_version=" + remoteStorageInfo.getImageFormatVersion();
+            LOG.info("start to download image.{} version:{}, from {}", remoteImageVersion,
+                    remoteStorageInfo.getImageFormatVersion(), url);
+            File dir;
+            if (remoteStorageInfo.getImageFormatVersion() == ImageFormatVersion.v1) {
+                dir = new File(dirStr);
+            } else {
+                dir = new File(dirStr, remoteStorageInfo.getImageFormatVersion().toString());
+            }
+            MetaHelper.downloadImageFile(url, HTTP_TIMEOUT_SECOND * 1000, Long.toString(remoteImageVersion), dir);
         } else {
             LOG.info("skip download image for {}, current version {} >= version {} from {}",
-                    dirStr, localImageVersion, version, helperNode);
+                    dirStr, localImageVersion, remoteImageVersion, helperNode);
         }
     }
 
@@ -1168,8 +1176,8 @@ public class NodeMgr {
         return frontends;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.NODE_MGR, 1);
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.NODE_MGR, 1);
         writer.writeJson(this);
         writer.close();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -26,6 +26,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.persist.DropStorageVolumeLog;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.SetDefaultStorageVolumeLog;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -359,8 +360,8 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
         }
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.STORAGE_VOLUME_MGR, 1);
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.STORAGE_VOLUME_MGR, 1);
         writer.writeJson(this);
         writer.close();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -33,6 +33,7 @@ import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.metric.TableMetricsEntity;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -774,7 +775,7 @@ public class AnalyzeMgr implements Writable {
         return checksum;
     }
 
-    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
         List<AnalyzeStatus> analyzeStatuses = getAnalyzeStatusMap().values().stream()
                 .distinct().collect(Collectors.toList());
 
@@ -785,34 +786,34 @@ public class AnalyzeMgr implements Writable {
                 + 1 + externalBasicStatsMetaMap.size()
                 + 1 + externalHistogramStatsMetaMap.size();
 
-        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.ANALYZE_MGR, numJson);
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.ANALYZE_MGR, numJson);
 
-        writer.writeJson(analyzeJobMap.size());
+        writer.writeInt(analyzeJobMap.size());
         for (AnalyzeJob analyzeJob : analyzeJobMap.values()) {
             writer.writeJson(analyzeJob);
         }
 
-        writer.writeJson(analyzeStatuses.size());
+        writer.writeInt(analyzeStatuses.size());
         for (AnalyzeStatus analyzeStatus : analyzeStatuses) {
             writer.writeJson(analyzeStatus);
         }
 
-        writer.writeJson(basicStatsMetaMap.size());
+        writer.writeInt(basicStatsMetaMap.size());
         for (BasicStatsMeta basicStatsMeta : basicStatsMetaMap.values()) {
             writer.writeJson(basicStatsMeta);
         }
 
-        writer.writeJson(histogramStatsMetaMap.size());
+        writer.writeInt(histogramStatsMetaMap.size());
         for (HistogramStatsMeta histogramStatsMeta : histogramStatsMetaMap.values()) {
             writer.writeJson(histogramStatsMeta);
         }
 
-        writer.writeJson(externalBasicStatsMetaMap.size());
+        writer.writeInt(externalBasicStatsMetaMap.size());
         for (ExternalBasicStatsMeta basicStatsMeta : externalBasicStatsMetaMap.values()) {
             writer.writeJson(basicStatsMeta);
         }
 
-        writer.writeJson(externalHistogramStatsMetaMap.size());
+        writer.writeInt(externalHistogramStatsMetaMap.size());
         for (ExternalHistogramStatsMeta histogramStatsMeta : externalHistogramStatsMetaMap.values()) {
             writer.writeJson(histogramStatsMeta);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -370,11 +370,11 @@ public class AlterJobV2Test {
         AlterJobV2 alterJobV2Old = new ArrayList<>(alterJobs.values()).get(0);
 
         UtFrameUtils.PseudoImage alterImage = new UtFrameUtils.PseudoImage();
-        GlobalStateMgr.getCurrentState().getAlterJobMgr().save(alterImage.getDataOutputStream());
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().save(alterImage.getImageWriter());
 
-        SRMetaBlockReader reader = new SRMetaBlockReader(alterImage.getDataInputStream());
-        GlobalStateMgr.getCurrentState().getAlterJobMgr().load(reader);
-        reader.close();
+        SRMetaBlockReader srMetaBlockReader = alterImage.getMetaBlockReader();
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().load(srMetaBlockReader);
+        srMetaBlockReader.close();
 
         AlterJobV2 alterJobV2New =
                 GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2().get(alterJobV2Old.jobId);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
@@ -28,7 +28,6 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.persist.OperationType;
-import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -338,7 +337,7 @@ public class AlterTableTest {
 
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage initialImage = new UtFrameUtils.PseudoImage();
-        GlobalStateMgr.getCurrentState().getLocalMetastore().save(initialImage.getDataOutputStream());
+        GlobalStateMgr.getCurrentState().getLocalMetastore().save(initialImage.getImageWriter());
 
         // ** test alter table location to rack:*
         sql = "ALTER TABLE test.`test_location_alter` SET ('" +
@@ -360,7 +359,7 @@ public class AlterTableTest {
 
         // ** test replay from edit log: alter to rack:*
         LocalMetastore localMetastoreFollower = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
-        localMetastoreFollower.load(new SRMetaBlockReader(initialImage.getDataInputStream()));
+        localMetastoreFollower.load(initialImage.getMetaBlockReader());
         ModifyTablePropertyOperationLog info = (ModifyTablePropertyOperationLog)
                 UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TABLE_PROPERTIES);
         localMetastoreFollower.replayModifyTableProperty(OperationType.OP_ALTER_TABLE_PROPERTIES, info);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -41,6 +41,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.persist.CreateTableInfo;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.StmtExecutor;
@@ -4723,7 +4724,7 @@ public class CreateMaterializedViewTest {
         // init empty image
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage initialImage = new UtFrameUtils.PseudoImage();
-        GlobalStateMgr.getCurrentState().getLocalMetastore().save(initialImage.getDataOutputStream());
+        GlobalStateMgr.getCurrentState().getLocalMetastore().save(initialImage.getImageWriter());
 
         // Create a mv with specific location, we should expect the tablets of that mv will only distribute on
         // that single labeled backend.
@@ -4743,11 +4744,11 @@ public class CreateMaterializedViewTest {
 
         // make final image
         UtFrameUtils.PseudoImage finalImage = new UtFrameUtils.PseudoImage();
-        GlobalStateMgr.getCurrentState().getLocalMetastore().save(finalImage.getDataOutputStream());
+        GlobalStateMgr.getCurrentState().getLocalMetastore().save(finalImage.getImageWriter());
 
         // test replay
         LocalMetastore localMetastoreFollower = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
-        localMetastoreFollower.load(new SRMetaBlockReader(initialImage.getDataInputStream()));
+        localMetastoreFollower.load(new SRMetaBlockReaderV2(initialImage.getJsonReader()));
         CreateTableInfo info = (CreateTableInfo)
                 UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_CREATE_TABLE_V2);
         localMetastoreFollower.replayCreateTable(info);
@@ -4759,7 +4760,7 @@ public class CreateMaterializedViewTest {
 
         // test restart
         LocalMetastore localMetastoreLeader = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
-        localMetastoreLeader.load(new SRMetaBlockReader(finalImage.getDataInputStream()));
+        localMetastoreLeader.load(new SRMetaBlockReaderV2(finalImage.getJsonReader()));
         mv = (MaterializedView) localMetastoreLeader.getDb("test")
                 .getTable("mv_with_location");
         System.out.println(mv.getLocation());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -54,6 +54,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -596,9 +597,9 @@ public class BackupHandlerTest {
 
 
         UtFrameUtils.PseudoImage pseudoImage = new UtFrameUtils.PseudoImage();
-        handler.saveBackupHandlerV2(pseudoImage.getDataOutputStream());
+        handler.saveBackupHandlerV2(pseudoImage.getImageWriter());
         BackupHandler followerHandler = new BackupHandler(globalStateMgr);
-        SRMetaBlockReader reader = new SRMetaBlockReader(pseudoImage.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(pseudoImage.getJsonReader());
         followerHandler.loadBackupHandlerV2(reader);
         reader.close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -18,6 +18,7 @@ package com.starrocks.catalog;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateDbStmt;
@@ -333,10 +334,10 @@ public class ColocateTableIndexTest {
         OlapTable table = (OlapTable) db.getTable("tbl1");
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-        colocateTableIndex.saveColocateTableIndexV2(image.getDataOutputStream());
+        colocateTableIndex.saveColocateTableIndexV2(image.getImageWriter());
 
         ColocateTableIndex followerIndex = new ColocateTableIndex();
-        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image.getJsonReader());
         followerIndex.loadColocateTableIndexV2(reader);
         reader.close();
         Assert.assertEquals(colocateTableIndex.getAllGroupIds(), followerIndex.getAllGroupIds());

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SmallFileMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SmallFileMgrTest.java
@@ -41,6 +41,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.SmallFileMgr.SmallFile;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateFileStmt;
 import com.starrocks.utframe.UtFrameUtils;
@@ -176,10 +177,10 @@ public class SmallFileMgrTest {
         smallFileMgr.replayCreateFile(smallFile);
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-        smallFileMgr.saveSmallFilesV2(image.getDataOutputStream());
+        smallFileMgr.saveSmallFilesV2(image.getImageWriter());
 
         SmallFileMgr followerMgr = new SmallFileMgr();
-        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image.getJsonReader());
         followerMgr.loadSmallFilesV2(reader);
         reader.close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/encryption/KeyMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/encryption/KeyMgrTest.java
@@ -101,10 +101,10 @@ public class KeyMgrTest {
         keyMgr.replayAddKey(pb);
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-        keyMgr.save(image.getDataOutputStream());
+        keyMgr.save(image.getImageWriter());
 
         KeyMgr keyMgr2 = new KeyMgr();
-        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+        SRMetaBlockReader reader = image.getMetaBlockReader();
         keyMgr2.load(reader);
         reader.close();
 
@@ -125,10 +125,10 @@ public class KeyMgrTest {
             Assert.assertEquals(1, tGetKeysResponse.getKey_metasSize());
 
             UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-            keyMgr.save(image.getDataOutputStream());
+            keyMgr.save(image.getImageWriter());
 
             KeyMgr keyMgr2 = new KeyMgr();
-            SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+            SRMetaBlockReader reader = image.getMetaBlockReader();
             keyMgr2.load(reader);
             reader.close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
@@ -18,6 +18,7 @@ package com.starrocks.ha;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.server.RunMode;
@@ -89,8 +90,8 @@ public class BDBHATest {
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());
 
         UtFrameUtils.PseudoImage image1 = new UtFrameUtils.PseudoImage();
-        GlobalStateMgr.getCurrentState().getNodeMgr().save(image1.getDataOutputStream());
-        SRMetaBlockReader reader = new SRMetaBlockReader(image1.getDataInputStream());
+        GlobalStateMgr.getCurrentState().getNodeMgr().save(image1.getImageWriter());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image1.getJsonReader());
         NodeMgr nodeMgr = new NodeMgr();
         nodeMgr.load(reader);
         reader.close();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
@@ -24,17 +24,15 @@ import com.starrocks.lake.LakeTable;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -186,12 +184,11 @@ public class CompactionMgrTest {
             }
         };
 
-        ByteArrayOutputStream bstream = new ByteArrayOutputStream();
-        DataOutputStream ostream = new DataOutputStream(bstream);
-        compactionMgr.save(ostream);
+        UtFrameUtils.PseudoImage.setUpImageVersion();
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        compactionMgr.save(image.getImageWriter());
         CompactionMgr compactionMgr2 = new CompactionMgr();
-        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bstream.toByteArray()));
-        SRMetaBlockReader reader = new SRMetaBlockReader(dis);
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image.getJsonReader());
         compactionMgr2.load(reader);
         Assert.assertEquals(1, compactionMgr2.getPartitionStatsCount());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
@@ -21,6 +21,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.OrderByPair;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -130,10 +131,10 @@ public class ExportMgrTest {
         leaderMgr.replayCreateExportJob(job);
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-        leaderMgr.saveExportJobV2(image.getDataOutputStream());
+        leaderMgr.saveExportJobV2(image.getImageWriter());
 
         ExportMgr followerMgr = new ExportMgr();
-        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image.getJsonReader());
         followerMgr.loadExportJobV2(reader);
         reader.close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
@@ -41,6 +41,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -339,10 +340,10 @@ public class LoadMgrTest {
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
 
-        loadManager.saveLoadJobsV2JsonFormat(image.getDataOutputStream());
+        loadManager.saveLoadJobsV2JsonFormat(image.getImageWriter());
 
         LoadMgr loadManager2 = new LoadMgr(new LoadJobScheduler());
-        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image.getJsonReader());
         loadManager2.loadLoadJobsV2JsonFormat(reader);
         reader.close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -30,6 +30,7 @@ import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.PipeOpEntry;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowExecutor;
@@ -237,11 +238,11 @@ public class PipeManagerTest {
         CreatePipeStmt createStmt = (CreatePipeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         pm.createPipe(createStmt);
         UtFrameUtils.PseudoImage image1 = new UtFrameUtils.PseudoImage();
-        pm.getRepo().save(image1.getDataOutputStream());
+        pm.getRepo().save(image1.getImageWriter());
 
         // restore from image
         PipeManager pm1 = new PipeManager();
-        SRMetaBlockReader reader = new SRMetaBlockReader(image1.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image1.getJsonReader());
         pm1.getRepo().load(reader);
         reader.close();
         Assert.assertEquals(pm.getPipesUnlock(), pm1.getPipesUnlock());
@@ -255,11 +256,11 @@ public class PipeManagerTest {
         AlterPipeStmt alterPipeStmt = (AlterPipeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         pm.alterPipe(alterPipeStmt);
         UtFrameUtils.PseudoImage image2 = new UtFrameUtils.PseudoImage();
-        pm.getRepo().save(image2.getDataOutputStream());
+        pm.getRepo().save(image2.getImageWriter());
 
         // restore and check
         PipeManager pm2 = new PipeManager();
-        reader = new SRMetaBlockReader(image2.getDataInputStream());
+        reader = new SRMetaBlockReaderV2(image2.getJsonReader());
         pm2.getRepo().load(reader);
         reader.close();
         Assert.assertEquals(pm.getPipesUnlock(), pm2.getPipesUnlock());
@@ -1037,7 +1038,7 @@ public class PipeManagerTest {
                 "create pipe p_crash as insert into tbl select * from files('path'='fake://pipe', 'format'='parquet')";
         createPipe(sql);
         UtFrameUtils.PseudoImage image1 = new UtFrameUtils.PseudoImage();
-        pm.getRepo().save(image1.getDataOutputStream());
+        pm.getRepo().save(image1.getImageWriter());
 
         // loading file and crash
         String name = "p_crash";
@@ -1051,7 +1052,7 @@ public class PipeManagerTest {
         {
             PipeManager pm1 = new PipeManager();
             FileListRepo repo = pipe.getPipeSource().getFileListRepo();
-            SRMetaBlockReader reader = new SRMetaBlockReader(image1.getDataInputStream());
+            SRMetaBlockReader reader = new SRMetaBlockReaderV2(image1.getJsonReader());
             pm1.getRepo().load(reader);
             reader.close();
             Assert.assertEquals(pm.getPipesUnlock(), pm1.getPipesUnlock());
@@ -1078,7 +1079,7 @@ public class PipeManagerTest {
             };
 
             PipeManager pm1 = new PipeManager();
-            SRMetaBlockReader reader = new SRMetaBlockReader(image1.getDataInputStream());
+            SRMetaBlockReader reader = new SRMetaBlockReaderV2(image1.getJsonReader());
             pm1.getRepo().load(reader);
             reader.close();
             Assert.assertEquals(pm.getPipesUnlock(), pm1.getPipesUnlock());

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
@@ -51,6 +51,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
@@ -1039,9 +1040,9 @@ public class RoutineLoadManagerTest {
         leaderLoadManager.addRoutineLoadJob(pulsarRoutineLoadJob, db);
 
         UtFrameUtils.PseudoImage pseudoImage = new UtFrameUtils.PseudoImage();
-        leaderLoadManager.saveRoutineLoadJobsV2(pseudoImage.getDataOutputStream());
+        leaderLoadManager.saveRoutineLoadJobsV2(pseudoImage.getImageWriter());
         RoutineLoadMgr restartedRoutineLoadManager = new RoutineLoadMgr();
-        SRMetaBlockReader reader = new SRMetaBlockReader(pseudoImage.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(pseudoImage.getJsonReader());
         restartedRoutineLoadManager.loadRoutineLoadJobsV2(reader);
         reader.close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ImageLoaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ImageLoaderTest.java
@@ -1,0 +1,166 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+public class ImageLoaderTest {
+    private static Path imageDir;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        imageDir = Files.createTempDirectory(Paths.get("."), "ImageLoaderTest");
+        File v2Dir = new File(imageDir.toString(), "v2");
+        v2Dir.mkdirs();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        FileUtils.deleteDirectory(imageDir.toFile());
+    }
+
+    /**
+     *  meta/image/
+     *            image.1000
+     *            image.2000
+     *            v2/
+     *              image.ckpt
+     *              image.1000
+     *              checksum.100
+     *              image.2000
+     *              checksum.2000
+     */
+    @Test
+    public void testLoadMaxImage1() throws Exception {
+        List<Path> pathList = new ArrayList<>();
+        pathList.add(Path.of(imageDir.toString(), "image.1000"));
+        pathList.add(Path.of(imageDir.toString(), "image.2000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "image.1000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "checksum.1000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "image.2000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "checksum.2000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "image.ckpt"));
+        try {
+            for (Path path : pathList) {
+                Files.createFile(path);
+            }
+
+            ImageLoader imageLoader = new ImageLoader(imageDir.toString());
+            Assert.assertEquals("image.2000", imageLoader.getImageFile().getName());
+            Assert.assertEquals(ImageFormatVersion.v2, imageLoader.getImageFormatVersion());
+        } finally {
+            for (Path path : pathList) {
+                Files.delete(path);
+            }
+        }
+    }
+
+    /**
+     *  meta/image/
+     *            image.1000
+     *            image.2000
+     *            v2/
+     *              image.1000
+     *              checksum.1000
+     *              image.ckpt
+     */
+    @Test
+    public void testLoadMaxImage2() throws Exception {
+        List<Path> pathList = new ArrayList<>();
+        pathList.add(Path.of(imageDir.toString(), "image.1000"));
+        pathList.add(Path.of(imageDir.toString(), "image.2000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "image.1000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "checksum.1000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "image.ckpt"));
+        try {
+            for (Path path : pathList) {
+                Files.createFile(path);
+            }
+
+            ImageLoader imageLoader = new ImageLoader(imageDir.toString());
+            Assert.assertEquals("image.2000", imageLoader.getImageFile().getName());
+            Assert.assertEquals(ImageFormatVersion.v1, imageLoader.getImageFormatVersion());
+        } finally {
+            for (Path path : pathList) {
+                Files.delete(path);
+            }
+        }
+    }
+
+    /**
+     *  meta/image/
+     *            image.1000
+     *            v2/
+     *              image.2000
+     *              checksum.2000
+     */
+    @Test
+    public void testLoadMaxImage3() throws Exception {
+        List<Path> pathList = new ArrayList<>();
+        pathList.add(Path.of(imageDir.toString(), "image.1000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "image.2000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "checksum.2000"));
+        try {
+            for (Path path : pathList) {
+                Files.createFile(path);
+            }
+
+            ImageLoader imageLoader = new ImageLoader(imageDir.toString());
+            Assert.assertEquals("image.2000", imageLoader.getImageFile().getName());
+            Assert.assertEquals(ImageFormatVersion.v2, imageLoader.getImageFormatVersion());
+        } finally {
+            for (Path path : pathList) {
+                Files.delete(path);
+            }
+        }
+    }
+
+    @Test
+    public void testChecksum() throws Exception {
+        List<Path> pathList = new ArrayList<>();
+        pathList.add(Path.of(imageDir.toString(), "v2", "image.2000"));
+        pathList.add(Path.of(imageDir.toString(), "v2", "checksum.2000"));
+        try {
+            for (Path path : pathList) {
+                Files.createFile(path);
+            }
+
+            String content = "xxxxxxx=========aaabbccc";
+            Files.writeString(Path.of(imageDir.toString(), "v2", "image.2000"), content);
+            Checksum checksum = new CRC32();
+            checksum.update(content.getBytes());
+            Files.writeString(Path.of(imageDir.toString(), "v2", "checksum.2000"),
+                    String.valueOf(checksum.getValue()));
+
+        } finally {
+            for (Path path : pathList) {
+                Files.delete(path);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/StorageInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/StorageInfoTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class StorageInfoTest {
     @Test
     public void test() {
-        StorageInfo info = new StorageInfo(20);
+        StorageInfo info = new StorageInfo(20, ImageFormatVersion.v2);
         Assert.assertEquals(20, info.getImageJournalId());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/StorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/StorageTest.java
@@ -115,7 +115,6 @@ public class StorageTest {
     public void testConstruct() {
         Storage storage1 = new Storage(1, "token", "test");
         Assert.assertEquals(1, storage1.getClusterID());
-        Assert.assertEquals("test", storage1.getMetaDir());
     }
 
     @Test
@@ -135,15 +134,6 @@ public class StorageTest {
 
         storage.setImageJournalId(100);
         Assert.assertEquals(100, storage.getImageJournalId());
-
-        Assert.assertEquals("storageTestDir", storage.getMetaDir());
-        storage.setMetaDir("abcd");
-        Assert.assertEquals("abcd", storage.getMetaDir());
-
-        storage.setMetaDir("storageTestDir");
-        storage.clear();
-        File file = new File(storage.getMetaDir());
-        Assert.assertEquals(0, file.list().length);
 
         deleteDir();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/metablock/SRMetaBlockV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/metablock/SRMetaBlockV2Test.java
@@ -1,0 +1,227 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist.metablock;
+
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class SRMetaBlockV2Test {
+
+    private static Path tmpDir;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        tmpDir = Files.createTempDirectory(Paths.get("."), "SRMetaBlockV2Test");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        FileUtils.deleteDirectory(tmpDir.toFile());
+    }
+
+    private InputStream openInput(String name) throws IOException {
+        return Files.newInputStream(Paths.get(tmpDir.toFile().getAbsolutePath(), name));
+    }
+
+    private OutputStream openOutput(String name) throws IOException {
+        return Files.newOutputStream(Paths.get(tmpDir.toFile().getAbsolutePath(), name));
+    }
+
+    static class SimpleObject {
+        @SerializedName("name")
+        String name;
+
+        @SerializedName("value")
+        int value;
+
+        public SimpleObject(String name, int value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof SimpleObject)) {
+                return false;
+            }
+
+            SimpleObject sb = (SimpleObject) obj;
+
+            return name.equals(sb.name) && value == sb.value;
+        }
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        String fileName = "simple";
+
+        // write 5 json
+        OutputStream out = openOutput(fileName);
+        SRMetaBlockWriter writer = new SRMetaBlockWriterV2(new JsonWriter(new OutputStreamWriter(out)),
+                SRMetaBlockID.RESOURCE_MGR, 6);
+        writer.writeInt(5);
+        writer.writeJson(new SimpleObject("n1", 1));
+        writer.writeJson(new SimpleObject("n2", 2));
+        writer.writeJson(new SimpleObject("n3", 3));
+        writer.writeJson(new SimpleObject("n4", 4));
+        writer.writeJson(new SimpleObject("n5", 5));
+        writer.close();
+        out.close();
+
+        InputStream in = openInput(fileName);
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(new JsonReader(new InputStreamReader(in)));
+        Assert.assertEquals(SRMetaBlockID.RESOURCE_MGR, reader.getHeader().getSrMetaBlockID());
+        Assert.assertEquals(5, reader.readInt());
+        Assert.assertEquals(new SimpleObject("n1", 1), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n2", 2), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n3", 3), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n4", 4), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n5", 5), reader.readJson(SimpleObject.class));
+        Assert.assertThrows(SRMetaBlockEOFException.class, () -> reader.readJson(SimpleObject.class));
+        reader.close();
+        in.close();
+    }
+
+    @Test
+    public void testMultiBlock() throws Exception {
+        String fileName = "multi_block";
+        OutputStream out = openOutput(fileName);
+        JsonWriter jsonWriter = new JsonWriter(new OutputStreamWriter(out));
+
+        // write block1
+        SRMetaBlockWriter writer = new SRMetaBlockWriterV2(jsonWriter, SRMetaBlockID.RESOURCE_MGR, 2);
+        writer.writeJson(new SimpleObject("n1", 1));
+        writer.writeJson(new SimpleObject("n2", 2));
+        writer.close();
+
+        // write block2
+        writer = new SRMetaBlockWriterV2(jsonWriter, SRMetaBlockID.TASK_MGR, 4);
+        writer.writeJson(new SimpleObject("n1", 1));
+        writer.writeJson(new SimpleObject("n2", 2));
+        writer.writeJson(new SimpleObject("n3", 3));
+        writer.writeJson(new SimpleObject("n4", 4));
+        writer.close();
+
+        out.close();
+
+        // ======= normal read =======
+        InputStream in = openInput(fileName);
+        JsonReader jsonReader = new JsonReader(new InputStreamReader(in));
+        //read block1
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(jsonReader);
+        Assert.assertEquals(SRMetaBlockID.RESOURCE_MGR, reader.getHeader().getSrMetaBlockID());
+        Assert.assertEquals(new SimpleObject("n1", 1), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n2", 2), reader.readJson(SimpleObject.class));
+        reader.close();
+
+        //read block2
+        reader = new SRMetaBlockReaderV2(jsonReader);
+        Assert.assertEquals(SRMetaBlockID.TASK_MGR, reader.getHeader().getSrMetaBlockID());
+        Assert.assertEquals(new SimpleObject("n1", 1), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n2", 2), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n3", 3), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n4", 4), reader.readJson(SimpleObject.class));
+        reader.close();
+
+        in.close();
+
+        // ======= skip read ========
+        in = openInput(fileName);
+        jsonReader = new JsonReader(new InputStreamReader(in));
+
+        // read block1, but only read 1 json, close() will skip the rest
+        reader = new SRMetaBlockReaderV2(jsonReader);
+        Assert.assertEquals(SRMetaBlockID.RESOURCE_MGR, reader.getHeader().getSrMetaBlockID());
+        Assert.assertEquals(new SimpleObject("n1", 1), reader.readJson(SimpleObject.class));
+        reader.close();
+
+        // read block2, and read more object, SRMetaBlockEOFException will be thrown
+        reader = new SRMetaBlockReaderV2(jsonReader);
+        Assert.assertEquals(SRMetaBlockID.TASK_MGR, reader.getHeader().getSrMetaBlockID());
+        Assert.assertEquals(new SimpleObject("n1", 1), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n2", 2), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n3", 3), reader.readJson(SimpleObject.class));
+        Assert.assertEquals(new SimpleObject("n4", 4), reader.readJson(SimpleObject.class));
+        SRMetaBlockReader finalReader = reader;
+        Assert.assertThrows(SRMetaBlockEOFException.class, () -> finalReader.readJson(SimpleObject.class));
+        reader.close();
+
+        // read block3, and it does not exist, EOFException will be thrown
+        JsonReader finalJsonReader = jsonReader;
+        Assert.assertThrows(EOFException.class, () -> new SRMetaBlockReaderV2(finalJsonReader));
+        in.close();
+    }
+
+    @Test
+    public void testWriteBadBlock0Json() throws Exception {
+        String name = "badWriter0Json";
+        OutputStream out = openOutput(name);
+        // write 0 json
+        try {
+            new SRMetaBlockWriterV2(new JsonWriter(new OutputStreamWriter(out)), SRMetaBlockID.TASK_MGR, 0);
+            Assert.fail();
+        } catch (SRMetaBlockException e) {
+            Assert.assertTrue(e.getMessage().contains("invalid numJson: 0"));
+        }
+    }
+
+    @Test
+    public void testWriteBadBlockMoreJson() throws Exception {
+        String name = "badWriterMoreJson";
+        OutputStream dos = openOutput(name);
+        SRMetaBlockWriter writer = new SRMetaBlockWriterV2(new JsonWriter(new OutputStreamWriter(dos)),
+                SRMetaBlockID.TASK_MGR, 1);
+        writer.writeJson(new SimpleObject("n1", 1));
+        // write more json than declared
+        try {
+            writer.writeJson(new SimpleObject("n2", 2));
+            Assert.fail();
+        } catch (SRMetaBlockException e) {
+            Assert.assertTrue(e.getMessage().contains("About to write json more than"));
+        }
+    }
+
+    @Test
+    public void testWriteBadBlockLessJson() throws Exception {
+        String name = "badWriterLessJson";
+        OutputStream dos = openOutput(name);
+        SRMetaBlockWriter writer = new SRMetaBlockWriterV2(new JsonWriter(new OutputStreamWriter(dos)),
+                SRMetaBlockID.TASK_MGR, 2);
+        writer.writeJson(new SimpleObject("n1", 1));
+        // write less json than declared
+        try {
+            writer.close();
+            Assert.fail();
+        } catch (SRMetaBlockException e) {
+            Assert.assertTrue(e.getMessage().contains("Block json number mismatch: expect 2 actual 1"));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/AuthorizationMgrTest.java
@@ -16,6 +16,7 @@
 package com.starrocks.privilege;
 
 import com.google.common.collect.Lists;
+import com.google.gson.stream.JsonReader;
 import com.starrocks.analysis.TableName;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.catalog.Column;
@@ -28,12 +29,14 @@ import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.UserException;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.meta.MetaContext;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.RolePrivilegeCollectionInfo;
 import com.starrocks.persist.UserPrivilegeCollectionInfo;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.GlobalVariable;
@@ -69,8 +72,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -273,22 +274,22 @@ public class AuthorizationMgrTest {
                 ctx.getCurrentUserIdentity(), ctx.getCurrentRoleIds(), InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME));
     }
 
-    void saveRBACPrivilege(GlobalStateMgr globalStateMgr, DataOutputStream dataOutputStream) throws IOException {
+    void saveRBACPrivilege(GlobalStateMgr globalStateMgr, ImageWriter imageWriter) throws IOException {
         AuthenticationMgr authenticationMgr = globalStateMgr.getAuthenticationMgr();
         AuthorizationMgr authorizationMgr = globalStateMgr.getAuthorizationMgr();
-        authenticationMgr.saveV2(dataOutputStream);
-        authorizationMgr.saveV2(dataOutputStream);
+        authenticationMgr.saveV2(imageWriter);
+        authorizationMgr.saveV2(imageWriter);
     }
 
-    void loadRBACPrivilege(GlobalStateMgr globalStateMgr, DataInputStream dataInputStream)
+    void loadRBACPrivilege(GlobalStateMgr globalStateMgr, JsonReader jsonReader)
             throws IOException, SRMetaBlockEOFException, SRMetaBlockException, PrivilegeException {
         AuthenticationMgr authenticationMgr = globalStateMgr.getAuthenticationMgr();
         AuthorizationMgr authorizationMgr = globalStateMgr.getAuthorizationMgr();
 
-        SRMetaBlockReader srMetaBlockReader = new SRMetaBlockReader(dataInputStream);
+        SRMetaBlockReader srMetaBlockReader = new SRMetaBlockReaderV2(jsonReader);
         authenticationMgr.loadV2(srMetaBlockReader);
         srMetaBlockReader.close();
-        srMetaBlockReader = new SRMetaBlockReader(dataInputStream);
+        srMetaBlockReader = new SRMetaBlockReaderV2(jsonReader);
         authorizationMgr.loadV2(srMetaBlockReader);
         srMetaBlockReader.close();
 
@@ -310,7 +311,7 @@ public class AuthorizationMgrTest {
 
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getImageWriter());
 
         setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
         String sql = "grant select on db.tbl1 to test_user";
@@ -322,7 +323,7 @@ public class AuthorizationMgrTest {
                 PrivilegeType.SELECT);
 
         UtFrameUtils.PseudoImage grantImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, grantImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, grantImage.getImageWriter());
 
         sql = "revoke select on db.tbl1 from test_user";
         setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
@@ -332,10 +333,10 @@ public class AuthorizationMgrTest {
         Assert.assertThrows(AccessDeniedException.class, () -> Authorizer.checkTableAction(
                 ctx.getCurrentUserIdentity(), ctx.getCurrentRoleIds(), DB_NAME, TABLE_NAME_1, PrivilegeType.SELECT));
         UtFrameUtils.PseudoImage revokeImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, revokeImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, revokeImage.getImageWriter());
 
         // start to replay
-        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataInputStream());
+        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getJsonReader());
         AuthorizationMgr followerManager = masterGlobalStateMgr.getAuthorizationMgr();
 
         UserPrivilegeCollectionInfo info = (UserPrivilegeCollectionInfo)
@@ -353,12 +354,12 @@ public class AuthorizationMgrTest {
                 ctx.getCurrentRoleIds(), DB_NAME, TABLE_NAME_1, PrivilegeType.SELECT));
 
         // check image
-        loadRBACPrivilege(masterGlobalStateMgr, grantImage.getDataInputStream());
+        loadRBACPrivilege(masterGlobalStateMgr, grantImage.getJsonReader());
         authorizationMgr.invalidateUserInCache(ctx.getCurrentUserIdentity());
         Authorizer.checkTableAction(ctx.getCurrentUserIdentity(), ctx.getCurrentRoleIds(), DB_NAME, TABLE_NAME_1,
                 PrivilegeType.SELECT);
 
-        loadRBACPrivilege(masterGlobalStateMgr, revokeImage.getDataInputStream());
+        loadRBACPrivilege(masterGlobalStateMgr, revokeImage.getJsonReader());
         authorizationMgr.invalidateUserInCache(ctx.getCurrentUserIdentity());
         Assert.assertThrows(AccessDeniedException.class, () -> Authorizer.checkTableAction(ctx.getCurrentUserIdentity(),
                 ctx.getCurrentRoleIds(), DB_NAME, TABLE_NAME_1, PrivilegeType.SELECT));
@@ -378,7 +379,7 @@ public class AuthorizationMgrTest {
 
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getImageWriter());
 
         setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
         sql = "grant root to role r1";
@@ -399,7 +400,7 @@ public class AuthorizationMgrTest {
                 ctx.getCurrentUserIdentity(), ctx.getCurrentRoleIds(), DB_NAME, TABLE_NAME_1, PrivilegeType.SELECT));
 
         // start to replay
-        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataInputStream());
+        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getJsonReader());
         AuthorizationMgr followerManager = masterGlobalStateMgr.getAuthorizationMgr();
 
         RolePrivilegeCollectionInfo info = (RolePrivilegeCollectionInfo)
@@ -428,13 +429,13 @@ public class AuthorizationMgrTest {
 
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        authorizationMgr.saveV2(emptyImage.getDataOutputStream());
+        authorizationMgr.saveV2(emptyImage.getImageWriter());
 
-        SRMetaBlockReader reader = new SRMetaBlockReader(emptyImage.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(emptyImage.getJsonReader());
         // read the whole first
         reader.readJson(AuthorizationMgr.class);
         // read the number of user
-        int numUser = reader.readJson(int.class);
+        int numUser = reader.readInt();
         // there should be only 2 users: root and test_user
         Assert.assertEquals(2, numUser);
 
@@ -446,10 +447,10 @@ public class AuthorizationMgrTest {
         }
 
         // read the number of roles
-        int numRole = reader.readJson(int.class);
+        int numRole = reader.readInt();
         for (int i = 0; i != numRole; ++i) {
             // 2 json for each role(kv)
-            Long roleId = reader.readJson(Long.class);
+            Long roleId = reader.readLong();
             RolePrivilegeCollectionV2 collection = reader.readJson(RolePrivilegeCollectionV2.class);
             if (PrivilegeBuiltinConstants.IMMUTABLE_BUILT_IN_ROLE_IDS.contains(roleId)) {
                 // built-in role's priv collection should not be saved
@@ -534,8 +535,8 @@ public class AuthorizationMgrTest {
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
 
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataOutputStream());
-        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getImageWriter());
+        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getImageWriter());
         Assert.assertFalse(masterManager.checkRoleExists("test_persist_role0"));
         Assert.assertFalse(masterManager.checkRoleExists("test_persist_role1"));
 
@@ -547,7 +548,7 @@ public class AuthorizationMgrTest {
             Assert.assertTrue(masterManager.checkRoleExists("test_persist_role" + i));
         }
         UtFrameUtils.PseudoImage createRoleImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, createRoleImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, createRoleImage.getImageWriter());
 
         // 2. grant select on db.tbl<i> to role
         for (int i = 0; i != 2; ++i) {
@@ -555,7 +556,7 @@ public class AuthorizationMgrTest {
                     "grant select on db.tbl" + i + " to role test_persist_role" + i, ctx), ctx);
         }
         UtFrameUtils.PseudoImage grantPrivsToRoleImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, grantPrivsToRoleImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, grantPrivsToRoleImage.getImageWriter());
         assertTableSelectOnTest(masterManager, false, false);
 
         // 3. grant test_persist_role0 to test_user
@@ -563,28 +564,28 @@ public class AuthorizationMgrTest {
                 "grant test_persist_role0 to test_user", ctx), ctx);
         assertTableSelectOnTest(masterManager, true, false);
         UtFrameUtils.PseudoImage grantRoleToUserImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, grantRoleToUserImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, grantRoleToUserImage.getImageWriter());
 
         // 4. grant test_persist_role1 to role test_persist_role0
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
                 "grant test_persist_role1 to role test_persist_role0", ctx), ctx);
         assertTableSelectOnTest(masterManager, true, true);
         UtFrameUtils.PseudoImage grantRoleToRoleImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, grantRoleToRoleImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, grantRoleToRoleImage.getImageWriter());
 
         // 5. revoke test_persist_role1 from role test_persist_role0
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
                 "revoke test_persist_role1 from role test_persist_role0", ctx), ctx);
         assertTableSelectOnTest(masterManager, true, false);
         UtFrameUtils.PseudoImage revokeRoleFromRoleImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, revokeRoleFromRoleImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, revokeRoleFromRoleImage.getImageWriter());
 
         // 6. revoke test_persist_role0 from test_user
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
                 "revoke test_persist_role0 from test_user", ctx), ctx);
         assertTableSelectOnTest(masterManager, false, false);
         UtFrameUtils.PseudoImage revokeRoleFromUserImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, revokeRoleFromUserImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, revokeRoleFromUserImage.getImageWriter());
 
         // 7. drop 2 roles
         for (int i = 0; i != 2; ++i) {
@@ -593,13 +594,13 @@ public class AuthorizationMgrTest {
             Assert.assertFalse(masterManager.checkRoleExists("test_persist_role" + i));
         }
         UtFrameUtils.PseudoImage dropRoleImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, dropRoleImage.getDataOutputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, dropRoleImage.getImageWriter());
 
         //
         // start to replay
         //
-        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataInputStream());
-        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataInputStream());
+        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getJsonReader());
+        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getJsonReader());
         AuthorizationMgr followerManager = masterGlobalStateMgr.getAuthorizationMgr();
         Assert.assertFalse(followerManager.checkRoleExists("test_persist_role0"));
         Assert.assertFalse(followerManager.checkRoleExists("test_persist_role1"));
@@ -664,39 +665,39 @@ public class AuthorizationMgrTest {
         // check image
         //
         // 1. check image after create role
-        loadRBACPrivilege(masterGlobalStateMgr, createRoleImage.getDataInputStream());
+        loadRBACPrivilege(masterGlobalStateMgr, createRoleImage.getJsonReader());
         AuthorizationMgr imageManager = masterGlobalStateMgr.getAuthorizationMgr();
 
         Assert.assertTrue(imageManager.checkRoleExists("test_persist_role0"));
         Assert.assertTrue(imageManager.checkRoleExists("test_persist_role1"));
 
         // 2. check image after grant select on db.tbl<i> to role
-        loadRBACPrivilege(masterGlobalStateMgr, grantPrivsToRoleImage.getDataInputStream());
+        loadRBACPrivilege(masterGlobalStateMgr, grantPrivsToRoleImage.getJsonReader());
         assertTableSelectOnTest(imageManager, false, false);
 
         // 3. check image after grant test_persist_role0 to test_user
         loadRBACPrivilege(masterGlobalStateMgr,
-                grantRoleToUserImage.getDataInputStream());
+                grantRoleToUserImage.getJsonReader());
         assertTableSelectOnTest(imageManager, true, false);
 
         // 4. check image after grant test_persist_role1 to role test_persist_role0
         loadRBACPrivilege(masterGlobalStateMgr,
-                grantRoleToRoleImage.getDataInputStream());
+                grantRoleToRoleImage.getJsonReader());
         assertTableSelectOnTest(imageManager, true, true);
 
         // 5. check image after revoke test_persist_role1 from role test_persist_role0
         loadRBACPrivilege(masterGlobalStateMgr,
-                revokeRoleFromRoleImage.getDataInputStream());
+                revokeRoleFromRoleImage.getJsonReader());
         assertTableSelectOnTest(imageManager, true, false);
 
         // 6. check image after revoke test_persist_role0 from test_user
         loadRBACPrivilege(masterGlobalStateMgr,
-                revokeRoleFromUserImage.getDataInputStream());
+                revokeRoleFromUserImage.getJsonReader());
         assertTableSelectOnTest(imageManager, false, false);
 
         // 7. check image after drop 2 roles
         loadRBACPrivilege(masterGlobalStateMgr,
-                dropRoleImage.getDataInputStream());
+                dropRoleImage.getJsonReader());
         imageManager = masterGlobalStateMgr.getAuthorizationMgr();
         Assert.assertFalse(imageManager.checkRoleExists("test_persist_role0"));
         Assert.assertFalse(imageManager.checkRoleExists("test_persist_role1"));
@@ -1737,10 +1738,10 @@ public class AuthorizationMgrTest {
         }
 
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        masterGlobalStateMgr.getAuthorizationMgr().saveV2(emptyImage.getDataOutputStream());
+        masterGlobalStateMgr.getAuthorizationMgr().saveV2(emptyImage.getImageWriter());
 
         AuthorizationMgr authorizationMgr = new AuthorizationMgr();
-        SRMetaBlockReader reader = new SRMetaBlockReader(emptyImage.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(emptyImage.getJsonReader());
         authorizationMgr.loadV2(reader);
 
         Assert.assertNotNull(authorizationMgr.getRolePrivilegeCollection("test_persist_role0"));
@@ -1822,8 +1823,8 @@ public class AuthorizationMgrTest {
         GlobalStateMgr masterGlobalStateMgr = connectCtx.getGlobalStateMgr();
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, image.getDataOutputStream());
-        loadRBACPrivilege(masterGlobalStateMgr, image.getDataInputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, image.getImageWriter());
+        loadRBACPrivilege(masterGlobalStateMgr, image.getJsonReader());
 
         AuthorizationMgr authorizationMgr = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
         UserPrivilegeCollectionV2 up1 = authorizationMgr.getUserPrivilegeCollectionUnlockedAllowNull(
@@ -1840,8 +1841,8 @@ public class AuthorizationMgrTest {
         authorizationMgr.checkAction(up3, ObjectType.CATALOG, PrivilegeType.USAGE,
                 Lists.newArrayList("hive_catalog_1"));
 
-        saveRBACPrivilege(masterGlobalStateMgr, image.getDataOutputStream());
-        loadRBACPrivilege(masterGlobalStateMgr, image.getDataInputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, image.getImageWriter());
+        loadRBACPrivilege(masterGlobalStateMgr, image.getJsonReader());
     }
 
     @Test
@@ -1859,8 +1860,8 @@ public class AuthorizationMgrTest {
         masterManager.grant(grantStmt);
 
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataOutputStream());
-        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getDataInputStream());
+        saveRBACPrivilege(masterGlobalStateMgr, emptyImage.getImageWriter());
+        loadRBACPrivilege(masterGlobalStateMgr, emptyImage.getJsonReader());
 
         sql = "show grants for user_for_system";
         ShowGrantsStmt showStreamLoadStmt = (ShowGrantsStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/CatalogMgrTest.java
@@ -23,6 +23,7 @@ import com.starrocks.persist.DropCatalogLog;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.utframe.StarRocksAssert;
@@ -149,8 +150,8 @@ public class CatalogMgrTest {
 
         UtFrameUtils.PseudoImage.setUpImageVersion();
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-        catalogMgr.save(image.getDataOutputStream());
-        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+        catalogMgr.save(image.getImageWriter());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image.getJsonReader());
 
         CatalogMgr loadCatalogMgr = new CatalogMgr(new ConnectorMgr());
         loadCatalogMgr.load(reader);
@@ -158,7 +159,7 @@ public class CatalogMgrTest {
 
         // test load with ddl exception
         loadCatalogMgr = new CatalogMgr(new ConnectorMgr());
-        reader = new SRMetaBlockReader(image.getDataInputStream());
+        reader = new SRMetaBlockReaderV2(image.getJsonReader());
         new MockUp<CatalogMgr>() {
             @mockit.Mock
             public void replayCreateCatalog(Catalog catalog) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -51,6 +51,8 @@ import com.starrocks.journal.JournalInconsistentException;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ImageFormatVersion;
+import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OperationType;
 import com.starrocks.sql.ast.ModifyFrontendAddressClause;
 import com.starrocks.system.Frontend;
@@ -88,9 +90,11 @@ public class GlobalStateMgrTest {
     public void testSaveLoadHeader() throws Exception {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
 
+        ImageWriter imageWriter = new ImageWriter("", ImageFormatVersion.v2, 0);
         // test json-format header
         UtFrameUtils.PseudoImage image2 = new UtFrameUtils.PseudoImage();
-        globalStateMgr.saveHeader(image2.getDataOutputStream());
+        imageWriter.setOutputStream(image2.getDataOutputStream());
+        globalStateMgr.saveHeader(imageWriter.getDataOutputStream());
         MetaContext.get().setStarRocksMetaVersion(StarRocksFEMetaVersion.VERSION_4);
         globalStateMgr.loadHeader(image2.getDataInputStream());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -46,6 +46,7 @@ import com.starrocks.persist.ModifyPartitionInfo;
 import com.starrocks.persist.PhysicalPartitionPersistInfoV2;
 import com.starrocks.persist.TruncateTableInfo;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.ColumnRenameClause;
 import com.starrocks.thrift.TStorageMedium;
@@ -159,9 +160,9 @@ public class LocalMetaStoreTest {
                 GlobalStateMgr.getCurrentState().getColocateTableIndex());
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
-        localMetaStore.save(image.getDataOutputStream());
+        localMetaStore.save(image.getImageWriter());
 
-        SRMetaBlockReader reader = new SRMetaBlockReader(image.getDataInputStream());
+        SRMetaBlockReader reader = new SRMetaBlockReaderV2(image.getJsonReader());
         localMetaStore.load(reader);
         reader.close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.persist.OperationType;
-import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.MetaUtils;
@@ -120,9 +119,9 @@ public class AnalyzeMgrTest {
         analyzeMgr.addAnalyzeStatus(analyzeStatus);
         // test persist by image
         UtFrameUtils.PseudoImage testImage = new UtFrameUtils.PseudoImage();
-        analyzeMgr.save(testImage.getDataOutputStream());
+        analyzeMgr.save(testImage.getImageWriter());
 
-        analyzeMgr.load(new SRMetaBlockReader(testImage.getDataInputStream()));
+        analyzeMgr.load(testImage.getMetaBlockReader());
         Assert.assertEquals(1, analyzeMgr.getAnalyzeStatusMap().size());
         AnalyzeStatus analyzeStatus1 = analyzeMgr.getAnalyzeStatusMap().get(100L);
         Assert.assertEquals("hive0", analyzeStatus1.getCatalogName());
@@ -172,8 +171,8 @@ public class AnalyzeMgrTest {
         analyzeMgr.addAnalyzeJob(externalAnalyzeJob);
 
         testImage = new UtFrameUtils.PseudoImage();
-        analyzeMgr.save(testImage.getDataOutputStream());
-        analyzeMgr.load(new SRMetaBlockReader(testImage.getDataInputStream()));
+        analyzeMgr.save(testImage.getImageWriter());
+        analyzeMgr.load(testImage.getMetaBlockReader());
         Assert.assertEquals(2, analyzeMgr.getAllAnalyzeJobList().size());
         NativeAnalyzeJob analyzeJob = (NativeAnalyzeJob) analyzeMgr.getAllAnalyzeJobList().get(0);
         Assert.assertEquals(123, analyzeJob.getDbId());
@@ -233,8 +232,8 @@ public class AnalyzeMgrTest {
         analyzeMgr.addExternalBasicStatsMeta(externalBasicStatsMeta);
 
         testImage = new UtFrameUtils.PseudoImage();
-        analyzeMgr.save(testImage.getDataOutputStream());
-        analyzeMgr.load(new SRMetaBlockReader(testImage.getDataInputStream()));
+        analyzeMgr.save(testImage.getImageWriter());
+        analyzeMgr.load(testImage.getMetaBlockReader());
         Assert.assertEquals(1, analyzeMgr.getExternalBasicStatsMetaMap().size());
 
         ExternalBasicStatsMeta replayBasicStatsMeta = (ExternalBasicStatsMeta) UtFrameUtils.PseudoJournalReplayer.
@@ -279,8 +278,8 @@ public class AnalyzeMgrTest {
         analyzeMgr.addExternalHistogramStatsMeta(externalHistogramStatsMeta);
         // test persist by image
         UtFrameUtils.PseudoImage testImage = new UtFrameUtils.PseudoImage();
-        analyzeMgr.save(testImage.getDataOutputStream());
-        analyzeMgr.load(new SRMetaBlockReader(testImage.getDataInputStream()));
+        analyzeMgr.save(testImage.getImageWriter());
+        analyzeMgr.load(testImage.getMetaBlockReader());
         Assert.assertEquals(1, analyzeMgr.getExternalHistogramStatsMetaMap().size());
         // test replay json to histogram stats
         ExternalHistogramStatsMeta replayHistogramStatsMeta =

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.gson.stream.JsonReader;
 import com.staros.starlet.StarletAgentFactory;
 import com.starrocks.analysis.HintNode;
 import com.starrocks.analysis.SetVarHint;
@@ -82,6 +83,10 @@ import com.starrocks.journal.JournalTask;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ImageFormatVersion;
+import com.starrocks.persist.ImageWriter;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
@@ -145,6 +150,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
 import java.net.ServerSocket;
 import java.nio.channels.FileLock;
@@ -1060,6 +1066,7 @@ public class UtFrameUtils {
     public static class PseudoImage {
         private static AtomicBoolean isSetup = new AtomicBoolean(false);
         private DataOutputBuffer buffer;
+        private ImageWriter imageWriter;
         private static final int OUTPUT_BUFFER_INIT_SIZE = 128;
 
         public static void setUpImageVersion() {
@@ -1072,10 +1079,16 @@ public class UtFrameUtils {
         public PseudoImage() throws IOException {
             assert (isSetup.get());
             buffer = new DataOutputBuffer(OUTPUT_BUFFER_INIT_SIZE);
+            imageWriter = new ImageWriter("", ImageFormatVersion.v2, 0);
+            imageWriter.setOutputStream(buffer);
         }
 
         public DataOutputStream getDataOutputStream() {
             return buffer;
+        }
+
+        public ImageWriter getImageWriter() {
+            return imageWriter;
         }
 
         /**
@@ -1083,6 +1096,17 @@ public class UtFrameUtils {
          */
         public DataInputStream getDataInputStream() throws IOException {
             return new DataInputStream(new ByteArrayInputStream(buffer.getData(), 0, buffer.getLength()));
+        }
+
+        public SRMetaBlockReader getMetaBlockReader() throws IOException {
+            JsonReader jsonReader = new JsonReader(new InputStreamReader(new ByteArrayInputStream(buffer.getData(),
+                    0, buffer.getLength())));
+            return new SRMetaBlockReaderV2(jsonReader);
+        }
+
+        public JsonReader getJsonReader() throws IOException {
+            return new JsonReader(new InputStreamReader(new ByteArrayInputStream(buffer.getData(),
+                    0, buffer.getLength())));
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Currently, JSON serialization supports a maximum of 2G, because serialization converts the object into a JSON string first, and then writes the string into the image file, and the maximum size of a string in Java is only 2G.

## What I'm doing:
To support large json string, we can use the stream api of GSON: `JsonWriter` and `JsonReader`. 
Since we cannot know the length of the string in advance, so a new image file format is introduced: a json string must begin with "{" or "[", so primitive type is not supported, and there is nothing between the json string. To support rollback, we use a double write solution. The dir format is as follows
```
meta/image
         image.111
         /v2
              image.111
              checksum.111
```
`meta/image/image.111` is the old format image file, and `meta/image/v2/image.111` is the new format image file. Since the JsonReader will cache some chars in advance, so we cannot calculate the checksum of the specific meta-block, and the checksum is put into another file `checksum.111`;


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
