### PR TITLE
[Enhancement] Protect be from crash when failed to filter unused columns

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1569,6 +1569,12 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
         }
     }
 
+    if (UNLIKELY(read_indexes.size() > output_schema().num_fields())) {
+        // May only occur in certain situations in cross-cluster replication
+        return Status::Corruption(
+                "Failed to filter unused columns, please set enable_filter_unused_columns_in_scan_stage = false");
+    }
+
     // map output_schema[cid, index] to read_schema[cid index]
     ctx->_read_index_map.resize(read_indexes.size());
     for (size_t i = 0; i < read_indexes.size(); i++) {


### PR DESCRIPTION
## Why I'm doing:
When failed to filter unused columns, be will crash.

## What I'm doing:
Protect be from crash when failed to filter unused columns

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
