### PR TITLE
[BugFix] fix parser tracer only worked when enable profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -39,7 +39,7 @@ public class Tracers {
     // [empty tracer, real tracer]
     private final Tracer[] allTracer = new Tracer[] {EMPTY_TRACER, EMPTY_TRACER};
 
-    // mark enable module, default enable parser module.
+    // mark enable module, default enable parser module
     private int moduleMask = 1 << Module.PARSER.ordinal();
 
     // mark enable mode, default enable timer mode

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -28,7 +28,7 @@ public class Tracers {
     }
 
     public enum Module {
-        NONE, ALL, BASE, OPTIMIZER, SCHEDULER, ANALYZE, MV, EXTERNAL
+        NONE, ALL, BASE, OPTIMIZER, SCHEDULER, ANALYZE, MV, EXTERNAL, PARSER
     }
 
     private static final Tracer EMPTY_TRACER = new Tracer() {
@@ -39,11 +39,11 @@ public class Tracers {
     // [empty tracer, real tracer]
     private final Tracer[] allTracer = new Tracer[] {EMPTY_TRACER, EMPTY_TRACER};
 
-    // mark enable module
-    private int moduleMask = 0;
+    // mark enable module, default enable parser module.
+    private int moduleMask = 1 << Module.PARSER.ordinal();
 
-    // mark enable mode
-    private int modeMask = 0;
+    // mark enable mode, default enable timer mode
+    private int modeMask = 1 << Mode.TIMER.ordinal();
 
     private boolean isCommandLog = false;
 
@@ -102,6 +102,9 @@ public class Tracers {
      */
     public static void init(Mode mode, Module module, boolean enableProfile, boolean checkMV) {
         Tracers tracers = THREAD_LOCAL.get();
+        // reset all mark
+        tracers.moduleMask = 0;
+        tracers.modeMask = 0;
         if (Module.NONE == module || null == module) {
             tracers.moduleMask = 0;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -309,9 +309,7 @@ public class ConnectProcessor {
         try {
             ctx.setQueryId(UUIDUtil.genUUID());
             List<StatementBase> stmts;
-            // init tracer to record parser time
-            Tracers.init(ctx, Tracers.Mode.TIMER, null);
-            try (Timer ignored = Tracers.watchScope("Parser")) {
+            try (Timer ignored = Tracers.watchScope(Tracers.Module.PARSER, "Parser")) {
                 stmts = com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable());
             } catch (ParsingException parsingException) {
                 throw new AnalysisException(parsingException.getMessage());
@@ -336,7 +334,6 @@ public class ConnectProcessor {
                     }
                 }
                 parsedStmt.setOrigStmt(new OriginStatement(originStmt, i));
-                // update tracer info from parsed stmt
                 Tracers.init(ctx, parsedStmt.getTraceMode(), parsedStmt.getTraceModule());
 
                 executor = new StmtExecutor(ctx, parsedStmt);


### PR DESCRIPTION
## Why I'm doing:
trace times not record parser time when disable profile.
## What I'm doing:
enable parser module and timer mode by default.
```
mysql> trace times select abs(1);
+--------------------------------------------------+
| Explain String                                   |
+--------------------------------------------------+
| 0ms|-- Parser[1] 0                               |
| 0ms|-- Total[1] 4ms                              |
| 0ms|    -- Lock[1] 0                             |
| 0ms|    -- Analyzer[1] 0                         |
| 1ms|    -- Transformer[1] 0                      |
| 1ms|    -- Optimizer[1] 2ms                      |
| 2ms|        -- MVPreprocess[1] 0                 |
| 2ms|            -- MVChooseCandidates[1] 0       |
| 2ms|            -- MVGenerateMvPlan[1] 0         |
| 2ms|            -- MVValidateMv[1] 0             |
| 2ms|            -- MVProcessWithView[1] 0        |
| 3ms|        -- RuleBaseOptimize[1] 0             |
| 4ms|        -- CostBaseOptimize[1] 0             |
| 4ms|        -- PhysicalRewrite[1] 0              |
| 4ms|        -- PlanValidate[1] 0                 |
| 4ms|            -- InputDependenciesChecker[1] 0 |
| 4ms|            -- TypeChecker[1] 0              |
| 4ms|            -- CTEUniqueChecker[1] 0         |
| 4ms|            -- ColumnReuseChecker[1] 0       |
| 4ms|    -- ExecPlanBuild[1] 0                    |
| Tracer Cost: 71us                                |
+--------------------------------------------------+
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
