### PR TITLE
[BugFix] Fix pk concurrent apply issue

### DIFF
--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -331,6 +331,10 @@ public:
     void remove_all_delta_column_group_cache() const;
     void remove_all_delta_column_group_cache_unlocked() const;
 
+    [[nodiscard]] bool is_dropping() const { return is_dropping; }
+    // set true when start to drop tablet. only set in `TabletManager::drop_tablet` right now
+    void set_is_dropping(bool is_dropping) { _is_dropping = is_dropping; }
+
 protected:
     void on_shutdown() override;
 
@@ -450,6 +454,8 @@ private:
     // another tablet with the same tablet id
     // currently, it will be used in Restore process
     bool _will_be_force_replaced = false;
+
+    std::atomic<bool> _is_dropping{false};
 };
 
 inline bool Tablet::init_succeeded() {

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -331,7 +331,7 @@ public:
     void remove_all_delta_column_group_cache() const;
     void remove_all_delta_column_group_cache_unlocked() const;
 
-    [[nodiscard]] bool is_dropping() const { return is_dropping; }
+    [[nodiscard]] bool is_dropping() const { return _is_dropping; }
     // set true when start to drop tablet. only set in `TabletManager::drop_tablet` right now
     void set_is_dropping(bool is_dropping) { _is_dropping = is_dropping; }
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -396,7 +396,7 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
         dropped_tablet = it->second;
         dropped_tablet->set_is_dropping(true);
         // we can not erase tablet from tablet map here.
-        // because if tablet is a primary key tablet. If tablet is a primary key table, deleting it may wait for apply
+        // if tablet is a primary key table, deleting it may wait for apply
         // to complete, which can take a while. If a clone occurs in the meantime, a new tablet will be created, and
         // the new tablet and the old tablet may apply at the same time, modifying the primary key index at the same time.
     }
@@ -444,7 +444,9 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
         std::unique_lock wlock(_get_tablets_shard_lock(tablet_id));
         TabletMap& tablet_map = _get_tablet_map(tablet_id);
         auto it = tablet_map.find(tablet_id);
-        tablet_map.erase(it);
+        if (it != tablet_map.end()) {
+            tablet_map.erase(it);
+        }
         _remove_tablet_from_partition(*dropped_tablet);
     }
     dropped_tablet->deregister_tablet_from_dir();

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -394,8 +394,11 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
 
         LOG(INFO) << "Start to drop tablet " << tablet_id;
         dropped_tablet = it->second;
-        tablet_map.erase(it);
-        _remove_tablet_from_partition(*dropped_tablet);
+        dropped_tablet->set_is_dropping(true);
+        // we can not erase tablet from tablet map here.
+        // because if tablet is a primary key tablet. If tablet is a primary key table, deleting it may wait for apply
+        // to complete, which can take a while. If a clone occurs in the meantime, a new tablet will be created, and
+        // the new tablet and the old tablet may apply at the same time, modifying the primary key index at the same time.
     }
     if (config::enable_event_based_compaction_framework) {
         dropped_tablet->stop_compaction();
@@ -435,6 +438,14 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
         _add_shutdown_tablet_unlocked(tablet_id, std::move(drop_info));
     } else {
         DCHECK_EQ(kKeepMetaAndFiles, flag);
+    }
+    // erase tablet from tablet map
+    {
+        std::unique_lock wlock(_get_tablets_shard_lock(tablet_id));
+        TabletMap& tablet_map = _get_tablet_map(tablet_id);
+        auto it = tablet_map.find(tablet_id);
+        tablet_map.erase(it);
+        _remove_tablet_from_partition(*dropped_tablet);
     }
     dropped_tablet->deregister_tablet_from_dir();
     LOG(INFO) << "Succeed to drop tablet " << tablet_id;

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -110,6 +110,10 @@ Status EngineCloneTask::execute() {
         if (Tablet::check_migrate(tablet)) {
             return Status::Corruption("Fail to check migrate tablet");
         }
+        // if tablet is under dropping but not finished yet, reject the clone request.
+        if (tablet->is_dropping()) {
+            return Status::Corruption("Tablet is under dropping");
+        }
         Status st;
         if (tablet->updates() != nullptr) {
             st = _do_clone_primary_tablet(tablet.get());


### PR DESCRIPTION
## Why I'm doing:
There's an issue with pk tables applying at the same time:
1. BE receive a increment clone request, and tablet1(tablet id is x) execute apply in thread1
2. BE receive drop tablet1 request and erase it from `tablet_manager`,  but drop is not finished because need to wait for apply finished.
3. BE receive a new clone request and create a new tablet2(tablet id is also x).
4. BE receive a new incremental clone request and tablet2 execute apply in thread2
5. tablet1 and tablet2 are doing apply at the same time. These two tablets are different tablet but has the same tablet id, so they will get the same `primary index` in memory and update at the same time. It will cause unexpected issue.


## What I'm doing:
1. remove tablet from `tablet_manager` at the last step of dropping tablet.
2. reject clone request when we find tablet is under dropping but not finished.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
