### PR TITLE
[BugFix] Fix DeleteMgr use Read Lock in the scope of IS Lock bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockType.java
@@ -65,6 +65,19 @@ public class LockType {
         return !CONFLICT_MATRIX[id][requestedType.id];
     }
 
+    public boolean isIntentionLock() throws NotSupportLockException {
+        switch (id) {
+            case 0:
+            case 1:
+                return false;
+            case 2:
+            case 3:
+                return true;
+        }
+
+        throw new NotSupportLockException("Lock Internal Error");
+    }
+
     @Override
     public String toString() {
         if (id == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
@@ -103,10 +103,12 @@ public class MultiUserLock extends Lock {
                      * The outer layer has already obtained the intention lock,
                      * and the inner layer code should not apply for read-write locks.
                      */
-                    if ((lockOwnerLockType == LockType.INTENTION_SHARED || lockOwnerLockType == LockType.INTENTION_EXCLUSIVE)
-                            && (lockRequestLockType == LockType.READ || lockRequestLockType == LockType.WRITE)) {
-                        throw new NotSupportLockException("Can't request " + lockRequestLockType
-                                + " in the scope of " + lockOwnerLockType + ", " + lockOwner.getLocker().getLockerStackTrace());
+
+                    if (lockOwnerLockType.isIntentionLock() && !lockRequestLockType.isIntentionLock()) {
+                        throw new NotSupportLockException("Can't request Database " + lockRequestLockType + " Lock ("
+                                + lockHolderRequest.getLocker().getLockerStackTrace() + ")"
+                                + " in the scope of Database " + lockOwnerLockType
+                                + "Lock (" + lockOwner.getLocker().getLockerStackTrace() + ")");
                     }
 
                     /*

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -190,7 +190,7 @@ public class DeleteMgr implements Writable, MemoryTrackable {
         try {
             List<Partition> partitions = Lists.newArrayList();
             Locker locker = new Locker();
-            locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.READ);
+            locker.lockDatabase(db, LockType.READ);
             try {
                 if (!table.isOlapOrCloudNativeTable()) {
                     throw new DdlException("Delete is not supported on " + table.getType() + " table");
@@ -212,7 +212,7 @@ public class DeleteMgr implements Writable, MemoryTrackable {
                 }
                 throw new DdlException(t.getMessage(), t);
             } finally {
-                locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.READ);
+                locker.unLockDatabase(db, LockType.READ);
             }
 
             deleteJob.run(stmt, db, table, partitions);


### PR DESCRIPTION
## Why I'm doing:
In DeleteMgr::process, Intend Lock is used first, but checkDatabaseDataQuota is called internally in DatabaseTransaction::beginTransaction. This function uses DB read Lock internally, which may cause a deadlock risk.
## What I'm doing:
For the time being, the logic here just rolled back.
Fixes https://github.com/StarRocks/StarRocksTest/issues/8226

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
