### PR TITLE
[BugFix] Fix spark plan error by using `sql_select_limit`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -54,6 +54,7 @@ import com.starrocks.planner.PlanFragment;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -212,10 +213,13 @@ public class TableQueryPlanAction extends RestBaseAction {
              * currently only used in Spark/Flink Connector
              */
             context.getSessionVariable().setSingleNodeExecPlan(true);
+            long limit = context.getSessionVariable().getSqlSelectLimit();
+            context.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
             statementBase =
                     com.starrocks.sql.parser.SqlParser.parse(sql, context.getSessionVariable()).get(0);
-            execPlan = new StatementPlanner().plan(statementBase, context);
+            execPlan = StatementPlanner.plan(statementBase, context);
             context.getSessionVariable().setSingleNodeExecPlan(false);
+            context.getSessionVariable().setSqlSelectLimit(limit);
         } catch (Exception e) {
             LOG.error("error occurred when optimizing queryId: {}", context.getQueryId(), e);
             throw new StarRocksHttpException(HttpResponseStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
```
curl --location-trusted -u root: -d  '{"sql": "select * from `ssb`.`part` "}'  -XPOST http://172.26.95.213:8030/api/ssb/part/_query_plan
{"exception":"Planner should plan just only one PlanFragment but found [ 2]","status":500}
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
