### PR TITLE
[Enhancement] configure S3 client rename_file operation timeout

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -853,6 +853,9 @@ CONF_Int64(object_storage_connect_timeout_ms, "-1");
 // value is greater than 0 and less than 1000.
 // When it's 0, low speed limit check will be disabled.
 CONF_Int64(object_storage_request_timeout_ms, "-1");
+// Request timeout for object storage specialized for rename_file operation.
+// if this parameter is 0, use object_storage_request_timeout_ms instead.
+CONF_Int64(object_storage_rename_file_request_timeout_ms, "30000");
 
 CONF_Strings(fallback_to_hadoop_fs_list, "");
 CONF_Strings(s3_compatible_fs_list, "s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://");

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -112,7 +112,8 @@ public:
     }
 
     // Only use for UT
-    bool find_client_cache_keys_by_config_TEST(const Aws::Client::ClientConfiguration& config) {
+    bool find_client_cache_keys_by_config_TEST(const Aws::Client::ClientConfiguration& config,
+                                               AWSCloudConfiguration* cloud_config = nullptr) {
         return _find_client_cache_keys_by_config_TEST(config);
     }
 
@@ -135,9 +136,11 @@ private:
     constexpr static int kMaxItems = 8;
 
     // Only use for UT
-    bool _find_client_cache_keys_by_config_TEST(const Aws::Client::ClientConfiguration& config) {
+    bool _find_client_cache_keys_by_config_TEST(const Aws::Client::ClientConfiguration& config,
+                                                AWSCloudConfiguration* cloud_config = nullptr) {
         for (size_t i = 0; i < _items; i++) {
-            if (_client_cache_keys[i] == ClientCacheKey{config, AWSCloudConfiguration{}}) return true;
+            if (_client_cache_keys[i] == ClientCacheKey{config, cloud_config == nullptr ?
+                                                                AWSCloudConfiguration{} : *cloud_config}) return true;
         }
         return false;
     }
@@ -321,7 +324,7 @@ static std::shared_ptr<Aws::S3::S3Client> new_s3client(
         const TCloudConfiguration& tCloudConfiguration = (opts.cloud_configuration != nullptr)
                                                                  ? *opts.cloud_configuration
                                                                  : hdfs_properties->cloud_configuration;
-        return S3ClientFactory::instance().new_client(tCloudConfiguration);
+        return S3ClientFactory::instance().new_client(tCloudConfiguration, operation_type);
     } else if (hdfs_properties != nullptr) {
         DCHECK(hdfs_properties->__isset.end_point);
         if (hdfs_properties->__isset.end_point) {

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -139,8 +139,9 @@ private:
     bool _find_client_cache_keys_by_config_TEST(const Aws::Client::ClientConfiguration& config,
                                                 AWSCloudConfiguration* cloud_config = nullptr) {
         for (size_t i = 0; i < _items; i++) {
-            if (_client_cache_keys[i] == ClientCacheKey{config, cloud_config == nullptr ?
-                                                                AWSCloudConfiguration{} : *cloud_config}) return true;
+            if (_client_cache_keys[i] ==
+                ClientCacheKey{config, cloud_config == nullptr ? AWSCloudConfiguration{} : *cloud_config})
+                return true;
         }
         return false;
     }

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -544,12 +544,37 @@ TEST_F(S3FileSystemTest, test_new_S3_client_with_rename_operation) {
     ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config));
 
     // use config::object_storage_request_timeout_ms instead
+    int old_object_storage_rename_file_request_timeout_ms = config::object_storage_rename_file_request_timeout_ms;
+    int old_object_storage_request_timeout_ms = config::object_storage_request_timeout_ms;
     config::object_storage_rename_file_request_timeout_ms = -1;
     config::object_storage_request_timeout_ms = 1000;
     // only used for generate a new S3 client into global cache
     (void)fs->rename_file(S3Path("/dir/source_name"), S3Path("/dir/target_name"));
     config.requestTimeoutMs = config::object_storage_request_timeout_ms;
     ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config));
+    config::object_storage_rename_file_request_timeout_ms = old_object_storage_rename_file_request_timeout_ms;
+    config::object_storage_request_timeout_ms = old_object_storage_request_timeout_ms;
+
+    std::map<std::string, std::string> test_properties;
+    test_properties[AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR] = "true";
+    TCloudConfiguration tCloudConfiguration;
+    tCloudConfiguration.__set_cloud_type(TCloudType::AWS);
+    tCloudConfiguration.__set_cloud_properties_v2(test_properties);
+    auto cloud_config = CloudConfigurationFactory::create_aws(tCloudConfiguration);
+
+    config.requestTimeoutMs = config::object_storage_rename_file_request_timeout_ms;
+    (void)S3ClientFactory::instance().new_client(tCloudConfiguration, S3ClientFactory::OperationType::RENAME_FILE);
+    ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config, &cloud_config));
+
+    old_object_storage_rename_file_request_timeout_ms = config::object_storage_rename_file_request_timeout_ms;
+    old_object_storage_request_timeout_ms = config::object_storage_request_timeout_ms;
+    config::object_storage_rename_file_request_timeout_ms = -1;
+    config::object_storage_request_timeout_ms = 1000;
+    (void)S3ClientFactory::instance().new_client(tCloudConfiguration, S3ClientFactory::OperationType::RENAME_FILE);
+    config.requestTimeoutMs = config::object_storage_request_timeout_ms;
+    ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config, &cloud_config));
+    config::object_storage_rename_file_request_timeout_ms = old_object_storage_rename_file_request_timeout_ms;
+    config::object_storage_request_timeout_ms = old_object_storage_request_timeout_ms;
 }
 
 } // namespace starrocks

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 
 #include "common/config.h"
+#include "fs/fs_s3.cpp"
 #include "gutil/strings/join.h"
 #include "testutil/assert.h"
 #include "util/uid_util.h"
@@ -509,6 +510,46 @@ TEST_F(S3FileSystemTest, test_delete_dir_recursive_v1) {
 TEST_F(S3FileSystemTest, test_delete_nonexist_file) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("s3://"));
     ASSERT_OK(fs->delete_file(S3Path("/nonexist.dat")));
+}
+
+TEST_F(S3FileSystemTest, test_new_S3_client_with_rename_operation) {
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("s3://"));
+    // only used for generate a new S3 client into global cache
+    (void)fs->rename_file(S3Path("/dir/source_name"), S3Path("/dir/target_name"));
+
+    // basic config
+    Aws::Client::ClientConfiguration config = S3ClientFactory::getClientConfig();
+    S3URI src_uri;
+    ASSERT_TRUE(src_uri.parse(S3Path("/dir/source_name")));
+    if (!src_uri.endpoint().empty()) {
+        config.endpointOverride = src_uri.endpoint();
+    } else if (!config::object_storage_endpoint.empty()) {
+        config.endpointOverride = config::object_storage_endpoint;
+    } else if (config::object_storage_endpoint_use_https) {
+        config.scheme = Aws::Http::Scheme::HTTPS;
+    } else {
+        config.scheme = Aws::Http::Scheme::HTTP;
+    }
+    if (!config::object_storage_region.empty()) {
+        config.region = config::object_storage_region;
+    }
+    config.maxConnections = config::object_storage_max_connection;
+    if (config::object_storage_connect_timeout_ms > 0) {
+        config.connectTimeoutMs = config::object_storage_connect_timeout_ms;
+    }
+
+    // reset requestTimeoutMs as config::object_storage_rename_file_request_timeout_ms
+    // to check hit the cache or not.
+    config.requestTimeoutMs = config::object_storage_rename_file_request_timeout_ms;
+    ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config));
+
+    // use config::object_storage_request_timeout_ms instead
+    config::object_storage_rename_rename_file_timeout_ms = -1;
+    config::object_storage_request_timeout_ms = 1000;
+    // only used for generate a new S3 client into global cache
+    (void)fs->rename_file(S3Path("/dir/source_name"), S3Path("/dir/target_name"));
+    config.requestTimeoutMs = config::object_storage_request_timeout_ms;
+    ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config));
 }
 
 } // namespace starrocks

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -544,7 +544,7 @@ TEST_F(S3FileSystemTest, test_new_S3_client_with_rename_operation) {
     ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config));
 
     // use config::object_storage_request_timeout_ms instead
-    config::object_storage_rename_rename_file_timeout_ms = -1;
+    config::object_storage_rename_file_request_timeout_ms = -1;
     config::object_storage_request_timeout_ms = 1000;
     // only used for generate a new S3 client into global cache
     (void)fs->rename_file(S3Path("/dir/source_name"), S3Path("/dir/target_name"));

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -513,6 +513,8 @@ TEST_F(S3FileSystemTest, test_delete_nonexist_file) {
 }
 
 TEST_F(S3FileSystemTest, test_new_S3_client_with_rename_operation) {
+    int default_value = config::object_storage_rename_file_request_timeout_ms;
+    config::object_storage_rename_file_request_timeout_ms = 2000;
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("s3://"));
     // only used for generate a new S3 client into global cache
     (void)fs->rename_file(S3Path("/dir/source_name"), S3Path("/dir/target_name"));
@@ -573,7 +575,7 @@ TEST_F(S3FileSystemTest, test_new_S3_client_with_rename_operation) {
     (void)S3ClientFactory::instance().new_client(tCloudConfiguration, S3ClientFactory::OperationType::RENAME_FILE);
     config.requestTimeoutMs = config::object_storage_request_timeout_ms;
     ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config, &cloud_config));
-    config::object_storage_rename_file_request_timeout_ms = old_object_storage_rename_file_request_timeout_ms;
+    config::object_storage_rename_file_request_timeout_ms = default_value;
     config::object_storage_request_timeout_ms = old_object_storage_request_timeout_ms;
 }
 


### PR DESCRIPTION
## Why I'm doing:
Currently, sr use object_storage_request_timeout_ms as the S3 client request timeout. But this parameter maybe too small in some case especially using by rename_file operation for large file (1GB, for example). Timeout maybe happen in this case

## What I'm doing:
We introduce a new BE/CN config called `object_storage_rename_file_request_timeout_ms` and it is used as following:
1. If `object_storage_rename_file_request_timeout_ms` >= 0, it will used for rename_file operation in S3 as the request timeout.
2. If `object_storage_rename_file_request_timeout_ms` < 0, the timeout limit for rename_file operation in S3 will be determinded by object_storage_request_timeout_ms.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
