### PR TITLE
[Feature] Add build arch info when showing FE/BE version

### DIFF
--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -66,6 +66,7 @@ std::string get_build_version(bool compact) {
     if (!compact) {
         ss << std::endl
            << "Build distributor id: " << STARROCKS_BUILD_DISTRO_ID << std::endl
+           << "Build arch: " << STARROCKS_BUILD_ARCH << std::endl
            << "Built on " << STARROCKS_BUILD_TIME << " by " << STARROCKS_BUILD_USER << "@" << STARROCKS_BUILD_HOST;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -320,6 +320,7 @@ public class StarRocksFE {
             System.out.println("Build type: " + Version.STARROCKS_BUILD_TYPE);
             System.out.println("Build time: " + Version.STARROCKS_BUILD_TIME);
             System.out.println("Build distributor id: " + Version.STARROCKS_BUILD_DISTRO_ID);
+            System.out.println("Build arch: " + Version.STARROCKS_BUILD_ARCH);
             System.out.println("Build user: " + Version.STARROCKS_BUILD_USER + "@" + Version.STARROCKS_BUILD_HOST);
             System.out.println("Java compile version: " + Version.STARROCKS_JAVA_COMPILE_VERSION);
             System.exit(0);


### PR DESCRIPTION
## Why I'm doing:
User can rely on this info to determin whether it's the right package to run on current host.

## What I'm doing:
Add build arch info when showing FE/BE version.

```
# sh bin/show_fe_version.sh
...
Build arch: arm64
...
```

Tested on macOS, AWS graviton, and x86 ECS,
the corresponding values are: `arm64`, `aarch64`, `x86_64`.

Fixes https://github.com/StarRocks/starrocks/issues/48575.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
