### PR TITLE
[BugFix] Fix the bug in the persistent index that checks whether page reading is supported.

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3070,11 +3070,9 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
         }
         FAIL_POINT_TRIGGER_EXECUTE(immutable_index_no_page_off, { meta.mutable_shards(i)->clear_page_off(); });
         if (src.page_off().size() == 0) {
-            int off = 0;
-            for (int i = 0; i < src.npage() + 1; i++) {
-                dest.page_off.emplace_back(off);
-                off += page_size;
-            }
+            // When upgrading from a historical version that does not support page compression, set page off to 0 to distinguish it 
+            // from the new version which support page compression.
+            dest.page_off.resize(src.npage() + 1, 0);
         } else {
             for (int i = 0; i < src.npage() + 1; i++) {
                 dest.page_off.emplace_back(src.page_off(i));


### PR DESCRIPTION
## Why I'm doing:
Pindex support read by page in following scenarios:
1. no compression
2. compress with page

There are the following scenarios:
1. upgrade from old version and no compression, the `uncompressed_size` is 0
2. generate by new version but disable compression, the `uncompressed_size` is 0
3. upgrade from old version and enable shard compression, the `uncompressed_size` is greater than 0
4. generate by new version and enable page compression, the `uncompressed_size` is greater than 0 and each compressed page size is saved in `page_off`

So when the `uncompressed_size` is greater than 0, we need to separate `shard-compression` and `page-compression`. We will use `page_off` to judge which compression type is used. So we need to set `page_offs` as 0 when we upgrade from old version.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
