### PR TITLE
[Enhancement] Migrate the alter table related logic scattered everywhere to AlterJobExecutor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -14,15 +14,22 @@
 
 package com.starrocks.alter;
 
-import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TableRef;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.common.util.DynamicPartitionUtil;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.AlterViewInfo;
@@ -64,14 +71,19 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SwapTableClause;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncatePartitionClause;
+import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.common.MetaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
 
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
     protected static final Logger LOG = LogManager.getLogger(AlterJobExecutor.class);
+    protected TableName tableName;
     protected Database db;
     protected Table table;
 
@@ -83,11 +95,87 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
         visit(statement, context);
     }
 
-    //Alter system clause
-
     @Override
     public Void visitNode(ParseNode node, ConnectContext context) {
         throw new AlterJobException("Not support alter table operation : " + node.getClass().getName());
+    }
+
+    @Override
+    public Void visitAlterTableStatement(AlterTableStmt statement, ConnectContext context) {
+        TableName tableName = statement.getTbl();
+        this.tableName = tableName;
+
+        Database db = MetaUtils.getDatabase(context, tableName);
+        Table table = MetaUtils.getTable(tableName);
+
+        if (table.getType() == Table.TableType.VIEW || table.getType() == Table.TableType.MATERIALIZED_VIEW) {
+            throw new SemanticException("The specified table [" + tableName + "] is not a table");
+        }
+
+        if (table instanceof OlapTable && ((OlapTable) table).getState() != OlapTable.OlapTableState.NORMAL) {
+            OlapTable olapTable = (OlapTable) table;
+            throw new AlterJobException("", InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName()));
+        }
+
+        this.db = db;
+        this.table = table;
+
+        for (AlterClause alterClause : statement.getAlterClauseList()) {
+            visit(alterClause, context);
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitAlterViewStatement(AlterViewStmt statement, ConnectContext context) {
+        TableName tableName = statement.getTableName();
+        Database db = MetaUtils.getDatabase(context, tableName);
+        Table table = MetaUtils.getTable(tableName);
+
+        if (table.getType() != Table.TableType.VIEW) {
+            throw new SemanticException("The specified table [" + tableName + "] is not a view");
+        }
+
+        this.db = db;
+        this.table = table;
+        AlterViewClause alterViewClause = (AlterViewClause) statement.getAlterClause();
+        visit(alterViewClause, context);
+        return null;
+    }
+
+    @Override
+    public Void visitAlterMaterializedViewStatement(AlterMaterializedViewStmt stmt, ConnectContext context) {
+        // check db
+        final TableName mvName = stmt.getMvName();
+        Database db = MetaUtils.getDatabase(context, mvName);
+
+        Locker locker = new Locker();
+        if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
+            throw new AlterJobException("alter materialized failed. database:" + db.getFullName() + " not exist");
+        }
+
+        try {
+            Table table = MetaUtils.getTable(mvName);
+            if (!table.isMaterializedView()) {
+                throw new SemanticException("The specified table [" + mvName + "] is not a view");
+            }
+            this.db = db;
+            this.table = table;
+
+            MaterializedView materializedView = (MaterializedView) table;
+            // check materialized view state
+            if (materializedView.getState() != OlapTable.OlapTableState.NORMAL) {
+                throw new AlterJobException("Materialized view [" + materializedView.getName() + "]'s state is not NORMAL. "
+                        + "Do not allow to do ALTER ops");
+            }
+
+            MaterializedViewMgr.getInstance().stopMaintainMV(materializedView);
+            visit(stmt.getAlterTableClause());
+            MaterializedViewMgr.getInstance().rebuildMaintainMV(materializedView);
+            return null;
+        } finally {
+            locker.unLockDatabase(db, LockType.WRITE);
+        }
     }
 
     //Alter table clause
@@ -120,44 +208,46 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
     public Void visitSwapTableClause(SwapTableClause clause, ConnectContext context) {
         // must hold db write lock
         Locker locker = new Locker();
-        Preconditions.checkState(locker.isDbWriteLockHeldByCurrentThread(db));
-
-        OlapTable origTable = (OlapTable) table;
-
-        String origTblName = origTable.getName();
-        String newTblName = clause.getTblName();
-        Table newTbl = db.getTable(newTblName);
-        if (newTbl == null || !(newTbl.isOlapOrCloudNativeTable() || newTbl.isMaterializedView())) {
-            throw new AlterJobException("Table " + newTblName + " does not exist or is not OLAP/LAKE table");
-        }
-        OlapTable olapNewTbl = (OlapTable) newTbl;
-
-        // First, we need to check whether the table to be operated on can be renamed
+        locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.WRITE);
         try {
-            olapNewTbl.checkAndSetName(origTblName, true);
-            origTable.checkAndSetName(newTblName, true);
-
-            if (origTable.isMaterializedView() || newTbl.isMaterializedView()) {
-                if (!(origTable.isMaterializedView() && newTbl.isMaterializedView())) {
-                    throw new AlterJobException("Materialized view can only SWAP WITH materialized view");
-                }
+            OlapTable origTable = (OlapTable) table;
+            String origTblName = origTable.getName();
+            String newTblName = clause.getTblName();
+            Table newTbl = db.getTable(newTblName);
+            if (newTbl == null || !(newTbl.isOlapOrCloudNativeTable() || newTbl.isMaterializedView())) {
+                throw new AlterJobException("Table " + newTblName + " does not exist or is not OLAP/LAKE table");
             }
+            OlapTable olapNewTbl = (OlapTable) newTbl;
 
-            // inactive the related MVs
-            LocalMetastore.inactiveRelatedMaterializedView(db, origTable,
-                    MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(origTblName));
-            LocalMetastore.inactiveRelatedMaterializedView(db, olapNewTbl,
-                    MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(newTblName));
+            // First, we need to check whether the table to be operated on can be renamed
+            try {
+                olapNewTbl.checkAndSetName(origTblName, true);
+                origTable.checkAndSetName(newTblName, true);
 
-            SwapTableOperationLog log = new SwapTableOperationLog(db.getId(), origTable.getId(), olapNewTbl.getId());
-            GlobalStateMgr.getCurrentState().getAlterJobMgr().swapTableInternal(log);
-            GlobalStateMgr.getCurrentState().getEditLog().logSwapTable(log);
+                if (origTable.isMaterializedView() || newTbl.isMaterializedView()) {
+                    if (!(origTable.isMaterializedView() && newTbl.isMaterializedView())) {
+                        throw new AlterJobException("Materialized view can only SWAP WITH materialized view");
+                    }
+                }
 
-            LOG.info("finish swap table {}-{} with table {}-{}", origTable.getId(), origTblName, newTbl.getId(),
-                    newTblName);
-            return null;
-        } catch (DdlException e) {
-            throw new AlterJobException(e.getMessage(), e);
+                // inactive the related MVs
+                LocalMetastore.inactiveRelatedMaterializedView(db, origTable,
+                        MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(origTblName));
+                LocalMetastore.inactiveRelatedMaterializedView(db, olapNewTbl,
+                        MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(newTblName));
+
+                SwapTableOperationLog log = new SwapTableOperationLog(db.getId(), origTable.getId(), olapNewTbl.getId());
+                GlobalStateMgr.getCurrentState().getAlterJobMgr().swapTableInternal(log);
+                GlobalStateMgr.getCurrentState().getEditLog().logSwapTable(log);
+
+                LOG.info("finish swap table {}-{} with table {}-{}", origTable.getId(), origTblName, newTbl.getId(),
+                        newTblName);
+                return null;
+            } catch (DdlException e) {
+                throw new AlterJobException(e.getMessage(), e);
+            }
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.WRITE);
         }
     }
 
@@ -229,7 +319,8 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitCompactionClause(CompactionClause clause, ConnectContext context) {
-        unsupportedException("Not support");
+        ErrorReport.wrapWithRuntimeException(() ->
+                CompactionHandler.process(Lists.newArrayList(clause), db, (OlapTable) table));
         return null;
     }
 
@@ -248,38 +339,98 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
     //Alter partition clause
 
     @Override
-    public Void visitModifyPartitionClause(ModifyPartitionClause clause, ConnectContext context) {
-        unsupportedException("Not support");
-        return null;
-    }
-
-    @Override
     public Void visitAddPartitionClause(AddPartitionClause clause, ConnectContext context) {
-        unsupportedException("Not support");
+        /*
+         * This check is not appropriate here. However, because the dynamically generated Partition Clause needs to be analyzed,
+         * this check cannot be placed in analyze.
+         * For the same reason, it cannot be placed in LocalMetastore.addPartition.
+         * If there is a subsequent refactoring, this check logic should be placed in a more appropriate location.
+         */
+        if (!clause.isTempPartition() && table instanceof OlapTable) {
+            DynamicPartitionUtil.checkAlterAllowed((OlapTable) table);
+        }
+        ErrorReport.wrapWithRuntimeException(() ->
+                GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(context, db, table.getName(), clause));
         return null;
     }
 
     @Override
     public Void visitDropPartitionClause(DropPartitionClause clause, ConnectContext context) {
-        unsupportedException("Not support");
+        /*
+         * This check is not appropriate here. However, because the dynamically generated Partition Clause needs to be analyzed,
+         * this check cannot be placed in analyze.
+         * For the same reason, it cannot be placed in LocalMetastore.dropPartition.
+         * If there is a subsequent refactoring, this check logic should be placed in a more appropriate location.
+         */
+        if (!clause.isTempPartition() && table instanceof OlapTable) {
+            DynamicPartitionUtil.checkAlterAllowed((OlapTable) table);
+        }
+
+        ErrorReport.wrapWithRuntimeException(() ->
+                GlobalStateMgr.getCurrentState().getLocalMetastore().dropPartition(db, table, clause));
         return null;
     }
 
     @Override
     public Void visitTruncatePartitionClause(TruncatePartitionClause clause, ConnectContext context) {
-        unsupportedException("Not support");
+        // This logic is used to adapt mysql syntax.
+        // ALTER TABLE test TRUNCATE PARTITION p1;
+        TableRef tableRef = new TableRef(tableName, null, clause.getPartitionNames());
+        TruncateTableStmt tStmt = new TruncateTableStmt(tableRef);
+        ConnectContext ctx = new ConnectContext();
+        ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+
+        ErrorReport.wrapWithRuntimeException(() ->
+                GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(tStmt, ctx));
         return null;
     }
 
     @Override
     public Void visitReplacePartitionClause(ReplacePartitionClause clause, ConnectContext context) {
-        unsupportedException("Not support");
+        ErrorReport.wrapWithRuntimeException(() ->
+                GlobalStateMgr.getCurrentState().getLocalMetastore().replaceTempPartition(db, table.getName(), clause));
         return null;
     }
 
     @Override
     public Void visitPartitionRenameClause(PartitionRenameClause clause, ConnectContext context) {
         unsupportedException("Not support");
+        return null;
+    }
+
+    @Override
+    public Void visitModifyPartitionClause(ModifyPartitionClause clause, ConnectContext context) {
+        try {
+            // expand the partition names if it is 'Modify Partition(*)'
+            List<String> partitionNames = clause.getPartitionNames();
+            if (clause.isNeedExpand()) {
+                partitionNames.clear();
+                for (Partition partition : table.getPartitions()) {
+                    partitionNames.add(partition.getName());
+                }
+            }
+            Map<String, String> properties = clause.getProperties();
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
+                if (table.isCloudNativeTable()) {
+                    throw new SemanticException("Lake table not support alter in_memory");
+                }
+
+                SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+                schemaChangeHandler.updatePartitionsInMemoryMeta(
+                        db, table.getName(), partitionNames, properties);
+            }
+
+            Locker locker = new Locker();
+            locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.WRITE);
+            try {
+                AlterJobMgr alterJobMgr = GlobalStateMgr.getCurrentState().getAlterJobMgr();
+                alterJobMgr.modifyPartitionsProperty(db, (OlapTable) table, partitionNames, properties);
+            } finally {
+                locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.WRITE);
+            }
+        } catch (DdlException | AnalysisException e) {
+            throw new AlterJobException(e.getMessage());
+        }
         return null;
     }
 
@@ -294,75 +445,5 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
         GlobalStateMgr.getCurrentState().getAlterJobMgr().alterView(alterViewInfo);
         GlobalStateMgr.getCurrentState().getEditLog().logModifyViewDef(alterViewInfo);
         return null;
-    }
-
-    @Override
-    public Void visitAlterTableStatement(AlterTableStmt statement, ConnectContext context) {
-        TableName tableName = statement.getTbl();
-        Database db = MetaUtils.getDatabase(context, tableName);
-        Table table = MetaUtils.getTable(tableName);
-
-        if (table.getType() == Table.TableType.VIEW || table.getType() == Table.TableType.MATERIALIZED_VIEW) {
-            throw new SemanticException("The specified table [" + tableName + "] is not a table");
-        }
-
-        this.db = db;
-        this.table = table;
-        for (AlterClause alterClause : statement.getAlterClauseList()) {
-            visit(alterClause, context);
-        }
-        return null;
-    }
-
-    @Override
-    public Void visitAlterViewStatement(AlterViewStmt statement, ConnectContext context) {
-        TableName tableName = statement.getTableName();
-        Database db = MetaUtils.getDatabase(context, tableName);
-        Table table = MetaUtils.getTable(tableName);
-
-        if (table.getType() != Table.TableType.VIEW) {
-            throw new SemanticException("The specified table [" + tableName + "] is not a view");
-        }
-
-        this.db = db;
-        this.table = table;
-        AlterViewClause alterViewClause = (AlterViewClause) statement.getAlterClause();
-        visit(alterViewClause, context);
-        return null;
-    }
-
-    @Override
-    public Void visitAlterMaterializedViewStatement(AlterMaterializedViewStmt stmt, ConnectContext context) {
-        // check db
-        final TableName mvName = stmt.getMvName();
-        Database db = MetaUtils.getDatabase(context, mvName);
-
-        Locker locker = new Locker();
-        if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
-            throw new AlterJobException("alter materialized failed. database:" + db.getFullName() + " not exist");
-        }
-
-        try {
-            Table table = MetaUtils.getTable(mvName);
-            if (!table.isMaterializedView()) {
-                throw new SemanticException("The specified table [" + mvName + "] is not a view");
-            }
-            this.db = db;
-            this.table = table;
-
-            MaterializedView materializedView = (MaterializedView) table;
-            // check materialized view state
-            if (materializedView.getState() != OlapTable.OlapTableState.NORMAL) {
-                throw new AlterJobException("Materialized view [" + materializedView.getName() + "]'s state is not NORMAL. "
-                        + "Do not allow to do ALTER ops");
-            }
-
-            MaterializedViewMgr.getInstance().stopMaintainMV(materializedView);
-            visit(stmt.getAlterTableClause());
-            MaterializedViewMgr.getInstance().rebuildMaintainMV(materializedView);
-            return null;
-        } finally {
-            locker.unLockDatabase(db, LockType.WRITE);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -535,6 +535,11 @@ public class AlterJobMgr {
         if (table == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
         }
+        OlapTable olapTable = (OlapTable) table;
+
+        // some operations will take long time to process, need to be done outside the databse lock
+        boolean needProcessOutsideDatabaseLock = false;
+        boolean isSynchronous = true;
 
         // some operations will take long time to process, need to be done outside the databse lock
         boolean needProcessOutsideDatabaseLock = false;
@@ -543,7 +548,6 @@ public class AlterJobMgr {
         if (!(table.isOlapOrCloudNativeTable() || table.isMaterializedView())) {
             throw new DdlException("Do not support alter non-native table/materialized-view[" + tableName + "]");
         }
-        OlapTable olapTable = (OlapTable) table;
 
         List<AlterClause> alterClauses = stmt.getAlterClauseList();
         Locker locker = new Locker();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.TableName;
-import com.starrocks.analysis.TableRef;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.ColocateTableIndex;
@@ -72,10 +71,8 @@ import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.common.util.Util;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
@@ -102,35 +99,27 @@ import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStatusClause;
 import com.starrocks.sql.ast.AlterSystemStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ColumnRenameClause;
-import com.starrocks.sql.ast.CompactionClause;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
-import com.starrocks.sql.ast.DropPartitionClause;
-import com.starrocks.sql.ast.ModifyPartitionClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.sql.ast.PartitionRenameClause;
 import com.starrocks.sql.ast.QueryStatement;
-import com.starrocks.sql.ast.ReplacePartitionClause;
 import com.starrocks.sql.ast.RollupRenameClause;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRenameClause;
-import com.starrocks.sql.ast.TruncatePartitionClause;
-import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTabletType;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
@@ -156,7 +145,6 @@ public class AlterJobMgr {
     private final SchemaChangeHandler schemaChangeHandler;
     private final MaterializedViewHandler materializedViewHandler;
     private final SystemHandler clusterHandler;
-    private final CompactionHandler compactionHandler;
 
     public AlterJobMgr(SchemaChangeHandler schemaChangeHandler,
                        MaterializedViewHandler materializedViewHandler,
@@ -165,7 +153,6 @@ public class AlterJobMgr {
         this.schemaChangeHandler = schemaChangeHandler;
         this.materializedViewHandler = materializedViewHandler;
         this.clusterHandler = systemHandler;
-        this.compactionHandler = compactionHandler;
     }
 
     public void start() {
@@ -535,11 +522,7 @@ public class AlterJobMgr {
         if (table == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
         }
-        OlapTable olapTable = (OlapTable) table;
 
-        // some operations will take long time to process, need to be done outside the databse lock
-        boolean needProcessOutsideDatabaseLock = false;
-        boolean isSynchronous = true;
 
         // some operations will take long time to process, need to be done outside the databse lock
         boolean needProcessOutsideDatabaseLock = false;
@@ -548,6 +531,7 @@ public class AlterJobMgr {
         if (!(table.isOlapOrCloudNativeTable() || table.isMaterializedView())) {
             throw new DdlException("Do not support alter non-native table/materialized-view[" + tableName + "]");
         }
+        OlapTable olapTable = (OlapTable) table;
 
         List<AlterClause> alterClauses = stmt.getAlterClauseList();
         Locker locker = new Locker();
@@ -567,66 +551,8 @@ public class AlterJobMgr {
             } else if (stmt.hasRollupOp()) {
                 materializedViewHandler.process(alterClauses, db, olapTable);
                 isSynchronous = false;
-            } else if (stmt.hasPartitionOp()) {
-                Preconditions.checkState(alterClauses.size() == 1);
-                AlterClause alterClause = alterClauses.get(0);
-                if (alterClause instanceof DropPartitionClause) {
-                    DropPartitionClause dropPartitionClause = (DropPartitionClause) alterClause;
-                    if (!dropPartitionClause.isTempPartition()) {
-                        DynamicPartitionUtil.checkAlterAllowed((OlapTable) db.getTable(tableName));
-                    }
-                    if (dropPartitionClause.getPartitionName() != null && dropPartitionClause.getPartitionName()
-                            .startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX)) {
-                        throw new DdlException("Deletion of shadow partitions is not allowed");
-                    }
-                    List<String> partitionNames = dropPartitionClause.getPartitionNames();
-                    if (CollectionUtils.isNotEmpty(partitionNames)) {
-                        boolean hasShadowPartition = partitionNames.stream()
-                                .anyMatch(partitionName -> partitionName.startsWith(
-                                        ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX));
-                        if (hasShadowPartition) {
-                            throw new DdlException("Deletion of shadow partitions is not allowed");
-                        }
-                    }
-                    GlobalStateMgr.getCurrentState().getLocalMetastore().dropPartition(db, olapTable, dropPartitionClause);
-                } else if (alterClause instanceof ReplacePartitionClause) {
-                    ReplacePartitionClause replacePartitionClause = (ReplacePartitionClause) alterClause;
-                    List<String> partitionNames = replacePartitionClause.getPartitionNames();
-                    for (String partitionName : partitionNames) {
-                        if (partitionName.startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX)) {
-                            throw new DdlException("Replace shadow partitions is not allowed");
-                        }
-                    }
-                    GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .replaceTempPartition(db, tableName, replacePartitionClause);
-                } else if (alterClause instanceof ModifyPartitionClause) {
-                    ModifyPartitionClause clause = ((ModifyPartitionClause) alterClause);
-                    // expand the partition names if it is 'Modify Partition(*)'
-                    if (clause.isNeedExpand()) {
-                        List<String> partitionNames = clause.getPartitionNames();
-                        partitionNames.clear();
-                        for (Partition partition : olapTable.getPartitions()) {
-                            partitionNames.add(partition.getName());
-                        }
-                    }
-                    Map<String, String> properties = clause.getProperties();
-                    if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
-                        needProcessOutsideDatabaseLock = true;
-                    } else {
-                        List<String> partitionNames = clause.getPartitionNames();
-                        modifyPartitionsProperty(db, olapTable, partitionNames, properties);
-                    }
-                } else if (alterClause instanceof AddPartitionClause) {
-                    needProcessOutsideDatabaseLock = true;
-                } else {
-                    throw new DdlException("Invalid alter operation: " + alterClause.getOpType());
-                }
-            } else if (stmt.contains(AlterOpType.TRUNCATE_PARTITION)) {
-                needProcessOutsideDatabaseLock = true;
             } else if (stmt.contains(AlterOpType.RENAME)) {
                 processRename(db, olapTable, alterClauses);
-            } else if (stmt.contains(AlterOpType.SWAP)) {
-                new AlterJobExecutor().process(stmt, ConnectContext.get());
             } else if (stmt.contains(AlterOpType.ALTER_COMMENT)) {
                 processAlterComment(db, olapTable, alterClauses);
             } else if (stmt.contains(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC)) {
@@ -644,42 +570,7 @@ public class AlterJobMgr {
         if (needProcessOutsideDatabaseLock) {
             Preconditions.checkState(alterClauses.size() == 1);
             AlterClause alterClause = alterClauses.get(0);
-            if (alterClause instanceof AddPartitionClause) {
-                if (!((AddPartitionClause) alterClause).isTempPartition()) {
-                    DynamicPartitionUtil.checkAlterAllowed((OlapTable) db.getTable(tableName));
-                }
-                GlobalStateMgr.getCurrentState().getLocalMetastore()
-                        .addPartitions(Util.getOrCreateConnectContext(), db, tableName, (AddPartitionClause) alterClause);
-            } else if (alterClause instanceof TruncatePartitionClause) {
-                // This logic is used to adapt mysql syntax.
-                // ALTER TABLE test TRUNCATE PARTITION p1;
-                TruncatePartitionClause clause = (TruncatePartitionClause) alterClause;
-                TableRef tableRef = new TableRef(stmt.getTbl(), null, clause.getPartitionNames());
-                TruncateTableStmt tStmt = new TruncateTableStmt(tableRef);
-                ConnectContext ctx = new ConnectContext();
-                ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
-                GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(tStmt, ctx);
-            } else if (alterClause instanceof ModifyPartitionClause) {
-                ModifyPartitionClause clause = ((ModifyPartitionClause) alterClause);
-                Map<String, String> properties = clause.getProperties();
-                List<String> partitionNames = clause.getPartitionNames();
-                // currently, only in memory property could reach here
-                Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY));
-                olapTable = (OlapTable) db.getTable(tableName);
-                if (olapTable.isCloudNativeTable()) {
-                    throw new DdlException("Lake table not support alter in_memory");
-                }
-
-                schemaChangeHandler.updatePartitionsInMemoryMeta(
-                        db, tableName, partitionNames, properties);
-
-                locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.WRITE);
-                try {
-                    modifyPartitionsProperty(db, olapTable, partitionNames, properties);
-                } finally {
-                    locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.WRITE);
-                }
-            } else if (alterClause instanceof ModifyTablePropertiesClause) {
+            if (alterClause instanceof ModifyTablePropertiesClause) {
                 Map<String, String> properties = alterClause.getProperties();
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX) ||
@@ -726,10 +617,6 @@ public class AlterJobMgr {
                 } else {
                     throw new DdlException("Invalid alter operation: " + alterClause.getOpType());
                 }
-            } else if (alterClause instanceof CompactionClause) {
-                String s = (((CompactionClause) alterClause).isBaseCompaction() ? "base" : "cumulative")
-                        + " compact " + tableName + " partitions: " + ((CompactionClause) alterClause).getPartitionNames();
-                compactionHandler.process(alterClauses, db, olapTable);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/CompactionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/CompactionHandler.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -33,14 +32,12 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterClause;
-import com.starrocks.sql.ast.CancelStmt;
 import com.starrocks.sql.ast.CompactionClause;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.task.CompactionTask;
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.hadoop.util.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,28 +47,12 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CompactionHandler extends AlterHandler {
+public class CompactionHandler  {
     private static final Logger LOG = LogManager.getLogger(CompactionHandler.class);
 
-    public CompactionHandler() {
-        super("compaction");
-    }
-
-
-    @Override
-    protected void runAfterCatalogReady() {
-        super.runAfterCatalogReady();
-    }
-
-    @Override
-    public List<List<Comparable>> getAlterJobInfosByDb(Database db) {
-        throw new NotImplementedException();
-    }
-
-    @Override
     // add synchronized to avoid process 2 or more stmts at same time
-    public synchronized ShowResultSet process(List<AlterClause> alterClauses, Database db,
-                                              OlapTable olapTable) throws UserException {
+    public static synchronized ShowResultSet process(List<AlterClause> alterClauses, Database db,
+                                                     OlapTable olapTable) throws UserException {
         Preconditions.checkArgument(alterClauses.size() == 1);
         AlterClause alterClause = alterClauses.get(0);
         Preconditions.checkState(alterClause instanceof CompactionClause);
@@ -142,7 +123,7 @@ public class CompactionHandler extends AlterHandler {
     }
 
     @NotNull
-    private List<Partition> findAllPartitions(OlapTable olapTable, CompactionClause compactionClause) {
+    private static List<Partition> findAllPartitions(OlapTable olapTable, CompactionClause compactionClause) {
         List<Partition> allPartitions = new ArrayList<>();
         if (compactionClause.getPartitionNames().isEmpty()) {
             allPartitions.addAll(olapTable.getPartitions());
@@ -159,10 +140,4 @@ public class CompactionHandler extends AlterHandler {
         }
         return allPartitions;
     }
-
-    @Override
-    public synchronized void cancel(CancelStmt stmt) throws DdlException {
-        throw new NotImplementedException();
-    }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -386,7 +386,6 @@ public class ListPartitionInfo extends PartitionInfo {
                     long partitionId = partition.getId();
                     PartitionDesc partitionDesc = entry.second;
                     Preconditions.checkArgument(partitionDesc instanceof SinglePartitionDesc);
-                    Preconditions.checkArgument(((SinglePartitionDesc) partitionDesc).isAnalyzed());
                     this.idToDataProperty.put(partitionId, partitionDesc.getPartitionDataProperty());
                     this.idToReplicationNum.put(partitionId, partitionDesc.getReplicationNum());
                     this.idToInMemory.put(partitionId, partitionDesc.isInMemory());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -231,7 +231,6 @@ public class RangePartitionInfo extends PartitionInfo {
 
     public Range<PartitionKey> handleNewSinglePartitionDesc(Map<ColumnId, Column> schema, SingleRangePartitionDesc desc,
                                                             long partitionId, boolean isTemp) throws DdlException {
-        Preconditions.checkArgument(desc.isAnalyzed());
         Range<PartitionKey> range;
         try {
             range = checkAndCreateRange(schema, desc, isTemp);
@@ -277,7 +276,6 @@ public class RangePartitionInfo extends PartitionInfo {
                 if (!existPartitionNameSet.contains(partition.getName())) {
                     long partitionId = partition.getId();
                     SingleRangePartitionDesc desc = (SingleRangePartitionDesc) entry.second;
-                    Preconditions.checkArgument(desc.isAnalyzed());
                     Range<PartitionKey> range;
                     try {
                         range = checkAndCreateRange(schema, (SingleRangePartitionDesc) entry.second, isTemp);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -405,12 +405,12 @@ public class DynamicPartitionUtil {
         return analyzedProperties;
     }
 
-    public static void checkAlterAllowed(OlapTable olapTable) throws DdlException {
+    public static void checkAlterAllowed(OlapTable olapTable) {
         TableProperty tableProperty = olapTable.getTableProperty();
         if (tableProperty != null && tableProperty.getDynamicPartitionProperty() != null &&
                 tableProperty.getDynamicPartitionProperty().isExists() &&
                 tableProperty.getDynamicPartitionProperty().isEnabled()) {
-            throw new DdlException("Cannot add/drop partition on a Dynamic Partition Table, " +
+            throw new SemanticException("Cannot add/drop partition on a Dynamic Partition Table, " +
                     "Use command `ALTER TABLE tbl_name SET (\"dynamic_partition.enable\" = \"false\")` firstly.");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -261,8 +261,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void alterTable(AlterTableStmt stmt) throws UserException {
-        normal.alterTable(stmt);
+    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws UserException {
+        normal.alterTable(context, stmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -286,7 +286,7 @@ public interface ConnectorMetadata {
     default void abortSink(String dbName, String table, List<TSinkCommitInfo> commitInfos) {
     }
 
-    default void alterTable(AlterTableStmt stmt) throws UserException {
+    default void alterTable(ConnectContext context, AlterTableStmt stmt) throws UserException {
         throw new StarRocksConnectorException("This connector doesn't support alter table");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -401,7 +401,7 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void alterTable(AlterTableStmt stmt) throws UserException {
+    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws UserException {
         // (FIXME) add this api just for tests of external table
         List<AlterClause> alterClauses = stmt.getAlterClauseList();
         for (AlterClause alterClause : alterClauses) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -294,7 +294,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void alterTable(AlterTableStmt stmt) throws UserException {
+    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws UserException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         org.apache.iceberg.Table table = icebergCatalog.getTable(dbName, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -393,7 +393,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitAlterTableStatement(AlterTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+                context.getGlobalStateMgr().getMetadataMgr().alterTable(context, stmt);
             });
             return null;
         }
@@ -1097,7 +1097,7 @@ public class DDLStmtExecutor {
         public ShowResultSet visitCreateDictionaryStatement(CreateDictionaryStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
                 context.getGlobalStateMgr().getDictionaryMgr().createDictionary(stmt,
-                                                context.getCurrentCatalog(), context.getDatabase());
+                        context.getCurrentCatalog(), context.getDatabase());
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -47,6 +47,7 @@ import com.google.common.collect.Sets;
 import com.staros.proto.FilePathInfo;
 import com.starrocks.alter.AlterJobExecutor;
 import com.starrocks.alter.AlterMVJobExecutor;
+import com.starrocks.alter.AlterOpType;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.HintNode;
@@ -862,7 +863,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
         } finally {
             locker.unLockDatabase(db, LockType.READ);
         }
-        addPartitions(ctx, db, tableName, addPartitionClause.getResolvedPartitionDescList(), addPartitionClause);
+        addPartitions(ctx, db, tableName,
+                addPartitionClause.getResolvedPartitionDescList(),
+                addPartitionClause.isTempPartition(),
+                addPartitionClause.getDistributionDesc());
     }
 
     private OlapTable checkTable(Database db, String tableName) throws DdlException {
@@ -892,12 +896,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
         }
     }
 
-    private DistributionInfo getDistributionInfo(OlapTable olapTable, AddPartitionClause addPartitionClause)
+    private DistributionInfo getDistributionInfo(OlapTable olapTable, DistributionDesc distributionDesc)
             throws DdlException {
         DistributionInfo distributionInfo;
         List<Column> baseSchema = olapTable.getBaseSchema();
         DistributionInfo defaultDistributionInfo = olapTable.getDefaultDistributionInfo();
-        DistributionDesc distributionDesc = addPartitionClause.getDistributionDesc();
         if (distributionDesc != null) {
             distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
             // for now. we only support modify distribution's bucket num
@@ -1020,10 +1023,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
     }
 
     private void updatePartitionInfo(PartitionInfo partitionInfo, List<Pair<Partition, PartitionDesc>> partitionList,
-                                     Set<String> existPartitionNameSet, AddPartitionClause addPartitionClause,
+                                     Set<String> existPartitionNameSet, boolean isTempPartition,
                                      OlapTable olapTable)
             throws DdlException {
-        boolean isTempPartition = addPartitionClause.isTempPartition();
         if (partitionInfo instanceof RangePartitionInfo) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
             rangePartitionInfo.handleNewRangePartitionDescs(olapTable.getIdToColumn(),
@@ -1054,9 +1056,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
     }
 
     private void addRangePartitionLog(Database db, OlapTable olapTable, List<PartitionDesc> partitionDescs,
-                                      AddPartitionClause addPartitionClause, PartitionInfo partitionInfo,
+                                      boolean isTempPartition, PartitionInfo partitionInfo,
                                       List<Partition> partitionList, Set<String> existPartitionNameSet) {
-        boolean isTempPartition = addPartitionClause.isTempPartition();
         int partitionLen = partitionList.size();
         List<PartitionPersistInfoV2> partitionInfoV2List = Lists.newArrayListWithCapacity(partitionLen);
         if (partitionLen == 1) {
@@ -1104,7 +1105,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
 
     @VisibleForTesting
     public void addListPartitionLog(Database db, OlapTable olapTable, List<PartitionDesc> partitionDescs,
-                                    AddPartitionClause addPartitionClause, PartitionInfo partitionInfo,
+                                    boolean isTempPartition, PartitionInfo partitionInfo,
                                     List<Partition> partitionList, Set<String> existPartitionNameSet)
             throws DdlException {
         if (partitionList == null) {
@@ -1116,7 +1117,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
         // TODO: add only 1 log for multi list partition
         int i = 0;
         for (Partition partition : partitionList) {
-            boolean isTempPartition = addPartitionClause.isTempPartition();
             if (existPartitionNameSet.contains(partition.getName())) {
                 LOG.info("add partition[{}] which already exists", partition.getName());
                 continue;
@@ -1138,15 +1138,15 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
     }
 
     private void addPartitionLog(Database db, OlapTable olapTable, List<PartitionDesc> partitionDescs,
-                                 AddPartitionClause addPartitionClause, PartitionInfo partitionInfo,
+                                 boolean isTempPartition, PartitionInfo partitionInfo,
                                  List<Partition> partitionList, Set<String> existPartitionNameSet)
             throws DdlException {
         PartitionType partitionType = partitionInfo.getType();
         if (partitionInfo.isRangePartition()) {
-            addRangePartitionLog(db, olapTable, partitionDescs, addPartitionClause, partitionInfo, partitionList,
+            addRangePartitionLog(db, olapTable, partitionDescs, isTempPartition, partitionInfo, partitionList,
                     existPartitionNameSet);
         } else if (partitionType == PartitionType.LIST) {
-            addListPartitionLog(db, olapTable, partitionDescs, addPartitionClause, partitionInfo, partitionList,
+            addListPartitionLog(db, olapTable, partitionDescs, isTempPartition, partitionInfo, partitionList,
                     existPartitionNameSet);
         } else {
             throw new DdlException("Only support adding partition log to range/list partitioned table");
@@ -1197,7 +1197,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
     }
 
     private void addPartitions(ConnectContext ctx, Database db, String tableName, List<PartitionDesc> partitionDescs,
-                               AddPartitionClause addPartitionClause) throws DdlException {
+                               boolean isTempPartition, DistributionDesc distributionDesc) throws DdlException {
         DistributionInfo distributionInfo;
         OlapTable olapTable;
         OlapTable copiedTable;
@@ -1215,7 +1215,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
             checkPartitionType(partitionInfo);
 
             // get distributionInfo
-            distributionInfo = getDistributionInfo(olapTable, addPartitionClause).copy();
+            distributionInfo = getDistributionInfo(olapTable, distributionDesc).copy();
             olapTable.inferDistribution(distributionInfo);
 
             // check colocation
@@ -1273,7 +1273,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
                 checkPartitionType(partitionInfo);
 
                 // update partition info
-                updatePartitionInfo(partitionInfo, newPartitions, existPartitionNameSet, addPartitionClause, olapTable);
+                updatePartitionInfo(partitionInfo, newPartitions, existPartitionNameSet, isTempPartition, olapTable);
 
                 try {
                     colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */,
@@ -1283,7 +1283,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
                 }
 
                 // add partition log
-                addPartitionLog(db, olapTable, partitionDescs, addPartitionClause, partitionInfo, partitionList,
+                addPartitionLog(db, olapTable, partitionDescs, isTempPartition, partitionInfo, partitionList,
                         existPartitionNameSet);
             } finally {
                 cleanExistPartitionNameSet(existPartitionNameSet, partitionNameToTabletSet);
@@ -1615,12 +1615,12 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
     }
 
     public void addSubPartitions(Database db, OlapTable table, Partition partition,
-            int numSubPartition, long warehouseId) throws DdlException {
+                                 int numSubPartition, long warehouseId) throws DdlException {
         addSubPartitions(db, table, partition, numSubPartition, null, warehouseId);
     }
 
     public void addSubPartitions(Database db, OlapTable table, Partition partition,
-            int numSubPartition, String[] subPartitionNames, long warehouseId) throws DdlException {
+                                 int numSubPartition, String[] subPartitionNames, long warehouseId) throws DdlException {
         OlapTable olapTable;
         OlapTable copiedTable;
 
@@ -2973,8 +2973,19 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
      * including SchemaChangeHandler and RollupHandler
      */
     @Override
-    public void alterTable(AlterTableStmt stmt) throws UserException {
-        stateMgr.getAlterJobMgr().processAlterTable(stmt);
+    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws UserException {
+        /*
+         * Due to the implementation of the Table Level Lock transformation plan,
+         * we need to sort out the lock layering logic. Therefore, we plan to gradually
+         * migrate the alter table related logic scattered everywhere to AlterJobExecutor.
+         * This is a compatible logic, so that the functions that have not been migrated still use the original logic.
+         */
+        if (stmt.hasPartitionOp() || stmt.contains(AlterOpType.SWAP) || stmt.contains(AlterOpType.COMPACT)) {
+            AlterJobExecutor alterJobExecutor = new AlterJobExecutor();
+            alterJobExecutor.process(stmt, context);
+        } else {
+            stateMgr.getAlterJobMgr().processAlterTable(stmt);
+        }
     }
 
     /**
@@ -3417,7 +3428,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
         boolean force = refreshMaterializedViewStatement.isForceRefresh();
         PartitionRangeDesc range = refreshMaterializedViewStatement.getPartitionRangeDesc();
         return refreshMaterializedView(dbName, mvName, force, range, Constants.TaskRunPriority.HIGH.value(),
-               Config.enable_mv_refresh_sync_refresh_mergeable, true, refreshMaterializedViewStatement.isSync());
+                Config.enable_mv_refresh_sync_refresh_mergeable, true, refreshMaterializedViewStatement.isSync());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -373,7 +373,7 @@ public class MetadataMgr {
         }
     }
 
-    public void alterTable(AlterTableStmt stmt) throws UserException {
+    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws UserException {
         String catalogName = stmt.getCatalogName();
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
 
@@ -388,7 +388,7 @@ public class MetadataMgr {
                 throw new DdlException("Table '" + tableName + "' does not exist in database '" + dbName + "'");
             }
 
-            connectorMetadata.get().alterTable(stmt);
+            connectorMetadata.get().alterTable(context, stmt);
         } else {
             throw new DdlException("Invalid catalog " + catalogName + " , ConnectorMetadata doesn't exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.DynamicPartitionProperty;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
@@ -99,6 +100,7 @@ import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.StructFieldDesc;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.common.MetaUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
@@ -937,6 +939,17 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
         if (clause.getProperties() != null && !clause.getProperties().isEmpty()) {
             throw new SemanticException("Unknown properties: " + clause.getProperties());
         }
+
+
+        if (table instanceof OlapTable) {
+            List<String> partitionNames = clause.getPartitionNames();
+            for (String partitionName : partitionNames) {
+                if (partitionName.startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX)) {
+                    throw new SemanticException("Replace shadow partitions is not allowed");
+                }
+            }
+        }
+
         return null;
     }
 
@@ -1198,6 +1211,21 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             clause.setResolvedPartitionNames(Lists.newArrayList(clause.getPartitionName()));
         } else if (clause.getPartitionNames() != null) {
             clause.setResolvedPartitionNames(clause.getPartitionNames());
+        }
+
+        if (table instanceof OlapTable) {
+            if (clause.getPartitionName() != null && clause.getPartitionName().startsWith(
+                    ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX)) {
+                throw new SemanticException("Deletion of shadow partitions is not allowed");
+            }
+            List<String> partitionNames = clause.getPartitionNames();
+            if (CollectionUtils.isNotEmpty(partitionNames)) {
+                boolean hasShadowPartition = partitionNames.stream().anyMatch(partitionName ->
+                        partitionName.startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX));
+                if (hasShadowPartition) {
+                    throw new SemanticException("Deletion of shadow partitions is not allowed");
+                }
+            }
         }
 
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -41,6 +41,7 @@ public class AlterTableStatementAnalyzer {
         TableName tbl = statement.getTbl();
         MetaUtils.normalizationTableName(context, tbl);
         MetaUtils.checkNotSupportCatalog(tbl.getCatalog(), "ALTER");
+
         List<AlterClause> alterClauseList = statement.getAlterClauseList();
         if (alterClauseList == null || alterClauseList.isEmpty()) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_NO_ALTER_OPERATION);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterTableStmt.java
@@ -67,9 +67,11 @@ public class AlterTableStmt extends DdlStmt {
 
     public boolean hasPartitionOp() {
         List<AlterOpType> currentOps = alterClauseList.stream().map(AlterClause::getOpType).collect(Collectors.toList());
-        return currentOps.contains(AlterOpType.ADD_PARTITION) || currentOps.contains(AlterOpType.DROP_PARTITION)
-                || currentOps.contains(AlterOpType.REPLACE_PARTITION) ||
-                currentOps.contains(AlterOpType.MODIFY_PARTITION);
+        return currentOps.contains(AlterOpType.ADD_PARTITION)
+                || currentOps.contains(AlterOpType.DROP_PARTITION)
+                || currentOps.contains(AlterOpType.REPLACE_PARTITION)
+                || currentOps.contains(AlterOpType.MODIFY_PARTITION)
+                || currentOps.contains(AlterOpType.TRUNCATE_PARTITION);
     }
 
     public boolean hasSchemaChangeOp() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
@@ -70,16 +70,10 @@ public class MultiItemListPartitionDesc extends SinglePartitionDesc {
     }
 
     public void analyze(List<ColumnDef> columnDefList, Map<String, String> tableProperties) throws AnalysisException {
-        if (isAnalyzed) {
-            return;
-        }
-
         FeNameFormat.checkPartitionName(getPartitionName());
         analyzeValues(columnDefList.size());
         analyzeProperties(tableProperties, null);
         this.columnDefList = columnDefList;
-
-        isAnalyzed = true;
     }
 
     private void analyzeValues(int partitionColSize) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
@@ -59,10 +59,6 @@ public class SingleItemListPartitionDesc extends SinglePartitionDesc {
     }
 
     public void analyze(List<ColumnDef> columnDefList, Map<String, String> tableProperties) throws AnalysisException {
-        if (isAnalyzed) {
-            return;
-        }
-
         FeNameFormat.checkPartitionName(this.getPartitionName());
         analyzeProperties(tableProperties, null);
 
@@ -70,8 +66,6 @@ public class SingleItemListPartitionDesc extends SinglePartitionDesc {
             throw new AnalysisException("Partition column size should be one when use single list partition ");
         }
         this.columnDefList = columnDefList;
-
-        isAnalyzed = true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SinglePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SinglePartitionDesc.java
@@ -47,8 +47,6 @@ public abstract class SinglePartitionDesc extends PartitionDesc {
     private boolean isInMemory;
     private DataCacheInfo dataCacheInfo;
 
-    protected boolean isAnalyzed;
-
     public SinglePartitionDesc(boolean ifNotExists, String partName, Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.partName = partName;
@@ -60,7 +58,6 @@ public abstract class SinglePartitionDesc extends PartitionDesc {
         this.versionInfo = null;
         this.isInMemory = false;
         this.dataCacheInfo = null;
-        this.isAnalyzed = false;
     }
 
     @Override
@@ -106,10 +103,6 @@ public abstract class SinglePartitionDesc extends PartitionDesc {
     @Override
     public DataCacheInfo getDataCacheInfo() {
         return dataCacheInfo;
-    }
-
-    public boolean isAnalyzed() {
-        return isAnalyzed;
     }
 
     protected void analyzeProperties(Map<String, String> tableProperties,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -42,10 +42,6 @@ public class SingleRangePartitionDesc extends SinglePartitionDesc {
     }
 
     public void analyze(int partColNum, Map<String, String> tableProperties) throws AnalysisException {
-        if (isAnalyzed) {
-            return;
-        }
-
         FeNameFormat.checkPartitionName(getPartitionName());
         partitionKeyDesc.analyze(partColNum);
 
@@ -54,7 +50,6 @@ public class SingleRangePartitionDesc extends SinglePartitionDesc {
         } else {
             analyzeProperties(tableProperties, null);
         }
-        isAnalyzed = true;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
@@ -94,7 +94,7 @@ public class AlterTableTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_alter_bucket_size SET (\"bucket_size\" = \"-1\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class AlterTableTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_alter_cool_down_ttl SET (\"storage_cooldown_ttl\" = \"3 day\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
 
         Table table = GlobalStateMgr.getCurrentState().getDb("test").getTable("test_alter_cool_down_ttl");
         OlapTable olapTable = (OlapTable) table;
@@ -157,7 +157,7 @@ public class AlterTableTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_alter_cool_down_ttl_2 SET (\"storage_cooldown_ttl\" = \"abc\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
 
     @Test
@@ -198,7 +198,8 @@ public class AlterTableTest {
         String sql = "ALTER TABLE test_alter_cool_down_ttl_partition\n" +
                 "MODIFY PARTITION (*) SET(\"storage_cooldown_ttl\" = \"2 day\", \"storage_medium\" = \"SSD\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        AlterJobExecutor alterJobExecutor = new AlterJobExecutor();
+        alterJobExecutor.process(alterTableStmt, ctx);
 
         p20200321 = rangePartitionInfo.getDataProperty(olapTable.getPartition("p20200321").getId());
         p20200322 = rangePartitionInfo.getDataProperty(olapTable.getPartition("p20200322").getId());
@@ -236,7 +237,7 @@ public class AlterTableTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_partition_live_number SET(\"partition_live_number\" = \"-1\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
         Set<Pair<Long, Long>> ttlPartitionInfo = GlobalStateMgr.getCurrentState()
                 .getDynamicPartitionScheduler().getTtlPartitionInfo();
         Database db = GlobalStateMgr.getCurrentState().getDb("test");
@@ -244,7 +245,7 @@ public class AlterTableTest {
         Assert.assertFalse(ttlPartitionInfo.contains(new Pair<>(db.getId(), table.getId())));
         sql = "ALTER TABLE test_partition_live_number SET(\"partition_live_number\" = \"1\");";
         alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
         Assert.assertTrue(ttlPartitionInfo.contains(new Pair<>(db.getId(), table.getId())));
     }
 
@@ -271,7 +272,7 @@ public class AlterTableTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_partition_storage_medium SET(\"default.storage_medium\" = \"SSD\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
         Database db = GlobalStateMgr.getCurrentState().getDb("test");
         OlapTable olapTable = (OlapTable) db.getTable("test_partition_storage_medium");
         Assert.assertTrue(olapTable.getStorageMedium().equals("SSD"));

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -335,7 +335,7 @@ public class AlterTest {
     private static void alterTableWithNewParser(String sql, boolean expectedException) throws Exception {
         try {
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+            DDLStmtExecutor.execute(alterTableStmt, connectContext);
             if (expectedException) {
                 Assert.fail();
             }
@@ -350,7 +350,7 @@ public class AlterTest {
     private static void alterTableWithNewParserAndExceptionMsg(String sql, String msg) throws Exception {
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, alterTableStmt);
         } catch (Exception e) {
             Assert.assertEquals(msg, e.getMessage());
         }
@@ -1863,7 +1863,7 @@ public class AlterTest {
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         String stmt = "alter table modify_bucket set (\"dynamic_partition.buckets\" = \"10\");\n";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
 
     @Test
@@ -2425,7 +2425,7 @@ public class AlterTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE t_recharge_detail DROP PARTITION p2 force;";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        DDLStmtExecutor.execute(alterTableStmt, ctx);
     }
 
     @Test(expected = AnalysisException.class)
@@ -2433,7 +2433,7 @@ public class AlterTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE site_access_date_trunc ADD PARTITION p20210101 VALUES [(\"2021-01-01\"), (\"2021-01-02\"));";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
 
     @Test(expected = AnalysisException.class)
@@ -2442,7 +2442,7 @@ public class AlterTest {
         String sql = "ALTER TABLE site_access_time_slice\n" +
                 "ADD PARTITIONS START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 1 day)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
 
     @Test(expected = AnalysisException.class)
@@ -2451,7 +2451,7 @@ public class AlterTest {
         String sql = "ALTER TABLE site_access_date_trunc\n" +
                 "ADD PARTITIONS START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 2 day)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
 
     @Test
@@ -2529,7 +2529,7 @@ public class AlterTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE t2 ADD PARTITIONS START (\"2021-01-04\") END (\"2021-01-06\") EVERY (INTERVAL 1 DAY);";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -65,7 +65,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
 
     private static void alterTable(ConnectContext connectContext, String sql) throws Exception {
         AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(stmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, stmt);
     }
 
     private LakeTableAsyncFastSchemaChangeJob getAlterJob(Table table) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -82,7 +82,7 @@ public class LakeTableSchemaChangeJobTest {
 
     private static void alterTable(ConnectContext connectContext, String sql) throws Exception {
         AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(stmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, stmt);
     }
 
     private LakeTableSchemaChangeJob getAlterJob(Table table) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -21,6 +21,7 @@ import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
@@ -67,7 +68,7 @@ public class CatalogRecycleBinLakeTableTest {
 
     private static void alterTable(ConnectContext connectContext, String sql) throws Exception {
         AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(stmt);
+        DDLStmtExecutor.execute(stmt, connectContext);
     }
 
     private static void recoverDatabase(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -101,7 +101,7 @@ public class CreateTableTest {
 
     private static void alterTableWithNewParser(String sql) throws Exception {
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, alterTableStmt);
     }
 
     @Test(expected = DdlException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionTest.java
@@ -37,6 +37,7 @@ package com.starrocks.catalog;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
@@ -91,7 +92,7 @@ public class DropPartitionTest {
 
     private void dropPartition(String sql) throws Exception {
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        DDLStmtExecutor.execute(alterTableStmt, connectContext);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -27,6 +27,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
@@ -615,11 +616,11 @@ public class MaterializedViewTest {
         String bloomfilterSql = "alter table test.index_mv_to_check set (\"bloom_filter_columns\"=\"k2\")";
 
         AlterTableStmt alterMVStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(bitmapSql, connectContext);
-        GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterMVStmt);
+        DDLStmtExecutor.execute(alterMVStmt, connectContext);
         waitForSchemaChangeAlterJobFinish();
 
         alterMVStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(bloomfilterSql, connectContext);
-        GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterMVStmt);
+        DDLStmtExecutor.execute(alterMVStmt, connectContext);
         waitForSchemaChangeAlterJobFinish();
 
         Assert.assertEquals(QueryState.MysqlStateType.OK, connectContext.getState().getStateType());
@@ -658,7 +659,7 @@ public class MaterializedViewTest {
         AlterTableStmt alterViewStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(bitmapSql, connectContext);
         Assert.assertThrows("Do not support alter non-native table/materialized-view[index_view_to_check]",
                 DdlException.class,
-                () -> GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterViewStmt));
+                () -> DDLStmtExecutor.execute(alterViewStmt, connectContext));
     }
 
     public void testCreateMV(String mvSql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StorageMediumInferTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StorageMediumInferTest.java
@@ -37,6 +37,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
@@ -79,7 +80,7 @@ public class StorageMediumInferTest {
 
     private static void alterTableWithNewParser(String sql) throws Exception {
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        DDLStmtExecutor.execute(alterTableStmt, connectContext);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
@@ -44,6 +44,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
@@ -111,7 +112,7 @@ public class TempPartitionTest {
     private void alterTableWithNewAnalyzer(String sql, boolean expectedException) throws Exception {
         try {
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterTableStmt);
+            DDLStmtExecutor.execute(alterTableStmt, ctx);
             if (expectedException) {
                 Assert.fail("expected exception not thrown");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
@@ -74,7 +74,7 @@ public class AlterTableTest extends TableTestBase {
         Assert.assertTrue(clause.isCreate());
         Assert.assertEquals(clause.getBranchName(), "test_branch_1");
         Assert.assertEquals(clause.getOpType(), AlterOpType.ALTER_BRANCH);
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 1);
         Assert.assertTrue(mockedNativeTableB.refs().containsKey("test_branch_1"));
@@ -88,7 +88,7 @@ public class AlterTableTest extends TableTestBase {
                 "snapshots 2 days", snapshotId);
 
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertTrue(mockedNativeTableB.refs().containsKey("test_branch_2"));
         SnapshotRef snapshotRef = mockedNativeTableB.refs().get("test_branch_2");
@@ -104,7 +104,7 @@ public class AlterTableTest extends TableTestBase {
                 "with snapshot retention 2 " +
                 "snapshots 2 days", snapshotId);
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         Assert.assertEquals(3, mockedNativeTableB.refs().size());
 
         sql = String.format("alter table iceberg_catalog.db.srTableName create or replace branch test_branch_3 " +
@@ -114,7 +114,7 @@ public class AlterTableTest extends TableTestBase {
                 "snapshots 2 days", snapshotId);
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assert.assertTrue(((CreateOrReplaceBranchClause) stmt.getAlterClauseList().get(0)).isReplace());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(4, mockedNativeTableB.refs().size());
 
@@ -125,7 +125,7 @@ public class AlterTableTest extends TableTestBase {
                 "snapshots 2 days", snapshotId);
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assert.assertTrue(((CreateOrReplaceBranchClause) stmt.getAlterClauseList().get(0)).isIfNotExists());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         Assert.assertEquals(4, mockedNativeTableB.refs().size());
     }
 
@@ -157,7 +157,7 @@ public class AlterTableTest extends TableTestBase {
         Assert.assertTrue(clause.isCreate());
         Assert.assertEquals(clause.getTagName(), "test_tag_1");
         Assert.assertEquals(clause.getOpType(), AlterOpType.ALTER_TAG);
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 2);
         Assert.assertTrue(mockedNativeTableB.refs().containsKey("test_tag_1"));
@@ -168,7 +168,7 @@ public class AlterTableTest extends TableTestBase {
                 "as of version %s retain 7 days ", snapshotId);
 
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertTrue(mockedNativeTableB.refs().containsKey("test_tag_2"));
         SnapshotRef snapshotRef = mockedNativeTableB.refs().get("test_tag_2");
@@ -178,21 +178,21 @@ public class AlterTableTest extends TableTestBase {
 
         sql = "alter table iceberg_catalog.db.srTableName create or replace tag test_tag_3 ";
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(4, mockedNativeTableB.refs().size());
 
         sql = "alter table iceberg_catalog.db.srTableName create or replace tag test_tag_3 ";
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assert.assertTrue(((CreateOrReplaceTagClause) stmt.getAlterClauseList().get(0)).isReplace());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(4, mockedNativeTableB.refs().size());
 
         sql = "alter table iceberg_catalog.db.srTableName create tag if not exists test_tag_3 ";
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assert.assertTrue(((CreateOrReplaceTagClause) stmt.getAlterClauseList().get(0)).isIfNotExists());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(4, mockedNativeTableB.refs().size());
     }
@@ -219,21 +219,21 @@ public class AlterTableTest extends TableTestBase {
         mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
         String sql = "alter table iceberg_catalog.db.srTableName create branch test_branch_1";
         AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 2);
         Assert.assertTrue(mockedNativeTableB.refs().containsKey("test_branch_1"));
 
         sql = "alter table iceberg_catalog.db.srTableName drop branch test_branch_1";
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 1);
         Assert.assertFalse(mockedNativeTableB.refs().containsKey("test_branch_1"));
 
         sql = "alter table iceberg_catalog.db.srTableName drop branch if exists test_branch_1";
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 1);
         Assert.assertFalse(mockedNativeTableB.refs().containsKey("test_branch_1"));
@@ -261,21 +261,21 @@ public class AlterTableTest extends TableTestBase {
         mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
         String sql = "alter table iceberg_catalog.db.srTableName create tag test_tag";
         AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 2);
         Assert.assertTrue(mockedNativeTableB.refs().containsKey("test_tag"));
 
         sql = "alter table iceberg_catalog.db.srTableName drop tag test_tag";
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 1);
         Assert.assertFalse(mockedNativeTableB.refs().containsKey("test_branch_1"));
 
         sql = "alter table iceberg_catalog.db.srTableName drop tag if exists test_tag";
         stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
-        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(stmt);
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
         mockedNativeTableB.refresh();
         Assert.assertEquals(mockedNativeTableB.refs().size(), 1);
         Assert.assertFalse(mockedNativeTableB.refs().containsKey("test_tag"));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1153,7 +1153,7 @@ public class IcebergMetadataTest extends TableTestBase {
         clauses.add(addColumnClause);
         clauses.add(addColumnsClause);
         AlterTableStmt stmt = new AlterTableStmt(tableName, clauses);
-        metadata.alterTable(stmt);
+        metadata.alterTable(new ConnectContext(), stmt);
         clauses.clear();
 
         // must be default null
@@ -1161,7 +1161,7 @@ public class IcebergMetadataTest extends TableTestBase {
         AddColumnClause addC4 = new AddColumnClause(c4, null, null, new HashMap<>());
         clauses.add(addC4);
         AlterTableStmt stmtC4 = new AlterTableStmt(tableName, clauses);
-        Assert.assertThrows(DdlException.class, () -> metadata.alterTable(stmtC4));
+        Assert.assertThrows(DdlException.class, () -> metadata.alterTable(new ConnectContext(), stmtC4));
         clauses.clear();
 
         // drop/rename/modify column
@@ -1174,13 +1174,13 @@ public class IcebergMetadataTest extends TableTestBase {
         clauses.add(dropColumnClause);
         clauses.add(columnRenameClause);
         clauses.add(modifyColumnClause);
-        metadata.alterTable(new AlterTableStmt(tableName, clauses));
+        metadata.alterTable(new ConnectContext(), new AlterTableStmt(tableName, clauses));
 
         // rename table
         clauses.clear();
         TableRenameClause tableRenameClause = new TableRenameClause("newTbl");
         clauses.add(tableRenameClause);
-        metadata.alterTable(new AlterTableStmt(tableName, clauses));
+        metadata.alterTable(new ConnectContext(), new AlterTableStmt(tableName, clauses));
 
         // modify table properties/comment
         clauses.clear();
@@ -1193,14 +1193,15 @@ public class IcebergMetadataTest extends TableTestBase {
         AlterTableCommentClause alterTableCommentClause = new AlterTableCommentClause("new comment", NodePosition.ZERO);
         clauses.add(modifyTablePropertiesClause);
         clauses.add(alterTableCommentClause);
-        metadata.alterTable(new AlterTableStmt(tableName, clauses));
+        metadata.alterTable(new ConnectContext(), new AlterTableStmt(tableName, clauses));
 
         // modify empty properties
         clauses.clear();
         Map<String, String> emptyProperties = new HashMap<>();
         ModifyTablePropertiesClause emptyPropertiesClause = new ModifyTablePropertiesClause(emptyProperties);
         clauses.add(emptyPropertiesClause);
-        Assert.assertThrows(DdlException.class, () -> metadata.alterTable(new AlterTableStmt(tableName, clauses)));
+        Assert.assertThrows(DdlException.class,
+                () -> metadata.alterTable(new ConnectContext(), new AlterTableStmt(tableName, clauses)));
 
         // modify unsupported properties
         clauses.clear();
@@ -1209,7 +1210,8 @@ public class IcebergMetadataTest extends TableTestBase {
         invalidProperties.put(COMPRESSION_CODEC, "zzz");
         ModifyTablePropertiesClause invalidCompressionClause = new ModifyTablePropertiesClause(invalidProperties);
         clauses.add(invalidCompressionClause);
-        Assert.assertThrows(DdlException.class, () -> metadata.alterTable(new AlterTableStmt(tableName, clauses)));
+        Assert.assertThrows(DdlException.class,
+                () -> metadata.alterTable(new ConnectContext(), new AlterTableStmt(tableName, clauses)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/AlterTest.java
@@ -251,7 +251,7 @@ public class AlterTest {
         String sql = "ALTER TABLE t1 COMPACT p1";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, alterTableStmt);
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -1226,7 +1226,7 @@ public class FrontendServiceImplTest {
         partitionList.add(p19910425);
 
         currentState.getLocalMetastore().addListPartitionLog(testDb, olapTable, partitionDescs,
-                addPartitionClause, partitionInfo, partitionList, Sets.newSet("p19900425"));
+                addPartitionClause.isTempPartition(), partitionInfo, partitionList, Sets.newSet("p19900425"));
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -1161,9 +1161,9 @@ public class PrivilegeCheckerTest {
 
         // check alter table: ALTER
         verifyGrantRevoke(
-                "alter table db1.tbl1 drop partition p1",
-                "grant ALTER on db1.tbl1 to test",
-                "revoke ALTER on db1.tbl1 from test",
+                "alter table db2.tbl1 drop partition p1",
+                "grant ALTER on db2.tbl1 to test",
+                "revoke ALTER on db2.tbl1 from test",
                 "Access denied; you need (at least one of) the ALTER privilege(s) on TABLE tbl1 for this operation");
 
         // check cancel alter table: ALTER

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -700,14 +700,14 @@ public class StarRocksAssert {
         Assert.assertFalse(alterTableStmt.getAlterClauseList().isEmpty());
         Assert.assertTrue(alterTableStmt.getAlterClauseList().get(0) instanceof ModifyTablePropertiesClause);
         Analyzer.analyze(alterTableStmt, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
         return this;
     }
 
     public StarRocksAssert alterTable(String sql) throws Exception {
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         Analyzer.analyze(alterTableStmt, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
         return this;
     }
 
@@ -1004,7 +1004,7 @@ public class StarRocksAssert {
     // Add rollup
     public StarRocksAssert withRollup(String sql) throws Exception {
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
         checkAlterJob();
         return this;
     }


### PR DESCRIPTION
## Why I'm doing:
  /*
   * Due to the implementation of the Table Level Lock transformation plan,
   * we need to sort out the lock layering logic. Therefore, we plan to gradually
   * migrate the alter table related logic scattered everywhere to AlterJobExecutor.
   * This is a compatible logic, so that the functions that have not been migrated still use the original logic.
   */
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
