### PR TITLE
[Enhancement] Introduce datacache adaptive populate

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -99,7 +99,9 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.enable_scan_datacache) {
         _use_datacache &= state->query_options().enable_scan_datacache;
     }
-    if (state->query_options().__isset.enable_populate_datacache) {
+    if (hdfs_scan_node.__isset.datacache_options && hdfs_scan_node.datacache_options.__isset.enable_populate_datacache) {
+        _enable_populate_datacache = hdfs_scan_node.datacache_options.enable_populate_datacache;
+    } else if (state->query_options().__isset.enable_populate_datacache) {
         _enable_populate_datacache = state->query_options().enable_populate_datacache;
     }
     if (state->query_options().__isset.enable_datacache_async_populate_mode) {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -99,7 +99,8 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.enable_scan_datacache) {
         _use_datacache &= state->query_options().enable_scan_datacache;
     }
-    if (hdfs_scan_node.__isset.datacache_options && hdfs_scan_node.datacache_options.__isset.enable_populate_datacache) {
+    if (hdfs_scan_node.__isset.datacache_options &&
+        hdfs_scan_node.datacache_options.__isset.enable_populate_datacache) {
         _enable_populate_datacache = hdfs_scan_node.datacache_options.enable_populate_datacache;
     } else if (state->query_options().__isset.enable_populate_datacache) {
         _enable_populate_datacache = state->query_options().enable_populate_datacache;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -164,7 +164,7 @@ public class RemoteScanRangeLocations {
 
         if (dataCacheOptions != null) {
             TDataCacheOptions tDataCacheOptions = new TDataCacheOptions();
-            dataCacheOptions.toThrift(tDataCacheOptions);
+            tDataCacheOptions.setPriority(dataCacheOptions.getPriority());
             hdfsScanRange.setDatacache_options(tDataCacheOptions);
         }
 
@@ -218,7 +218,7 @@ public class RemoteScanRangeLocations {
         hdfsScanRange.setUse_hudi_jni_reader(useJNIReader);
         if (dataCacheOptions != null) {
             TDataCacheOptions tDataCacheOptions = new TDataCacheOptions();
-            dataCacheOptions.toThrift(tDataCacheOptions);
+            tDataCacheOptions.setPriority(dataCacheOptions.getPriority());
             hdfsScanRange.setDatacache_options(tDataCacheOptions);
         }
 
@@ -249,7 +249,8 @@ public class RemoteScanRangeLocations {
         Expr predicates = dataCacheRule.get().getPredicates();
         if (predicates == null) {
             for (int i = 0; i < partitionKeys.size(); i++) {
-                dataCacheOptions.add(new DataCacheOptions(dataCacheRule.get().getPriority()));
+                dataCacheOptions.add(DataCacheOptions.DataCacheOptionsBuilder.builder()
+                        .setPriority(dataCacheRule.get().getPriority()).build());
             }
         } else {
             // evaluate partition predicates
@@ -269,7 +270,8 @@ public class RemoteScanRangeLocations {
                 op = scalarRewriter.rewrite(op, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
                 if (op.isConstantTrue()) {
                     // matched partition predicates
-                    dataCacheOptions.add(new DataCacheOptions(dataCacheRule.get().getPriority()));
+                    dataCacheOptions.add(DataCacheOptions.DataCacheOptionsBuilder.builder()
+                            .setPriority(dataCacheRule.get().getPriority()).build());
                 } else {
                     // not matched, add null DataCacheOption
                     dataCacheOptions.add(null);

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheOptions.java
@@ -14,8 +14,6 @@
 
 package com.starrocks.datacache;
 
-import com.starrocks.thrift.TDataCacheOptions;
-
 public class DataCacheOptions {
     private final boolean enablePopulate;
     // todo remove later

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheOptions.java
@@ -17,17 +17,43 @@ package com.starrocks.datacache;
 import com.starrocks.thrift.TDataCacheOptions;
 
 public class DataCacheOptions {
+    private final boolean enablePopulate;
+    // todo remove later
     private final int priority;
 
-    public DataCacheOptions(int priority) {
-        this.priority = priority;
+    private DataCacheOptions(DataCacheOptionsBuilder builder) {
+        this.enablePopulate = builder.enablePopulate;
+        this.priority = builder.priority;
     }
 
     public int getPriority() {
         return priority;
     }
 
-    public void toThrift(TDataCacheOptions tDataCacheOptions) {
-        tDataCacheOptions.setPriority(priority);
+    public boolean isEnablePopulate() {
+        return enablePopulate;
+    }
+
+    public static class DataCacheOptionsBuilder {
+        private boolean enablePopulate = false;
+        private int priority = 0;
+
+        public static DataCacheOptionsBuilder builder() {
+            return new DataCacheOptionsBuilder();
+        }
+
+        public DataCacheOptionsBuilder setPriority(int priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        public DataCacheOptionsBuilder setEnablePopulate(boolean enablePopulate) {
+            this.enablePopulate = enablePopulate;
+            return this;
+        }
+
+        public DataCacheOptions build() {
+            return new DataCacheOptions(this);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCachePopulateMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCachePopulateMode.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public enum DataCachePopulateMode {
+    AUTO("auto"),
+    NEVER("never"),
+    ALWAYS("always");
+
+    private final String modeName;
+
+    private DataCachePopulateMode(String modeName) {
+        this.modeName = modeName;
+    }
+
+    public static DataCachePopulateMode fromName(String modeName) {
+        checkArgument(modeName != null, "Populate mode name is null");
+
+        if (AUTO.modeName().equalsIgnoreCase(modeName)) {
+            return AUTO;
+        } else if (NEVER.modeName().equalsIgnoreCase(modeName)) {
+            return NEVER;
+        } else if (ALWAYS.modeName().equalsIgnoreCase(modeName)) {
+            return ALWAYS;
+        } else {
+            throw new IllegalArgumentException(
+                    "Unknown populate mode: " + modeName + ", only support auto, never and always");
+        }
+    }
+
+    public String modeName() {
+        return modeName;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -44,6 +44,7 @@ public class DataCacheSelectExecutor {
         // force enable datacache and populate
         tmpSessionVariable.setEnableScanDataCache(true);
         tmpSessionVariable.setEnablePopulateDataCache(true);
+        tmpSessionVariable.setDataCachePopulateMode(DataCachePopulateMode.ALWAYS.modeName());
         // make sure all accessed data must be cached
         tmpSessionVariable.setEnableDataCacheAsyncPopulateMode(false);
         tmpSessionVariable.setEnableDataCacheIOAdaptor(false);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -238,11 +238,11 @@ public class DeltaLakeScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
-        if (dataCacheOptions != null) {
-            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-        }
-
         if (detailLevel == TExplainLevel.VERBOSE) {
+            if (dataCacheOptions != null) {
+                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+            }
+
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -238,6 +238,10 @@ public class DeltaLakeScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
+        if (dataCacheOptions != null) {
+            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+        }
+
         if (detailLevel == TExplainLevel.VERBOSE) {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -275,6 +275,7 @@ public class DeltaLakeScanNode extends ScanNode {
         HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration);
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setPartitionConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
+        HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -239,9 +239,7 @@ public class DeltaLakeScanNode extends ScanNode {
         output.append("\n");
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            if (dataCacheOptions != null) {
-                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-            }
+            HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
 
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -149,6 +149,10 @@ public class FileTableScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
+        if (dataCacheOptions != null) {
+            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+        }
+
         if (detailLevel == TExplainLevel.VERBOSE) {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -149,11 +149,11 @@ public class FileTableScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
-        if (dataCacheOptions != null) {
-            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-        }
-
         if (detailLevel == TExplainLevel.VERBOSE) {
+            if (dataCacheOptions != null) {
+                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+            }
+
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -178,6 +178,7 @@ public class FileTableScanNode extends ScanNode {
         HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration);
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setNonPartitionConjunctsToThrift(msg, this, this.getScanNodePredicates());
+        HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -150,9 +150,7 @@ public class FileTableScanNode extends ScanNode {
         output.append("\n");
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            if (dataCacheOptions != null) {
-                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-            }
+            HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
 
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -149,9 +149,7 @@ public class HdfsScanNode extends ScanNode {
         output.append("\n");
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            if (dataCacheOptions != null) {
-                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-            }
+            HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
 
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
@@ -184,6 +182,13 @@ public class HdfsScanNode extends ScanNode {
         setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         setNonPartitionConjunctsToThrift(msg, this, this.getScanNodePredicates());
         setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
+    }
+
+    public static void appendDataCacheOptionsInExplain(StringBuilder output, String prefix, DataCacheOptions dataCacheOptions) {
+        if (dataCacheOptions != null) {
+            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+            output.append("\n");
+        }
     }
 
     public static void setScanOptimizeOptionToThrift(THdfsScanNode tHdfsScanNode, ScanNode scanNode) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -25,10 +25,12 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.RemoteScanRangeLocations;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.datacache.DataCacheOptions;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.ScanOptimzeOption;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.thrift.TCloudConfiguration;
+import com.starrocks.thrift.TDataCacheOptions;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.THdfsScanNode;
 import com.starrocks.thrift.TPlanNode;
@@ -177,6 +179,7 @@ public class HdfsScanNode extends ScanNode {
         setNonEvalPartitionConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         setNonPartitionConjunctsToThrift(msg, this, this.getScanNodePredicates());
+        setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
     }
 
     public static void setScanOptimizeOptionToThrift(THdfsScanNode tHdfsScanNode, ScanNode scanNode) {
@@ -191,6 +194,14 @@ public class HdfsScanNode extends ScanNode {
             TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
             cc.toThrift(tCloudConfiguration);
             tHdfsScanNode.setCloud_configuration(tCloudConfiguration);
+        }
+    }
+
+    public static void setDataCacheOptionsToThrift(THdfsScanNode tHdfsScanNode, DataCacheOptions options) {
+        if (options != null) {
+            TDataCacheOptions tDataCacheOptions = new TDataCacheOptions();
+            tDataCacheOptions.setEnable_populate_datacache(options.isEnablePopulate());
+            tHdfsScanNode.setDatacache_options(tDataCacheOptions);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -148,6 +148,10 @@ public class HdfsScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
+        if (dataCacheOptions != null) {
+            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+        }
+
         if (detailLevel == TExplainLevel.VERBOSE) {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -148,11 +148,11 @@ public class HdfsScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
-        if (dataCacheOptions != null) {
-            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-        }
-
         if (detailLevel == TExplainLevel.VERBOSE) {
+            if (dataCacheOptions != null) {
+                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+            }
+
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -152,6 +152,7 @@ public class HudiScanNode extends ScanNode {
         HdfsScanNode.setNonEvalPartitionConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setNonPartitionConjunctsToThrift(msg, this, this.getScanNodePredicates());
+        HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -122,9 +122,7 @@ public class HudiScanNode extends ScanNode {
         output.append("\n");
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            if (dataCacheOptions != null) {
-                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-            }
+            HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
 
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -121,6 +121,10 @@ public class HudiScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
+        if (dataCacheOptions != null) {
+            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+        }
+
         if (detailLevel == TExplainLevel.VERBOSE) {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -121,11 +121,11 @@ public class HudiScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
-        if (dataCacheOptions != null) {
-            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-        }
-
         if (detailLevel == TExplainLevel.VERBOSE) {
+            if (dataCacheOptions != null) {
+                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+            }
+
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -377,9 +377,7 @@ public class IcebergScanNode extends ScanNode {
         output.append("\n");
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            if (dataCacheOptions != null) {
-                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-            }
+            HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
 
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -418,6 +418,7 @@ public class IcebergScanNode extends ScanNode {
         HdfsScanNode.setScanOptimizeOptionToThrift(tHdfsScanNode, this);
         HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration);
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
+        HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -376,11 +376,11 @@ public class IcebergScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
-        if (dataCacheOptions != null) {
-            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-        }
-
         if (detailLevel == TExplainLevel.VERBOSE) {
+            if (dataCacheOptions != null) {
+                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+            }
+
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -376,6 +376,10 @@ public class IcebergScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s", avgRowSize));
         output.append("\n");
 
+        if (dataCacheOptions != null) {
+            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+        }
+
         if (detailLevel == TExplainLevel.VERBOSE) {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -337,6 +337,10 @@ public class PaimonScanNode extends ScanNode {
 
         output.append(prefix).append(String.format("avgRowSize=%s\n", avgRowSize));
 
+        if (dataCacheOptions != null) {
+            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+        }
+
         if (detailLevel == TExplainLevel.VERBOSE) {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -369,6 +369,7 @@ public class PaimonScanNode extends ScanNode {
         HdfsScanNode.setNonEvalPartitionConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setNonPartitionConjunctsToThrift(msg, this, this.getScanNodePredicates());
+        HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -338,9 +338,7 @@ public class PaimonScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s\n", avgRowSize));
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            if (dataCacheOptions != null) {
-                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-            }
+            HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
 
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -337,11 +337,11 @@ public class PaimonScanNode extends ScanNode {
 
         output.append(prefix).append(String.format("avgRowSize=%s\n", avgRowSize));
 
-        if (dataCacheOptions != null) {
-            output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
-        }
-
         if (detailLevel == TExplainLevel.VERBOSE) {
+            if (dataCacheOptions != null) {
+                output.append(prefix).append(String.format("dataCacheOptions={populate: %s}", dataCacheOptions.isEnablePopulate()));
+            }
+
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -40,6 +40,7 @@ import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.common.UserException;
+import com.starrocks.datacache.DataCacheOptions;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.optimizer.ScanOptimzeOption;
 import com.starrocks.thrift.TColumnAccessPath;
@@ -58,6 +59,7 @@ public abstract class ScanNode extends PlanNode {
     protected Map<String, PartitionColumnFilter> columnFilters;
     protected String sortColumn = null;
     protected List<ColumnAccessPath> columnAccessPaths;
+    protected DataCacheOptions dataCacheOptions = null;
     protected long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
     protected ScanOptimzeOption scanOptimzeOption;
 
@@ -72,6 +74,10 @@ public abstract class ScanNode extends PlanNode {
 
     public void setColumnAccessPaths(List<ColumnAccessPath> columnAccessPaths) {
         this.columnAccessPaths = columnAccessPaths;
+    }
+
+    public void setDataCacheOptions(DataCacheOptions dataCacheOptions) {
+        this.dataCacheOptions = dataCacheOptions;
     }
 
     public void setWarehouseId(long warehouseId) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -49,6 +49,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PlanMode;
+import com.starrocks.datacache.DataCachePopulateMode;
 import com.starrocks.monitor.unit.TimeValue;
 import com.starrocks.qe.VariableMgr.VarAttr;
 import com.starrocks.server.GlobalStateMgr;
@@ -474,6 +475,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_SCAN_DATACACHE = "enable_scan_datacache";
     public static final String ENABLE_POPULATE_DATACACHE = "enable_populate_datacache";
+    public static final String POPULATE_DATACACHE_MODE = "populate_datacache_mode";
     public static final String ENABLE_DATACACHE_ASYNC_POPULATE_MODE = "enable_datacache_async_populate_mode";
     public static final String ENABLE_DATACACHE_IO_ADAPTOR = "enable_datacache_io_adaptor";
     public static final String DATACACHE_EVICT_PROBABILITY = "datacache_evict_probability";
@@ -1634,8 +1636,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_SCAN_DATACACHE, alias = ENABLE_SCAN_BLOCK_CACHE)
     private boolean enableScanDataCache = true;
 
-    @VariableMgr.VarAttr(name = ENABLE_POPULATE_DATACACHE, alias = ENABLE_POPULATE_BLOCK_CACHE)
+    @VariableMgr.VarAttr(name = ENABLE_POPULATE_DATACACHE, alias = ENABLE_POPULATE_BLOCK_CACHE, flag = VariableMgr.INVISIBLE)
     private boolean enablePopulateDataCache = true;
+
+    @VariableMgr.VarAttr(name = POPULATE_DATACACHE_MODE)
+    private String dataCachePopulateMode = DataCachePopulateMode.AUTO.modeName();
 
     @VariableMgr.VarAttr(name = CATALOG, flag = VariableMgr.SESSION_ONLY)
     private String catalog = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
@@ -2319,8 +2324,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableScanDataCache = enableScanDataCache;
     }
 
+    public boolean isEnablePopulateDataCache() {
+        return this.enablePopulateDataCache;
+    }
+
     public void setEnablePopulateDataCache(boolean enablePopulateDataCache) {
         this.enablePopulateDataCache = enablePopulateDataCache;
+    }
+
+    public DataCachePopulateMode getDataCachePopulateMode() {
+        return DataCachePopulateMode.fromName(this.dataCachePopulateMode);
     }
 
     public void setEnableDataCacheAsyncPopulateMode(boolean enableDataCacheAsyncPopulateMode) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2336,6 +2336,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return DataCachePopulateMode.fromName(this.dataCachePopulateMode);
     }
 
+    public void setDataCachePopulateMode(String mode) {
+        this.dataCachePopulateMode = mode;
+    }
+
     public void setEnableDataCacheAsyncPopulateMode(boolean enableDataCacheAsyncPopulateMode) {
         this.enableDataCacheAsyncPopulateMode = enableDataCacheAsyncPopulateMode;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -34,6 +34,7 @@ import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PlanMode;
+import com.starrocks.datacache.DataCachePopulateMode;
 import com.starrocks.monitor.unit.TimeValue;
 import com.starrocks.mysql.MysqlPassword;
 import com.starrocks.qe.ConnectContext;
@@ -309,6 +310,11 @@ public class SetStmtAnalyzer {
         // check plan mode
         if (variable.equalsIgnoreCase(SessionVariable.PLAN_MODE)) {
             PlanMode.fromName(resolvedExpression.getStringValue());
+        }
+
+        // check populate datacache mode
+        if (variable.equalsIgnoreCase(SessionVariable.POPULATE_DATACACHE_MODE)) {
+            DataCachePopulateMode.fromName(resolvedExpression.getStringValue());
         }
 
         var.setResolvedExpression(resolvedExpression);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -853,7 +853,7 @@ public class Optimizer {
         }
 
         result = new AddIndexOnlyPredicateRule().rewrite(result, rootTaskContext);
-        result = new DataCachePopulateRewriteRule(connectContext.getSessionVariable()).rewrite(result, rootTaskContext);
+        result = new DataCachePopulateRewriteRule(connectContext).rewrite(result, rootTaskContext);
 
         result.setPlanCount(planCount);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -83,6 +83,7 @@ import com.starrocks.sql.optimizer.rule.transformation.pruner.UniquenessBasedTab
 import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rule.tree.AddIndexOnlyPredicateRule;
 import com.starrocks.sql.optimizer.rule.tree.CloneDuplicateColRefRule;
+import com.starrocks.sql.optimizer.rule.tree.DataCachePopulateRewriteRule;
 import com.starrocks.sql.optimizer.rule.tree.ExchangeSortToMergeRule;
 import com.starrocks.sql.optimizer.rule.tree.ExtractAggregateColumn;
 import com.starrocks.sql.optimizer.rule.tree.JoinLocalShuffleRule;
@@ -282,7 +283,7 @@ public class Optimizer {
                 .setPlanMemCosts(costs.getMemoryCost());
         OptExpression finalPlan;
         try (Timer ignored = Tracers.watchScope("PhysicalRewrite")) {
-            finalPlan = physicalRuleRewrite(rootTaskContext, result);
+            finalPlan = physicalRuleRewrite(connectContext, rootTaskContext, result);
             OptimizerTraceUtil.logOptExpression("final plan after physical rewrite:\n%s", finalPlan);
         }
 
@@ -816,7 +817,7 @@ public class Optimizer {
         context.getTaskScheduler().executeTasks(rootTaskContext);
     }
 
-    private OptExpression physicalRuleRewrite(TaskContext rootTaskContext, OptExpression result) {
+    private OptExpression physicalRuleRewrite(ConnectContext connectContext, TaskContext rootTaskContext, OptExpression result) {
         Preconditions.checkState(result.getOp().isPhysical());
 
         int planCount = result.getPlanCount();
@@ -852,6 +853,7 @@ public class Optimizer {
         }
 
         result = new AddIndexOnlyPredicateRule().rewrite(result, rootTaskContext);
+        result = new DataCachePopulateRewriteRule(connectContext.getSessionVariable()).rewrite(result, rootTaskContext);
 
         result.setPlanCount(planCount);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.TableVersionRange;
+import com.starrocks.datacache.DataCacheOptions;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.RowOutputInfo;
 import com.starrocks.sql.optimizer.ScanOptimzeOption;
@@ -49,6 +50,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
     protected ImmutableList<ColumnAccessPath> columnAccessPaths;
     protected ScanOptimzeOption scanOptimzeOption;
     protected TableVersionRange tableVersionRange;
+    protected DataCacheOptions dataCacheOptions = null;
 
     protected PhysicalScanOperator(OperatorType type) {
         super(type);
@@ -155,6 +157,14 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
 
     public List<ColumnAccessPath> getColumnAccessPaths() {
         return columnAccessPaths;
+    }
+
+    public void setDataCacheOptions(DataCacheOptions dataCacheOptions) {
+        this.dataCacheOptions = dataCacheOptions;
+    }
+
+    public DataCacheOptions getDataCacheOptions() {
+        return dataCacheOptions;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.datacache.DataCacheOptions;
+import com.starrocks.datacache.DataCachePopulateMode;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+public class DataCachePopulateRewriteRule implements TreeRewriteRule {
+    private static final Logger LOG = LogManager.getLogger(DataCachePopulateRewriteRule.class);
+
+    private final SessionVariable sessionVariable;
+
+    public DataCachePopulateRewriteRule(SessionVariable sessionVariable) {
+        this.sessionVariable = sessionVariable;
+    }
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        if (!sessionVariable.isEnableScanDataCache()) {
+            return root;
+        }
+        DataCachePopulateMode populateMode = sessionVariable.getDataCachePopulateMode();
+        if (!sessionVariable.isEnablePopulateDataCache()) {
+            // be compatible with old parameter
+            populateMode = DataCachePopulateMode.NEVER;
+        }
+
+        // for NEVER or ALWAYS mode, we don't need to rewrite it
+        if (populateMode == DataCachePopulateMode.NEVER || populateMode == DataCachePopulateMode.ALWAYS) {
+            return root;
+        }
+
+        DataCachePopulateRewriteVisitor visitor = new DataCachePopulateRewriteVisitor();
+        root.getOp().accept(visitor, root, taskContext);
+        return root;
+    }
+
+    private static class DataCachePopulateRewriteVisitor extends OptExpressionVisitor<Void, TaskContext> {
+        @Override
+        public Void visit(OptExpression optExpression, TaskContext context) {
+            for (OptExpression input : optExpression.getInputs()) {
+                input.getOp().accept(this, input, context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitPhysicalScan(OptExpression optExpression, TaskContext context) {
+            PhysicalScanOperator scanOperator = (PhysicalScanOperator) optExpression.getOp();
+            Table table = scanOperator.getTable();
+
+            if (!isValidScanOperatorType(scanOperator.getOpType())) {
+                return null;
+            }
+
+            // ignore full table scan
+            if (checkIsFullColumnScan(table, scanOperator)) {
+                rewritePhysicalScanOperator(scanOperator, false);
+                return null;
+            }
+
+            ScanOperatorPredicates predicates = null;
+            try {
+                // ScanOperatorPredicates maybe nullptr, we have to check it
+                predicates = scanOperator.getScanOperatorPredicates();
+            } catch (AnalysisException e) {
+                LOG.warn("Failed to get ScanOperatorPredicates", e);
+            }
+
+            if (predicates == null) {
+                LOG.warn("ScanOperatorPredicates can't be null");
+                return null;
+            }
+
+            // ignore full partition scan
+            if (checkIsFullPartitionScan(predicates)) {
+                rewritePhysicalScanOperator(scanOperator, false);
+                return null;
+            }
+
+            rewritePhysicalScanOperator(scanOperator, true);
+
+            return null;
+        }
+
+        private boolean isValidScanOperatorType(OperatorType operatorType) {
+            if (operatorType == OperatorType.PHYSICAL_HIVE_SCAN || operatorType == OperatorType.PHYSICAL_ICEBERG_SCAN ||
+                    operatorType == OperatorType.PHYSICAL_FILE_SCAN ||
+                    operatorType == OperatorType.PHYSICAL_HUDI_SCAN ||
+                    operatorType == OperatorType.PHYSICAL_DELTALAKE_SCAN ||
+                    operatorType == OperatorType.PHYSICAL_PAIMON_SCAN) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        private boolean checkIsFullColumnScan(Table table, PhysicalScanOperator scanOperator) {
+            int totalColumns = table.getColumns().size();
+            // If it has only one column, ignore check
+            if (totalColumns == 1) {
+                return false;
+            }
+            int usedColumns = scanOperator.getUsedColumns().size();
+            return usedColumns == totalColumns;
+        }
+
+        private boolean checkIsFullPartitionScan(ScanOperatorPredicates scanOperatorPredicates) {
+            if (scanOperatorPredicates.getSelectedPartitionIds().size() == 1) {
+                // for none-partition table, it has one partition id
+                return false;
+            }
+            return scanOperatorPredicates.getSelectedPartitionIds().size() ==
+                    scanOperatorPredicates.getIdToPartitionKey().size();
+        }
+
+        private void rewritePhysicalScanOperator(PhysicalScanOperator op, boolean enablePopulate) {
+            op.setDataCacheOptions(
+                    DataCacheOptions.DataCacheOptionsBuilder.builder().setEnablePopulate(enablePopulate).build());
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
@@ -166,7 +166,7 @@ public class DataCachePopulateRewriteRule implements TreeRewriteRule {
         }
 
         private boolean checkIsFullPartitionScan(ScanOperatorPredicates scanOperatorPredicates) {
-            if (scanOperatorPredicates.getSelectedPartitionIds().size() == 1) {
+            if (scanOperatorPredicates.getIdToPartitionKey().size() == 1) {
                 // for none-partition table, it has one partition id
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1090,6 +1090,7 @@ public class PlanFragmentBuilder {
             }
 
             hudiScanNode.setLimit(node.getLimit());
+            hudiScanNode.setDataCacheOptions(node.getDataCacheOptions());
 
             tupleDescriptor.computeMemLayout();
             context.getScanNodes().add(hudiScanNode);
@@ -1132,6 +1133,7 @@ public class PlanFragmentBuilder {
             }
 
             hdfsScanNode.setLimit(node.getLimit());
+            hdfsScanNode.setDataCacheOptions(node.getDataCacheOptions());
 
             tupleDescriptor.computeMemLayout();
             context.getScanNodes().add(hdfsScanNode);
@@ -1172,6 +1174,7 @@ public class PlanFragmentBuilder {
             }
 
             fileTableScanNode.setLimit(node.getLimit());
+            fileTableScanNode.setDataCacheOptions(node.getDataCacheOptions());
 
             tupleDescriptor.computeMemLayout();
             context.getScanNodes().add(fileTableScanNode);
@@ -1226,6 +1229,7 @@ public class PlanFragmentBuilder {
             }
 
             deltaLakeScanNode.setLimit(node.getLimit());
+            deltaLakeScanNode.setDataCacheOptions(node.getDataCacheOptions());
 
             tupleDescriptor.computeMemLayout();
             context.getScanNodes().add(deltaLakeScanNode);
@@ -1270,6 +1274,7 @@ public class PlanFragmentBuilder {
             }
 
             paimonScanNode.setLimit(node.getLimit());
+            paimonScanNode.setDataCacheOptions(node.getDataCacheOptions());
 
             tupleDescriptor.computeMemLayout();
             context.getScanNodes().add(paimonScanNode);
@@ -1414,6 +1419,7 @@ public class PlanFragmentBuilder {
             }
 
             icebergScanNode.setLimit(node.getLimit());
+            icebergScanNode.setDataCacheOptions(node.getDataCacheOptions());
 
             tupleDescriptor.computeMemLayout();
             context.getScanNodes().add(icebergScanNode);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -1187,6 +1187,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
 
         List<FieldSchema> cols = Lists.newArrayList();
         cols.add(new FieldSchema("age", "int", null));
+        cols.add(new FieldSchema("name", "string", null));
         StorageDescriptor sd =
                 new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS,
                         "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
@@ -1322,16 +1323,12 @@ public class MockedHiveMetadata implements ConnectorMetadata {
 
         List<FieldSchema> cols = Lists.newArrayList();
         cols.add(new FieldSchema("r_regionkey", "int", null));
-        cols.add(new FieldSchema("r_name", "string", null));
-        cols.add(new FieldSchema("r_comment", "string", null));
         StorageDescriptor sd =
                 new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS, "", false,
                         -1, null, Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap());
 
         CaseInsensitiveMap<String, ColumnStatistic> regionStats = new CaseInsensitiveMap<>();
         regionStats.put("r_regionkey", new ColumnStatistic(0, 4, 0, 4, 5));
-        regionStats.put("r_name", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 6.8, 5));
-        regionStats.put("r_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 66, 5));
 
         Table region =
                 new Table("normal_table", "datacache_db", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheAutomaticPopulateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheAutomaticPopulateTest.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +43,7 @@ public class DataCacheAutomaticPopulateTest extends PlanTestBase {
     public void resetSessionVariable() {
         connectContext.setStatisticsContext(false);
         SessionVariable sessionVariable = connectContext.getSessionVariable();
+        sessionVariable.setEnableScanDataCache(true);
         sessionVariable.setEnablePopulateDataCache(true);
         sessionVariable.setDataCachePopulateMode(DataCachePopulateMode.AUTO.modeName());
         // just for mock
@@ -111,5 +113,12 @@ public class DataCacheAutomaticPopulateTest extends PlanTestBase {
         connectContext.setStatisticsContext(true);
         String sql = "select * from hive0.datacache_db.normal_table";
         assertPlanContains(sql, "dataCacheOptions={populate: false}");
+    }
+
+    @Test
+    public void testDisableDataCache() throws Exception {
+        connectContext.getSessionVariable().setEnableScanDataCache(false);
+        String sql = "select * from hive0.datacache_db.normal_table";
+        Assert.assertFalse(getFragmentPlan(sql).contains("dataCacheOptions"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheAutomaticPopulateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheAutomaticPopulateTest.java
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import com.starrocks.analysis.Expr;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class DataCacheAutomaticPopulateTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        AnalyzeTestUtil.setConnectContext(connectContext);
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+    }
+
+    @Before
+    public void resetSessionVariable() {
+        connectContext.setStatisticsContext(false);
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        sessionVariable.setEnablePopulateDataCache(true);
+        sessionVariable.setDataCachePopulateMode(DataCachePopulateMode.AUTO.modeName());
+        // just for mock
+        connectContext.setExecutor(new StmtExecutor(connectContext, new QueryStatement(new QueryRelation() {
+            @Override
+            public List<Expr> getOutputExpression() {
+                return List.of();
+            }
+        })));
+    }
+
+
+    @Test
+    public void testCompatibleWithOldParameter() throws Exception {
+        String sql = "select age from hive0.datacache_db.multi_partition_table where l_shipdate>='1998-01-03' and l_orderkey=1";
+        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+
+        connectContext.getSessionVariable().setEnablePopulateDataCache(false);
+        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+    }
+
+    @Test
+    public void testAlwaysMode() throws Exception {
+        String sql = "select * from hive0.datacache_db.multi_partition_table";
+        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+
+        connectContext.getSessionVariable().setDataCachePopulateMode(DataCachePopulateMode.ALWAYS.modeName());
+
+        sql = "select * from hive0.datacache_db.multi_partition_table";
+        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+    }
+
+    @Test
+    public void testAllColumnsScan() throws Exception {
+        // two columns, not populate
+        String sql = "select * from hive0.datacache_db.multi_partition_table where l_shipdate>='1998-01-03' and l_orderkey=1";
+        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+
+        // specific one column, should not ignore it
+        sql = "select age from hive0.datacache_db.multi_partition_table where l_shipdate>='1998-01-03' and l_orderkey=1";
+        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+    }
+
+    @Test
+    public void testAllPartitionScan() throws Exception {
+        // all partitions scan
+        String sql = "select age from hive0.datacache_db.multi_partition_table";
+        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+    }
+
+    @Test
+    public void testOneColumnOnePartitionScan() throws Exception {
+        // normal_table has only one column, should not ignore it
+        String sql = "select * from hive0.datacache_db.normal_table";
+        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+    }
+
+    @Test
+    public void testNoneQueryStatement() throws Exception {
+        connectContext.setExecutor(new StmtExecutor(connectContext, new InsertStmt(null, NodePosition.ZERO)));
+        String sql = "select * from hive0.datacache_db.normal_table";
+        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+    }
+
+    @Test
+    public void testStatisticsCollectSQL() throws Exception {
+        connectContext.setStatisticsContext(true);
+        String sql = "select * from hive0.datacache_db.normal_table";
+        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheAutomaticPopulateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheAutomaticPopulateTest.java
@@ -59,66 +59,66 @@ public class DataCacheAutomaticPopulateTest extends PlanTestBase {
     @Test
     public void testCompatibleWithOldParameter() throws Exception {
         String sql = "select age from hive0.datacache_db.multi_partition_table where l_shipdate>='1998-01-03' and l_orderkey=1";
-        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: true}");
 
         connectContext.getSessionVariable().setEnablePopulateDataCache(false);
-        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: false}");
     }
 
     @Test
     public void testAlwaysMode() throws Exception {
         String sql = "select * from hive0.datacache_db.multi_partition_table";
-        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: false}");
 
         connectContext.getSessionVariable().setDataCachePopulateMode(DataCachePopulateMode.ALWAYS.modeName());
 
         sql = "select * from hive0.datacache_db.multi_partition_table";
-        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: true}");
     }
 
     @Test
     public void testAllColumnsScan() throws Exception {
         // two columns, not populate
         String sql = "select * from hive0.datacache_db.multi_partition_table where l_shipdate>='1998-01-03' and l_orderkey=1";
-        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: false}");
 
         // specific one column, should not ignore it
         sql = "select age from hive0.datacache_db.multi_partition_table where l_shipdate>='1998-01-03' and l_orderkey=1";
-        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: true}");
     }
 
     @Test
     public void testAllPartitionScan() throws Exception {
         // all partitions scan
         String sql = "select age from hive0.datacache_db.multi_partition_table";
-        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: false}");
     }
 
     @Test
     public void testOneColumnOnePartitionScan() throws Exception {
         // normal_table has only one column, should not ignore it
         String sql = "select * from hive0.datacache_db.normal_table";
-        assertPlanContains(sql, "dataCacheOptions={populate: true}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: true}");
     }
 
     @Test
     public void testNoneQueryStatement() throws Exception {
         connectContext.setExecutor(new StmtExecutor(connectContext, new InsertStmt(null, NodePosition.ZERO)));
         String sql = "select * from hive0.datacache_db.normal_table";
-        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: false}");
     }
 
     @Test
     public void testStatisticsCollectSQL() throws Exception {
         connectContext.setStatisticsContext(true);
         String sql = "select * from hive0.datacache_db.normal_table";
-        assertPlanContains(sql, "dataCacheOptions={populate: false}");
+        assertVerbosePlanContains(sql, "dataCacheOptions={populate: false}");
     }
 
     @Test
     public void testDisableDataCache() throws Exception {
         connectContext.getSessionVariable().setEnableScanDataCache(false);
         String sql = "select * from hive0.datacache_db.normal_table";
-        Assert.assertFalse(getFragmentPlan(sql).contains("dataCacheOptions"));
+        Assert.assertFalse(getVerboseExplain(sql).contains("dataCacheOptions"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCachePopulateModeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCachePopulateModeTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DataCachePopulateModeTest {
+
+    @Test
+    public void testModeName() {
+        Assert.assertEquals("always", DataCachePopulateMode.ALWAYS.modeName());
+        Assert.assertEquals("never", DataCachePopulateMode.NEVER.modeName());
+        Assert.assertEquals("auto", DataCachePopulateMode.AUTO.modeName());
+    }
+
+    @Test
+    public void testFromName() {
+        Assert.assertEquals(DataCachePopulateMode.AUTO, DataCachePopulateMode.fromName("Auto"));
+        Assert.assertEquals(DataCachePopulateMode.NEVER, DataCachePopulateMode.fromName("NEVER"));
+        Assert.assertEquals(DataCachePopulateMode.ALWAYS, DataCachePopulateMode.fromName("always"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DataCachePopulateMode.fromName("other"));
+    }
+}

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
@@ -116,6 +116,7 @@ NON-PARTITION PREDICATES: 11: l_shipdate <= '1998-12-01'
 MIN/MAX PREDICATES: 11: l_shipdate <= '1998-12-01'
 partitions=1/1
 avgRowSize=70.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 column statistics:
 * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
@@ -191,6 +191,7 @@ TABLE: nation
 NON-PARTITION PREDICATES: 34: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 25
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
@@ -248,6 +249,7 @@ NON-PARTITION PREDICATES: 26: l_returnflag = 'R'
 MIN/MAX PREDICATES: 26: l_returnflag <= 'R', 26: l_returnflag >= 'R'
 partitions=1/1
 avgRowSize=25.0
+dataCacheOptions={populate: false}
 cardinality: 200012634
 probe runtime filters:
 - filter_id = 0, probe_expr = (18: l_orderkey)
@@ -278,6 +280,7 @@ NON-PARTITION PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '19
 MIN/MAX PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
 partitions=1/1
 avgRowSize=20.0
+dataCacheOptions={populate: false}
 cardinality: 5738046
 column statistics:
 * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 5738045.738045738] ESTIMATE
@@ -295,6 +298,7 @@ TABLE: customer
 NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=217.0
+dataCacheOptions={populate: false}
 cardinality: 15000000
 probe runtime filters:
 - filter_id = 2, probe_expr = (4: c_nationkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
@@ -137,6 +137,7 @@ TABLE: partsupp
 NON-PARTITION PREDICATES: 20: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=20.0
+dataCacheOptions={populate: false}
 cardinality: 80000000
 probe runtime filters:
 - filter_id = 3, probe_expr = (20: ps_suppkey)
@@ -179,6 +180,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 24: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 2, probe_expr = (27: s_nationkey)
@@ -205,6 +207,7 @@ NON-PARTITION PREDICATES: 32: n_name = 'PERU'
 MIN/MAX PREDICATES: 32: n_name <= 'PERU', 32: n_name >= 'PERU'
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 1
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
@@ -258,6 +261,7 @@ TABLE: partsupp
 NON-PARTITION PREDICATES: 2: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=28.0
+dataCacheOptions={populate: false}
 cardinality: 80000000
 probe runtime filters:
 - filter_id = 1, probe_expr = (2: ps_suppkey)
@@ -301,6 +305,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 6: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (9: s_nationkey)
@@ -327,6 +332,7 @@ NON-PARTITION PREDICATES: 14: n_name = 'PERU'
 MIN/MAX PREDICATES: 14: n_name <= 'PERU', 14: n_name >= 'PERU'
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 1
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
@@ -92,6 +92,7 @@ TABLE: orders
 NON-PARTITION PREDICATES: 1: o_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=23.0
+dataCacheOptions={populate: false}
 cardinality: 150000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (1: o_orderkey)
@@ -120,6 +121,7 @@ NON-PARTITION PREDICATES: 24: l_shipmode IN ('REG AIR', 'MAIL'), 21: l_commitdat
 MIN/MAX PREDICATES: 24: l_shipmode >= 'MAIL', 24: l_shipmode <= 'REG AIR', 22: l_receiptdate >= '1997-01-01', 22: l_receiptdate < '1998-01-01'
 partitions=1/1
 avgRowSize=30.0
+dataCacheOptions={populate: false}
 cardinality: 6125233
 column statistics:
 * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 6125233.086195324] ESTIMATE
@@ -128,4 +130,3 @@ column statistics:
 * l_receiptdate-->[8.52048E8, 8.83584E8, 0.0, 4.0, 2554.0] ESTIMATE
 * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
 [end]
-

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q13.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q13.sql
@@ -115,6 +115,7 @@ OutPut Exchange Id: 04
 TABLE: customer
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 15000000
 column statistics:
 * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
@@ -139,6 +140,7 @@ TABLE: orders
 NON-PARTITION PREDICATES: NOT (17: o_comment LIKE '%unusual%deposits%')
 partitions=1/1
 avgRowSize=95.0
+dataCacheOptions={populate: false}
 cardinality: 112500000
 probe runtime filters:
 - filter_id = 0, probe_expr = (10: o_custkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
@@ -101,6 +101,7 @@ NON-PARTITION PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997
 MIN/MAX PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997-03-01'
 partitions=1/1
 avgRowSize=28.0
+dataCacheOptions={populate: false}
 cardinality: 6653886
 column statistics:
 * l_partkey-->[1.0, 2.0E7, 0.0, 8.0, 6653885.645940593] ESTIMATE
@@ -119,6 +120,7 @@ TABLE: part
 NON-PARTITION PREDICATES: 17: p_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
+dataCacheOptions={populate: false}
 cardinality: 20000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (17: p_partkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
@@ -72,6 +72,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 1: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=84.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 1, probe_expr = (1: s_suppkey)
@@ -218,6 +219,7 @@ NON-PARTITION PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995
 MIN/MAX PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995-10-01'
 partitions=1/1
 avgRowSize=40.0
+dataCacheOptions={populate: false}
 cardinality: 21862767
 column statistics:
 * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
@@ -256,6 +258,7 @@ NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995
 MIN/MAX PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995-10-01'
 partitions=1/1
 avgRowSize=40.0
+dataCacheOptions={populate: false}
 cardinality: 21862767
 column statistics:
 * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
@@ -154,6 +154,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 21: s_comment LIKE '%Customer%Complaints%'
 partitions=1/1
 avgRowSize=105.0
+dataCacheOptions={populate: false}
 cardinality: 250000
 column statistics:
 * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 250000.0] ESTIMATE
@@ -171,6 +172,7 @@ NON-PARTITION PREDICATES: 9: p_brand != 'Brand#43', NOT (10: p_type LIKE 'PROMO 
 MIN/MAX PREDICATES: 11: p_size >= 1, 11: p_size <= 43
 partitions=1/1
 avgRowSize=47.0
+dataCacheOptions={populate: false}
 cardinality: 2304000
 column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2304000.0] ESTIMATE
@@ -189,6 +191,7 @@ TABLE: partsupp
 NON-PARTITION PREDICATES: 1: ps_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0
+dataCacheOptions={populate: false}
 cardinality: 80000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (1: ps_partkey)
@@ -196,4 +199,3 @@ column statistics:
 * ps_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2.0E7] ESTIMATE
 * ps_suppkey-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
 [end]
-

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
@@ -117,6 +117,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 2: l_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=24.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 probe runtime filters:
 - filter_id = 0, probe_expr = (2: l_partkey)
@@ -144,6 +145,7 @@ NON-PARTITION PREDICATES: 20: p_brand = 'Brand#35', 23: p_container = 'JUMBO CAS
 MIN/MAX PREDICATES: 20: p_brand <= 'Brand#35', 20: p_brand >= 'Brand#35', 23: p_container <= 'JUMBO CASE', 23: p_container >= 'JUMBO CASE'
 partitions=1/1
 avgRowSize=28.0
+dataCacheOptions={populate: false}
 cardinality: 20000
 column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 20000.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
@@ -157,6 +157,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 34: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 column statistics:
 * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
@@ -219,6 +220,7 @@ TABLE: customer
 NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
+dataCacheOptions={populate: false}
 cardinality: 15000000
 column statistics:
 * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
@@ -235,6 +237,7 @@ TABLE: orders
 NON-PARTITION PREDICATES: 10: o_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=28.0
+dataCacheOptions={populate: false}
 cardinality: 150000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (10: o_custkey)
@@ -255,6 +258,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 column statistics:
 * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
@@ -76,6 +76,7 @@ NON-PARTITION PREDICATES: 20: p_brand IN ('Brand#45', 'Brand#11', 'Brand#21'), 2
 MIN/MAX PREDICATES: 20: p_brand >= 'Brand#11', 20: p_brand <= 'Brand#45', 22: p_size <= 15, 23: p_container >= 'LG BOX', 23: p_container <= 'SM PKG', 22: p_size >= 1
 partitions=1/1
 avgRowSize=32.0
+dataCacheOptions={populate: false}
 cardinality: 5714286
 column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5714285.714285714] ESTIMATE
@@ -108,6 +109,7 @@ NON-PARTITION PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmod
 MIN/MAX PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmode >= 'AIR', 15: l_shipmode <= 'AIR REG', 14: l_shipinstruct <= 'DELIVER IN PERSON', 14: l_shipinstruct >= 'DELIVER IN PERSON'
 partitions=1/1
 avgRowSize=67.0
+dataCacheOptions={populate: false}
 cardinality: 26240725
 probe runtime filters:
 - filter_id = 0, probe_expr = (2: l_partkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
@@ -227,6 +227,7 @@ TABLE: partsupp
 NON-PARTITION PREDICATES: 17: ps_partkey IS NOT NULL, 18: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=24.0
+dataCacheOptions={populate: false}
 cardinality: 80000000
 probe runtime filters:
 - filter_id = 2, probe_expr = (17: ps_partkey)
@@ -256,6 +257,7 @@ NON-PARTITION PREDICATES: 6: p_size = 12, 5: p_type LIKE '%COPPER'
 MIN/MAX PREDICATES: 6: p_size <= 12, 6: p_size >= 12
 partitions=1/1
 avgRowSize=62.0
+dataCacheOptions={populate: false}
 cardinality: 100000
 column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 100000.0] ESTIMATE
@@ -314,6 +316,7 @@ OutPut Exchange Id: 10
 TABLE: supplier
 partitions=1/1
 avgRowSize=197.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 1, probe_expr = (13: s_nationkey)
@@ -364,6 +367,7 @@ TABLE: nation
 NON-PARTITION PREDICATES: 22: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
+dataCacheOptions={populate: false}
 cardinality: 25
 probe runtime filters:
 - filter_id = 0, probe_expr = (24: n_regionkey)
@@ -391,9 +395,9 @@ NON-PARTITION PREDICATES: 27: r_name = 'AMERICA'
 MIN/MAX PREDICATES: 27: r_name <= 'AMERICA', 27: r_name >= 'AMERICA'
 partitions=1/1
 avgRowSize=10.8
+dataCacheOptions={populate: false}
 cardinality: 1
 column statistics:
 * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 * r_name-->[-Infinity, Infinity, 0.0, 6.8, 1.0] ESTIMATE
 [end]
-

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
@@ -101,6 +101,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 4: s_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=73.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 3, probe_expr = (4: s_nationkey)
@@ -129,6 +130,7 @@ NON-PARTITION PREDICATES: 9: n_name = 'ARGENTINA'
 MIN/MAX PREDICATES: 9: n_name <= 'ARGENTINA', 9: n_name >= 'ARGENTINA'
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 1
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
@@ -245,6 +247,7 @@ TABLE: part
 NON-PARTITION PREDICATES: 17: p_partkey IS NOT NULL, 18: p_name LIKE 'sienna%'
 partitions=1/1
 avgRowSize=63.0
+dataCacheOptions={populate: false}
 cardinality: 5000000
 column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
@@ -261,6 +264,7 @@ TABLE: partsupp
 NON-PARTITION PREDICATES: 13: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=20.0
+dataCacheOptions={populate: false}
 cardinality: 80000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (12: ps_partkey)
@@ -303,6 +307,7 @@ NON-PARTITION PREDICATES: 29: l_suppkey IS NOT NULL, 37: l_shipdate >= '1993-01-
 MIN/MAX PREDICATES: 37: l_shipdate >= '1993-01-01', 37: l_shipdate < '1994-01-01'
 partitions=1/1
 avgRowSize=24.0
+dataCacheOptions={populate: false}
 cardinality: 86738152
 probe runtime filters:
 - filter_id = 1, probe_expr = (28: l_partkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
@@ -205,6 +205,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 20: l_receiptdate > 19: l_commitdate
 partitions=1/1
 avgRowSize=20.0
+dataCacheOptions={populate: false}
 cardinality: 300018951
 probe runtime filters:
 - filter_id = 1, probe_expr = (10: l_suppkey)
@@ -251,6 +252,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 1: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (4: s_nationkey)
@@ -278,6 +280,7 @@ NON-PARTITION PREDICATES: 34: n_name = 'CANADA'
 MIN/MAX PREDICATES: 34: n_name <= 'CANADA', 34: n_name >= 'CANADA'
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 1
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
@@ -302,6 +305,7 @@ NON-PARTITION PREDICATES: 26: o_orderstatus = 'F'
 MIN/MAX PREDICATES: 26: o_orderstatus <= 'F', 26: o_orderstatus >= 'F'
 partitions=1/1
 avgRowSize=9.0
+dataCacheOptions={populate: false}
 cardinality: 50000000
 probe runtime filters:
 - filter_id = 2, probe_expr = (24: o_orderkey)
@@ -329,6 +333,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 66: l_receiptdate > 65: l_commitdate
 partitions=1/1
 avgRowSize=20.0
+dataCacheOptions={populate: false}
 cardinality: 300018951
 probe runtime filters:
 - filter_id = 3, probe_expr = (54: l_orderkey)
@@ -349,6 +354,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 37: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 probe runtime filters:
 - filter_id = 4, probe_expr = (37: l_orderkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
@@ -126,6 +126,7 @@ TABLE: customer
 NON-PARTITION PREDICATES: substring(5: c_phone, 1, 2) IN ('21', '28', '24', '32', '35', '34', '37')
 partitions=1/1
 avgRowSize=31.0
+dataCacheOptions={populate: false}
 cardinality: 7500000
 column statistics:
 * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 7500000.0] ESTIMATE
@@ -179,6 +180,7 @@ NON-PARTITION PREDICATES: 14: c_acctbal > 0.00, substring(13: c_phone, 1, 2) IN 
 MIN/MAX PREDICATES: 14: c_acctbal > 0.00
 partitions=1/1
 avgRowSize=23.0
+dataCacheOptions={populate: false}
 cardinality: 6818187
 column statistics:
 * c_phone-->[-Infinity, Infinity, 0.0, 15.0, 6818187.396704358] ESTIMATE
@@ -194,6 +196,7 @@ OutPut Exchange Id: 01
 TABLE: orders
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 150000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (20: o_custkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
@@ -121,6 +121,7 @@ NON-PARTITION PREDICATES: 13: o_orderdate < '1995-03-11'
 MIN/MAX PREDICATES: 13: o_orderdate < '1995-03-11'
 partitions=1/1
 avgRowSize=24.0
+dataCacheOptions={populate: false}
 cardinality: 72661123
 probe runtime filters:
 - filter_id = 0, probe_expr = (10: o_custkey)
@@ -149,6 +150,7 @@ NON-PARTITION PREDICATES: 7: c_mktsegment = 'HOUSEHOLD'
 MIN/MAX PREDICATES: 7: c_mktsegment <= 'HOUSEHOLD', 7: c_mktsegment >= 'HOUSEHOLD'
 partitions=1/1
 avgRowSize=18.0
+dataCacheOptions={populate: false}
 cardinality: 3000000
 column statistics:
 * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
@@ -177,6 +179,7 @@ NON-PARTITION PREDICATES: 28: l_shipdate > '1995-03-11'
 MIN/MAX PREDICATES: 28: l_shipdate > '1995-03-11'
 partitions=1/1
 avgRowSize=28.0
+dataCacheOptions={populate: false}
 cardinality: 323426370
 probe runtime filters:
 - filter_id = 1, probe_expr = (18: l_orderkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
@@ -103,6 +103,7 @@ NON-PARTITION PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994
 MIN/MAX PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994-12-01'
 partitions=1/1
 avgRowSize=27.0
+dataCacheOptions={populate: false}
 cardinality: 5675676
 column statistics:
 * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 5675675.675675674] ESTIMATE
@@ -127,6 +128,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 22: l_receiptdate > 21: l_commitdate
 partitions=1/1
 avgRowSize=16.0
+dataCacheOptions={populate: false}
 cardinality: 300018951
 probe runtime filters:
 - filter_id = 0, probe_expr = (10: l_orderkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
@@ -142,6 +142,7 @@ TABLE: customer
 NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
+dataCacheOptions={populate: false}
 cardinality: 15000000
 column statistics:
 * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
@@ -168,6 +169,7 @@ NON-PARTITION PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '19
 MIN/MAX PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
 partitions=1/1
 avgRowSize=20.0
+dataCacheOptions={populate: false}
 cardinality: 22765073
 column statistics:
 * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 2.2765072765072763E7] ESTIMATE
@@ -219,6 +221,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=28.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 probe runtime filters:
 - filter_id = 2, probe_expr = (20: l_suppkey)
@@ -268,6 +271,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 34: s_suppkey IS NOT NULL, 37: s_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 1, probe_expr = (37: s_nationkey)
@@ -312,6 +316,7 @@ TABLE: nation
 NON-PARTITION PREDICATES: 41: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
+dataCacheOptions={populate: false}
 cardinality: 25
 probe runtime filters:
 - filter_id = 0, probe_expr = (43: n_regionkey)
@@ -339,6 +344,7 @@ NON-PARTITION PREDICATES: 46: r_name = 'AFRICA'
 MIN/MAX PREDICATES: 46: r_name <= 'AFRICA', 46: r_name >= 'AFRICA'
 partitions=1/1
 avgRowSize=10.8
+dataCacheOptions={populate: false}
 cardinality: 1
 column statistics:
 * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
@@ -41,6 +41,7 @@ NON-PARTITION PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996
 MIN/MAX PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996-01-01', 7: l_discount >= 0.02, 7: l_discount <= 0.04, 5: l_quantity < 24
 partitions=1/1
 avgRowSize=44.0
+dataCacheOptions={populate: false}
 cardinality: 8142765
 column statistics:
 * l_quantity-->[1.0, 24.0, 0.0, 8.0, 50.0] ESTIMATE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
@@ -117,6 +117,7 @@ TABLE: customer
 NON-PARTITION PREDICATES: 33: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
+dataCacheOptions={populate: false}
 cardinality: 15000000
 column statistics:
 * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
@@ -228,6 +229,7 @@ NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '199
 MIN/MAX PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '1996-12-31'
 partitions=1/1
 avgRowSize=32.0
+dataCacheOptions={populate: false}
 cardinality: 173476304
 probe runtime filters:
 - filter_id = 1, probe_expr = (10: l_suppkey)
@@ -281,6 +283,7 @@ TABLE: supplier
 NON-PARTITION PREDICATES: 1: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 0, probe_expr = (4: s_nationkey)
@@ -314,6 +317,7 @@ NON-PARTITION PREDICATES: 42: n_name IN ('CANADA', 'IRAN')
 MIN/MAX PREDICATES: 42: n_name >= 'CANADA', 42: n_name <= 'IRAN'
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 25
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
@@ -331,6 +335,7 @@ NON-PARTITION PREDICATES: 46: n_name IN ('IRAN', 'CANADA')
 MIN/MAX PREDICATES: 46: n_name >= 'CANADA', 46: n_name <= 'IRAN'
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 25
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
@@ -347,6 +352,7 @@ TABLE: orders
 NON-PARTITION PREDICATES: 24: o_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0
+dataCacheOptions={populate: false}
 cardinality: 150000000
 probe runtime filters:
 - filter_id = 2, probe_expr = (24: o_orderkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
@@ -159,6 +159,7 @@ TABLE: nation
 NON-PARTITION PREDICATES: 54: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 25
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
@@ -251,6 +252,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_partkey IS NOT NULL, 19: l_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=36.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 probe runtime filters:
 - filter_id = 3, probe_expr = (18: l_partkey)
@@ -280,6 +282,7 @@ NON-PARTITION PREDICATES: 5: p_type = 'ECONOMY ANODIZED STEEL'
 MIN/MAX PREDICATES: 5: p_type <= 'ECONOMY ANODIZED STEEL', 5: p_type >= 'ECONOMY ANODIZED STEEL'
 partitions=1/1
 avgRowSize=33.0
+dataCacheOptions={populate: false}
 cardinality: 133333
 column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 133333.33333333334] ESTIMATE
@@ -323,6 +326,7 @@ NON-PARTITION PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1
 MIN/MAX PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
 partitions=1/1
 avgRowSize=20.0
+dataCacheOptions={populate: false}
 cardinality: 45530146
 probe runtime filters:
 - filter_id = 2, probe_expr = (34: o_custkey)
@@ -366,6 +370,7 @@ TABLE: customer
 NON-PARTITION PREDICATES: 42: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
+dataCacheOptions={populate: false}
 cardinality: 15000000
 probe runtime filters:
 - filter_id = 1, probe_expr = (45: c_nationkey)
@@ -407,6 +412,7 @@ TABLE: nation
 NON-PARTITION PREDICATES: 50: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 25
 probe runtime filters:
 - filter_id = 0, probe_expr = (52: n_regionkey)
@@ -433,6 +439,7 @@ NON-PARTITION PREDICATES: 59: r_name = 'MIDDLE EAST'
 MIN/MAX PREDICATES: 59: r_name <= 'MIDDLE EAST', 59: r_name >= 'MIDDLE EAST'
 partitions=1/1
 avgRowSize=10.8
+dataCacheOptions={populate: false}
 cardinality: 1
 column statistics:
 * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
@@ -448,6 +455,7 @@ OutPut Exchange Id: 01
 TABLE: supplier
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 5, probe_expr = (10: s_suppkey)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q9.sql
@@ -148,6 +148,7 @@ TABLE: partsupp
 NON-PARTITION PREDICATES: 34: ps_suppkey IS NOT NULL, 33: ps_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=24.0
+dataCacheOptions={populate: false}
 cardinality: 80000000
 column statistics:
 * ps_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2.0E7] ESTIMATE
@@ -190,6 +191,7 @@ OutPut Exchange Id: 17
 TABLE: supplier
 partitions=1/1
 avgRowSize=8.0
+dataCacheOptions={populate: false}
 cardinality: 1000000
 probe runtime filters:
 - filter_id = 1, probe_expr = (13: s_nationkey)
@@ -208,6 +210,7 @@ TABLE: nation
 NON-PARTITION PREDICATES: 47: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=29.0
+dataCacheOptions={populate: false}
 cardinality: 25
 column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
@@ -271,6 +274,7 @@ TABLE: orders
 NON-PARTITION PREDICATES: 38: o_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
+dataCacheOptions={populate: false}
 cardinality: 150000000
 column statistics:
 * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
@@ -324,6 +328,7 @@ TABLE: lineitem
 NON-PARTITION PREDICATES: 19: l_suppkey IS NOT NULL, 18: l_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=44.0
+dataCacheOptions={populate: false}
 cardinality: 600037902
 probe runtime filters:
 - filter_id = 0, probe_expr = (18: l_partkey)
@@ -354,6 +359,7 @@ TABLE: part
 NON-PARTITION PREDICATES: 2: p_name LIKE '%peru%'
 partitions=1/1
 avgRowSize=63.0
+dataCacheOptions={populate: false}
 cardinality: 5000000
 column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE

--- a/gensrc/thrift/DataCache.thrift
+++ b/gensrc/thrift/DataCache.thrift
@@ -16,7 +16,12 @@ namespace cpp starrocks
 namespace java com.starrocks.thrift
 
 struct TDataCacheOptions {
-    1: optional i32 priority
+    // just placeholder, not needed now
+    // 1: optional bool enable_scan_datacache;
+    2: optional bool enable_populate_datacache;
+
+    // not public to user now
+    100: optional i32 priority;
 }
 
 enum TDataCacheStatus {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1109,6 +1109,8 @@ struct THdfsScanNode {
 
     // for jni scan factory selection scanner
     21: optional string metadata_table_type
+
+    22: optional DataCache.TDataCacheOptions datacache_options;
 }
 
 struct TProjectNode {


### PR DESCRIPTION
## Why I'm doing:
We turn on DataCache by default from branch-3.3. Considering DataCache's space is valuable, we hope it should store important data.

## What I'm doing:
Introduce the new session variable `populate_datacache_mode`, which contains three values:
1. `auto`: Decided whether populate automatically
2. `never`: Never populate data to DataCache
3. `always`: Always populate data to DataCache

Make the original session variable `enable_populate_datacache` invisible. If the user has set `enable_populate_datacache=false`, we will set `populate_datacache_mode=never` automatically for compatibility.

Explain about `auto` mode: will only populate data to DataCache when SQL meets the following constraints:
1. Must be QueryStatement, means will ignore SQL like `INSERT INTO xxx SELECT xxx`
2. Not statistic collect SQL, ignore SQL like `analyze table xxxx`
3. ScanTable must be hive/paimon/delta lake/hudi/iceberg
4. Can't be full columns select(except for one column), like `select * from tbl`
5. Can't be full partitions scan(except for one partition), like `select * from partition_tbl` without partition predicates.

You can using explain to check DataCache's behavior on specific table:
```sql
mysql> explain select c1 from insert_tmp;
+-----------------------------------------+
| Explain String                          |
+-----------------------------------------+
| PLAN FRAGMENT 0                         |
|  OUTPUT EXPRS:1: c1                     |
|   PARTITION: UNPARTITIONED              |
|                                         |
|   RESULT SINK                           |
|                                         |
|   1:EXCHANGE                            |
|                                         |
| PLAN FRAGMENT 1                         |
|  OUTPUT EXPRS:                          |
|   PARTITION: RANDOM                     |
|                                         |
|   STREAM DATA SINK                      |
|     EXCHANGE ID: 01                     |
|     UNPARTITIONED                       |
|                                         |
|   0:HdfsScanNode                        |
|      TABLE: insert_tmp                  |
|      partitions=1/1                     |
|      cardinality=4                      |
|      avgRowSize=1.0                     |
|      dataCacheOptions={populate: false} |
+-----------------------------------------+
22 rows in set (0.01 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
