### PR TITLE
[Enhancement] Set python3 as the default python version when compiling

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -38,19 +38,16 @@ fi
 
 # check python
 if [[ -z ${PYTHON} ]]; then
-    export PYTHON=python
+    export PYTHON=python3
 fi
 
-if ! ${PYTHON} --version; then
-    export PYTHON=python2.7
-    if ! ${PYTHON} --version; then
-        export PYTHON=python3
-        if ! ${PYTHON} --version; then
-            echo "Error: python is not found"
-            exit 1
-        fi
-    fi
+if ${PYTHON} --version | grep -q '^Python 3\.'; then
+    echo "Found python3, version: `\${PYTHON} --version`"
+else
+    echo "Error: python3 is needed"
+    exit 1
 fi
+
 
 # set GCC HOME
 if [[ -z ${STARROCKS_GCC_HOME} ]]; then
@@ -59,7 +56,7 @@ fi
 
 gcc_ver=`${STARROCKS_GCC_HOME}/bin/gcc -dumpfullversion -dumpversion`
 required_ver="5.3.1"
-if [[ ! "$(printf '%s\n' "$required_ver" "$gcc_ver" | sort -V | head -n1)" = "$required_ver" ]]; then 
+if [[ ! "$(printf '%s\n' "$required_ver" "$gcc_ver" | sort -V | head -n1)" = "$required_ver" ]]; then
     echo "Error: GCC version (${gcc_ver}) must be greater than or equal to ${required_ver}"
     exit 1
 fi


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Also remove the support of python2, python3 and python2 are not compatible
and python2 is out of maintance for years(since January 1, 2020), we better remove it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
