### PR TITLE
[BugFix] Fixed a bug where a colocation group was marked as unstable when it was first created

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateMatchResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateMatchResult.java
@@ -16,10 +16,16 @@ package com.starrocks.clone;
 
 public class ColocateMatchResult {
     long lockTotalTime;
-    boolean isGroupStable;
+    Status status;
 
-    public ColocateMatchResult(long lockTotalTime, boolean isGroupStable) {
+    public ColocateMatchResult(long lockTotalTime, Status status) {
         this.lockTotalTime = lockTotalTime;
-        this.isGroupStable = isGroupStable;
+        this.status = status;
+    }
+
+    public enum Status {
+        STABLE,
+        UNSTABLE,
+        UNKNOWN
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -49,6 +49,7 @@ import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
+import com.starrocks.clone.ColocateMatchResult.Status;
 import com.starrocks.clone.TabletSchedCtx.Priority;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -727,12 +728,12 @@ public class ColocateTableBalancer extends FrontendDaemon {
         List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
         Database db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(groupId.dbId);
         if (db == null) {
-            return new ColocateMatchResult(lockTotalTime, false);
+            return new ColocateMatchResult(lockTotalTime, Status.UNKNOWN);
         }
 
         List<Set<Long>> backendBucketsSeq = colocateIndex.getBackendsPerBucketSeqSet(groupId);
         if (backendBucketsSeq.isEmpty()) {
-            return new ColocateMatchResult(lockTotalTime, false);
+            return new ColocateMatchResult(lockTotalTime, Status.UNKNOWN);
         }
 
         boolean isGroupStable = true;
@@ -771,7 +772,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                         locker.lockDatabase(db, LockType.READ);
                         lockStart = System.nanoTime();
                         if (globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(groupId.dbId) == null) {
-                            return new ColocateMatchResult(lockTotalTime, false);
+                            return new ColocateMatchResult(lockTotalTime, Status.UNKNOWN);
                         }
                         if (globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, olapTable.getId()) == null) {
                             continue TABLE;
@@ -887,7 +888,8 @@ public class ColocateTableBalancer extends FrontendDaemon {
             locker.unLockDatabase(db, LockType.READ);
         }
 
-        return new ColocateMatchResult(lockTotalTime - waitTotalTimeMs * 1000000, isGroupStable);
+        return new ColocateMatchResult(lockTotalTime - waitTotalTimeMs * 1000000,
+                isGroupStable ? Status.STABLE : Status.UNSTABLE);
     }
 
     private ColocateMatchResult matchOneGroupUrgent(GroupId groupId,
@@ -925,10 +927,10 @@ public class ColocateTableBalancer extends FrontendDaemon {
             ColocateMatchResult nonUrgentResult = matchOneGroupNonUrgent(groupId, globalStateMgr, colocateIndex, tabletScheduler);
             lockTotalTime += nonUrgentResult.lockTotalTime;
 
-            if (urgentResult.isGroupStable && nonUrgentResult.isGroupStable) {
-                colocateIndex.markGroupStable(groupId, true);
-            } else {
+            if (urgentResult.status == Status.UNSTABLE || nonUrgentResult.status == Status.UNSTABLE) {
                 colocateIndex.markGroupUnstable(groupId, true);
+            } else if (urgentResult.status == Status.STABLE && nonUrgentResult.status == Status.STABLE) {
+                colocateIndex.markGroupStable(groupId, true);
             }
         } // end for groups
 


### PR DESCRIPTION
## Why I'm doing:
When creating a new colocation group, the groupId is first added into ColocateTableIndex and then the backendSequence is added. During this period, if ColocateTableBalancer performs a matchGroup operation, it will mistakenly mark the group as unstable because the backend sequence obtained through groupId is empty at this time.

## What I'm doing:
When the backend sequence is empty, return the status as UNKNOWN, and the upper layer does not process this status.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
