### PR TITLE
[BugFix] Fix forget erase the partition root directory for UnPartitioned table in share data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1393,6 +1393,12 @@ public class OlapTable extends Table {
                     partitionInfo.getReplicationNum(partition.getId()),
                     partitionInfo.getIsInMemory(partition.getId()),
                     partitionInfo.getDataCacheInfo(partition.getId()));
+        } else if (partitionInfo.isUnPartitioned()) {
+            return new RecycleUnPartitionInfo(dbId, id, partition,
+                    partitionInfo.getDataProperty(partition.getId()),
+                    partitionInfo.getReplicationNum(partition.getId()),
+                    partitionInfo.getIsInMemory(partition.getId()),
+                    partitionInfo.getDataCacheInfo(partition.getId()));
         } else {
             throw new RuntimeException("Unknown partition type: " + partitionInfo.getType());
         }
@@ -2768,10 +2774,7 @@ public class OlapTable extends Table {
         // drop source partition
         Partition srcPartition = nameToPartition.get(sourcePartitionName);
         if (srcPartition != null) {
-            idToPartition.remove(srcPartition.getId());
-            nameToPartition.remove(sourcePartitionName);
-            partitionInfo.dropPartition(srcPartition.getId());
-            GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(srcPartition);
+            dropPartition(-1, sourcePartitionName, true);
         }
 
         Partition partition = tempPartitions.getPartition(tempPartitionName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleUnPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleUnPartitionInfo.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.lake.DataCacheInfo;
+
+// This class is simply used as the Interface to trigger the background task
+// in CatalogRecycleBin
+public class RecycleUnPartitionInfo extends RecyclePartitionInfoV2 {
+    public RecycleUnPartitionInfo(long dbId, long tableId, Partition partition, DataProperty dataProperty,
+                                  short replicationNum, boolean isInMemory,
+                                  DataCacheInfo dataCacheInfo) {
+        super(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, dataCacheInfo);
+        setRecoverable(false);
+    }
+
+    @Override
+    public void recover(OlapTable table) throws DdlException {
+        throw new DdlException("Does not support recover unpartitioned");
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -240,6 +240,12 @@ public class LakeTable extends OlapTable {
                     partitionInfo.getReplicationNum(partition.getId()),
                     partitionInfo.getIsInMemory(partition.getId()),
                     partitionInfo.getDataCacheInfo(partition.getId()));
+        } else if (partitionInfo.isUnPartitioned()) {
+            return new RecycleLakeUnPartitionInfo(dbId, id, partition,
+                    partitionInfo.getDataProperty(partition.getId()),
+                    partitionInfo.getReplicationNum(partition.getId()),
+                    partitionInfo.getIsInMemory(partition.getId()),
+                    partitionInfo.getDataCacheInfo(partition.getId()));
         } else {
             throw new RuntimeException("Unknown partition type: " + partitionInfo.getType());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.staros.client.StarClientException;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.RecycleUnPartitionInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.Warehouse;
+
+// This class is simply used as the Interface to trigger the background task
+// in CatalogRecycleBin
+public class RecycleLakeUnPartitionInfo extends RecycleUnPartitionInfo {
+    public RecycleLakeUnPartitionInfo(long dbId, long tableId, Partition partition,
+                                        DataProperty dataProperty, short replicationNum,
+                                        boolean isInMemory, DataCacheInfo dataCacheInfo) {
+        super(dbId, tableId, partition, dataProperty, replicationNum, isInMemory, dataCacheInfo);
+    }
+
+    @Override
+    public boolean delete() {
+        if (isRecoverable()) {
+            setRecoverable(false);
+            GlobalStateMgr.getCurrentState().getEditLog().logDisablePartitionRecovery(partition.getId());
+        }
+        try {
+            WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            Warehouse warehouse = manager.getBackgroundWarehouse();
+            if (LakeTableHelper.removePartitionDirectory(partition, warehouse.getId())) {
+                GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
+                return true;
+            } else {
+                return false;
+            }
+        } catch (StarClientException e) {
+            return false;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -109,6 +109,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.RecycleListPartitionInfo;
 import com.starrocks.catalog.RecyclePartitionInfoV2;
 import com.starrocks.catalog.RecycleRangePartitionInfo;
+import com.starrocks.catalog.RecycleUnPartitionInfo;
 import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.catalog.ScalarType;
@@ -124,6 +125,7 @@ import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.RecycleLakeListPartitionInfo;
 import com.starrocks.lake.RecycleLakeRangePartitionInfo;
+import com.starrocks.lake.RecycleLakeUnPartitionInfo;
 import com.starrocks.lake.backup.LakeBackupJob;
 import com.starrocks.lake.backup.LakeRestoreJob;
 import com.starrocks.lake.backup.LakeTableSnapshotInfo;
@@ -296,7 +298,9 @@ public class GsonUtils {
             .registerSubtype(RecycleRangePartitionInfo.class, "RecycleRangePartitionInfo")
             .registerSubtype(RecycleLakeRangePartitionInfo.class, "RecycleLakeRangePartitionInfo")
             .registerSubtype(RecycleListPartitionInfo.class, "RecycleListPartitionInfo")
-            .registerSubtype(RecycleLakeListPartitionInfo.class, "RecycleLakeListPartitionInfo");
+            .registerSubtype(RecycleLakeListPartitionInfo.class, "RecycleLakeListPartitionInfo")
+            .registerSubtype(RecycleUnPartitionInfo.class, "RecycleUnPartitionInfo")
+            .registerSubtype(RecycleLakeUnPartitionInfo.class, "RecycleLakeUnPartitionInfo");
 
     private static final RuntimeTypeAdapterFactory<com.starrocks.catalog.Table> TABLE_TYPE_ADAPTER_FACTORY
             = RuntimeTypeAdapterFactory.of(com.starrocks.catalog.Table.class, "clazz")

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.staros.client.StarClientException;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.ShardInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.persist.EditLog;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.warehouse.DefaultWarehouse;
+import com.starrocks.warehouse.Warehouse;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Test;
+
+public class ReplaceLakePartitionTest {
+    long dbId = 9010;
+    long tableId = 9011;
+    long partitionId = 9012;
+    long indexId = 9013;
+    long[] tabletId = {9014, 90015};
+    long tempPartitionId = 9020;
+    long nextTxnId = 20000;
+    String partitionName = "p0";
+    String tempPartitionName = "temp_" + partitionName;
+
+    LakeTable tbl = null;
+    private final ShardInfo shardInfo;
+
+    @Mocked
+    private EditLog editLog;
+
+    @Mocked
+    private StarOSAgent starOSAgent;
+
+    @Mocked
+    private WarehouseManager warehouseManager;
+
+    public ReplaceLakePartitionTest() {
+        shardInfo = ShardInfo.newBuilder().setFilePath(FilePathInfo.newBuilder().setFullPath("oss://1/2")).build();
+        warehouseManager = new WarehouseManager();
+        warehouseManager.initDefaultWarehouse();
+        editLog = new EditLog(null);
+    }
+
+    LakeTable buildLakeTableWithTempPartition(PartitionType partitionType) {
+        MaterializedIndex index = new MaterializedIndex(indexId);
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        for (long id : tabletId) {
+            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, 0, 0, TStorageMedium.HDD, true);
+            invertedIndex.addTablet(id, tabletMeta);
+            index.addTablet(new LakeTablet(id), tabletMeta);
+        }
+        Partition partition = new Partition(partitionId, partitionName, index, null);
+        Partition tempPartition = new Partition(tempPartitionId, tempPartitionName, index, null);
+
+        PartitionInfo partitionInfo = new PartitionInfo(partitionType);
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+        partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, false));
+
+        LakeTable table = new LakeTable(
+                tableId, "t0",
+                Lists.newArrayList(new Column("c0", Type.BIGINT)),
+                KeysType.DUP_KEYS, partitionInfo, null);
+        table.addPartition(partition);
+        table.addTempPartition(tempPartition);
+        return table;
+    }
+
+    @Test
+    public void testUnPartitionedLakeTableReplacePartition() {
+        LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.UNPARTITIONED);
+        tbl.replacePartition(partitionName, tempPartitionName);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getWarehouseMgr();
+                minTimes = 0;
+                result = warehouseManager;
+
+                GlobalStateMgr.getCurrentState().getEditLog();
+                minTimes = 0;
+                result = editLog;
+
+                editLog.logErasePartition(anyLong);
+                minTimes = 0;
+                result = new Delegate() {
+                    public void logErasePartition(Long partitionId) {
+                    }
+                };
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public ShardInfo getShardInfo(long shardId, long workerGroupId) throws StarClientException {
+                return shardInfo;
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Warehouse getBackgroundWarehouse() {
+                return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            }
+        };
+        GlobalStateMgr.getCurrentState().getRecycleBin().erasePartition(Long.MAX_VALUE);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
If the we execute INSERT INTO OVERWRITE or OPTIMIZE TABLE for UnPartitioned table, the files for
the old partition will be leaked and can not be removed by CatalogRecycleBin. The reason is that, OlapTable/LakeTable::replacePartition interface will not call OlapTable/LakeTable::dropParition for the old one. And no parition CatalogRecycleBin background task will be generated for the old partition. But the cleaning job for removing the old partition directory is depending on the background task in CatalogRecycleBin and we will leak the old partition files in remote storage.

## What I'm doing:
Use OlapTable/LakeTable::dropParition instead.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/48022

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
