### PR TITLE
[Feature] Support kill query by query_id (backport #47632)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -121,6 +121,8 @@ public enum ErrorCode {
             "View's SELECT and view's field list have different column counts"),
     ERR_NO_DEFAULT_FOR_FIELD(1364, new byte[] {'H', 'Y', '0', '0', '0'},
             "Field '%s' is not null but doesn't have a default value"),
+    ERR_NO_SUCH_QUERY(1365, new byte[] {'H', 'Y', '0', '0', '0'}, "Unknown query id: %s"),
+
     ERR_PASSWD_LENGTH(1372, new byte[] {'H', 'Y', '0', '0', '0'},
             "Password hash should be a %d-digit hexadecimal number"),
     ERR_CANNOT_USER(1396, new byte[] {'H', 'Y', '0', '0', '0'}, "Operation %s failed for %s"),
@@ -141,7 +143,7 @@ public enum ErrorCode {
             "data cannot be inserted into table with empty partition. " +
                     "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERR_NO_SUCH_PARTITION(1749, new byte[] {'H', 'Y', '0', '0', '0'}, "partition '%s' doesn't exist"),
-    
+
     // Following is StarRocks's error code, which start from 5000
     ERR_NOT_OLAP_TABLE(5000, new byte[] {'H', 'Y', '0', '0', '0'}, "Table '%s' is not a OLAP table"),
     ERR_WRONG_PROC_PATH(5001, new byte[] {'H', 'Y', '0', '0', '0'}, "Proc path '%s' doesn't exist"),
@@ -316,6 +318,7 @@ public enum ErrorCode {
             "Backup job not found when checking privilege"),
     ERROR_DYNAMIC_PARTITION_HISTORY_PARTITION_NUM_ZERO(5092, new byte[] {'4', '2', '0', '0', '0'},
             "Dynamic history partition num must greater than 0"),
+    ERR_FORWARD_TOO_MANY_TIMES(5401, new byte[] {'X', 'X', '0', '0', '0'}, "forward too many times %d"),
     ERR_PLAN_VALIDATE_ERROR(6000, new byte[] {'0', '7', '0', '0', '0'},
             "Incorrect logical plan found in operator: %s. Invalid reason: %s"),
     ERR_INVALID_DATE_ERROR(6001, new byte[] {'2', '2', '0', '0', '0'}, "Incorrect %s value %s"),

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -52,6 +52,7 @@ public class ErrorReport {
         ConnectContext ctx = ConnectContext.get();
         if (ctx != null) {
             ctx.getState().setError(errMsg);
+            ctx.getState().setErrorCode(errorCode);
         }
         // TODO(zc): think about LOG to file
         return errMsg;

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReportException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReportException.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import com.starrocks.qe.ConnectContext;
+
+public class ErrorReportException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    private ErrorReportException(ErrorCode errorCode, String errorMsg) {
+        super(errorMsg);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public static String report(ErrorCode errorCode, Object... objs) {
+        String errMsg = errorCode.formatErrorMsg(objs);
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx != null) {
+            ctx.getState().setError(errMsg);
+            ctx.getState().setErrorCode(errorCode);
+        }
+        throw new ErrorReportException(errorCode, errMsg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -745,6 +745,7 @@ public class ConnectProcessor {
         }
         result.setPacket(getResultPacket());
         result.setState(ctx.getState().getStateType().toString());
+        result.setErrorMsg(ctx.getState().getErrorMessage());
         if (executor != null) {
             if (executor.getProxyResultSet() != null) {  // show statement
                 result.setResultSet(executor.getProxyResultSet().tothrift());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
@@ -188,6 +189,15 @@ public class ConnectScheduler {
 
     public ConnectContext getContext(long connectionId) {
         return connectionMap.get(connectionId);
+    }
+
+    public ConnectContext findContextByQueryId(String queryId) {
+        return connectionMap.values().stream().filter(
+                        (Predicate<ConnectContext>) c ->
+                                c.getQueryId() != null
+                                && queryId.equals(c.getQueryId().toString())
+                )
+                .findFirst().orElse(null);
     }
 
     public int getConnectionNum() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -172,6 +172,10 @@ public class QueryState {
         return errorCode;
     }
 
+    public void setErrorCode(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
     public long getAffectedRows() {
         return affectedRows;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/KillStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/KillStmt.java
@@ -21,14 +21,15 @@ import com.starrocks.sql.parser.NodePosition;
 /**
  * Representation of a Kill statement.
  * Acceptable syntax:
- * KILL [QUERY | CONNECTION] connection_id
+ * KILL [QUERY | CONNECTION] connection_id | query_id
  */
 public class KillStmt extends StatementBase {
-    private final boolean isConnectionKill;
-    private final long connectionId;
+    private boolean isConnectionKill;
+    private long connectionId;
+    private String queryId;
 
-    public KillStmt(boolean isConnectionKill, long connectionId) {
-        this(isConnectionKill, connectionId, NodePosition.ZERO);
+    public KillStmt(long connectionId, NodePosition pos) {
+        this(false, connectionId, pos);
     }
 
     public KillStmt(boolean isConnectionKill, long connectionId, NodePosition pos) {
@@ -37,12 +38,21 @@ public class KillStmt extends StatementBase {
         this.connectionId = connectionId;
     }
 
+    public KillStmt(String queryId, NodePosition pos) {
+        super(pos);
+        this.queryId = queryId;
+    }
+
     public boolean isConnectionKill() {
         return isConnectionKill;
     }
 
     public long getConnectionId() {
         return connectionId;
+    }
+
+    public String getQueryId() {
+        return queryId;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2045,10 +2045,17 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitKillStatement(StarRocksParser.KillStatementContext context) {
         NodePosition pos = createPos(context);
-        long id = Long.parseLong(context.INTEGER_VALUE().getText());
+        long id = context.connId != null ? Long.parseLong(context.connId.getText()) : -1;
+        String queryId = context.queryId != null ? ((StringLiteral) visit(context.queryId)).getStringValue() : null;
         if (context.QUERY() != null) {
-            return new KillStmt(false, id, pos);
+            if (queryId != null) {
+                return new KillStmt(queryId, pos);
+            }
+            return new KillStmt(id, pos);
         } else {
+            if (queryId != null) {
+                throw new ParsingException(String.format("connection id %s should be a positive integer", queryId));
+            }
             return new KillStmt(true, id, pos);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -664,7 +664,7 @@ adminSetPartitionVersion
     ;
 
 killStatement
-    : KILL (CONNECTION? | QUERY) INTEGER_VALUE
+    : KILL (CONNECTION? | QUERY) (connId=INTEGER_VALUE | queryId=string)
     ;
 
 syncStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/KillStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/KillStmtTest.java
@@ -47,7 +47,13 @@ public class KillStmtTest {
         String sql_3 = "kill connection 3";
         AnalyzeTestUtil.analyzeSuccess(sql_3);
 
-        String sql_4 = "kill q 4";
-        AnalyzeTestUtil.analyzeFail(sql_4);
+        String sql_4 = "kill query 'abc'";
+        AnalyzeTestUtil.analyzeSuccess(sql_4);
+
+        String sql_6 = "kill connection '1'";
+        AnalyzeTestUtil.analyzeFail(sql_6);
+
+        String sql_7 = "kill q 4";
+        AnalyzeTestUtil.analyzeFail(sql_7);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
@@ -1,0 +1,194 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.rpc.FrontendServiceProxy;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TMasterOpResult;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.channels.SocketChannel;
+import java.util.UUID;
+
+public class KillQueryHandleTest {
+
+    private static StarRocksAssert starRocksAssert;
+
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        connectContext = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        starRocksAssert = new StarRocksAssert(connectContext);
+    }
+
+    @Test
+    public void testKillStmt(@Mocked SocketChannel socketChannel) throws Exception {
+        // test killing query successfully
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        Assert.assertFalse(ctx1.isKilled());
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), false);
+        // isKilled is set
+        Assert.assertTrue(ctx1.isKilled());
+        Assert.assertEquals(QueryState.MysqlStateType.OK, ctx.getState().getStateType());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    @Test
+    public void testKillStmt2(@Mocked SocketChannel socketChannel, @Mocked TMasterOpResult result)
+            throws Exception {
+        // test killing query is forwarded to fe and query is successfully killed
+        new MockUp(FrontendServiceProxy.class) {
+            @Mock
+            public <T> T call(TNetworkAddress address, int timeoutMs, int retryTimes,
+                              FrontendServiceProxy.MethodCallable<T> callable) throws Exception {
+                result.state = "OK";
+                return (T) result;
+            }
+        };
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        Assert.assertEquals(QueryState.MysqlStateType.OK, ctx.getState().getStateType());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    @Test
+    public void testKillStmtWhenQueryIdNotFound(@Mocked SocketChannel socketChannel)
+            throws Exception {
+        // test killing query but query not found
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        ConnectContext ctx = kill("xxx", false);
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
+        Assert.assertEquals("Unknown query id: xxx", ctx.getState().getErrorMessage());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    @Test
+    public void testKillStmtWhenQueryIdNotFound2(@Mocked SocketChannel socketChannel, @Mocked TMasterOpResult result)
+            throws Exception {
+        // test killing query is forwarded to fe and query not found
+        new MockUp<TMasterOpResult>() {
+            @Mock
+            public boolean isSetErrorMsg() {
+                return true;
+            }
+
+            @Mock
+            public String getErrorMsg() {
+                return "query xxx not found";
+            }
+        };
+        new MockUp(FrontendServiceProxy.class) {
+            @Mock
+            public <T> T call(TNetworkAddress address, int timeoutMs, int retryTimes,
+                              FrontendServiceProxy.MethodCallable<T> callable) throws Exception {
+                result.state = "ERR";
+                return (T) result;
+            }
+        };
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
+        Assert.assertEquals("query xxx not found", ctx.getState().getErrorMessage());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    @Test
+    public void testKillStmtWhenConnectionFail(@Mocked SocketChannel socketChannel) throws Exception {
+        // test killing query is forwarded to fe but fe is down
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
+        Assert.assertEquals("Failed to connect to fe 127.0.0.1:9020", ctx.getState().getErrorMessage());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    @Test
+    public void testKillStmtWhenForwardWithUnknownError(@Mocked SocketChannel socketChannel) throws Exception {
+        // test killing query is forwarded to fe with unexpected error
+        new MockUp(FrontendServiceProxy.class) {
+            @Mock
+            public <T> T call(TNetworkAddress address, int timeoutMs, int retryTimes,
+                              FrontendServiceProxy.MethodCallable<T> callable) throws Exception {
+                throw new Exception("Unknown error x");
+            }
+        };
+        ConnectContext ctx1 = prepareConnectContext(socketChannel);
+
+        ConnectContext ctx = kill(ctx1.getQueryId().toString(), true);
+        Assert.assertEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
+        Assert.assertEquals("Failed to connect to fe 127.0.0.1:9020 due to Unknown error x",
+                ctx.getState().getErrorMessage());
+
+        ctx1.getConnectScheduler().unregisterConnection(ctx1);
+    }
+
+    private ConnectContext prepareConnectContext(SocketChannel socketChannel) {
+        ConnectContext ctx1 = new ConnectContext(socketChannel) {
+            @Override
+            public void kill(boolean killConnection) {
+                super.isKilled = true;
+            }
+        };
+        ctx1.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx1.setQualifiedUser("root");
+        ctx1.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        ctx1.setConnectionId(1);
+        ctx1.setQueryId(UUID.randomUUID());
+        ctx1.setConnectScheduler(ExecuteEnv.getInstance().getScheduler());
+
+        ExecuteEnv.getInstance().getScheduler().registerConnection(ctx1);
+        return ctx1;
+    }
+
+    private ConnectContext kill(String queryId, boolean forward) throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        ctx.setConnectScheduler(ExecuteEnv.getInstance().getScheduler());
+        // reset state
+        ctx.getState().reset();
+        ctx.setForwardTimes(0);
+        if (!forward) {
+            ctx.setForwardTimes(1);
+        }
+        StatementBase killStatement =
+                UtFrameUtils.parseStmtWithNewParser("kill query '" + queryId + "'", ctx);
+        StmtExecutor stmtExecutor = new StmtExecutor(starRocksAssert.getCtx(), killStatement);
+        stmtExecutor.execute();
+        return ctx;
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -659,6 +659,7 @@ struct TMasterOpResult {
 
     6: optional string resource_group_name;
     7: optional TAuditStatistics audit_statistics;
+    8: optional string errorMsg;
 }
 
 struct TIsMethodSupportedRequest {


### PR DESCRIPTION
Backport version 3.1 for PR (#47632)

## Why I'm doing:
User want to kill query id

## What I'm doing:
Allow killing query by query id in all running fe(leader, follower, observer).

Usage:
```sql

select ...;

-- find queryId
show proc '/current_queries';
kill query 'xx';

```
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

