### PR TITLE
[BugFix] Fix 'PartitionKey' field of cloud native table if different with     shared nothing table when run 'show partitions' command

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -377,8 +377,8 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(physicalPartition.getVisibleVersion()); // VisibleVersion
         partitionInfo.add(physicalPartition.getNextVersion()); // NextVersion
         partitionInfo.add(partition.getState()); // State
-        partitionInfo.add(Joiner.on(", ")
-                .join(tblPartitionInfo.getPartitionColumns(table.getIdToColumn()))); // PartitionKey
+        partitionInfo.add(Joiner.on(", ").join(tblPartitionInfo.getPartitionColumns(table.getIdToColumn())
+                .stream().map(Column::getName).collect(Collectors.toList()))); // Partition key
         partitionInfo.add(findRangeOrListValues(tblPartitionInfo, partition.getId())); // List or Range
         partitionInfo.add(distributionKeyAsString(table, partition.getDistributionInfo())); // DistributionKey
         partitionInfo.add(partition.getDistributionInfo().getBucketNum()); // Buckets

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.common.proc;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeTable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class PartitionsProcDirTest {
+    private Database db;
+    private LakeTable cloudNativTable;
+
+    @Before
+    public void setUp() throws DdlException, AnalysisException {
+        db = new Database(10000L, "PartitionsProcDirTestDB");
+        Map<String, Long> indexNameToId = Maps.newHashMap();
+        indexNameToId.put("index1", 1000L);
+
+        List<Column> col = Lists.newArrayList(new Column("province", Type.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        DataCacheInfo dataCache = new DataCacheInfo(true, false);
+        long partitionId = 1025;
+        listPartition.setDataCacheInfo(partitionId, dataCache);
+        cloudNativTable = new LakeTable(1024L, "cloud_native_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        cloudNativTable.addPartition(new Partition(partitionId, "p1", index, new RandomDistributionInfo(10)));
+
+        db.registerTableUnlocked(cloudNativTable);
+    }
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        BaseProcResult result = (BaseProcResult) new PartitionsProcDir(db, cloudNativTable, false).fetchResult();
+        List<List<String>> rows = result.getRows();
+        List<String> list1 = rows.get(0);
+        Assert.assertEquals("1025", list1.get(0));
+        Assert.assertEquals("p1", list1.get(1));
+        Assert.assertEquals("0", list1.get(2));
+        Assert.assertEquals("1", list1.get(3));
+        Assert.assertEquals("2", list1.get(4));
+        Assert.assertEquals("NORMAL", list1.get(5));
+        Assert.assertEquals("province", list1.get(6));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue https://github.com/StarRocks/StarRocksTest/issues/8019

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
