### PR TITLE
[Tool] fix centos7 yum repo mirrorlist

### DIFF
--- a/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/CentOS-Base-Local-List.repo
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/CentOS-Base-Local-List.repo
@@ -1,0 +1,22 @@
+[base]
+name=CentOS-$releasever - Base
+mirrorlist=file:///etc/yum-mirrorlist/$basearch/yum-base-mirrorlist.txt
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64
+
+[updates]
+name=CentOS-$releasever - Updates
+mirrorlist=file:///etc/yum-mirrorlist/$basearch/yum-updates-mirrorlist.txt
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64
+
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=file:///etc/yum-mirrorlist/$basearch/yum-extras-mirrorlist.txt
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64

--- a/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/yum-base-mirrorlist.txt
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/yum-base-mirrorlist.txt
@@ -1,0 +1,7 @@
+# local mirrorlist for $releasever - $basearch
+https://vault.centos.org/altarch/$releasever/os/$basearch/
+https://archive.kernel.org/centos-vault/altarch/$releasever/os/$basearch/
+https://linuxsoft.cern.ch/centos-vault/altarch/$releasever/os/$basearch/
+https://mirror.nsc.liu.se/centos-store/altarch/$releasever/os/$basearch/
+https://mirrors.163.com/centos-vault/altarch/$releasever/os/$basearch/
+https://mirrors.aliyun.com/centos-vault/altarch/$releasever/os/$basearch/

--- a/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/yum-extras-mirrorlist.txt
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/yum-extras-mirrorlist.txt
@@ -1,0 +1,7 @@
+# local mirrorlist for $releasever - $basearch
+https://vault.centos.org/altarch/$releasever/updates/$basearch/
+https://archive.kernel.org/centos-vault/altarch/$releasever/updates/$basearch/
+https://linuxsoft.cern.ch/centos-vault/altarch/$releasever/updates/$basearch/
+https://mirror.nsc.liu.se/centos-store/altarch/$releasever/updates/$basearch/
+https://mirrors.163.com/centos-vault/altarch/$releasever/updates/$basearch/
+https://mirrors.aliyun.com/centos-vault/altarch/$releasever/updates/$basearch/

--- a/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/yum-updates-mirrorlist.txt
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/aarch64/yum-updates-mirrorlist.txt
@@ -1,0 +1,7 @@
+# local mirrorlist for $releasever - $basearch
+https://vault.centos.org/altarch/$releasever/updates/$basearch/
+https://archive.kernel.org/centos-vault/altarch/$releasever/updates/$basearch/
+https://linuxsoft.cern.ch/centos-vault/altarch/$releasever/updates/$basearch/
+https://mirror.nsc.liu.se/centos-store/altarch/$releasever/updates/$basearch/
+https://mirrors.163.com/centos-vault/altarch/$releasever/updates/$basearch/
+https://mirrors.aliyun.com/centos-vault/altarch/$releasever/updates/$basearch/

--- a/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/CentOS-Base-Local-List.repo
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/CentOS-Base-Local-List.repo
@@ -1,0 +1,19 @@
+[base]
+name=CentOS-$releasever - Base
+mirrorlist=file:///etc/yum-mirrorlist/$basearch/yum-base-mirrorlist.txt
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[updates]
+name=CentOS-$releasever - Updates
+mirrorlist=file:///etc/yum-mirrorlist/$basearch/yum-updates-mirrorlist.txt
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=file:///etc/yum-mirrorlist/$basearch/yum-extras-mirrorlist.txt
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/yum-base-mirrorlist.txt
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/yum-base-mirrorlist.txt
@@ -1,0 +1,7 @@
+# local mirrorlist for $releasever - $basearch
+https://vault.centos.org/centos/$releasever/os/$basearch/
+https://archive.kernel.org/centos-vault/centos/$releasever/os/$basearch/
+https://linuxsoft.cern.ch/centos-vault/centos/$releasever/os/$basearch/
+https://mirror.nsc.liu.se/centos-store/centos/$releasever/os/$basearch/
+https://mirrors.163.com/centos-vault/centos/$releasever/os/$basearch/
+https://mirrors.aliyun.com/centos-vault/centos/$releasever/os/$basearch/

--- a/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/yum-extras-mirrorlist.txt
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/yum-extras-mirrorlist.txt
@@ -1,0 +1,7 @@
+# local mirrorlist for $releasever - $basearch
+https://vault.centos.org/centos/$releasever/extras/$basearch/
+https://archive.kernel.org/centos-vault/centos/$releasever/extras/$basearch/
+https://linuxsoft.cern.ch/centos-vault/centos/$releasever/extras/$basearch/
+https://mirror.nsc.liu.se/centos-store/centos/$releasever/extras/$basearch/
+https://mirrors.163.com/centos-vault/centos/$releasever/extras/$basearch/
+https://mirrors.aliyun.com/centos-vault/centos/$releasever/extras/$basearch/

--- a/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/yum-updates-mirrorlist.txt
+++ b/docker/dockerfiles/toolchains/yum-mirrorlist/x86_64/yum-updates-mirrorlist.txt
@@ -1,0 +1,7 @@
+# local mirrorlist for $releasever - $basearch
+https://vault.centos.org/centos/$releasever/updates/$basearch/
+https://archive.kernel.org/centos-vault/centos/$releasever/updates/$basearch/
+https://linuxsoft.cern.ch/centos-vault/centos/$releasever/updates/$basearch/
+https://mirror.nsc.liu.se/centos-store/centos/$releasever/updates/$basearch/
+https://mirrors.163.com/centos-vault/centos/$releasever/updates/$basearch/
+https://mirrors.aliyun.com/centos-vault/centos/$releasever/updates/$basearch/


### PR DESCRIPTION
* centos7 is EOL as of July 1st, 2024, the mirrorlist is gone too
* fix it by turn to vault mirrors

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
