### PR TITLE
[BugFix] Fix input dependency cols check failed when rewrite mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -80,6 +81,10 @@ public class MVColumnPruner {
                     scanOperator.getColRefToColumnMetaMap().keySet().stream().filter(requiredOutputColumns::contains)
                             .collect(Collectors.toSet());
             outputColumns.addAll(Utils.extractColumnRef(scanOperator.getPredicate()));
+            if (scanOperator instanceof LogicalOlapScanOperator) {
+                ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates()
+                        .forEach(o -> outputColumns.addAll(Utils.extractColumnRef(o)));
+            }
             if (outputColumns.isEmpty()) {
                 outputColumns.add(
                         Utils.findSmallestColumnRefFromTable(scanOperator.getColRefToColumnMetaMap(), scanOperator.getTable()));


### PR DESCRIPTION
## Why I'm doing:
for a sql like 
```sql
            SELECT
              1
            FROM
              lineorder 
            WHERE lo_orderkey in (
                SELECT
                  lo_linenumber
                FROM
                  lineorder2
                WHERE
                  LO_ORDERDATE = '1998-01-01'
              )
            GROUP BY
              lo_orderkey;
```
when `lineorder2` is a partitioned olap table who is `partitioned by date_trunc('day', LO_ORDERDATE)`

this sql fails due to

`PhysicalOlapScanOperator {table=31105, selectedPartitionId=[31110], selectedIndexId=31106, outputColumns=[56: lo_linenumber], projection=[56: lo_linenumber], predicate=null, prunedPartitionPredicates=[57: lo_orderdate = 1998-01-01], limit=-1}Input dependency cols check failed. The required cols {57} cannot obtain from input cols {56}.`

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
