### PR TITLE
[Enhancement] support prune generate column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -537,7 +537,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (generatedColumnExpr == null) {
             return null;
         }
-        return generatedColumnExpr.convertToColumnNameExpr(schema).clone();
+        Expr res = generatedColumnExpr.convertToColumnNameExpr(schema).clone();
+        res.setType(type);
+        return res;
     }
 
     public void setGeneratedColumnExpr(ColumnIdExpr expr) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -121,6 +121,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
@@ -146,6 +147,10 @@ public class ExpressionAnalyzer {
 
     public void analyzeIgnoreSlot(Expr expression, AnalyzeState analyzeState, Scope scope) {
         IgnoreSlotVisitor visitor = new IgnoreSlotVisitor(analyzeState, session);
+        bottomUpAnalyze(visitor, expression, scope);
+    }
+
+    public void analyzeWithVisitor(Expr expression, AnalyzeState analyzeState, Scope scope, Visitor visitor) {
         bottomUpAnalyze(visitor, expression, scope);
     }
 
@@ -2057,6 +2062,23 @@ public class ExpressionAnalyzer {
         }
     }
 
+    static class ResolveSlotVisitor extends Visitor {
+
+        private java.util.function.Consumer<SlotRef> resolver;
+
+        public ResolveSlotVisitor(AnalyzeState state, ConnectContext session,
+                                  java.util.function.Consumer<SlotRef> slotResolver) {
+            super(state, session);
+            resolver = slotResolver;
+        }
+
+        @Override
+        public Void visitSlot(SlotRef node, Scope scope) {
+            resolver.accept(node);
+            return null;
+        }
+    }
+
     public static void analyzeExpression(Expr expression, AnalyzeState state, Scope scope, ConnectContext session) {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(session);
         expressionAnalyzer.analyze(expression, state, scope);
@@ -2068,5 +2090,14 @@ public class ExpressionAnalyzer {
                 new Scope(RelationId.anonymous(), new RelationFields()));
     }
 
+    public static void analyzeExpressionResolveSlot(Expr expression, ConnectContext session,
+                                                    Consumer<SlotRef> slotRefConsumer) {
+        ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(session);
+        AnalyzeState state = new AnalyzeState();
+        Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+
+        ResolveSlotVisitor visitor = new ResolveSlotVisitor(new AnalyzeState(), ConnectContext.get(), slotRefConsumer);
+        expressionAnalyzer.analyzeWithVisitor(expression, state, scope, visitor);
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -45,7 +45,7 @@ public class BinaryPredicateOperator extends PredicateOperator {
                     .put(BinaryType.GT, BinaryType.LE)
                     .build();
 
-    private final BinaryType type;
+    private BinaryType type;
 
     public BinaryPredicateOperator(BinaryType type, ScalarOperator... arguments) {
         super(OperatorType.BINARY, arguments);
@@ -57,6 +57,10 @@ public class BinaryPredicateOperator extends PredicateOperator {
         super(OperatorType.BINARY, arguments);
         this.type = type;
         Preconditions.checkState(arguments.size() == 2);
+    }
+
+    public void setBinaryType(BinaryType type) {
+        this.type = type;
     }
 
     public BinaryType getBinaryType() {
@@ -98,13 +102,14 @@ public class BinaryPredicateOperator extends PredicateOperator {
         if (getBinaryType() == BinaryType.NE) {
             return null;
         }
+        BinaryPredicateOperator result = (BinaryPredicateOperator) clone();
         if (getBinaryType() == BinaryType.LT) {
-            return new BinaryPredicateOperator(BinaryType.LE, getChildren());
+            result.setBinaryType(BinaryType.LE);
         }
         if (getBinaryType() == BinaryType.GT) {
-            return new BinaryPredicateOperator(BinaryType.GE, getChildren());
+            result.setBinaryType(BinaryType.GE);
         }
-        return (BinaryPredicateOperator) clone();
+        return result;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -89,6 +89,24 @@ public class BinaryPredicateOperator extends PredicateOperator {
         }
     }
 
+    /**
+     * For Non-Strict Monotonic function, we need to convert
+     * 1. > to >=, and < to <=
+     * 2. !=, not supported
+     */
+    public BinaryPredicateOperator normalizeNonStrictMonotonic() {
+        if (getBinaryType() == BinaryType.NE) {
+            return null;
+        }
+        if (getBinaryType() == BinaryType.LT) {
+            return new BinaryPredicateOperator(BinaryType.LE, getChildren());
+        }
+        if (getBinaryType() == BinaryType.GT) {
+            return new BinaryPredicateOperator(BinaryType.GE, getChildren());
+        }
+        return (BinaryPredicateOperator) clone();
+    }
+
     @Override
     public String toString() {
         return getChild(0).toString() + " " + type.toString() + " " + getChild(1).toString();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -403,7 +403,7 @@ public class OptExternalPartitionPruner {
         if (table instanceof HiveMetaStoreTable) {
             ListPartitionPruner partitionPruner =
                     new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions,
-                            scanOperatorPredicates.getPartitionConjuncts(), null, operator);
+                            scanOperatorPredicates.getPartitionConjuncts(), null);
             Collection<Long> selectedPartitionIds = partitionPruner.prune();
             if (selectedPartitionIds == null) {
                 selectedPartitionIds = scanOperatorPredicates.getIdToPartitionKey().keySet();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -403,7 +403,7 @@ public class OptExternalPartitionPruner {
         if (table instanceof HiveMetaStoreTable) {
             ListPartitionPruner partitionPruner =
                     new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions,
-                            scanOperatorPredicates.getPartitionConjuncts(), null);
+                            scanOperatorPredicates.getPartitionConjuncts(), null, operator);
             Collection<Long> selectedPartitionIds = partitionPruner.prune();
             if (selectedPartitionIds == null) {
                 selectedPartitionIds = scanOperatorPredicates.getIdToPartitionKey().keySet();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -348,8 +348,9 @@ public class OptOlapPartitionPruner {
         }
 
         List<ScalarOperator> scalarOperatorList = Utils.extractConjuncts(operator.getPredicate());
-        PartitionPruner partitionPruner = new ListPartitionPruner(columnToPartitionValuesMap,
-                columnToNullPartitions, scalarOperatorList, specifyPartitionIds, listPartitionInfo, operator);
+        ListPartitionPruner partitionPruner = new ListPartitionPruner(columnToPartitionValuesMap,
+                columnToNullPartitions, scalarOperatorList, specifyPartitionIds, listPartitionInfo);
+        partitionPruner.prepareDeduceExtraConjuncts(operator);
         try {
             List<Long> prune = partitionPruner.prune();
             if (prune == null && isTemporaryPartitionPrune) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -349,7 +349,7 @@ public class OptOlapPartitionPruner {
 
         List<ScalarOperator> scalarOperatorList = Utils.extractConjuncts(operator.getPredicate());
         PartitionPruner partitionPruner = new ListPartitionPruner(columnToPartitionValuesMap,
-                columnToNullPartitions, scalarOperatorList, specifyPartitionIds, listPartitionInfo);
+                columnToNullPartitions, scalarOperatorList, specifyPartitionIds, listPartitionInfo, operator);
         try {
             List<Long> prune = partitionPruner.prune();
             if (prune == null && isTemporaryPartitionPrune) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -209,6 +209,21 @@ public enum ScalarOperatorEvaluator {
         return root;
     }
 
+    public boolean isMonotonicFunction(CallOperator call) {
+        FunctionSignature signature;
+        if (call.getFunction() != null) {
+            Function fn = call.getFunction();
+            List<Type> argTypes = Arrays.asList(fn.getArgs());
+            signature = new FunctionSignature(fn.functionName().toUpperCase(), argTypes, fn.getReturnType());
+        } else {
+            List<Type> argTypes = call.getArguments().stream().map(ScalarOperator::getType).collect(Collectors.toList());
+            signature = new FunctionSignature(call.getFnName().toUpperCase(), argTypes, call.getType());
+        }
+
+        FunctionInvoker invoker = functions.get(signature);
+
+        return invoker != null && invoker.isMonotonic;
+    }
 
     private boolean isMonotonicFunc(FunctionInvoker invoker, CallOperator operator) {
         if (!invoker.isMonotonic) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -53,6 +53,10 @@ public class ScalarOperatorRewriter {
             ConsolidateLikesRule.INSTANCE
     );
 
+    public static final List<ScalarOperatorRewriteRule> FOLD_CONSTANT_RULES = Lists.newArrayList(
+            new FoldConstantsRule()
+    );
+
     private static final List<ScalarOperatorRewriteRule> CASE_WHEN_PREDICATE_RULE = Lists.newArrayList(
             SimplifiedCaseWhenRule.INSTANCE,
             PruneTediousPredicateRule.INSTANCE

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -320,7 +320,10 @@ public class ListPartitionPruner implements PartitionPruner {
 
             @Override
             public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator operator, Void context) {
-                ScalarOperator result = operator.clone();
+                BinaryPredicateOperator result = operator.normalizeNonStrictMonotonic();
+                if (result == null) {
+                    return null;
+                }
                 result.setChild(0, generatedColumn);
                 result.setChild(1, replaceExpr(1));
                 return result;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
@@ -98,7 +98,7 @@ public class ListPartitionPrunerTest {
         columnToNullPartitions.put(intColumn, Sets.newHashSet(9L));
 
         conjuncts = Lists.newArrayList();
-        pruner = new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions, conjuncts, null);
+        pruner = new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions, conjuncts, null, null);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -192,8 +192,8 @@ public class PartitionPruneTest extends PlanTestBase {
     @Test
     public void testGeneratedColumnPrune() throws Exception {
         // c2
-//        starRocksAssert.query("select * from t_gen_col where c2 = 1 ")
-//                .explainContains("partitions=3/7");
+        starRocksAssert.query("select * from t_gen_col where c2 = 1 ")
+                .explainContains("partitions=3/7");
 
         // c1
         starRocksAssert.query("select * from t_gen_col where c1 = '2024-01-01' ")
@@ -201,9 +201,33 @@ public class PartitionPruneTest extends PlanTestBase {
         starRocksAssert.query("select * from t_gen_col where c1 = '2024-02-01' ")
                 .explainContains("partitions=2/7");
         starRocksAssert.query("select * from t_gen_col where c1 < '2024-02-01' ")
+                .explainContains("partitions=4/7");
+        starRocksAssert.query("select * from t_gen_col where c1 <= '2024-02-01' ")
+                .explainContains("partitions=4/7");
+        starRocksAssert.query("select * from t_gen_col where c1 > '2024-02-01' ")
+                .explainContains("partitions=4/7");
+        starRocksAssert.query("select * from t_gen_col where c1 >= '2024-02-01' ")
+                .explainContains("partitions=4/7");
+        starRocksAssert.query("select * from t_gen_col where c1 in ('2024-02-01') ")
+                .explainContains("partitions=2/7");
+        starRocksAssert.query("select * from t_gen_col where c1 in ('2024-02-01', '2024-01-01') ")
+                .explainContains("partitions=4/7");
+        starRocksAssert.query("select * from t_gen_col where c1 in ('2027-01-01') ")
+                .explainContains("partitions=0/7");
+        starRocksAssert.query("select * from t_gen_col where c1 != '2024-02-01' ")
+                .explainContains("partitions=7/7");
+
+        // compound
+        starRocksAssert.query("select * from t_gen_col where c1 >= '2024-02-01' and c1 <= '2024-03-01' ")
+                .explainContains("partitions=4/7");
+        starRocksAssert.query("select * from t_gen_col where c1 >= '2024-02-01' and c1 = '2027-03-01' ")
+                .explainContains("partitions=0/7");
+        starRocksAssert.query("select * from t_gen_col where c1 = '2024-02-01' or c1 = '2024-03-01' ")
+                .explainContains("partitions=4/7");
+        starRocksAssert.query("select * from t_gen_col where c1 = '2024-02-01' or c1 = '2027-03-01' ")
                 .explainContains("partitions=2/7");
 
-        // c1 & c2
+        // c1 && c2
         starRocksAssert.query("select * from t_gen_col where c1 = '2024-01-01' and c2 = 1 ")
                 .explainContains("partitions=1/7");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -192,8 +192,8 @@ public class PartitionPruneTest extends PlanTestBase {
     @Test
     public void testGeneratedColumnPrune() throws Exception {
         // c2
-        starRocksAssert.query("select * from t_gen_col where c2 = 1 ")
-                .explainContains("partitions=3/7");
+//        starRocksAssert.query("select * from t_gen_col where c2 = 1 ")
+//                .explainContains("partitions=3/7");
 
         // c1
         starRocksAssert.query("select * from t_gen_col where c1 = '2024-01-01' ")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -46,6 +46,7 @@ public class PartitionPruneTest extends PlanTestBase {
                 + "\"in_memory\" = \"false\"\n"
                 + ");");
 
+        // date_trunc('month', c1)
         starRocksAssert.withTable("CREATE TABLE t_gen_col (" +
                 " c1 datetime NOT NULL," +
                 " c2 bigint," +
@@ -60,6 +61,17 @@ public class PartitionPruneTest extends PlanTestBase {
         starRocksAssert.ddl("ALTER TABLE t_gen_col ADD PARTITION p2_202401 VALUES IN (('2', '2024-01-01'))");
         starRocksAssert.ddl("ALTER TABLE t_gen_col ADD PARTITION p2_202402 VALUES IN (('2', '2024-02-01'))");
         starRocksAssert.ddl("ALTER TABLE t_gen_col ADD PARTITION p2_202403 VALUES IN (('2', '2024-03-01'))");
+
+        // year(c1)
+        starRocksAssert.withTable("CREATE TABLE t_gen_col_1 (" +
+                " c1 datetime NOT NULL," +
+                " c2 bigint," +
+                " c3 tinyint NULL AS month(c1) " +
+                " ) " +
+                " DUPLICATE KEY(c1) " +
+                " PARTITION BY (c2, c3) " +
+                " PROPERTIES('replication_num'='1')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_col_1 ADD PARTITION p1_01 VALUES IN (('1', '1'))");
     }
 
     @Test
@@ -192,43 +204,55 @@ public class PartitionPruneTest extends PlanTestBase {
     @Test
     public void testGeneratedColumnPrune() throws Exception {
         // c2
-        starRocksAssert.query("select * from t_gen_col where c2 = 1 ")
+        starRocksAssert.query("select count(*) from t_gen_col where c2 = 1 ")
                 .explainContains("partitions=3/7");
 
         // c1
-        starRocksAssert.query("select * from t_gen_col where c1 = '2024-01-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-01-01' ")
                 .explainContains("partitions=2/7");
-        starRocksAssert.query("select * from t_gen_col where c1 = '2024-02-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-02-01' ")
                 .explainContains("partitions=2/7");
-        starRocksAssert.query("select * from t_gen_col where c1 < '2024-02-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 < '2024-02-01' ")
                 .explainContains("partitions=4/7");
-        starRocksAssert.query("select * from t_gen_col where c1 <= '2024-02-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 <= '2024-02-01' ")
                 .explainContains("partitions=4/7");
-        starRocksAssert.query("select * from t_gen_col where c1 > '2024-02-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 > '2024-02-01' ")
                 .explainContains("partitions=4/7");
-        starRocksAssert.query("select * from t_gen_col where c1 >= '2024-02-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 >= '2024-02-01' ")
                 .explainContains("partitions=4/7");
-        starRocksAssert.query("select * from t_gen_col where c1 in ('2024-02-01') ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 in ('2024-02-01') ")
                 .explainContains("partitions=2/7");
-        starRocksAssert.query("select * from t_gen_col where c1 in ('2024-02-01', '2024-01-01') ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 in ('2024-02-01', '2024-01-01') ")
                 .explainContains("partitions=4/7");
-        starRocksAssert.query("select * from t_gen_col where c1 in ('2027-01-01') ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 in ('2027-01-01') ")
                 .explainContains("partitions=0/7");
-        starRocksAssert.query("select * from t_gen_col where c1 != '2024-02-01' ")
+
+        // c1 not supported
+        starRocksAssert.query("select count(*) from t_gen_col where c1 != '2024-02-01' ")
+                .explainContains("partitions=7/7");
+        starRocksAssert.query("select count(*) from t_gen_col where c1 = c2 ")
+                .explainContains("partitions=7/7");
+        starRocksAssert.query("select count(*) from t_gen_col where date_trunc('year', c1) = '2024-02-01' ")
+                .explainContains("partitions=7/7");
+        starRocksAssert.query("select count(*) from t_gen_col where date_trunc('year', c1) = '2024-02-01' ")
                 .explainContains("partitions=7/7");
 
         // compound
-        starRocksAssert.query("select * from t_gen_col where c1 >= '2024-02-01' and c1 <= '2024-03-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 >= '2024-02-01' and c1 <= '2024-03-01' ")
                 .explainContains("partitions=4/7");
-        starRocksAssert.query("select * from t_gen_col where c1 >= '2024-02-01' and c1 = '2027-03-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 >= '2024-02-01' and c1 = '2027-03-01' ")
                 .explainContains("partitions=0/7");
-        starRocksAssert.query("select * from t_gen_col where c1 = '2024-02-01' or c1 = '2024-03-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-02-01' or c1 = '2024-03-01' ")
                 .explainContains("partitions=4/7");
-        starRocksAssert.query("select * from t_gen_col where c1 = '2024-02-01' or c1 = '2027-03-01' ")
+        starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-02-01' or c1 = '2027-03-01' ")
                 .explainContains("partitions=2/7");
 
         // c1 && c2
         starRocksAssert.query("select * from t_gen_col where c1 = '2024-01-01' and c2 = 1 ")
                 .explainContains("partitions=1/7");
+
+        // non-monotonic function
+        starRocksAssert.query("select count(*) from t_gen_col_1 where c1 = '2024-01-01' ")
+                .explainContains("partitions=2/2");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Give a table and query:
```
CREATE TABLE t1(
  c1 datetime,
  c2 int,
  c3 DATE AS date_trunc('month', c1)
)
PARTITION BY (c3);

select * from t1 where c1 = '2024-01-01'
```

In this case:
- `c1` is the query column, `c3=date_trunc('month', c1)` is the partition column
- So if the predicate is `c1='2024-01-01'`, we can deduce another predicate `c3=date_trunc('month', '2024-01-01')` to allow for partition pruning


## What I'm doing:
- Support partition pruning for partition by GeneratedColumn
- Notes
  - Only support monotonic function in the GeneratedColumn
  - Only support BinaryPredicate and InPredicate


`Strict Monotonic` and `Non-Strict Monotonic` 
- `Strict Monotonic` means: `if x > y, f(x) > f(y)`
- `Non-Strict Monotonic` means: `if x > y, f(x) >= f(y)`
- E.g. `2024-01-02 > 2024-01-01`, but `date_trunc('month', '2024-01-02') == date_trunc('month', '2024-01--1')`
- A `monotonic` ScalarFunctions in StarRocks actually mean `Non-Strict Monotonic` 
- So we will convert `>` to `>=` when building the predicate


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
