### PR TITLE
[Enhancement] Add the cache item count and bytes statistics to datacache metrics.

### DIFF
--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -158,6 +158,11 @@ void DataCacheAction::_handle_stat(HttpRequest* req, BlockCache* cache) {
         root.AddMember("miss_bytes_last_minute", rapidjson::Value(metrics.detail_l2->miss_bytes_last_minite),
                        allocator);
 
+        root.AddMember("buffer_item_count", rapidjson::Value(metrics.detail_l2->buffer_item_count), allocator);
+        root.AddMember("buffer_item_bytes", rapidjson::Value(metrics.detail_l2->buffer_item_bytes), allocator);
+        root.AddMember("object_item_count", rapidjson::Value(metrics.detail_l2->object_item_count), allocator);
+        root.AddMember("object_item_bytes", rapidjson::Value(metrics.detail_l2->object_item_bytes), allocator);
+
         root.AddMember("read_mem_bytes", rapidjson::Value(metrics.detail_l2->read_mem_bytes), allocator);
         root.AddMember("read_disk_bytes", rapidjson::Value(metrics.detail_l2->read_disk_bytes), allocator);
 


### PR DESCRIPTION
## Why I'm doing:
Sometimes we need to know the current distribution of cache space and the situation of cache objects based on the cache item count, such as whether they contain a large number of small cache objects.

## What I'm doing:
Add the cache item count and bytes statistics to the datacache action metrics.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5