### PR TITLE
[BugFix] there is no need to set the delegation token when HMS has not enabled SASL

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -286,11 +286,14 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
                             open();
                             return null;
                         });
-                String delegationTokenPropString = "DelegationTokenForHiveMetaStoreServer";
-                String delegationTokenStr = getDelegationToken(proxyUser, proxyUser);
-                SecurityUtils.setTokenStr(UserGroupInformation.getCurrentUser(), delegationTokenStr,
-                        delegationTokenPropString);
-                MetastoreConf.setVar(this.conf, ConfVars.TOKEN_SIGNATURE, delegationTokenPropString);
+                boolean useSasl = MetastoreConf.getBoolVar(conf, ConfVars.USE_THRIFT_SASL);
+                if (useSasl) {
+                    String delegationTokenPropString = "DelegationTokenForHiveMetaStoreServer";
+                    String delegationTokenStr = getDelegationToken(proxyUser, proxyUser);
+                    SecurityUtils.setTokenStr(UserGroupInformation.getCurrentUser(), delegationTokenStr,
+                            delegationTokenPropString);
+                    MetastoreConf.setVar(this.conf, ConfVars.TOKEN_SIGNATURE, delegationTokenPropString);
+                }
                 close();
             } catch (Exception e) {
                 LOG.error("Error while setting delegation token for " + proxyUser, e);


### PR DESCRIPTION

## Why I'm doing:
When I use a Hadoop proxy user to access HMS, the following exception is thrown
`Error while setting delegation token for xxx org.apache.thrift.TException: method not implemented at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getDelegationToken(HiveMetaStoreClient.java:1827) ~[starrocks-fe.jar:?] at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:290) ~[starrocks-fe.jar:?] at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?] at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?] at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?] at java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[?:?]`

In fact, HMS has not enabled hive.metastore.sasl.enabled, so there is no need to generate a token. Moreover, the getDelegationToken method is not implemented and directly throws an exception.

## What I'm doing:
Determine whether hive.metastore.sasl.enabled is enabled. If it is not, there is no need to generate a token, ensuring a successful connection to HMS.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5