### PR TITLE
[BugFix] store query_id instead of start_task_run_id in task_run_history

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -121,7 +121,7 @@ public class TaskRunHistoryTable {
 
                 return MessageFormat.format(INSERT_SQL_VALUE,
                         String.valueOf(status.getTaskId()),
-                        Strings.quote(status.getStartTaskRunId()),
+                        Strings.quote(status.getQueryId()),
                         Strings.quote(status.getTaskName()),
                         Strings.quote(status.getState().toString()),
                         createTime,

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -72,7 +72,7 @@ public class TaskRunHistoryTest {
                         "task_state, create_time, finish_time, expire_time, history_content_json) " +
                         "VALUES(0, 'aaa', 't1', 'SUCCESS', '1970-01-01 08:00:00', " +
                         "'1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
-                        "'{\"startTaskRunId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
+                        "'{\"queryId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
                         "\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false,\"source\":\"CTAS\"," +
                         "\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"SUCCESS\"," +
                         "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
@@ -84,7 +84,7 @@ public class TaskRunHistoryTest {
 
         TaskRunHistoryTable history = new TaskRunHistoryTable();
         TaskRunStatus status = new TaskRunStatus();
-        status.setStartTaskRunId("aaa");
+        status.setQueryId("aaa");
         status.setTaskName("t1");
         status.setState(Constants.TaskRunState.SUCCESS);
         history.addHistory(status);
@@ -224,7 +224,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDML(
                         "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, task_state, " +
-                                "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'null', 't2'," +
+                                "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'q2', 't2'," +
                                 " 'SUCCESS', '1970-01-01 08:00:00', '1970-01-01 08:00:00', '2024-07-05 15:38:00', " +
                                 "'{\"queryId\":\"q2\",\"taskId\":0,\"taskName\":\"t2\",\"createTime\":0," +
                                 "\"expireTime\":1720165080904,\"priority\":0,\"mergeRedundant\":false," +


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- we should store the `query_id` as `task_run_id`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
