### PR TITLE
[BugFix] Fix lowcardinality error on temporary partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1295,6 +1295,16 @@ public class OlapTable extends Table {
         dropPartition(dbId, partitionName, isForceDrop, false);
     }
 
+    // check input partition has temporary partition
+    public boolean inputHasTempPartition(List<Long> partitionIds) {
+        for (Long pid : partitionIds) {
+            if (tempPartitions.getPartition(pid) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /*
      * A table may contain both formal and temporary partitions.
      * There are several methods to get the partition of a table.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -939,6 +939,11 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             if (table.hasForbiddenGlobalDict()) {
                 continue;
             }
+            // skip low-cardinality optimize for temp partition
+            // our dict collection won't collect temp partition we could support it later
+            if (table.inputHasTempPartition(scanOperator.getSelectedPartitionId())) {
+                continue;
+            }
             for (ColumnRefOperator column : scanOperator.getColRefToColumnMetaMap().keySet()) {
                 // Condition 1:
                 if (!column.getType().isVarchar()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -530,6 +530,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         if (table.hasForbiddenGlobalDict()) {
             return DecodeInfo.EMPTY;
         }
+        if (table.inputHasTempPartition(scan.getSelectedPartitionId())) {
+            return DecodeInfo.EMPTY;
+        }
 
         // check dict column
         DecodeInfo info = new DecodeInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1909,4 +1909,18 @@ public class LowCardinalityTest extends PlanTestBase {
         assertContains(plan, "if(DictDecode(10: S_ADDRESS, [<place-holder> = '']), ''," +
                 " substr(md5(DictDecode(10: S_ADDRESS, [<place-holder>])), 1, 3))");
     }
+
+    @Test
+    public void testTempPartition() throws Exception {
+        FeConstants.unitTestView = false;
+        try {
+            String sql = "ALTER TABLE lineitem_partition ADD TEMPORARY PARTITION px VALUES [('1998-01-01'), ('1999-01-01'));";
+            starRocksAssert.alterTable(sql);
+            sql = "select distinct L_COMMENT from lineitem_partition TEMPORARY PARTITION(px)";
+            String plan = getFragmentPlan(sql);
+            assertNotContains(plan, "dict_col");
+        } finally {
+            FeConstants.unitTestView = true;
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2143,4 +2143,18 @@ public class LowCardinalityTest2 extends PlanTestBase {
         assertContains(plan, "17: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
         assertContains(plan, "15: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
     }
+
+    @Test
+    public void testTempPartition() throws Exception {
+        FeConstants.unitTestView = false;
+        try {
+            String sql = "ALTER TABLE lineitem_partition ADD TEMPORARY PARTITION px VALUES [('1998-01-01'), ('1999-01-01'));";
+            starRocksAssert.alterTable(sql);
+            sql = "select distinct L_COMMENT from lineitem_partition TEMPORARY PARTITION(px)";
+            String plan = getFragmentPlan(sql);
+            assertNotContains(plan, "dict_col");
+        } finally {
+            FeConstants.unitTestView = true;
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
reproduce case:
```

CREATE TABLE `allstringy` (
  `c0` bigint DEFAULT NULL,
  `c1` string DEFAULT NULL
) ENGINE=OLAP 
DUPLICATE KEY(`c0`)
COMMENT "OLAP"
PARTITION BY RANGE(`c0`)
(
PARTITION p1 VALUES [("-2147483648"), ("0")),
PARTITION p2 VALUES [("0"), ("1024")),
PARTITION p3 VALUES [("1024"), ("2048")),
PARTITION p4 VALUES [("2048"), ("4096")),
PARTITION p5 VALUES [("4096"), ("8192")),
PARTITION p6 VALUES [("8192"), ("65536")),
PARTITION p7 VALUES [("65536"), ("2100000000")))
DISTRIBUTED BY HASH(`c0`) BUCKETS 4
PROPERTIES (
"replication_num" = "1",
"compression" = "LZ4"
);

insert into allstringy values (1, 'S0');
insert into allstringy values (4096, 'S1');
select distinct c1 from allstringy order by 1;
function: wait_global_dict_ready('c1', 'allstringy')

ALTER TABLE allstringy ADD TEMPORARY PARTITION px VALUES [("4096"), ("8192"));
insert into allstringy TEMPORARY PARTITION(px) values (4096, 'S2');
select distinct c1 from allstringy order by 1;
function: wait_global_dict_ready('c1', 'allstringy')
select distinct c1 from allstringy TEMPORARY PARTITION (px) order by 1;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
