### PR TITLE
[Enhancement] add a lower limit for the parse_token

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -228,8 +228,7 @@ public class SqlParser {
         StarRocksLexer lexer = new StarRocksLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
         lexer.setSqlMode(sessionVariable.getSqlMode());
         CommonTokenStream tokenStream = new CommonTokenStream(lexer);
-        int exprLimit = Math.max(MIN_TOKEN_LIMIT,
-                Math.max(Config.expr_children_limit, sessionVariable.getExprChildrenLimit()));
+        int exprLimit = Math.max(Config.expr_children_limit, sessionVariable.getExprChildrenLimit());
         int tokenLimit = Math.max(MIN_TOKEN_LIMIT, sessionVariable.getParseTokensLimit());
         StarRocksParser parser = new StarRocksParser(tokenStream);
         parser.removeErrorListeners();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -53,6 +53,7 @@ import static com.starrocks.sql.common.UnsupportedException.unsupportedException
 public class SqlParser {
     private static final Logger LOG = LogManager.getLogger(SqlParser.class);
     private static final String EOF = "<EOF>";
+    private static final int MIN_TOKEN_LIMIT = 100;
     private final AstBuilder.AstBuilderFactory astBuilderFactory;
 
     public SqlParser(AstBuilder.AstBuilderFactory astBuilderFactory) {
@@ -227,12 +228,14 @@ public class SqlParser {
         StarRocksLexer lexer = new StarRocksLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
         lexer.setSqlMode(sessionVariable.getSqlMode());
         CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        int exprLimit = Math.max(MIN_TOKEN_LIMIT,
+                Math.max(Config.expr_children_limit, sessionVariable.getExprChildrenLimit()));
+        int tokenLimit = Math.max(MIN_TOKEN_LIMIT, sessionVariable.getParseTokensLimit());
         StarRocksParser parser = new StarRocksParser(tokenStream);
         parser.removeErrorListeners();
         parser.addErrorListener(new ErrorHandler());
         parser.removeParseListeners();
-        parser.addParseListener(new PostProcessListener(sessionVariable.getParseTokensLimit(),
-                Math.max(Config.expr_children_limit, sessionVariable.getExprChildrenLimit())));
+        parser.addParseListener(new PostProcessListener(tokenLimit, exprLimit));
         if (!Config.enable_parser_context_cache) {
             DFA[] decisionDFA = new DFA[parser.getATN().getNumberOfDecisions()];
             for (int i = 0; i < parser.getATN().getNumberOfDecisions(); i++) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- If set the variable `parse_token_limit` to 0, there's no way to recover the FE, so it's better to add a lower limit to it

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
