### PR TITLE
[Enhancement] Inject error in S3 & HDFS output stream

### DIFF
--- a/be/src/util/failpoint/fail_point.cpp
+++ b/be/src/util/failpoint/fail_point.cpp
@@ -189,5 +189,6 @@ FailPointRegisterer::FailPointRegisterer(FailPoint* fp) {
 }
 
 DEFINE_FAIL_POINT(random_error);
+DEFINE_FAIL_POINT(output_stream_io_error);
 
 } // namespace starrocks::failpoint

--- a/test/sql/test_sink/R/test_fault_injection_hdfs
+++ b/test/sql/test_sink/R/test_fault_injection_hdfs
@@ -63,7 +63,7 @@ admin disable failpoint 'output_stream_io_error';
 -- result:
 []
 -- !result
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
 1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
 1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
@@ -158,7 +158,7 @@ admin disable failpoint 'output_stream_io_error';
 -- result:
 []
 -- !result
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
 1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
 1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
@@ -253,7 +253,7 @@ admin disable failpoint 'output_stream_io_error';
 -- result:
 []
 -- !result
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
 1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
 1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe

--- a/test/sql/test_sink/R/test_fault_injection_hdfs
+++ b/test/sql/test_sink/R/test_fault_injection_hdfs
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection
+-- name: test_sink_parquet_fault_injection_hdfs
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -93,7 +93,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_orc_fault_injection
+-- name: test_sink_orc_fault_injection_hdfs
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -112,10 +112,13 @@ create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} p
 )
 as select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
-    "format" = "parquet"
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, "Access storage error. Error message: Aliyun OSS endpoint should not be null or empty. Please set proper endpoint with 'fs.oss.endpoint'.")
+[]
 -- !result
 admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 -- result:
@@ -129,7 +132,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911dfc231594771a804afbe280f1daa is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 [UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
@@ -139,7 +142,7 @@ E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911df
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911dfc231594771a804afbe280f1daa is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 [UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
@@ -149,7 +152,7 @@ E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911df
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911dfc231594771a804afbe280f1daa is not found.')
+[]
 -- !result
 admin disable failpoint 'output_stream_io_error';
 -- result:
@@ -157,11 +160,20 @@ admin disable failpoint 'output_stream_io_error';
 -- !result
 select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_db_2911dfc231594771a804afbe280f1daa.hive_sink_table_2911dfc231594771a804afbe280f1daa'.")
+1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
+1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
+1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
+1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
+1172038	186063	1100	2	14.000000000	16086.840000000	0.020000000	0E-9	R	F	1994-06-11	1994-08-06	1994-06-29	NONE	SHIP	hrough the carefully ironic foxes. depths
+1172038	186063	1100	2	14.000000000	16086.840000000	0.020000000	0E-9	R	F	1994-06-11	1994-08-06	1994-06-29	NONE	SHIP	hrough the carefully ironic foxes. depths
+1172039	16549	4053	4	6.000000000	8793.240000000	0.100000000	0.010000000	R	F	1992-04-02	1992-02-26	1992-04-04	NONE	SHIP	te. ironic, regular requests boos
+1172039	16549	4053	4	6.000000000	8793.240000000	0.100000000	0.010000000	R	F	1992-04-02	1992-02-26	1992-04-04	NONE	SHIP	te. ironic, regular requests boos
+1172039	122410	7435	1	45.000000000	64458.450000000	0.060000000	0.070000000	A	F	1992-05-01	1992-02-15	1992-05-08	TAKE BACK RETURN	TRUCK	leep carefully al
+1172039	122410	7435	1	45.000000000	64458.450000000	0.060000000	0.070000000	A	F	1992-05-01	1992-02-15	1992-05-08	TAKE BACK RETURN	TRUCK	leep carefully al
 -- !result
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_table_2911dfc231594771a804afbe280f1daa'.")
+[]
 -- !result
 drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
 -- result:
@@ -176,7 +188,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_textfile_fault_injection
+-- name: test_sink_textfile_fault_injection_hdfs
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -195,10 +207,13 @@ create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} p
 )
 as select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
-    "format" = "parquet"
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, "Access storage error. Error message: Aliyun OSS endpoint should not be null or empty. Please set proper endpoint with 'fs.oss.endpoint'.")
+[]
 -- !result
 admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 -- result:
@@ -212,7 +227,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55 is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 [UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
@@ -222,7 +237,7 @@ E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55 is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 [UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
@@ -232,7 +247,7 @@ E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55 is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 admin disable failpoint 'output_stream_io_error';
 -- result:
@@ -240,11 +255,20 @@ admin disable failpoint 'output_stream_io_error';
 -- !result
 select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_db_a9bb1b3e0d6b4709aa3870e33a39ae55.hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55'.")
+1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
+1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
+1172038	186063	1100	2	14.000000000	16086.840000000	0.020000000	0E-9	R	F	1994-06-11	1994-08-06	1994-06-29	NONE	SHIP	hrough the carefully ironic foxes. depths
+1172039	16549	4053	4	6.000000000	8793.240000000	0.100000000	0.010000000	R	F	1992-04-02	1992-02-26	1992-04-04	NONE	SHIP	te. ironic, regular requests boos
+1172039	122410	7435	1	45.000000000	64458.450000000	0.060000000	0.070000000	A	F	1992-05-01	1992-02-15	1992-05-08	TAKE BACK RETURN	TRUCK	leep carefully al
+1172039	130745	8285	3	8.000000000	14205.920000000	0.020000000	0.010000000	R	F	1992-03-08	1992-03-07	1992-03-19	DELIVER IN PERSON	RAIL	nstructions. special, idle requests lose 
+1172039	139010	9011	2	16.000000000	16784.160000000	0.050000000	0E-9	R	F	1992-02-25	1992-03-02	1992-03-14	COLLECT COD	TRUCK	 the carefully silent deposits
+1172064	22210	2211	2	39.000000000	44156.190000000	0.040000000	0.010000000	A	F	1995-01-18	1994-12-24	1995-02-13	DELIVER IN PERSON	MAIL	 quickly unusual requests. regular instru
+1172064	32655	5159	1	19.000000000	30165.350000000	0.060000000	0.060000000	R	F	1994-12-08	1995-02-10	1994-12-12	TAKE BACK RETURN	RAIL	s are carefully express, final packag
+1172064	77399	9907	3	49.000000000	67443.110000000	0.060000000	0.010000000	A	F	1995-03-22	1995-02-14	1995-04-18	TAKE BACK RETURN	RAIL	gle. even dependencies a
 -- !result
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55'.")
+[]
 -- !result
 drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
 -- result:

--- a/test/sql/test_sink/R/test_fault_injection_hdfs
+++ b/test/sql/test_sink/R/test_fault_injection_hdfs
@@ -1,0 +1,261 @@
+-- name: test_sink_parquet_fault_injection
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+create external catalog hive_sink_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+-- result:
+[]
+-- !result
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "parquet"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+[]
+-- !result
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+-- result:
+[]
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+admin disable failpoint 'output_stream_io_error';
+-- result:
+[]
+-- !result
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+-- result:
+1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
+1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
+1172038	186063	1100	2	14.000000000	16086.840000000	0.020000000	0E-9	R	F	1994-06-11	1994-08-06	1994-06-29	NONE	SHIP	hrough the carefully ironic foxes. depths
+1172039	16549	4053	4	6.000000000	8793.240000000	0.100000000	0.010000000	R	F	1992-04-02	1992-02-26	1992-04-04	NONE	SHIP	te. ironic, regular requests boos
+1172039	122410	7435	1	45.000000000	64458.450000000	0.060000000	0.070000000	A	F	1992-05-01	1992-02-15	1992-05-08	TAKE BACK RETURN	TRUCK	leep carefully al
+1172039	130745	8285	3	8.000000000	14205.920000000	0.020000000	0.010000000	R	F	1992-03-08	1992-03-07	1992-03-19	DELIVER IN PERSON	RAIL	nstructions. special, idle requests lose 
+1172039	139010	9011	2	16.000000000	16784.160000000	0.050000000	0E-9	R	F	1992-02-25	1992-03-02	1992-03-14	COLLECT COD	TRUCK	 the carefully silent deposits
+1172064	22210	2211	2	39.000000000	44156.190000000	0.040000000	0.010000000	A	F	1995-01-18	1994-12-24	1995-02-13	DELIVER IN PERSON	MAIL	 quickly unusual requests. regular instru
+1172064	32655	5159	1	19.000000000	30165.350000000	0.060000000	0.060000000	R	F	1994-12-08	1995-02-10	1994-12-12	TAKE BACK RETURN	RAIL	s are carefully express, final packag
+1172064	77399	9907	3	49.000000000	67443.110000000	0.060000000	0.010000000	A	F	1995-03-22	1995-02-14	1995-04-18	TAKE BACK RETURN	RAIL	gle. even dependencies a
+-- !result
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+-- result:
+[]
+-- !result
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog hive_sink_${uuid0};
+-- result:
+[]
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+-- name: test_sink_orc_fault_injection
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+create external catalog hive_sink_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+-- result:
+[]
+-- !result
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "orc"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet"
+);
+-- result:
+E: (1064, "Access storage error. Error message: Aliyun OSS endpoint should not be null or empty. Please set proper endpoint with 'fs.oss.endpoint'.")
+-- !result
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+-- result:
+[]
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911dfc231594771a804afbe280f1daa is not found.')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911dfc231594771a804afbe280f1daa is not found.')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_2911dfc231594771a804afbe280f1daa is not found.')
+-- !result
+admin disable failpoint 'output_stream_io_error';
+-- result:
+[]
+-- !result
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_db_2911dfc231594771a804afbe280f1daa.hive_sink_table_2911dfc231594771a804afbe280f1daa'.")
+-- !result
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_table_2911dfc231594771a804afbe280f1daa'.")
+-- !result
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog hive_sink_${uuid0};
+-- result:
+[]
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+-- name: test_sink_textfile_fault_injection
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+create external catalog hive_sink_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+-- result:
+[]
+-- !result
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "textfile"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet"
+);
+-- result:
+E: (1064, "Access storage error. Error message: Aliyun OSS endpoint should not be null or empty. Please set proper endpoint with 'fs.oss.endpoint'.")
+-- !result
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+-- result:
+[]
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55 is not found.')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55 is not found.')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55 is not found.')
+-- !result
+admin disable failpoint 'output_stream_io_error';
+-- result:
+[]
+-- !result
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_db_a9bb1b3e0d6b4709aa3870e33a39ae55.hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55'.")
+-- !result
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_table_a9bb1b3e0d6b4709aa3870e33a39ae55'.")
+-- !result
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog hive_sink_${uuid0};
+-- result:
+[]
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_sink/R/test_fault_injection_hdfs
+++ b/test/sql/test_sink/R/test_fault_injection_hdfs
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection_hdfs
+-- name: test_sink_parquet_fault_injection_hdfs @sequential
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -93,7 +93,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_orc_fault_injection_hdfs
+-- name: test_sink_orc_fault_injection_hdfs @sequential
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -188,7 +188,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_textfile_fault_injection_hdfs
+-- name: test_sink_textfile_fault_injection_hdfs @sequential
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0

--- a/test/sql/test_sink/R/test_fault_injection_oss
+++ b/test/sql/test_sink/R/test_fault_injection_oss
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection
+-- name: test_sink_parquet_fault_injection_oss
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -101,7 +101,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_orc_fault_injection
+-- name: test_sink_orc_fault_injection_oss
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -128,10 +128,13 @@ create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} p
 )
 as select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
-    "format" = "parquet"
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, "Access storage error. Error message: Aliyun OSS endpoint should not be null or empty. Please set proper endpoint with 'fs.oss.endpoint'.")
+[]
 -- !result
 admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 -- result:
@@ -145,7 +148,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0 is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 [UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
@@ -155,7 +158,7 @@ E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b29
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0 is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 [UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
@@ -165,7 +168,7 @@ E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b29
     "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0 is not found.')
+E: (5025, 'injected output_stream_io_error')
 -- !result
 admin disable failpoint 'output_stream_io_error';
 -- result:
@@ -173,11 +176,20 @@ admin disable failpoint 'output_stream_io_error';
 -- !result
 select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_db_e55b2904765c469d85ebe9ca59ad2df0.hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0'.")
+1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
+1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
+1172038	186063	1100	2	14.000000000	16086.840000000	0.020000000	0E-9	R	F	1994-06-11	1994-08-06	1994-06-29	NONE	SHIP	hrough the carefully ironic foxes. depths
+1172039	16549	4053	4	6.000000000	8793.240000000	0.100000000	0.010000000	R	F	1992-04-02	1992-02-26	1992-04-04	NONE	SHIP	te. ironic, regular requests boos
+1172039	122410	7435	1	45.000000000	64458.450000000	0.060000000	0.070000000	A	F	1992-05-01	1992-02-15	1992-05-08	TAKE BACK RETURN	TRUCK	leep carefully al
+1172039	130745	8285	3	8.000000000	14205.920000000	0.020000000	0.010000000	R	F	1992-03-08	1992-03-07	1992-03-19	DELIVER IN PERSON	RAIL	nstructions. special, idle requests lose 
+1172039	139010	9011	2	16.000000000	16784.160000000	0.050000000	0E-9	R	F	1992-02-25	1992-03-02	1992-03-14	COLLECT COD	TRUCK	 the carefully silent deposits
+1172064	22210	2211	2	39.000000000	44156.190000000	0.040000000	0.010000000	A	F	1995-01-18	1994-12-24	1995-02-13	DELIVER IN PERSON	MAIL	 quickly unusual requests. regular instru
+1172064	32655	5159	1	19.000000000	30165.350000000	0.060000000	0.060000000	R	F	1994-12-08	1995-02-10	1994-12-12	TAKE BACK RETURN	RAIL	s are carefully express, final packag
+1172064	77399	9907	3	49.000000000	67443.110000000	0.060000000	0.010000000	A	F	1995-03-22	1995-02-14	1995-04-18	TAKE BACK RETURN	RAIL	gle. even dependencies a
 -- !result
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0'.")
+[]
 -- !result
 drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
 -- result:
@@ -192,7 +204,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_textfile_fault_injection
+-- name: test_sink_textfile_fault_injection_oss
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0

--- a/test/sql/test_sink/R/test_fault_injection_oss
+++ b/test/sql/test_sink/R/test_fault_injection_oss
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection_oss
+-- name: test_sink_parquet_fault_injection_oss @sequential
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -101,7 +101,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_orc_fault_injection_oss
+-- name: test_sink_orc_fault_injection_oss @sequential
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0
@@ -204,7 +204,7 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0
 0
 
 -- !result
--- name: test_sink_textfile_fault_injection_oss
+-- name: test_sink_textfile_fault_injection_oss @sequential
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 -- result:
 0

--- a/test/sql/test_sink/R/test_fault_injection_oss
+++ b/test/sql/test_sink/R/test_fault_injection_oss
@@ -1,0 +1,298 @@
+-- name: test_sink_parquet_fault_injection
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+create external catalog hive_sink_${uuid0} PROPERTIES (
+    "type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+[]
+-- !result
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}"
+);
+-- result:
+[]
+-- !result
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "parquet"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+[]
+-- !result
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+-- result:
+[]
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+admin disable failpoint 'output_stream_io_error';
+-- result:
+[]
+-- !result
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+-- result:
+1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
+1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
+1172038	186063	1100	2	14.000000000	16086.840000000	0.020000000	0E-9	R	F	1994-06-11	1994-08-06	1994-06-29	NONE	SHIP	hrough the carefully ironic foxes. depths
+1172039	16549	4053	4	6.000000000	8793.240000000	0.100000000	0.010000000	R	F	1992-04-02	1992-02-26	1992-04-04	NONE	SHIP	te. ironic, regular requests boos
+1172039	122410	7435	1	45.000000000	64458.450000000	0.060000000	0.070000000	A	F	1992-05-01	1992-02-15	1992-05-08	TAKE BACK RETURN	TRUCK	leep carefully al
+1172039	130745	8285	3	8.000000000	14205.920000000	0.020000000	0.010000000	R	F	1992-03-08	1992-03-07	1992-03-19	DELIVER IN PERSON	RAIL	nstructions. special, idle requests lose 
+1172039	139010	9011	2	16.000000000	16784.160000000	0.050000000	0E-9	R	F	1992-02-25	1992-03-02	1992-03-14	COLLECT COD	TRUCK	 the carefully silent deposits
+1172064	22210	2211	2	39.000000000	44156.190000000	0.040000000	0.010000000	A	F	1995-01-18	1994-12-24	1995-02-13	DELIVER IN PERSON	MAIL	 quickly unusual requests. regular instru
+1172064	32655	5159	1	19.000000000	30165.350000000	0.060000000	0.060000000	R	F	1994-12-08	1995-02-10	1994-12-12	TAKE BACK RETURN	RAIL	s are carefully express, final packag
+1172064	77399	9907	3	49.000000000	67443.110000000	0.060000000	0.010000000	A	F	1995-03-22	1995-02-14	1995-04-18	TAKE BACK RETURN	RAIL	gle. even dependencies a
+-- !result
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+-- result:
+[]
+-- !result
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog hive_sink_${uuid0};
+-- result:
+[]
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+-- name: test_sink_orc_fault_injection
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+create external catalog hive_sink_${uuid0} PROPERTIES (
+    "type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+[]
+-- !result
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}"
+);
+-- result:
+[]
+-- !result
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "orc"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet"
+);
+-- result:
+E: (1064, "Access storage error. Error message: Aliyun OSS endpoint should not be null or empty. Please set proper endpoint with 'fs.oss.endpoint'.")
+-- !result
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+-- result:
+[]
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0 is not found.')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0 is not found.')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0 is not found.')
+-- !result
+admin disable failpoint 'output_stream_io_error';
+-- result:
+[]
+-- !result
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_db_e55b2904765c469d85ebe9ca59ad2df0.hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0'.")
+-- !result
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'hive_sink_table_e55b2904765c469d85ebe9ca59ad2df0'.")
+-- !result
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog hive_sink_${uuid0};
+-- result:
+[]
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+-- name: test_sink_textfile_fault_injection
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result
+create external catalog hive_sink_${uuid0} PROPERTIES (
+    "type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+[]
+-- !result
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}"
+);
+-- result:
+[]
+-- !result
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "textfile"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+    
+);
+-- result:
+[]
+-- !result
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+-- result:
+[]
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+-- result:
+E: (5025, 'injected output_stream_io_error')
+-- !result
+admin disable failpoint 'output_stream_io_error';
+-- result:
+[]
+-- !result
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+-- result:
+1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
+1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
+1172038	186063	1100	2	14.000000000	16086.840000000	0.020000000	0E-9	R	F	1994-06-11	1994-08-06	1994-06-29	NONE	SHIP	hrough the carefully ironic foxes. depths
+1172039	16549	4053	4	6.000000000	8793.240000000	0.100000000	0.010000000	R	F	1992-04-02	1992-02-26	1992-04-04	NONE	SHIP	te. ironic, regular requests boos
+1172039	122410	7435	1	45.000000000	64458.450000000	0.060000000	0.070000000	A	F	1992-05-01	1992-02-15	1992-05-08	TAKE BACK RETURN	TRUCK	leep carefully al
+1172039	130745	8285	3	8.000000000	14205.920000000	0.020000000	0.010000000	R	F	1992-03-08	1992-03-07	1992-03-19	DELIVER IN PERSON	RAIL	nstructions. special, idle requests lose 
+1172039	139010	9011	2	16.000000000	16784.160000000	0.050000000	0E-9	R	F	1992-02-25	1992-03-02	1992-03-14	COLLECT COD	TRUCK	 the carefully silent deposits
+1172064	22210	2211	2	39.000000000	44156.190000000	0.040000000	0.010000000	A	F	1995-01-18	1994-12-24	1995-02-13	DELIVER IN PERSON	MAIL	 quickly unusual requests. regular instru
+1172064	32655	5159	1	19.000000000	30165.350000000	0.060000000	0.060000000	R	F	1994-12-08	1995-02-10	1994-12-12	TAKE BACK RETURN	RAIL	s are carefully express, final packag
+1172064	77399	9907	3	49.000000000	67443.110000000	0.060000000	0.010000000	A	F	1995-03-22	1995-02-14	1995-04-18	TAKE BACK RETURN	RAIL	gle. even dependencies a
+-- !result
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+-- result:
+[]
+-- !result
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog hive_sink_${uuid0};
+-- result:
+[]
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_sink/R/test_fault_injection_oss
+++ b/test/sql/test_sink/R/test_fault_injection_oss
@@ -71,7 +71,7 @@ admin disable failpoint 'output_stream_io_error';
 -- result:
 []
 -- !result
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
 1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
 1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
@@ -174,7 +174,7 @@ admin disable failpoint 'output_stream_io_error';
 -- result:
 []
 -- !result
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
 1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
 1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe
@@ -278,7 +278,7 @@ admin disable failpoint 'output_stream_io_error';
 -- result:
 []
 -- !result
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 -- result:
 1172038	8214	8215	4	9.000000000	10099.890000000	0.100000000	0.060000000	A	F	1994-06-19	1994-07-18	1994-07-02	NONE	RAIL	 final packages cajole. fin
 1172038	148368	8369	3	40.000000000	56654.400000000	0.060000000	0.010000000	R	F	1994-06-15	1994-08-07	1994-07-10	DELIVER IN PERSON	MAIL	 along the carefully pe

--- a/test/sql/test_sink/T/test_fault_injection_hdfs
+++ b/test/sql/test_sink/T/test_fault_injection_hdfs
@@ -1,0 +1,161 @@
+-- name: test_sink_parquet_fault_injection
+
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+create external catalog hive_sink_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "parquet"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin disable failpoint 'output_stream_io_error';
+
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+drop catalog hive_sink_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+-- name: test_sink_orc_fault_injection
+
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+create external catalog hive_sink_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "orc"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet"
+);
+
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin disable failpoint 'output_stream_io_error';
+
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+drop catalog hive_sink_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+-- name: test_sink_textfile_fault_injection
+
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+create external catalog hive_sink_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "textfile"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet"
+);
+
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin disable failpoint 'output_stream_io_error';
+
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+drop catalog hive_sink_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null

--- a/test/sql/test_sink/T/test_fault_injection_hdfs
+++ b/test/sql/test_sink/T/test_fault_injection_hdfs
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection_hdfs
+-- name: test_sink_parquet_fault_injection_hdfs @sequential
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -54,7 +54,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_orc_fault_injection_hdfs
+-- name: test_sink_orc_fault_injection_hdfs @sequential
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -110,7 +110,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_textfile_fault_injection_hdfs
+-- name: test_sink_textfile_fault_injection_hdfs @sequential
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 

--- a/test/sql/test_sink/T/test_fault_injection_hdfs
+++ b/test/sql/test_sink/T/test_fault_injection_hdfs
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection
+-- name: test_sink_parquet_fault_injection_hdfs
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -54,7 +54,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_orc_fault_injection
+-- name: test_sink_orc_fault_injection_hdfs
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -66,7 +66,10 @@ create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} p
 )
 as select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
-    "format" = "parquet"
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 
 admin enable failpoint 'output_stream_io_error' with 0.5 probability;
@@ -107,7 +110,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_textfile_fault_injection
+-- name: test_sink_textfile_fault_injection_hdfs
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -119,7 +122,10 @@ create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} p
 )
 as select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
-    "format" = "parquet"
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 
 admin enable failpoint 'output_stream_io_error' with 0.5 probability;

--- a/test/sql/test_sink/T/test_fault_injection_hdfs
+++ b/test/sql/test_sink/T/test_fault_injection_hdfs
@@ -44,7 +44,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 
 admin disable failpoint 'output_stream_io_error';
 
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 
@@ -100,7 +100,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 
 admin disable failpoint 'output_stream_io_error';
 
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 
@@ -156,7 +156,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 
 admin disable failpoint 'output_stream_io_error';
 
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 

--- a/test/sql/test_sink/T/test_fault_injection_oss
+++ b/test/sql/test_sink/T/test_fault_injection_oss
@@ -1,0 +1,189 @@
+-- name: test_sink_parquet_fault_injection
+
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+create external catalog hive_sink_${uuid0} PROPERTIES (
+    "type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}"
+);
+
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "parquet"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin disable failpoint 'output_stream_io_error';
+
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+drop catalog hive_sink_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+-- name: test_sink_orc_fault_injection
+
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+create external catalog hive_sink_${uuid0} PROPERTIES (
+    "type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}"
+);
+
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "orc"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet"
+);
+
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin disable failpoint 'output_stream_io_error';
+
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+drop catalog hive_sink_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+-- name: test_sink_textfile_fault_injection
+
+shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
+
+create external catalog hive_sink_${uuid0} PROPERTIES (
+    "type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+create database hive_sink_${uuid0}.hive_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}"
+);
+
+create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} properties (
+    "file_format" = "textfile"
+)
+as select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+    
+);
+
+admin enable failpoint 'output_stream_io_error' with 0.5 probability;
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+[UC] insert into hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} select * from files (
+    "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
+);
+
+admin disable failpoint 'output_stream_io_error';
+
+select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+
+drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
+
+drop database hive_sink_${uuid0}.hive_sink_db_${uuid0};
+
+drop catalog hive_sink_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null

--- a/test/sql/test_sink/T/test_fault_injection_oss
+++ b/test/sql/test_sink/T/test_fault_injection_oss
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection_oss
+-- name: test_sink_parquet_fault_injection_oss @sequential
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -62,7 +62,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_orc_fault_injection_oss
+-- name: test_sink_orc_fault_injection_oss @sequential
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -126,7 +126,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_textfile_fault_injection_oss
+-- name: test_sink_textfile_fault_injection_oss @sequential
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 

--- a/test/sql/test_sink/T/test_fault_injection_oss
+++ b/test/sql/test_sink/T/test_fault_injection_oss
@@ -1,4 +1,4 @@
--- name: test_sink_parquet_fault_injection
+-- name: test_sink_parquet_fault_injection_oss
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -62,7 +62,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_orc_fault_injection
+-- name: test_sink_orc_fault_injection_oss
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
@@ -82,7 +82,10 @@ create table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} p
 )
 as select * from files (
     "path" = "oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet",
-    "format" = "parquet"
+    "format" = "parquet",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}"
 );
 
 admin enable failpoint 'output_stream_io_error' with 0.5 probability;
@@ -123,7 +126,7 @@ drop catalog hive_sink_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 
--- name: test_sink_textfile_fault_injection
+-- name: test_sink_textfile_fault_injection_oss
 
 shell: ossutil64 cp ./sql/test_across_engine/data/tpch_lineitem.parquet oss://${oss_bucket}/test_across_engine/test_sink/${uuid0}/tpch_lineitem.parquet > /dev/null
 

--- a/test/sql/test_sink/T/test_fault_injection_oss
+++ b/test/sql/test_sink/T/test_fault_injection_oss
@@ -52,7 +52,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 
 admin disable failpoint 'output_stream_io_error';
 
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 
@@ -116,7 +116,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 
 admin disable failpoint 'output_stream_io_error';
 
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 
@@ -181,7 +181,7 @@ admin enable failpoint 'output_stream_io_error' with 0.5 probability;
 
 admin disable failpoint 'output_stream_io_error';
 
-select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
+[UC] select * from hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} order by 1, 2, 3 limit 10;
 
 drop table hive_sink_${uuid0}.hive_sink_db_${uuid0}.hive_sink_table_${uuid0} force;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR utilized the injection framework introduced by https://github.com/StarRocks/starrocks/pull/23378. 

Define a new class of failpoint named `output_stream_io_error`, and inject into output stream of hdfs and s3.

Example:
```sql
admin enable failpoint 'output_stream_io_error' with 0.5 probability;
insert into target_table select * from source_table;
admin disable failpoint 'output_stream_io_error';
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
