### PR TITLE
[Doc] move configuration up

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -519,6 +519,18 @@
             "items": [
                 {
                     "type": "category",
+                    "label": "Configuration",
+                    "link": {
+                        "type": "doc",
+                        "id": "administration/management/configuration"
+                    },
+                    "items": [
+                        "administration/management/FE_configuration",
+                        "administration/management/BE_configuration"
+                ]
+                },
+                {
+                    "type": "category",
                     "label": "Management",
                     "link": {
                         "type": "doc",
@@ -528,8 +540,6 @@
                         "administration/management/Scale_up_down",
                         "administration/management/BE_blacklist",
                         "administration/management/Backup_and_restore",
-                        "administration/management/FE_configuration",
-                        "administration/management/BE_configuration",
                         {
                             "type": "category",
                             "label": "Monitor and Alert",
@@ -1987,6 +1997,18 @@
             "items": [
                 {
                     "type": "category",
+                    "label": "配置项",
+                    "link": {
+                        "type": "doc",
+                        "id": "administration/management/configuration"
+                    },
+                    "items": [
+                        "administration/management/FE_configuration",
+                        "administration/management/BE_configuration"
+                    ]
+                },
+                {
+                    "type": "category",
                     "label": "运维集群",
                     "link": {
                         "type": "doc",
@@ -1996,8 +2018,6 @@
                         "administration/management/Scale_up_down",
                         "administration/management/BE_blacklist",
                         "administration/management/Backup_and_restore",
-                        "administration/management/FE_configuration",
-                        "administration/management/BE_configuration",
                         {
                             "type": "category",
                             "label": "监控报警",

--- a/docs/en/administration/management/configuration.mdx
+++ b/docs/en/administration/management/configuration.mdx
@@ -1,0 +1,11 @@
+---
+displayed_sidebar: "English"
+---
+
+# Configuration
+
+Configuration parameters for FE and BE nodes.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/zh/administration/management/configuration.mdx
+++ b/docs/zh/administration/management/configuration.mdx
@@ -1,0 +1,9 @@
+---
+displayed_sidebar: "Chinese"
+---
+
+# 配置项
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />


### PR DESCRIPTION
Google search promotes an old v 3.0 doc for "configuration". This PR moves the FE and BE config pages to a "Configuration" section in the docs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5