### PR TITLE
[BugFix] fix incorrect healthy value in basicStatsMeta

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -867,7 +867,7 @@ public class AnalyzeMgr implements Writable {
                     StatsConstants.buildInitStatsProp(), loadedRows);
             GlobalStateMgr.getCurrentState().getAnalyzeMgr().getBasicStatsMetaMap().put(tableId, meta);
         } else {
-            basicStatsMeta.increaseUpdateRows(loadedRows);
+            basicStatsMeta.increaseDeltaRows(loadedRows);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -153,9 +153,9 @@ public class BasicStatsMeta implements Writable {
         if (updatePartitionCount == 0) {
             return 1;
         } else if (updatePartitionCount < StatsConstants.STATISTICS_PARTITION_UPDATED_THRESHOLD) {
-            updateRatio = (updateRows * 1.0) / updatePartitionRowCount;
+            updateRatio = (updatePartitionRowCount * 1.0) / Math.max(tableRowCount, updateRows);
         } else {
-            double rowUpdateRatio = (updateRows * 1.0) / updatePartitionRowCount;
+            double rowUpdateRatio = (updatePartitionRowCount * 1.0) / Math.max(tableRowCount, updateRows);
             double partitionUpdateRatio = (updatePartitionCount * 1.0) / totalPartitionCount;
             updateRatio = Math.min(rowUpdateRatio, partitionUpdateRatio);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -58,6 +58,9 @@ public class BasicStatsMeta implements Writable {
     @SerializedName("updateRows")
     private long updateRows;
 
+    @SerializedName("deltaRows")
+    private long deltaRows;
+
     public BasicStatsMeta(long dbId, long tableId, List<String> columns,
                           StatsConstants.AnalyzeType type,
                           LocalDateTime updateTime,
@@ -144,7 +147,7 @@ public class BasicStatsMeta implements Writable {
                 updatePartitionCount++;
             }
         }
-        updatePartitionRowCount = Math.max(1, Math.max(tableRowCount, updateRows) - cachedTableRowCount);
+        updatePartitionRowCount = Math.max(1, Math.max(tableRowCount + deltaRows, updateRows) - cachedTableRowCount);
 
         double updateRatio;
         // 1. If none updated partitions, health is 1
@@ -170,8 +173,9 @@ public class BasicStatsMeta implements Writable {
         this.updateRows = updateRows;
     }
 
-    public void increaseUpdateRows(Long delta) {
+    public void increaseDeltaRows(Long delta) {
         updateRows += delta;
+        deltaRows += delta;
     }
 
     public boolean isInitJobMeta() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -153,9 +153,9 @@ public class BasicStatsMeta implements Writable {
         if (updatePartitionCount == 0) {
             return 1;
         } else if (updatePartitionCount < StatsConstants.STATISTICS_PARTITION_UPDATED_THRESHOLD) {
-            updateRatio = (updatePartitionRowCount * 1.0) / Math.max(tableRowCount, updateRows);
+            updateRatio = (updatePartitionRowCount * 1.0) / tableRowCount;
         } else {
-            double rowUpdateRatio = (updatePartitionRowCount * 1.0) / Math.max(tableRowCount, updateRows);
+            double rowUpdateRatio = (updatePartitionRowCount * 1.0) / tableRowCount;
             double partitionUpdateRatio = (updatePartitionCount * 1.0) / totalPartitionCount;
             updateRatio = Math.min(rowUpdateRatio, partitionUpdateRatio);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.PlanTestBase;
+import mockit.Expectations;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class BasicStatsMetaTest extends PlanTestBase {
+
+    @Before
+    public void before() {
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Test
+    public void testHealthy() {
+        {
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
+            Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "region");
+            List<Partition> partitions = Lists.newArrayList(tbl.getPartitions());
+            new Expectations(partitions.get(0)) {{
+                partitions.get(0).getRowCount();
+                result = 100L;
+            }};
+            BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), tbl.getId(), List.of(),
+                    StatsConstants.AnalyzeType.FULL,
+                    LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 100);
+            Assert.assertEquals(0.05, basicStatsMeta.getHealthy(), 0.01);
+        }
+
+        {
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
+            Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "supplier");
+            List<Partition> partitions = Lists.newArrayList(tbl.getPartitions());
+            new Expectations(partitions.get(0)) {{
+                partitions.get(0).getRowCount();
+                result = 10000L;
+            }};
+            BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), tbl.getId(), List.of(),
+                    StatsConstants.AnalyzeType.FULL,
+                    LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 15000);
+            Assert.assertEquals(0.5, basicStatsMeta.getHealthy(), 0.01);
+        }
+
+    }
+
+    @After
+    public void after() {
+        FeConstants.runningUnitTest = false;
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -44,10 +44,12 @@ public class BasicStatsMetaTest extends PlanTestBase {
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
             Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "region");
             List<Partition> partitions = Lists.newArrayList(tbl.getPartitions());
-            new Expectations(partitions.get(0)) {{
-                partitions.get(0).getRowCount();
-                result = 100L;
-            }};
+            new Expectations(partitions.get(0)) {
+                {
+                    partitions.get(0).getRowCount();
+                    result = 100L;
+                }
+            };
             BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), tbl.getId(), List.of(),
                     StatsConstants.AnalyzeType.FULL,
                     LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 100);
@@ -56,12 +58,15 @@ public class BasicStatsMetaTest extends PlanTestBase {
 
         {
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
-            Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "supplier");
+            Table tbl =
+                    GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "supplier");
             List<Partition> partitions = Lists.newArrayList(tbl.getPartitions());
-            new Expectations(partitions.get(0)) {{
-                partitions.get(0).getRowCount();
-                result = 10000L;
-            }};
+            new Expectations(partitions.get(0)) {
+                {
+                    partitions.get(0).getRowCount();
+                    result = 10000L;
+                }
+            };
             BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), tbl.getId(), List.of(),
                     StatsConstants.AnalyzeType.FULL,
                     LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 15000);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -41,6 +41,7 @@ public class BasicStatsMetaTest extends PlanTestBase {
     @Test
     public void testHealthy() {
         {
+            // total row in cached table statistic is 6, the updated row is 100.
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
             Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "region");
             List<Partition> partitions = Lists.newArrayList(tbl.getPartitions());
@@ -57,6 +58,7 @@ public class BasicStatsMetaTest extends PlanTestBase {
         }
 
         {
+            // total row in cached table statistic is 10000, the updated row is 15000.
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
             Table tbl =
                     GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "supplier");

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -15,10 +15,12 @@
 package com.starrocks.statistic;
 
 import com.google.common.collect.Lists;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.io.Text;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
 import mockit.Expectations;
@@ -27,9 +29,16 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+
+import static com.starrocks.persist.gson.GsonUtils.GSON;
 
 public class BasicStatsMetaTest extends PlanTestBase {
 
@@ -58,7 +67,7 @@ public class BasicStatsMetaTest extends PlanTestBase {
         }
 
         {
-            // total row in cached table statistic is 10000, the updated row is 15000.
+            // total row in cached table statistic is 10000, the updated row is 10000, the delta row is 5000.
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
             Table tbl =
                     GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "supplier");
@@ -71,15 +80,77 @@ public class BasicStatsMetaTest extends PlanTestBase {
             };
             BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), tbl.getId(), List.of(),
                     StatsConstants.AnalyzeType.FULL,
-                    LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 15000);
+                    LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 10000);
+            basicStatsMeta.increaseDeltaRows(5000L);
+            basicStatsMeta.setUpdateRows(10000L);
             Assert.assertEquals(0.5, basicStatsMeta.getHealthy(), 0.01);
         }
+    }
 
+    @Test
+    public void testSerialization() throws IOException {
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
+        Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "region");
+        {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+            String s = "{\"dbId\":10001,\"tableId\":10177,\"columns\":[],\"type\":\"FULL\",\"updateTime\":1721650800," +
+                    "\"properties\":{},\"updateRows\":10000}";
+            Text.writeString(dataOutputStream, s);
+
+            byte[] bytes = byteArrayOutputStream.toByteArray();
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+            DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+            String deserializedString = Text.readString(dataInputStream);
+            BasicStatsMeta deserializedMeta = GSON.fromJson(deserializedString, BasicStatsMeta.class);
+            Assert.assertEquals(db.getId(), deserializedMeta.getDbId());
+
+        }
+
+        {
+            BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), tbl.getId(), List.of(),
+                    StatsConstants.AnalyzeType.FULL,
+                    LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 10000);
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+            String s = GSON.toJson(basicStatsMeta);
+            Text.writeString(dataOutputStream, s);
+            dataOutputStream.close();
+            byte[] bytes = byteArrayOutputStream.toByteArray();
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+            DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+            String deserializedString = Text.readString(dataInputStream);
+            BasicStatsMetaDemo deserializedMeta = GSON.fromJson(deserializedString, BasicStatsMetaDemo.class);
+            Assert.assertEquals(db.getId(), deserializedMeta.dbId);
+        }
     }
 
     @After
     public void after() {
         FeConstants.runningUnitTest = false;
+    }
+
+    private static class BasicStatsMetaDemo {
+        @SerializedName("dbId")
+        public long dbId;
+
+        @SerializedName("tableId")
+        public long tableId;
+
+        @SerializedName("columns")
+        public List<String> columns;
+
+        @SerializedName("type")
+        public StatsConstants.AnalyzeType type;
+
+        @SerializedName("updateTime")
+        public LocalDateTime updateTime;
+
+        @SerializedName("properties")
+        public Map<String, String> properties;
+
+        @SerializedName("updateRows")
+        public long updateRows;
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -357,7 +357,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), olapTable.getId(), null,
                 StatsConstants.AnalyzeType.SAMPLE,
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1), Maps.newHashMap());
-        basicStatsMeta.increaseUpdateRows(10000000L);
+        basicStatsMeta.increaseDeltaRows(10000000L);
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(basicStatsMeta);
 
         List<StatisticsCollectJob> jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
@@ -380,7 +380,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         BasicStatsMeta basicStatsMeta2 = new BasicStatsMeta(db.getId(), olapTable.getId(), null,
                 StatsConstants.AnalyzeType.SAMPLE,
-                LocalDateTime.of(2022, 1, 1, 1, 1, 1), Maps.newHashMap());
+                LocalDateTime.of(2022, 1, 1, 1, 1, 1), Maps.newHashMap(),
+                basicStatsMeta.getUpdateRows());
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(basicStatsMeta2);
 
         List<StatisticsCollectJob> jobs2 = StatisticsCollectJobFactory.buildStatisticsCollectJob(
@@ -390,7 +391,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         Maps.newHashMap(),
                         StatsConstants.ScheduleStatus.PENDING,
                         LocalDateTime.MIN));
-        Assert.assertEquals(0, jobs2.size());
+        Assert.assertEquals(1, jobs2.size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
`updateRows` in `BasicStatsMeta` had been modified as the sum of load rows and the previous total table rows. The calculation formula of healthy should also been modified.
Add a new attribute deltaRows. When basicStatsMeta is initialized, deltaRows should be set to 0. The number of rows imported during subsequent load tasks will update deltaRows, which helps us calculate the healthy value.

After #36472, updateRows records the value of totalTableRow_snapshot + deltaRows. When initializing a new basicStatsMeta, it should be set to the value of updateRows from the previous basicStatsMeta. When reporting tablet row counts, updateRows should be updated to totalTableRow_latest. This approach ensures that the CBO
can obtain more accurate row counts immediately after load tasks.

## What I'm doing:

use `(updatePartitionRowCount * 1.0) / tableRowCount` to calculate the update ratio.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
