### PR TITLE
[BugFix] Fix wrong result when enable spill preaggregation

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -926,7 +926,7 @@ Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk
         for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
             size_t id = _group_by_columns.size() + i;
             auto slot_id = slots[id]->id();
-            if (use_intermediate_as_input) {
+            if (_is_merge_funcs[i] || use_intermediate_as_input) {
                 DCHECK(i < _agg_input_columns.size() && _agg_input_columns[i].size() >= 1);
                 result_chunk->append_column(std::move(_agg_input_columns[i][0]), slot_id);
             } else {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -27,7 +27,11 @@
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
+#include "util/failpoint/fail_point.h"
 #include "util/race_detect.h"
+
+DEFINE_FAIL_POINT(spill_always_streaming);
+DEFINE_FAIL_POINT(spill_always_selection_streaming);
 
 namespace starrocks::pipeline {
 bool SpillableAggregateBlockingSinkOperator::need_input() const {
@@ -165,7 +169,25 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
     // goal: control buffered data memory usage, aggregate data as much as possible before spill
     // this strategy is similar to the LIMITED_MEM mode in agg streaming
 
-    if (_streaming_bytes + ht_mem_usage > max_mem_usage) {
+    bool always_streaming = false;
+    bool always_selection_streaming = false;
+
+    FAIL_POINT_TRIGGER_EXECUTE(spill_always_streaming, {
+        if (_aggregator->hash_map_variant().size() != 0) {
+            always_streaming = true;
+        }
+    });
+    FAIL_POINT_TRIGGER_EXECUTE(spill_always_selection_streaming, {
+        if (_aggregator->hash_map_variant().size() != 0) {
+            always_selection_streaming = true;
+        }
+    });
+
+    // if hash table don't need expand or it's still very small after expansion, just put all data into it
+    bool build_hash_table =
+            !ht_need_expansion || (ht_need_expansion && _streaming_bytes + ht_mem_usage * 2 <= max_mem_usage);
+    build_hash_table = build_hash_table && !always_selection_streaming;
+    if (_streaming_bytes + ht_mem_usage > max_mem_usage || always_streaming) {
         // if current memory usage exceeds limit,
         // use force streaming mode and spill all data
         SCOPED_TIMER(_aggregator->streaming_timer());
@@ -173,8 +195,7 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
         RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk.get(), &res));
         _add_streaming_chunk(res);
         return _spill_all_data(state, true);
-    } else if (!ht_need_expansion || (ht_need_expansion && _streaming_bytes + ht_mem_usage * 2 <= max_mem_usage)) {
-        // if hash table don't need expand or it's still very small after expansion, just put all data into it
+    } else if (build_hash_table) {
         SCOPED_TIMER(_aggregator->agg_compute_timer());
         TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());

--- a/test/sql/test_spill/R/test_spill_agg_streaming_strategy
+++ b/test/sql/test_spill/R/test_spill_agg_streaming_strategy
@@ -1,0 +1,58 @@
+-- name: test_spill_agg_streaming_strategy @sequential
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+set streaming_preaggregation_mode="force_streaming";
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+admin enable failpoint 'spill_always_streaming';
+-- result:
+-- !result
+select avg(k1) x from (select * from t1 union all select * from t1)t group by k2 order by x limit 10;
+-- result:
+1.0
+2.0
+3.0
+4.0
+5.0
+6.0
+7.0
+8.0
+9.0
+10.0
+-- !result
+admin disable failpoint 'spill_always_streaming';
+-- result:
+-- !result
+admin disable failpoint 'spill_always_selection_streaming';
+-- result:
+-- !result
+select avg(k1) x from (select * from t1 union all select * from t1)t group by k2 order by x limit 10;
+-- result:
+1.0
+2.0
+3.0
+4.0
+5.0
+6.0
+7.0
+8.0
+9.0
+10.0
+-- !result
+admin disable failpoint 'spill_always_selection_streaming';
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_agg_streaming_strategy
+++ b/test/sql/test_spill/T/test_spill_agg_streaming_strategy
@@ -1,0 +1,25 @@
+-- name: test_spill_agg_streaming_strategy @sequential
+
+set enable_spill=true;
+set spill_mode="force";
+set streaming_preaggregation_mode="force_streaming";
+
+CREATE TABLE t1 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+PROPERTIES('replication_num'='1');
+
+-- always streaming
+insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+
+-- set enable_agg_spill_preaggregation=false;
+
+admin enable failpoint 'spill_always_streaming';
+select avg(k1) x from (select * from t1 union all select * from t1)t group by k2 order by x limit 10;
+admin disable failpoint 'spill_always_streaming';
+
+admin disable failpoint 'spill_always_selection_streaming';
+select avg(k1) x from (select * from t1 union all select * from t1)t group by k2 order by x limit 10;
+admin disable failpoint 'spill_always_selection_streaming';
+


### PR DESCRIPTION
see test case test_spill_agg_streaming_strategy

## Why I'm doing:

```
    @     0x7effd3329e96 __assert_fail
    @          0xcd866f8 down_cast<>()
    @         0x1184ed88 starrocks::AvgAggregateFunction<>::convert_to_serialize_format()
    @         0x11dca990 starrocks::NullableAggregateFunctionBase<>::convert_to_serialize_format()
    @         0x1044eeab starrocks::Aggregator::output_chunk_by_streaming()
    @          0xff744dc starrocks::pipeline::SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto()
    @          0xff73428 starrocks::pipeline::SpillableAggregateBlockingSinkOperator::push_chunk()
    @          0xfe92539 starrocks::pipeline::PipelineDriver::process()
    @          0xfe494c9 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
