### PR TITLE
[BugFix] Fix Colocate Group marked as stable when checking urgent tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateMatchResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateMatchResult.java
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.clone;
+
+public class ColocateMatchResult {
+    long lockTotalTime;
+    boolean isGroupStable;
+
+    public ColocateMatchResult(long lockTotalTime, boolean isGroupStable) {
+        this.lockTotalTime = lockTotalTime;
+        this.isGroupStable = isGroupStable;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -365,6 +365,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                     ColocatePersistInfo info =
                             ColocatePersistInfo.createForBackendsPerBucketSeq(gid, balancedBackendsPerBucketSeq);
                     globalStateMgr.getEditLog().logColocateBackendsPerBucketSeq(info);
+                    colocateIndex.markGroupUnstable(groupId, true);
                     LOG.info("balance colocate per group , group id {}, " +
                                     "now backends per bucket sequence is: {}, " +
                                     "bucket sequence before balance: {}", gid, balancedBackendsPerBucketSeq,
@@ -670,6 +671,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                 ColocatePersistInfo info =
                         ColocatePersistInfo.createForBackendsPerBucketSeq(groupId, balancedBackendsPerBucketSeq);
                 globalStateMgr.getEditLog().logColocateBackendsPerBucketSeq(info);
+                colocateIndex.markGroupUnstable(groupId, true);
                 LOG.info("overall colocate balance for group {}, now backends per bucket sequence is: {}, " +
                                 "bucket sequence before balance: {}",
                         groupId, balancedBackendsPerBucketSeq, oldBackendsPerBucketSeq);
@@ -714,7 +716,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                 tablet.getId(), tablet.getReplicaInfos(), bucketSeq);
     }
 
-    private long doMatchOneGroup(GroupId groupId,
+    private ColocateMatchResult doMatchOneGroup(GroupId groupId,
                                  boolean isUrgent,
                                  GlobalStateMgr globalStateMgr,
                                  ColocateTableIndex colocateIndex,
@@ -725,12 +727,12 @@ public class ColocateTableBalancer extends FrontendDaemon {
         List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
         Database db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(groupId.dbId);
         if (db == null) {
-            return lockTotalTime;
+            return new ColocateMatchResult(lockTotalTime, false);
         }
 
         List<Set<Long>> backendBucketsSeq = colocateIndex.getBackendsPerBucketSeqSet(groupId);
         if (backendBucketsSeq.isEmpty()) {
-            return lockTotalTime;
+            return new ColocateMatchResult(lockTotalTime, false);
         }
 
         boolean isGroupStable = true;
@@ -769,7 +771,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                         locker.lockDatabase(db, LockType.READ);
                         lockStart = System.nanoTime();
                         if (globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(groupId.dbId) == null) {
-                            return lockTotalTime;
+                            return new ColocateMatchResult(lockTotalTime, false);
                         }
                         if (globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, olapTable.getId()) == null) {
                             continue TABLE;
@@ -880,28 +882,22 @@ public class ColocateTableBalancer extends FrontendDaemon {
                 } // end for partitions
             } // end for tables
 
-            // mark group as stable or unstable
-            if (isGroupStable) {
-                colocateIndex.markGroupStable(groupId, true);
-            } else {
-                colocateIndex.markGroupUnstable(groupId, true);
-            }
         } finally {
             lockTotalTime += System.nanoTime() - lockStart;
             locker.unLockDatabase(db, LockType.READ);
         }
 
-        return lockTotalTime - waitTotalTimeMs * 1000000;
+        return new ColocateMatchResult(lockTotalTime - waitTotalTimeMs * 1000000, isGroupStable);
     }
 
-    private long matchOneGroupUrgent(GroupId groupId,
+    private ColocateMatchResult matchOneGroupUrgent(GroupId groupId,
                                      GlobalStateMgr globalStateMgr,
                                      ColocateTableIndex colocateIndex,
                                      TabletScheduler tabletScheduler) {
         return doMatchOneGroup(groupId, true, globalStateMgr, colocateIndex, tabletScheduler);
     }
 
-    private long matchOneGroupNonUrgent(GroupId groupId,
+    private ColocateMatchResult matchOneGroupNonUrgent(GroupId groupId,
                                         GlobalStateMgr globalStateMgr,
                                         ColocateTableIndex colocateIndex,
                                         TabletScheduler tabletScheduler) {
@@ -923,8 +919,17 @@ public class ColocateTableBalancer extends FrontendDaemon {
         // check each group
         Set<GroupId> groupIds = colocateIndex.getAllGroupIds();
         for (GroupId groupId : groupIds) {
-            lockTotalTime += matchOneGroupUrgent(groupId, globalStateMgr, colocateIndex, tabletScheduler);
-            lockTotalTime += matchOneGroupNonUrgent(groupId, globalStateMgr, colocateIndex, tabletScheduler);
+            ColocateMatchResult urgentResult = matchOneGroupUrgent(groupId, globalStateMgr, colocateIndex, tabletScheduler);
+            lockTotalTime += urgentResult.lockTotalTime;
+
+            ColocateMatchResult nonUrgentResult = matchOneGroupNonUrgent(groupId, globalStateMgr, colocateIndex, tabletScheduler);
+            lockTotalTime += nonUrgentResult.lockTotalTime;
+
+            if (urgentResult.isGroupStable && nonUrgentResult.isGroupStable) {
+                colocateIndex.markGroupStable(groupId, true);
+            } else {
+                colocateIndex.markGroupUnstable(groupId, true);
+            }
         } // end for groups
 
         long cost = (System.nanoTime() - start) / 1000000;

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/ColocateMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/ColocateMetaService.java
@@ -295,7 +295,7 @@ public class ColocateMetaService {
     public static class BucketSeqAction extends ColocateMetaBaseAction {
         private static final Logger LOG = LogManager.getLogger(BucketSeqAction.class);
 
-        BucketSeqAction(ActionController controller) {
+        public BucketSeqAction(ActionController controller) {
             super(controller);
         }
 
@@ -353,7 +353,7 @@ public class ColocateMetaService {
             sendResult(request, response);
         }
 
-        private void updateBackendPerBucketSeq(GroupId groupId, List<List<Long>> backendsPerBucketSeq) {
+        public void updateBackendPerBucketSeq(GroupId groupId, List<List<Long>> backendsPerBucketSeq) {
             colocateIndex.addBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
             ColocatePersistInfo info2 =
                     ColocatePersistInfo.createForBackendsPerBucketSeq(groupId, backendsPerBucketSeq);

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/ColocateMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/ColocateMetaService.java
@@ -358,6 +358,7 @@ public class ColocateMetaService {
             ColocatePersistInfo info2 =
                     ColocatePersistInfo.createForBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
             GlobalStateMgr.getCurrentState().getEditLog().logColocateBackendsPerBucketSeq(info2);
+            colocateIndex.markGroupUnstable(groupId, true);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/ColocateMetaServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ColocateMetaServiceTest.java
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.http.meta.ColocateMetaService;
+import com.starrocks.persist.ColocatePersistInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ColocateMetaServiceTest {
+
+    @Test
+    public void testUpdateBackendPerBucketSeq(@Mocked EditLog editLog) {
+        new Expectations() {
+            {
+                editLog.logColocateBackendsPerBucketSeq((ColocatePersistInfo) any);
+                minTimes = 0;
+
+                editLog.logColocateMarkUnstable((ColocatePersistInfo) any);
+                minTimes = 0;
+            }
+        };
+
+        GlobalStateMgr.getCurrentState().setEditLog(editLog);
+        ColocateMetaService.BucketSeqAction action = new ColocateMetaService.BucketSeqAction(null);
+        List<List<Long>> seqs = new ArrayList<>();
+        seqs.add(Lists.newArrayList(1000L));
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(111, 222);
+        action.updateBackendPerBucketSeq(groupId, seqs);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/ColocateMetaServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ColocateMetaServiceTest.java
@@ -21,10 +21,7 @@ import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
 import mockit.Mocked;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;


### PR DESCRIPTION
## Why I'm doing:
The stability check of a group is divided into two parts: one part is to check the urgent table, and the other part is to check the non-urgent table. Stability should depend on all tables, not just some of them.

## What I'm doing:
1. If the results for both the urgent and non-urgent tables are stable, the group is marked as stable.
2. Once the backend sequence changes,  mark the group as unstable.

Fixes #SSU-1591

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
