### PR TITLE
[BugFix] fix Memory Leak in PredictionContextCache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3063,4 +3063,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static int max_column_number_per_table = 10000;
+
+    @ConfField
+    public static boolean enable_parser_context_cache = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -234,11 +234,11 @@ public class SqlParser {
         parser.addParseListener(new PostProcessListener(sessionVariable.getParseTokensLimit(),
                 Math.max(Config.expr_children_limit, sessionVariable.getExprChildrenLimit())));
         if (!Config.enable_parser_context_cache) {
-            DFA[] dicisionDFA = new DFA[parser.getATN().getNumberOfDecisions()];
+            DFA[] decisionDFA = new DFA[parser.getATN().getNumberOfDecisions()];
             for (int i = 0; i < parser.getATN().getNumberOfDecisions(); i++) {
-                dicisionDFA[i] = new DFA(parser.getATN().getDecisionState(i), i);
+                decisionDFA[i] = new DFA(parser.getATN().getDecisionState(i), i);
             }
-           parser.setInterpreter(new ParserATNSimulator(parser, parser.getATN(), dicisionDFA, new PredictionContextCache()));
+           parser.setInterpreter(new ParserATNSimulator(parser, parser.getATN(), decisionDFA, new PredictionContextCache()));
         }
 
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -35,7 +35,10 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
 import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -230,6 +233,14 @@ public class SqlParser {
         parser.removeParseListeners();
         parser.addParseListener(new PostProcessListener(sessionVariable.getParseTokensLimit(),
                 Math.max(Config.expr_children_limit, sessionVariable.getExprChildrenLimit())));
+        if (!Config.enable_parser_context_cache) {
+            DFA[] dicisionDFA = new DFA[parser.getATN().getNumberOfDecisions()];
+            for (int i = 0; i < parser.getATN().getNumberOfDecisions(); i++) {
+                dicisionDFA[i] = new DFA(parser.getATN().getDecisionState(i), i);
+            }
+           parser.setInterpreter(new ParserATNSimulator(parser, parser.getATN(), dicisionDFA, new PredictionContextCache()));
+        }
+
         try {
             // inspire by https://github.com/antlr/antlr4/issues/192#issuecomment-15238595
             // try SLL mode with BailErrorStrategy firstly

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -238,7 +238,7 @@ public class SqlParser {
             for (int i = 0; i < parser.getATN().getNumberOfDecisions(); i++) {
                 decisionDFA[i] = new DFA(parser.getATN().getDecisionState(i), i);
             }
-           parser.setInterpreter(new ParserATNSimulator(parser, parser.getATN(), decisionDFA, new PredictionContextCache()));
+            parser.setInterpreter(new ParserATNSimulator(parser, parser.getATN(), decisionDFA, new PredictionContextCache()));
         }
 
         try {


### PR DESCRIPTION
## Why I'm doing:
https://github.com/antlr/antlr4/issues/499
When grammar rules are complex, some special statements may cause the global cache in ANTLR to grow continuously, occupying a large amount of memory.

## What I'm doing:
We did not find reproducible SQL from the client's cluster. When the client encounters similar issues, we temporarily provide a parsing mode that does not use the cache. This mode is disabled by default, as enabling it will significantly reduce the parser's efficiency.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
