### PR TITLE
[Enhancement] metadata support LRU memory evict strategy in shared-nothing cluster

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -538,6 +538,9 @@ CONF_Int64(compaction_memory_limit_per_worker, "2147483648"); // 2GB
 CONF_String(consistency_max_memory_limit, "10G");
 CONF_Int32(consistency_max_memory_limit_percent, "20");
 CONF_Int32(update_memory_limit_percent, "60");
+// Metadata cache limit for shared-nothing mode. Not working for PK table now.
+// Disable metadata cache when metadata_cache_memory_limit_percent <= 0.
+CONF_mInt32(metadata_cache_memory_limit_percent, "30"); // 30%
 
 // if `enable_retry_apply`, it apply failed due to some tolerable error(e.g. memory exceed limit)
 // the failed apply task will retry after `retry_apply_interval_second`

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -121,6 +121,7 @@ add_library(Storage STATIC
     rowset/rowset_meta.cpp
     rowset/horizontal_update_rowset_writer.cpp
     rowset/bitmap_index_evaluator.cpp
+    rowset/metadata_cache.cpp
     task/engine_batch_load_task.cpp
     task/engine_checksum_task.cpp
     task/engine_clone_task.cpp

--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -46,7 +46,7 @@ void MetadataCache::_erase(const std::string& key) {
 
 void MetadataCache::_cache_value_deleter(const CacheKey& /*key*/, void* value) {
     // close this rowset, release metadata memory
-    static_cast<Rowset*>(value)->close();
+    reinterpret_cast<Rowset*>(value)->close();
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -24,11 +24,15 @@ MetadataCache::MetadataCache(size_t capacity) {
 }
 
 void MetadataCache::cache_rowset(Rowset* ptr) {
-    _insert(ptr->rowset_id_str(), ptr, ptr->total_memory_usage());
+    _insert(ptr->rowset_id_str(), ptr, ptr->segment_memory_usage());
 }
 
 void MetadataCache::evict_rowset(Rowset* ptr) {
     _erase(ptr->rowset_id_str());
+}
+
+size_t MetadataCache::get_memory_usage() const {
+    return _cache->get_memory_usage();
 }
 
 void MetadataCache::_insert(const std::string& key, Rowset* ptr, size_t size) {

--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/metadata_cache.h"
+
+#include "storage/rowset/rowset.h"
+#include "util/lru_cache.h"
+
+namespace starrocks {
+
+MetadataCache::MetadataCache(size_t capacity) {
+    _cache.reset(new_lru_cache(capacity));
+}
+
+void MetadataCache::cache_rowset(Rowset* ptr) {
+    _insert(ptr->rowset_id_str(), ptr, ptr->total_memory_usage());
+}
+
+void MetadataCache::evict_rowset(Rowset* ptr) {
+    _erase(ptr->rowset_id_str());
+}
+
+void MetadataCache::_insert(const std::string& key, Rowset* ptr, size_t size) {
+    Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, _cache_value_deleter);
+    _cache->release(handle);
+}
+
+void MetadataCache::_erase(const std::string& key) {
+    _cache->erase(CacheKey(key));
+}
+
+void MetadataCache::_cache_value_deleter(const CacheKey& /*key*/, void* value) {
+    // close this rowset, release metadata memory
+    static_cast<Rowset*>(value)->close();
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -40,6 +40,9 @@ public:
     // evict this rowset manually, will be called before rowset destroy.
     void evict_rowset(Rowset* ptr);
 
+    // Memory usage of lru cache
+    size_t get_memory_usage() const;
+
 private:
     void _insert(const std::string& key, Rowset* ptr, size_t size);
     void _erase(const std::string& key);

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string_view>
+#include <variant>
+
+#include "gutil/macros.h"
+
+namespace starrocks {
+class Cache;
+class CacheKey;
+class Rowset;
+
+class MetadataCache {
+public:
+    explicit MetadataCache(size_t capacity);
+
+    ~MetadataCache() {}
+
+    DISALLOW_COPY_AND_MOVE(MetadataCache);
+
+    // will be called after rowset load metadata.
+    void cache_rowset(Rowset* ptr);
+
+    // evict this rowset manually, will be called before rowset destroy.
+    void evict_rowset(Rowset* ptr);
+
+private:
+    void _insert(const std::string& key, Rowset* ptr, size_t size);
+    void _erase(const std::string& key);
+    static void _cache_value_deleter(const CacheKey& /*key*/, void* value);
+
+    // LRU cache for metadata
+    std::unique_ptr<Cache> _cache;
+};
+
+} // namespace starrocks

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -625,7 +625,6 @@ void Rowset::do_close() {
 }
 
 size_t Rowset::segment_memory_usage() {
-    std::lock_guard<std::mutex> load_lock(_lock);
     size_t total = 0;
     for (const auto& segment : _segments) {
         total += segment->mem_usage();

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -624,9 +624,9 @@ void Rowset::do_close() {
     _segments.clear();
 }
 
-size_t Rowset::total_memory_usage() {
+size_t Rowset::segment_memory_usage() {
     std::lock_guard<std::mutex> load_lock(_lock);
-    size_t total = _mem_usage();
+    size_t total = 0;
     for (const auto& segment : _segments) {
         total += segment->mem_usage();
     }

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -375,6 +375,10 @@ public:
 
     Status verify();
 
+    size_t total_memory_usage();
+    // For Test only
+    size_t TEST_load_segment_cnt() const { return _segments.size(); }
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -375,9 +375,7 @@ public:
 
     Status verify();
 
-    size_t total_memory_usage();
-    // For Test only
-    size_t TEST_load_segment_cnt() const { return _segments.size(); }
+    size_t segment_memory_usage();
 
 protected:
     friend class RowsetFactory;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -63,6 +63,7 @@
 #include "storage/memtable_flush_executor.h"
 #include "storage/publish_version_manager.h"
 #include "storage/replication_txn_manager.h"
+#include "storage/rowset/metadata_cache.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/rowset/rowset_meta_manager.h"
 #include "storage/rowset/unique_rowset_id_generator.h"

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -94,6 +94,8 @@ TabletManager::TabletManager(int64_t tablet_map_lock_shard_size)
     // 5% percent at least
     const int32_t lru_cache_limit = process_limit * std::max(5, config::metadata_cache_memory_limit_percent) / 100;
     _metadata_cache = std::make_unique<MetadataCache>(lru_cache_limit);
+    REGISTER_GAUGE_STARROCKS_METRIC(metadata_lru_cache_bytes_total,
+                                    [this]() { return _metadata_cache->get_memory_usage(); });
 #endif
 }
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -50,6 +50,7 @@
 #include "storage/compaction_manager.h"
 #include "storage/data_dir.h"
 #include "storage/olap_common.h"
+#include "storage/rowset/metadata_cache.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
@@ -88,6 +89,12 @@ TabletManager::TabletManager(int64_t tablet_map_lock_shard_size)
           _last_update_stat_ms(0) {
     CHECK_GT(_tablets_shards.size(), 0) << "tablets shard count greater than 0";
     CHECK_EQ(_tablets_shards.size() & _tablets_shards_mask, 0) << "tablets shard count must be power of two";
+#ifndef BE_TEST
+    const int64_t process_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
+    // 5% percent at least
+    const int32_t lru_cache_limit = process_limit * std::max(5, config::metadata_cache_memory_limit_percent) / 100;
+    _metadata_cache = std::make_unique<MetadataCache>(lru_cache_limit);
+#endif
 }
 
 Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bool update_meta, bool force) {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -91,8 +91,7 @@ TabletManager::TabletManager(int64_t tablet_map_lock_shard_size)
     CHECK_EQ(_tablets_shards.size() & _tablets_shards_mask, 0) << "tablets shard count must be power of two";
 #ifndef BE_TEST
     const int64_t process_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
-    // 5% percent at least
-    const int32_t lru_cache_limit = process_limit * std::max(5, config::metadata_cache_memory_limit_percent) / 100;
+    const int32_t lru_cache_limit = process_limit * config::metadata_cache_memory_limit_percent / 100;
     _metadata_cache = std::make_unique<MetadataCache>(lru_cache_limit);
     REGISTER_GAUGE_STARROCKS_METRIC(metadata_lru_cache_bytes_total,
                                     [this]() { return _metadata_cache->get_memory_usage(); });

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -93,7 +93,7 @@ TabletManager::TabletManager(int64_t tablet_map_lock_shard_size)
     const int64_t process_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
     const int32_t lru_cache_limit = process_limit * config::metadata_cache_memory_limit_percent / 100;
     _metadata_cache = std::make_unique<MetadataCache>(lru_cache_limit);
-    REGISTER_GAUGE_STARROCKS_METRIC(metadata_lru_cache_bytes_total,
+    REGISTER_GAUGE_STARROCKS_METRIC(metadata_cache_bytes_total,
                                     [this]() { return _metadata_cache->get_memory_usage(); });
 #endif
 }

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -61,6 +61,7 @@ namespace starrocks {
 class Tablet;
 class DataDir;
 struct TabletBasicInfo;
+class MetadataCache;
 
 // RowsetsAcqRel is a RAII wrapper for invocation of Rowset::acquire_readers and Rowset::release_readers
 class RowsetsAcqRel;
@@ -198,6 +199,8 @@ public:
 
     Status generate_pk_dump();
 
+    MetadataCache* metadata_cache() const { return _metadata_cache.get(); }
+
 private:
     using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;
     using TabletSet = std::unordered_set<int64_t>;
@@ -297,6 +300,9 @@ private:
     // context for compaction checker
     size_t _cur_shard = 0;
     std::unordered_set<int64_t> _shard_visited_tablet_ids;
+
+    // LRU cache for metadata
+    std::unique_ptr<MetadataCache> _metadata_cache;
 };
 
 inline bool TabletManager::LockTable::is_locked(int64_t tablet_id) {

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -220,6 +220,9 @@ public:
     // Accumulated time that task pends in the queue
     METRIC_DEFINE_INT_COUNTER(async_delta_writer_task_pending_duration_us, MetricUnit::MICROSECONDS);
 
+    // Metrics for metadata lru cache
+    METRIC_DEFINE_INT_GAUGE(metadata_lru_cache_bytes_total, MetricUnit::BYTES);
+
     // Metrics for delta writer
     // Accumulated time that delta writer waits for memtable flush. It's part of
     // async_delta_writer_task_execute_duration_us

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -221,7 +221,7 @@ public:
     METRIC_DEFINE_INT_COUNTER(async_delta_writer_task_pending_duration_us, MetricUnit::MICROSECONDS);
 
     // Metrics for metadata lru cache
-    METRIC_DEFINE_INT_GAUGE(metadata_lru_cache_bytes_total, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(metadata_cache_bytes_total, MetricUnit::BYTES);
 
     // Metrics for delta writer
     // Accumulated time that delta writer waits for memtable flush. It's part of

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -290,6 +290,7 @@ set(EXEC_FILES
         ./storage/rowset/cast_column_iterator_test.cpp
         ./storage/rowset/series_column_iterator_test.cpp
         ./storage/rowset/index_page_test.cpp
+        ./storage/rowset/metadata_cache_test.cpp
         ./storage/snapshot_meta_test.cpp
         ./storage/short_key_index_test.cpp
         ./storage/storage_types_test.cpp

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -26,6 +26,7 @@
 #include "storage/tablet_reader.h"
 #include "storage/tablet_schema.h"
 #include "storage/tablet_schema_helper.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 class MetadataCacheTest : public ::testing::Test {
@@ -110,7 +111,7 @@ TEST_F(MetadataCacheTest, test_auto_evcit) {
         rowsets.push_back(rowset_ptr);
     }
     for (int i = 0; i < 10; i++) {
-        ASSERT_TRUE(rowsets[i]->TEST_load_segment_cnt() == 0);
+        ASSERT_TRUE(rowsets[i]->segment_memory_usage() == 0);
     }
 }
 
@@ -126,14 +127,14 @@ TEST_F(MetadataCacheTest, test_manual_evcit) {
     for (int i = 0; i < 10; i++) {
         auto rowset_ptr = create_rowset(tablet_ptr, keys);
         ASSERT_TRUE(rowset_ptr->load().ok());
-        ASSERT_TRUE(rowset_ptr->total_memory_usage() > 0);
+        ASSERT_TRUE(rowset_ptr->segment_memory_usage() > 0);
         metadata_cache_ptr->cache_rowset(rowset_ptr.get());
         rowsets.push_back(rowset_ptr);
     }
     for (int i = 0; i < 10; i++) {
-        ASSERT_TRUE(rowsets[i]->TEST_load_segment_cnt() > 0);
+        ASSERT_TRUE(rowsets[i]->segment_memory_usage() > 0);
         metadata_cache_ptr->evict_rowset(rowsets[i].get());
-        ASSERT_TRUE(rowsets[i]->TEST_load_segment_cnt() == 0);
+        ASSERT_TRUE(rowsets[i]->segment_memory_usage() == 0);
     }
 }
 

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/metadata_cache.h"
+
+#include <gtest/gtest.h>
+
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_reader.h"
+#include "storage/tablet_schema.h"
+#include "storage/tablet_schema_helper.h"
+
+namespace starrocks {
+class MetadataCacheTest : public ::testing::Test {
+public:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (long key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+        }
+        EXPECT_TRUE(writer->flush_chunk(*chunk).ok());
+        return *writer->build();
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+};
+
+TEST_F(MetadataCacheTest, test_auto_evcit) {
+    const size_t N = 1000;
+    vector<int64_t> keys;
+    for (size_t i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    vector<RowsetSharedPtr> rowsets;
+    auto tablet_ptr = create_tablet(1001, 10002);
+    auto metadata_cache_ptr = std::make_unique<MetadataCache>(10);
+    for (int i = 0; i < 10; i++) {
+        auto rowset_ptr = create_rowset(tablet_ptr, keys);
+        ASSERT_TRUE(rowset_ptr->load().ok());
+        metadata_cache_ptr->cache_rowset(rowset_ptr.get());
+        rowsets.push_back(rowset_ptr);
+    }
+    for (int i = 0; i < 10; i++) {
+        ASSERT_TRUE(rowsets[i]->TEST_load_segment_cnt() == 0);
+    }
+}
+
+TEST_F(MetadataCacheTest, test_manual_evcit) {
+    const size_t N = 100;
+    vector<int64_t> keys;
+    for (size_t i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    vector<RowsetSharedPtr> rowsets;
+    auto tablet_ptr = create_tablet(1002, 10003);
+    auto metadata_cache_ptr = std::make_unique<MetadataCache>(10000000);
+    for (int i = 0; i < 10; i++) {
+        auto rowset_ptr = create_rowset(tablet_ptr, keys);
+        ASSERT_TRUE(rowset_ptr->load().ok());
+        ASSERT_TRUE(rowset_ptr->total_memory_usage() > 0);
+        metadata_cache_ptr->cache_rowset(rowset_ptr.get());
+        rowsets.push_back(rowset_ptr);
+    }
+    for (int i = 0; i < 10; i++) {
+        ASSERT_TRUE(rowsets[i]->TEST_load_segment_cnt() > 0);
+        metadata_cache_ptr->evict_rowset(rowsets[i].get());
+        ASSERT_TRUE(rowsets[i]->TEST_load_segment_cnt() == 0);
+    }
+}
+
+} // namespace starrocks

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -46,6 +46,7 @@
 #include "storage/olap_common.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
+#include "storage/rowset/metadata_cache.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"


### PR DESCRIPTION
## Why I'm doing:
In previous implementation, there is no memory limit for `metadata` in shared-nothing cluster. So if there are too many tablets and segment files, BE will OOM. We need a controllable `metadata` memory strategy.

## What I'm doing:
Add a lru cache for `metadata`, its capacity is controlled by be.conf `metadata_cache_memory_limit_percent`.
When `Rowset` performs a load action, it adds the `Rowset` to the lru cache, and if the lru cache memory exceeds the limit, it selectively eliminates the loaded `Rowset`, ultimately realizing the goal of controllable `metadata` memory.
This strategy is only support non-pk table now.

There will be two cases when evict the Rowset:
1. There is no reference hold by other user, Rowset's state will change from `ROWSET_LOADED` to `ROWSET_UNLOADED` , and then release the memory.
2. There are reference hold by other user (e.g. compaction or query),  Rowset's state will change from `ROWSET_LOADED` to `ROWSET_UNLOADING`. Memory will be release after compaction or query finish.

## Test Result 
![image](https://github.com/user-attachments/assets/8d0cf62b-27cb-4dd7-875f-76780de275a1)
1. Before turning on LRU cache control strategy, `metadata` continues to increase without limit.
2. After enabling LRU cache control strategy (with limit set to 1GB), `metadata` memory is stabilized at 1GB.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
