### PR TITLE
[BugFix] Fixed a bug where Compact and Schema Change could not be executed together

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
@@ -86,8 +86,6 @@ public enum AlterOpType {
         COMPATIBITLITY_MATRIX[DROP_ROLLUP.ordinal()][DROP_ROLLUP.ordinal()] = true;
         // schema change, such as add/modify/drop columns can be processed in batch
         COMPATIBITLITY_MATRIX[SCHEMA_CHANGE.ordinal()][SCHEMA_CHANGE.ordinal()] = true;
-        COMPATIBITLITY_MATRIX[SCHEMA_CHANGE.ordinal()][COMPACT.ordinal()] = true;
-        COMPATIBITLITY_MATRIX[ADD_ROLLUP.ordinal()][COMPACT.ordinal()] = true;
     }
 
     public boolean needCheckCapacity() {


### PR DESCRIPTION
## Why I'm doing:
In the current AlterJobMgr, different types of ops cannot be executed together. Only the same logic can be executed atomically, such as between schema changes. Therefore, this compatibility is incompatible.
## What I'm doing:
Disabling compaction and other schema changes to be executed logically atomically
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
