### PR TITLE
[Enhancement] Implement global query command

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDir.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/common/proc/ProcService.java
 
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -35,38 +35,20 @@
 package com.starrocks.common.proc;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryStatisticsInfo;
-import com.starrocks.qe.QueryStatisticsItem;
+import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /*
- * show proc "/current_queries"
+ * show proc "/global_current_queries"
  */
-public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
-    private static final Logger LOG = LogManager.getLogger(CurrentQueryStatisticsProcDir.class);
-    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("StartTime")
-            .add("QueryId")
-            .add("ConnectionId")
-            .add("Database")
-            .add("User")
-            .add("ScanBytes")
-            .add("ScanRows")
-            .add("MemoryUsage")
-            .add("DiskSpillSize")
-            .add("CPUTime")
-            .add("ExecTime")
-            .add("Warehouse")
-            .add("CustomQueryId")
-            .build();
+public class CurrentGlobalQueryStatisticsProcDir implements ProcDirInterface {
+    private static final Logger LOG = LogManager.getLogger(CurrentGlobalQueryStatisticsProcDir.class);
 
     @Override
     public boolean register(String name, ProcNodeInterface node) {
@@ -78,19 +60,20 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
         if (Strings.isNullOrEmpty(name)) {
             return null;
         }
-        final Map<String, QueryStatisticsItem> statistic = QeProcessorImpl.INSTANCE.getQueryStatistics();
-        final QueryStatisticsItem item = statistic.get(name);
-        if (item == null) {
-            throw new AnalysisException(name + " does't exist.");
-        }
-        return new CurrentQuerySqlProcDir(item);
+
+        throw new AnalysisException("not implemented");
     }
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {
         final BaseProcResult result = new BaseProcResult();
-        result.setNames(TITLE_NAMES.asList());
+        result.setNames(CurrentQueryStatisticsProcDir.TITLE_NAMES.asList());
         List<QueryStatisticsInfo> queryInfos = QueryStatisticsInfo.makeListFromMetricsAndMgrs();
+        List<QueryStatisticsInfo> otherQueryInfos = GlobalStateMgr.getCurrentState()
+                .getQueryStatisticsInfoFromOtherFEs();
+
+        queryInfos.addAll(otherQueryInfos);
+
         List<List<String>> sortedRowData = queryInfos
                 .stream()
                 .map(QueryStatisticsInfo::formatToList)

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDir.java
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /*
  * show proc "/global_current_queries"
@@ -69,12 +70,12 @@ public class CurrentGlobalQueryStatisticsProcDir implements ProcDirInterface {
         final BaseProcResult result = new BaseProcResult();
         result.setNames(CurrentQueryStatisticsProcDir.TITLE_NAMES.asList());
         List<QueryStatisticsInfo> queryInfos = QueryStatisticsInfo.makeListFromMetricsAndMgrs();
-        List<QueryStatisticsInfo> otherQueryInfos = GlobalStateMgr.getCurrentState()
-                .getQueryStatisticsInfoFromOtherFEs();
+        List<QueryStatisticsInfo> otherQueryInfos = GlobalStateMgr.getCurrentState().getQueryStatisticsInfoFromOtherFEs();
 
-        queryInfos.addAll(otherQueryInfos);
+        List<QueryStatisticsInfo> allInfos = Stream.concat(queryInfos.stream(), otherQueryInfos.stream())
+                .collect(Collectors.toList());
 
-        List<List<String>> sortedRowData = queryInfos
+        List<List<String>> sortedRowData = allInfos
                 .stream()
                 .map(QueryStatisticsInfo::formatToList)
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
@@ -54,6 +54,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(CurrentQueryStatisticsProcDir.class);
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("StartTime")
+            .add("feIp")
             .add("QueryId")
             .add("ConnectionId")
             .add("Database")

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
@@ -45,7 +45,6 @@ import org.apache.logging.log4j.Logger;
 public final class ProcService {
     private static final Logger LOG = LogManager.getLogger(ProcService.class);
     private static ProcService INSTANCE;
-
     private BaseProcDir root;
 
     private ProcService() {
@@ -63,6 +62,7 @@ public final class ProcService {
         root.register("transactions", new TransDbProcDir());
         root.register("monitor", new MonitorProcDir());
         root.register("current_queries", new CurrentQueryStatisticsProcDir());
+        root.register("global_current_queries", new CurrentGlobalQueryStatisticsProcDir());
         root.register("current_backend_instances", new CurrentQueryBackendInstanceProcDir());
         root.register("cluster_balance", new ClusterBalanceProcDir());
         root.register("routine_loads", new RoutineLoadsProcDir());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -1,0 +1,312 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/common/proc/ProcService.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.qe;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.proc.CurrentQueryInfoProvider;
+import com.starrocks.common.util.QueryStatisticsFormatter;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.thrift.TQueryStatisticsInfo;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class QueryStatisticsInfo {
+    private long queryStartTime;
+    private String queryId;
+    private String connId;
+    private String db;
+    private String user;
+    private long cpuCostNs;
+    private long scanBytes;
+    private long scanRows;
+    private long memUsageBytes;
+    private long spillBytes;
+    private long execTime;
+    private String wareHouseName;
+
+    public QueryStatisticsInfo() {
+    }
+
+    public QueryStatisticsInfo(long queryStartTime, String queryId, String connId, String db, String user, long cpuCostNs,
+                               long scanBytes, long scanRows, long memUsageBytes, long spillBytes, long execTime, String wareHouseName) {
+        this.queryStartTime = queryStartTime;
+        this.queryId = queryId;
+        this.connId = connId;
+        this.db = db;
+        this.user = user;
+        this.cpuCostNs = cpuCostNs;
+        this.scanBytes = scanBytes;
+        this.scanRows = scanRows;
+        this.memUsageBytes = memUsageBytes;
+        this.spillBytes = spillBytes;
+        this.execTime = execTime;
+        this.wareHouseName = wareHouseName;
+    }
+
+    public long getQueryStartTime() {
+        return queryStartTime;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public String getConnId() {
+        return connId;
+    }
+
+    public String getDb() {
+        return db;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public long getCpuCostNs() {
+        return cpuCostNs;
+    }
+
+    public long getScanBytes() {
+        return scanBytes;
+    }
+
+    public long getScanRows() {
+        return scanRows;
+    }
+
+    public long getMemUsageBytes() {
+        return memUsageBytes;
+    }
+
+    public long getSpillBytes() {
+        return spillBytes;
+    }
+
+    public long getExecTime() {
+        return execTime;
+    }
+
+    public String getWareHouseName() { return wareHouseName; }
+
+    public QueryStatisticsInfo withQueryStartTime(long queryStartTime) {
+        this.queryStartTime = queryStartTime;
+        return this;
+    }
+
+    public QueryStatisticsInfo withQueryId(String queryId) {
+        this.queryId = queryId;
+        return this;
+    }
+
+    public QueryStatisticsInfo withConnId(String connId) {
+        this.connId = connId;
+        return this;
+    }
+
+    public QueryStatisticsInfo withDb(String db) {
+        this.db = db;
+        return this;
+    }
+
+    public QueryStatisticsInfo withUser(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public QueryStatisticsInfo withCpuCostNs(long cpuCostNs) {
+        this.cpuCostNs = cpuCostNs;
+        return this;
+    }
+
+    public QueryStatisticsInfo withScanBytes(long scanBytes) {
+        this.scanBytes = scanBytes;
+        return this;
+    }
+
+    public QueryStatisticsInfo withScanRows(long scanRows) {
+        this.scanRows = scanRows;
+        return this;
+    }
+
+    public QueryStatisticsInfo withMemUsageBytes(long memUsageBytes) {
+        this.memUsageBytes = memUsageBytes;
+        return this;
+    }
+
+    public QueryStatisticsInfo withSpillBytes(long spillBytes) {
+        this.spillBytes = spillBytes;
+        return this;
+    }
+
+    public QueryStatisticsInfo withExecTime(long execTime) {
+        this.execTime = execTime;
+        return this;
+    }
+
+    public QueryStatisticsInfo withWareHouseName(String warehouseName) {
+        this.wareHouseName = warehouseName;
+        return this;
+    }
+
+    public TQueryStatisticsInfo toThrift() {
+        return new TQueryStatisticsInfo()
+                .setQueryStartTime(queryStartTime)
+                .setQueryId(queryId)
+                .setConnId(connId)
+                .setDb(db)
+                .setUser(user)
+                .setCpuCostNs(cpuCostNs)
+                .setScanBytes(scanBytes)
+                .setScanRows(scanRows)
+                .setMemUsageBytes(memUsageBytes)
+                .setSpillBytes(spillBytes)
+                .setExecTime(execTime)
+                .setWareHouseName(wareHouseName);
+    }
+
+    public static QueryStatisticsInfo fromThrift(TQueryStatisticsInfo tinfo) {
+        return new QueryStatisticsInfo()
+                .withQueryStartTime(tinfo.getQueryStartTime())
+                .withQueryId(tinfo.getQueryId())
+                .withConnId(tinfo.getConnId())
+                .withDb(tinfo.getDb())
+                .withUser(tinfo.getUser())
+                .withScanBytes(tinfo.getScanBytes())
+                .withScanRows(tinfo.getScanRows())
+                .withMemUsageBytes(tinfo.getMemUsageBytes())
+                .withSpillBytes(tinfo.getSpillBytes())
+                .withCpuCostNs(tinfo.getCpuCostNs())
+                .withExecTime(tinfo.getExecTime())
+                .withWareHouseName(tinfo.getWareHouseName());
+    }
+
+    public List<String> formatToList() {
+        final List<String> values = Lists.newArrayList();
+        values.add(TimeUtils.longToTimeString(this.getQueryStartTime()));
+        values.add(this.getQueryId());
+        values.add(this.getConnId());
+        values.add(this.getDb());
+        values.add(this.getUser());
+        values.add(QueryStatisticsFormatter.getBytes(this.getScanBytes()));
+        values.add(QueryStatisticsFormatter.getRowsReturned(this.getScanRows()));
+        values.add(QueryStatisticsFormatter.getBytes(this.getMemUsageBytes()));
+        values.add(QueryStatisticsFormatter.getBytes(this.getSpillBytes()));
+        values.add(QueryStatisticsFormatter.getSecondsFromNano(this.getCpuCostNs()));
+        values.add(QueryStatisticsFormatter.getSecondsFromMilli(this.getExecTime()));
+        values.add(this.getWareHouseName());
+        return values;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryStatisticsInfo that = (QueryStatisticsInfo) o;
+        return queryStartTime == that.queryStartTime && Objects.equals(queryId, that.queryId) &&
+                Objects.equals(connId, that.connId) && Objects.equals(db, that.db) &&
+                Objects.equals(user, that.user) && cpuCostNs == that.cpuCostNs && scanBytes == that.scanBytes &&
+                scanRows == that.scanRows && memUsageBytes == that.memUsageBytes && spillBytes == that.spillBytes &&
+                execTime == that.execTime && Objects.equals(wareHouseName, that.wareHouseName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(queryStartTime, queryId, connId, db, user, cpuCostNs, scanBytes, scanRows, memUsageBytes,
+                spillBytes, execTime, wareHouseName);
+    }
+
+    @Override
+    public String toString() {
+        return "QueryStatisticsInfo{" +
+                "queryStartTime='" + queryStartTime + '\'' +
+                ", queryId=" + queryId +
+                ", connId=" + connId +
+                ", db=" + db +
+                ", user=" + user +
+                ", cpuCostNs=" + cpuCostNs +
+                ", scanRows=" + scanBytes +
+                ", memUsageBytes=" + memUsageBytes +
+                ", spillBytes=" + spillBytes +
+                ", execTime=" + execTime +
+                ", wareHouseName=" + wareHouseName +
+                '}';
+    }
+
+    public static List<QueryStatisticsInfo> makeListFromMetricsAndMgrs() throws AnalysisException {
+        final Map<String, QueryStatisticsItem> statistic =
+                QeProcessorImpl.INSTANCE.getQueryStatistics();
+        final List<QueryStatisticsInfo> sortedRowData = Lists.newArrayList();
+
+        final CurrentQueryInfoProvider provider = new CurrentQueryInfoProvider();
+        final Map<String, CurrentQueryInfoProvider.QueryStatistics> statisticsMap
+                = provider.getQueryStatistics(statistic.values());
+        final List<QueryStatisticsItem> sorted =
+                statistic.values().stream()
+                        .sorted(Comparator.comparingLong(QueryStatisticsItem::getQueryStartTime))
+                        .collect(Collectors.toList());
+        for (QueryStatisticsItem item : sorted) {
+            final CurrentQueryInfoProvider.QueryStatistics statistics = statisticsMap.get(item.getQueryId());
+            if (statistics == null) {
+                continue;
+            }
+            QueryStatisticsInfo info = new QueryStatisticsInfo()
+                    .withQueryStartTime(item.getQueryStartTime())
+                    .withQueryId(item.getQueryId())
+                    .withConnId(item.getConnId())
+                    .withDb(item.getDb())
+                    .withUser(item.getUser())
+                    .withScanBytes(statistics.getScanBytes())
+                    .withScanRows(statistics.getScanRows())
+                    .withMemUsageBytes(statistics.getMemUsageBytes())
+                    .withSpillBytes(statistics.getSpillBytes())
+                    .withCpuCostNs(statistics.getCpuCostNs())
+                    .withExecTime(item.getQueryExecTime())
+                    .withWareHouseName(item.getWarehouseName());
+            sortedRowData.add(info);
+        }
+
+        return sortedRowData;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -178,6 +178,7 @@ import com.starrocks.qe.AuditEventProcessor;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.JournalObservable;
+import com.starrocks.qe.QueryStatisticsInfo;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.VariableMgr;
@@ -936,6 +937,14 @@ public class GlobalStateMgr {
 
     public WarehouseManager getWarehouseMgr() {
         return warehouseMgr;
+    }
+
+    public List<WarehouseInfo> getWarehouseInfosFromOtherFEs() {
+        return nodeMgr.getWarehouseInfosFromOtherFEs();
+    }
+
+    public List<QueryStatisticsInfo> getQueryStatisticsInfoFromOtherFEs() {
+        return nodeMgr.getQueryStatisticsInfoFromOtherFEs();
     }
 
     public StorageVolumeMgr getStorageVolumeMgr() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -939,10 +939,6 @@ public class GlobalStateMgr {
         return warehouseMgr;
     }
 
-    public List<WarehouseInfo> getWarehouseInfosFromOtherFEs() {
-        return nodeMgr.getWarehouseInfosFromOtherFEs();
-    }
-
     public List<QueryStatisticsInfo> getQueryStatisticsInfoFromOtherFEs() {
         return nodeMgr.getQueryStatisticsInfoFromOtherFEs();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -62,7 +62,6 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryStatisticsInfo;
-import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.service.FrontendOptions;
@@ -1095,8 +1094,9 @@ public class NodeMgr {
             }
 
             try {
-                TGetQueryStatisticsResponse response = FrontendServiceProxy
-                        .call(new TNetworkAddress(fe.getHost(), fe.getRpcPort()),
+                TGetQueryStatisticsResponse response = ThriftRPCRequestExecutor.call(
+                        ThriftConnectionPool.frontendPool,
+                        new TNetworkAddress(fe.getHost(), fe.getRpcPort()),
                                 Config.thrift_rpc_timeout_ms,
                                 Config.thrift_rpc_retry_times,
                                 client -> client.getQueryStatistics(request));

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -130,6 +130,7 @@ import com.starrocks.qe.ConnectProcessor;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.QueryStatisticsInfo;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.qe.VariableMgr;
@@ -208,6 +209,8 @@ import com.starrocks.thrift.TGetPartitionsMetaRequest;
 import com.starrocks.thrift.TGetPartitionsMetaResponse;
 import com.starrocks.thrift.TGetProfileRequest;
 import com.starrocks.thrift.TGetProfileResponse;
+import com.starrocks.thrift.TGetQueryStatisticsRequest;
+import com.starrocks.thrift.TGetQueryStatisticsResponse;
 import com.starrocks.thrift.TGetRoleEdgesRequest;
 import com.starrocks.thrift.TGetRoleEdgesResponse;
 import com.starrocks.thrift.TGetRoutineLoadJobsResult;
@@ -269,6 +272,7 @@ import com.starrocks.thrift.TObjectDependencyRes;
 import com.starrocks.thrift.TOlapTableIndexTablets;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
+import com.starrocks.thrift.TQueryStatisticsInfo;
 import com.starrocks.thrift.TRefreshTableRequest;
 import com.starrocks.thrift.TRefreshTableResponse;
 import com.starrocks.thrift.TReleaseSlotRequest;
@@ -2524,6 +2528,25 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         res.setWarehouse_infos(Collections.emptyList());
 
         return res;
+    }
+
+    @Override
+    public TGetQueryStatisticsResponse getQueryStatistics(TGetQueryStatisticsRequest request) throws TException {
+        try {
+            List<QueryStatisticsInfo> queryStatisticsInfos = QueryStatisticsInfo.makeListFromMetricsAndMgrs();
+            List<TQueryStatisticsInfo> queryStatisticsThrift = queryStatisticsInfos
+                    .stream()
+                    .map(QueryStatisticsInfo::toThrift)
+                    .collect(Collectors.toList());
+
+            TGetQueryStatisticsResponse res = new TGetQueryStatisticsResponse();
+            res.setStatus(new TStatus(OK));
+            res.setQueryStatistics_infos(queryStatisticsThrift);
+
+            return res;
+        } catch (AnalysisException e) {
+            throw new TException(e.getMessage());
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.common.proc;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.qe.QueryStatisticsInfo;
+import com.starrocks.server.NodeMgr;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+public class CurrentGlobalQueryStatisticsProcDirTest {
+
+    public static final QueryStatisticsInfo QUERY_ONE_LOCAL = new QueryStatisticsInfo()
+            .withQueryStartTime(1721866303)
+            .withFeIp("172.17.0.3")
+            .withQueryId("870d14e0-4a5d-11ef-a58a-0242ac110003")
+            .withConnId("33")
+            .withDb("example_db")
+            .withUser("root")
+            .withScanBytes(2676000)
+            .withScanRows(396288)
+            .withMemUsageBytes(610900000)
+            .withSpillBytes(0)
+            .withCpuCostNs(97323000)
+            .withExecTime(3533000)
+            .withWareHouseName("default_warehouse")
+            .withCustomQueryId("");
+
+
+    public static final QueryStatisticsInfo QUERY_TWO_LOCAL = new QueryStatisticsInfo()
+            .withQueryStartTime(1721866304)
+            .withFeIp("172.17.0.6")
+            .withQueryId("87e23f47-4a5d-11ef-b91e-0242ac110006")
+            .withConnId("0")
+            .withDb("example_db")
+            .withUser("root")
+            .withScanBytes(2676000)
+            .withScanRows(396288)
+            .withMemUsageBytes(613300000)
+            .withSpillBytes(0)
+            .withCpuCostNs(96576000)
+            .withExecTime(2086000)
+            .withWareHouseName("default_warehouse")
+            .withCustomQueryId("");
+
+    public static final QueryStatisticsInfo QUERY_ONE_REMOTE = new QueryStatisticsInfo()
+            .withQueryStartTime(1721866428)
+            .withFeIp("192.168.0.4")
+            .withQueryId("84192bde-7af4-4707-83e2-52b1a8653353")
+            .withConnId("33")
+            .withDb("example_db")
+            .withUser("root")
+            .withScanBytes(2676000)
+            .withScanRows(396288)
+            .withMemUsageBytes(610900000)
+            .withSpillBytes(0)
+            .withCpuCostNs(97456000)
+            .withExecTime(3687000)
+            .withWareHouseName("default_warehouse")
+            .withCustomQueryId("");
+
+
+    public static final QueryStatisticsInfo QUERY_TWO_REMOTE = new QueryStatisticsInfo()
+            .withQueryStartTime(1721866430)
+            .withFeIp("192.168.0.5")
+            .withQueryId("746f0274-6252-4f9a-a07e-ddacbbf71ee2")
+            .withConnId("0")
+            .withDb("example_db")
+            .withUser("root")
+            .withScanBytes(2689000)
+            .withScanRows(398988)
+            .withMemUsageBytes(723300000)
+            .withSpillBytes(0)
+            .withCpuCostNs(96686000)
+            .withExecTime(2196000)
+            .withWareHouseName("default_warehouse")
+            .withCustomQueryId("");
+
+    public static List<QueryStatisticsInfo> LOCAL_TEST_QUERIES =
+            new ArrayList<>(List.of(QUERY_ONE_LOCAL, QUERY_TWO_LOCAL));
+
+    public static List<QueryStatisticsInfo> REMOTE_TEST_QUERIES =
+            new ArrayList<>(List.of(QUERY_ONE_REMOTE, QUERY_TWO_REMOTE));
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        try (MockedStatic<QueryStatisticsInfo> queryStatisticsInfo = mockStatic(QueryStatisticsInfo.class)) {
+            queryStatisticsInfo.when(QueryStatisticsInfo::makeListFromMetricsAndMgrs)
+                    .thenReturn(LOCAL_TEST_QUERIES);
+
+            new MockUp<NodeMgr>() {
+                @Mock
+                public List<QueryStatisticsInfo> getQueryStatisticsInfoFromOtherFEs() {
+                    return REMOTE_TEST_QUERIES;
+                }
+            };
+
+            BaseProcResult result = (BaseProcResult) new CurrentGlobalQueryStatisticsProcDir().fetchResult();
+            Assert.assertEquals(LOCAL_TEST_QUERIES.size() + REMOTE_TEST_QUERIES.size(),
+                    result.getRows().size());
+
+            List<List<String>> expectedQueryStatisticsInfo =
+                    Stream.concat(LOCAL_TEST_QUERIES.stream(), REMOTE_TEST_QUERIES.stream())
+                            .map(QueryStatisticsInfo::formatToList)
+                            .collect(Collectors.toList());
+
+            assertThat(result.getRows()).containsExactlyInAnyOrderElementsOf(expectedQueryStatisticsInfo);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
@@ -75,20 +75,20 @@ public class CurrentQueryStatisticsProcDirTest {
         List<String> list1 = rows.get(0);
         Assert.assertEquals(list1.size(), CurrentQueryStatisticsProcDir.TITLE_NAMES.size());
         // QueryId
-        Assert.assertEquals("queryId1", list1.get(1));
+        Assert.assertEquals("queryId1", list1.get(2));
         // Warehouse
-        Assert.assertEquals("wh1", list1.get(11));
+        Assert.assertEquals("wh1", list1.get(12));
         // CustomQueryId
-        Assert.assertEquals("abc1", list1.get(12));
+        Assert.assertEquals("abc1", list1.get(13));
 
         List<String> list2 = rows.get(1);
         Assert.assertEquals(list2.size(), CurrentQueryStatisticsProcDir.TITLE_NAMES.size());
         // QueryId
-        Assert.assertEquals("queryId2", list2.get(1));
+        Assert.assertEquals("queryId2", list2.get(2));
         // Warehouse
-        Assert.assertEquals("wh1", list2.get(11));
+        Assert.assertEquals("wh1", list2.get(12));
         // CustomQueryId
-        Assert.assertEquals("abc2", list2.get(12));
+        Assert.assertEquals("abc2", list2.get(13));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.thrift.TQueryStatisticsInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.starrocks.common.proc.CurrentGlobalQueryStatisticsProcDirTest.QUERY_ONE_LOCAL;
+
+public class QueryStatisticsInfoTest {
+    QueryStatisticsInfo firstQuery = QUERY_ONE_LOCAL;
+
+    @Test
+    public void testEquality() {
+        QueryStatisticsInfo otherQuery = new QueryStatisticsInfo(
+                firstQuery.getQueryStartTime(),
+                firstQuery.getFeIp(),
+                firstQuery.getQueryId(),
+                firstQuery.getConnId(),
+                firstQuery.getDb(),
+                firstQuery.getUser(),
+                firstQuery.getCpuCostNs(),
+                firstQuery.getScanBytes(),
+                firstQuery.getScanRows(),
+                firstQuery.getMemUsageBytes(),
+                firstQuery.getSpillBytes(),
+                firstQuery.getExecTime(),
+                firstQuery.getWareHouseName(),
+                firstQuery.getCustomQueryId()
+        );
+        Assert.assertEquals(firstQuery, otherQuery);
+        Assert.assertEquals(firstQuery.hashCode(), otherQuery.hashCode());
+    }
+
+    @Test
+    public void testThrift() {
+        TQueryStatisticsInfo firstQueryThrift = firstQuery.toThrift();
+        QueryStatisticsInfo firstQueryTest = QueryStatisticsInfo.fromThrift(firstQueryThrift);
+        Assert.assertEquals(firstQuery, firstQueryTest);
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1568,17 +1568,19 @@ struct TGetQueryStatisticsRequest {
 
 struct TQueryStatisticsInfo {
     1: optional i64 queryStartTime
-    2: optional string queryId
-    3: optional string connId
-    4: optional string db
-    5: optional string user
-    6: optional i64 cpuCostNs
-    7: optional i64 scanBytes
-    8: optional i64 scanRows
-    9: optional i64 memUsageBytes
-    10: optional i64 spillBytes
-    11: optional i64 execTime
-    12: optional string wareHouseName
+    2: optional string feIp
+    3: optional string queryId
+    4: optional string connId
+    5: optional string db
+    6: optional string user
+    7: optional i64 cpuCostNs
+    8: optional i64 scanBytes
+    9: optional i64 scanRows
+    10: optional i64 memUsageBytes
+    11: optional i64 spillBytes
+    12: optional i64 execTime
+    13: optional string wareHouseName
+    14: optional string customQueryId
 }
 
 struct TGetQueryStatisticsResponse {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -877,7 +877,7 @@ struct TLoadTxnBeginRequest {
     // The real value of timeout should be i32. i64 ensures the compatibility of interface.
     10: optional i64 timeout
     11: optional Types.TUniqueId request_id
-    
+
     // begin from 101, in case of conflict with other's change
     101: optional string warehouse  // deprecated, use backend_id implicitly convey information about the warehouse
     102: optional i64 backend_id
@@ -946,7 +946,7 @@ struct TStreamLoadPutRequest {
     // only valid when file type is CSV
     54: optional byte escape
     55: optional Types.TPartialUpdateMode partial_update_mode
-    56: optional string payload_compression_type 
+    56: optional string payload_compression_type
 
     // begin from 101, in case of conflict with other's change
     101: optional string warehouse  // deprecated, use backend_id implicitly convey information about the warehouse
@@ -1563,6 +1563,29 @@ struct TUpdateResourceUsageResponse {
     1: optional Status.TStatus status
 }
 
+struct TGetQueryStatisticsRequest {
+}
+
+struct TQueryStatisticsInfo {
+    1: optional i64 queryStartTime
+    2: optional string queryId
+    3: optional string connId
+    4: optional string db
+    5: optional string user
+    6: optional i64 cpuCostNs
+    7: optional i64 scanBytes
+    8: optional i64 scanRows
+    9: optional i64 memUsageBytes
+    10: optional i64 spillBytes
+    11: optional i64 execTime
+    12: optional string wareHouseName
+}
+
+struct TGetQueryStatisticsResponse {
+    1: optional Status.TStatus status
+    2: optional list<TQueryStatisticsInfo> queryStatistics_infos;
+}
+
 struct TResourceLogicalSlot {
     1: optional Types.TUniqueId slot_id
     2: optional string request_fe_name
@@ -1891,6 +1914,8 @@ service FrontendService {
     TUpdateResourceUsageResponse updateResourceUsage(1: TUpdateResourceUsageRequest request)
 
     TGetWarehousesResponse getWarehouses(1: TGetWarehousesRequest request)
+
+    TGetQueryStatisticsResponse getQueryStatistics(1: TGetQueryStatisticsRequest request)
 
     // For Materialized View
     MVMaintenance.TMVReportEpochResponse mvReport(1: MVMaintenance.TMVMaintenanceTasks request)


### PR DESCRIPTION
Description
===========
Running `show proc '/current_queries'` on an FE node only obtains the queries running on that FE node.

Solution
========
Implement new command `show proc '/global_current_queries'` to show queries running on all FE nodes.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
