### PR TITLE
[BugFix] Fix always collect dictionary for no-lowcardinality column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -128,8 +128,10 @@ public class Status {
     }
 
     public void setInternalErrorStatus(String msg) {
-        this.errorCode = TStatusCode.INTERNAL_ERROR;
-        this.errorMsg = msg;
+        if (this.errorCode != TStatusCode.GLOBAL_DICT_ERROR) {
+            this.errorCode = TStatusCode.INTERNAL_ERROR;
+            this.errorMsg = msg;
+        }
     }
 
     public void setPstatus(StatusPB status) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -336,6 +336,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_ENABLE_GREEDY_JOIN_REORDER = "cbo_enable_greedy_join_reorder";
     public static final String CBO_ENABLE_REPLICATED_JOIN = "cbo_enable_replicated_join";
     public static final String CBO_USE_CORRELATED_JOIN_ESTIMATE = "cbo_use_correlated_join_estimate";
+    public static final String ALWAYS_COLLECT_LOW_CARD_DICT = "always_collect_low_card_dict";
     public static final String CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE = "cbo_enable_low_cardinality_optimize";
     public static final String LOW_CARDINALITY_OPTIMIZE_V2 = "low_cardinality_optimize_v2";
     public static final String ARRAY_LOW_CARDINALITY_OPTIMIZE = "array_low_cardinality_optimize";
@@ -1273,6 +1274,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_QUERY_DUMP)
     private boolean enableQueryDump = false;
+
+    // only used for test case
+    @VariableMgr.VarAttr(name = ALWAYS_COLLECT_LOW_CARD_DICT, flag = VariableMgr.INVISIBLE)
+    private boolean alwaysCollectDict = false;
 
     @VariableMgr.VarAttr(name = CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE)
     private boolean enableLowCardinalityOptimize = true;
@@ -3180,6 +3185,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setUseCorrelatedJoinEstimate(boolean useCorrelatedJoinEstimate) {
         this.useCorrelatedJoinEstimate = useCorrelatedJoinEstimate;
+    }
+
+    public boolean isAlwaysCollectDict() {
+        return alwaysCollectDict;
     }
 
     public boolean isEnableLowCardinalityOptimize() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -550,8 +550,11 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             ColumnStatistic columnStatistic = GlobalStateMgr.getCurrentState().getStatisticStorage()
                     .getColumnStatistic(table, column.getName());
             // Condition 2: the varchar column is low cardinality string column
-            if (!column.getType().isArrayType() && !FeConstants.USE_MOCK_DICT_MANAGER && (columnStatistic.isUnknown() ||
-                    columnStatistic.getDistinctValuesCount() > CacheDictManager.LOW_CARDINALITY_THRESHOLD)) {
+
+            boolean alwaysCollectDict = sessionVariable.isAlwaysCollectDict();
+            if (!alwaysCollectDict && !column.getType().isArrayType() && !FeConstants.USE_MOCK_DICT_MANAGER &&
+                    (columnStatistic.isUnknown() ||
+                            columnStatistic.getDistinctValuesCount() > CacheDictManager.LOW_CARDINALITY_THRESHOLD)) {
                 LOG.debug("{} isn't low cardinality string column", column.getName());
                 continue;
             }

--- a/test/sql/test_global_dict/R/collect_dict
+++ b/test/sql/test_global_dict/R/collect_dict
@@ -1,0 +1,48 @@
+-- name: test_collect_dict
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `string300` (
+  `v1` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into string300 SELECT generate_series FROM TABLE(generate_series(1,  300));
+-- result:
+-- !result
+set always_collect_low_card_dict = true;
+-- result:
+-- !result
+select distinct v1 from string300 order by 1 limit 10;
+-- result:
+1
+10
+100
+101
+102
+103
+104
+105
+106
+107
+-- !result
+function: try_collect_dict_N_times('v1', 'string300', 20)
+-- result:
+None
+-- !result
+function: assert_never_collect_dicts('v1', 'string300', 'db_${uuid0}')
+-- result:
+None
+-- !result

--- a/test/sql/test_global_dict/T/collect_dict
+++ b/test/sql/test_global_dict/T/collect_dict
@@ -1,0 +1,25 @@
+-- name: test_collect_dict
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `string300` (
+  `v1` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+insert into string300 SELECT generate_series FROM TABLE(generate_series(1,  300));
+set always_collect_low_card_dict = true;
+select distinct v1 from string300 order by 1 limit 10;
+function: try_collect_dict_N_times('v1', 'string300', 20)
+function: assert_never_collect_dicts('v1', 'string300', 'db_${uuid0}')
+
+
+


### PR DESCRIPTION
## Why I'm doing:

since 83e0656a change the 

```
LOG.warn(e);
coord.getExecStatus().setStatus(e.getMessage());
```

to 
```
coord.getExecStatus().setInternalErrorStatus(e.getMessage());
```

the error code in ExecStatus will be changed to INTERNAL_ERROR

so branch NO_DICT_STRING_COLUMNS will never reached
```
                            if (result.second.isGlobalDictError()) {
                                LOG.debug("{}-{} isn't low cardinality string column", tableId, columnName);
                                NO_DICT_STRING_COLUMNS.add(columnIdentifier);
                                return Optional.empty();
                            } else {
                                // check TStatisticData is not empty, There may be no such column Statistics in BE
                                if (!result.first.isEmpty()) {
                                    return deserializeColumnDict(tableId, columnName, result.first.get(0));
                                } else {
                                    return Optional.empty();
                                }
                            }
```


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
