### PR TITLE
[Enhancement] Support configurable hll_sketch and optimize hll_sketch performance

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
@@ -39,8 +39,8 @@ struct HLLUnionBuilder {
             resolver->add_aggregate_mapping<lt, TYPE_BIGINT, HyperLogLog>(
                     "approx_count_distinct", false, AggregateFactory::MakeHllNdvAggregateFunction<lt>());
 
-            resolver->add_aggregate_mapping<lt, TYPE_BIGINT, DataSketchesHll>(
-                    "approx_count_distinct_hll_sketch", false, AggregateFactory::MakeHllSketchAggregateFunction<lt>());
+            resolver->add_aggregate_mapping_variadic<lt, TYPE_BIGINT, HLLSketchState>(
+                    "ds_hll_count_distinct", false, AggregateFactory::MakeHllSketchAggregateFunction<lt>());
         }
     }
 };

--- a/be/src/exprs/agg/hll_sketch.h
+++ b/be/src/exprs/agg/hll_sketch.h
@@ -23,6 +23,10 @@
 
 namespace starrocks {
 
+struct HLLSketchState {
+    std::unique_ptr<DataSketchesHll> hll_sketch = nullptr;
+};
+
 /**
  * RETURN_TYPE: TYPE_BIGINT
  * ARGS_TYPE: ALL TYPE
@@ -30,16 +34,19 @@ namespace starrocks {
  */
 template <LogicalType LT, typename T = RunTimeCppType<LT>>
 class HllSketchAggregateFunction final
-        : public AggregateFunctionBatchHelper<DataSketchesHll, HllSketchAggregateFunction<LT, T>> {
+        : public AggregateFunctionBatchHelper<HLLSketchState, HllSketchAggregateFunction<LT, T>> {
 public:
     using ColumnType = RunTimeColumnType<LT>;
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
-        this->data(state).clear();
+        this->data(state).hll_sketch->clear();
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
+        // init state if needed
+        _init_if_needed(ctx, columns, state);
+
         uint64_t value = 0;
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
 
@@ -52,7 +59,7 @@ public:
         }
 
         if (value != 0) {
-            this->data(state).update(value);
+            this->data(state).hll_sketch->update(value);
         }
     }
 
@@ -68,7 +75,7 @@ public:
                 value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
 
                 if (value != 0) {
-                    this->data(state).update(value);
+                    this->data(state).hll_sketch->update(value);
                 }
             }
         } else {
@@ -78,7 +85,7 @@ public:
                 value = HashUtil::murmur_hash64A(&v[i], sizeof(v[i]), HashUtil::MURMUR_SEED);
 
                 if (value != 0) {
-                    this->data(state).update(value);
+                    this->data(state).hll_sketch->update(value);
                 }
             }
         }
@@ -86,18 +93,23 @@ public:
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_binary());
-
         const BinaryColumn* hll_column = down_cast<const BinaryColumn*>(column);
         DataSketchesHll hll(hll_column->get(row_num).get_slice());
-        this->data(state).merge(hll);
+        if (UNLIKELY(this->data(state).hll_sketch == nullptr)) {
+            this->data(state).hll_sketch =
+                    std::make_unique<DataSketchesHll>(hll.get_lg_config_k(), hll.get_target_type());
+        }
+        this->data(state).hll_sketch->merge(hll);
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
-        int64_t result = this->data(state).estimate_cardinality();
-
+        int64_t result = 0L;
+        if (LIKELY(this->data(state).hll_sketch != nullptr)) {
+            result = this->data(state).hll_sketch->estimate_cardinality();
+        }
         for (size_t i = start; i < end; ++i) {
             column->get_data()[i] = result;
         }
@@ -106,13 +118,15 @@ public:
     void serialize_to_column([[maybe_unused]] FunctionContext* ctx, ConstAggDataPtr __restrict state,
                              Column* to) const override {
         DCHECK(to->is_binary());
-
         auto* column = down_cast<BinaryColumn*>(to);
-        size_t size = this->data(state).serialize_size();
-        uint8_t result[size];
-
-        size = this->data(state).serialize(result);
-        column->append(Slice(result, size));
+        if (UNLIKELY(this->data(state).hll_sketch == nullptr)) {
+            column->append_default();
+        } else {
+            size_t size = this->data(state).hll_sketch->serialize_size();
+            uint8_t result[size];
+            size = this->data(state).hll_sketch->serialize(result);
+            column->append(Slice(result, size));
+        }
     }
 
     void convert_to_serialize_format([[maybe_unused]] FunctionContext* ctx, const Columns& src, size_t chunk_size,
@@ -126,8 +140,17 @@ public:
 
         size_t old_size = bytes.size();
         uint64_t value = 0;
+        uint8_t log_k;
+        datasketches::target_hll_type tgt_type;
+        std::vector<const Column*> src_datas;
+        src_datas.reserve(src.size());
+        for (const auto& col : src) {
+            src_datas.push_back(col.get());
+        }
+        const Column** src_datas_ptr = src_datas.data();
+        std::tie(log_k, tgt_type) = _parse_hll_sketch_args(ctx, src_datas_ptr);
         for (size_t i = 0; i < chunk_size; ++i) {
-            DataSketchesHll hll;
+            DataSketchesHll hll{log_k, tgt_type};
             if constexpr (lt_is_string<LT>) {
                 Slice s = column->get_slice(i);
                 value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
@@ -153,10 +176,50 @@ public:
         DCHECK(to->is_numeric());
 
         auto* column = down_cast<Int64Column*>(to);
-        column->append(this->data(state).estimate_cardinality());
+        if (UNLIKELY(this->data(state).hll_sketch == nullptr)) {
+            column->append(0L);
+        } else {
+            column->append(this->data(state).hll_sketch->estimate_cardinality());
+        }
     }
 
-    std::string get_name() const override { return "approx_count_distinct_hll_sketch"; }
+    std::string get_name() const override { return "ds_hll_count_distinct"; }
+
+private:
+    void _init_if_needed(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state) const {
+        if (UNLIKELY(this->data(state).hll_sketch == nullptr)) {
+            uint8_t log_k;
+            datasketches::target_hll_type tgt_type;
+            std::tie(log_k, tgt_type) = _parse_hll_sketch_args(ctx, columns);
+            this->data(state).hll_sketch = _init_hll_sketch(log_k, tgt_type);
+        }
+    }
+
+    std::tuple<uint8_t, datasketches::target_hll_type> _parse_hll_sketch_args(FunctionContext* ctx,
+                                                                              const Column** columns) const {
+        uint8_t log_k = DEFAULT_HLL_LOG_K;
+        datasketches::target_hll_type tgt_type = datasketches::HLL_6;
+        if (ctx->get_num_args() == 2) {
+            log_k = (uint8_t)(columns[1]->get(0).get_int32());
+        } else if (ctx->get_num_args() == 3) {
+            log_k = (uint8_t)(columns[1]->get(0).get_int32());
+            std::string tgt_type_str = columns[2]->get(0).get_slice().to_string();
+            std::transform(tgt_type_str.begin(), tgt_type_str.end(), tgt_type_str.begin(), ::toupper);
+            if (tgt_type_str == "HLL_4") {
+                tgt_type = datasketches::HLL_4;
+            } else if (tgt_type_str == "HLL_8") {
+                tgt_type = datasketches::HLL_8;
+            } else {
+                tgt_type = datasketches::HLL_6;
+            }
+        }
+        return {log_k, tgt_type};
+    }
+
+    std::unique_ptr<DataSketchesHll> _init_hll_sketch(
+            uint8_t log_k = DEFAULT_HLL_LOG_K, datasketches::target_hll_type tgt_type = datasketches::HLL_6) const {
+        return std::make_unique<DataSketchesHll>(log_k, tgt_type);
+    }
 };
 
 } // namespace starrocks

--- a/be/src/types/constexpr.h
+++ b/be/src/types/constexpr.h
@@ -29,7 +29,7 @@ constexpr int HLL_COLUMN_DEFAULT_LEN = HLL_REGISTERS_COUNT + 1;
 constexpr int HLL_EMPTY_SIZE = 1;
 
 const static int MAX_HLL_LOG_K = 20;
-const static int HLL_LOG_K = 17;
+const static uint8_t DEFAULT_HLL_LOG_K = 17;
 
 // For JSON type
 constexpr int kJsonDefaultSize = 128;

--- a/be/src/types/hll.cpp
+++ b/be/src/types/hll.cpp
@@ -623,33 +623,47 @@ bool DataSketchesHll::is_valid(const Slice& slice) {
 }
 
 void DataSketchesHll::update(uint64_t hash_value) {
-    _sketch.update(hash_value);
+    _sketch_union->update(hash_value);
+    this->mark_changed();
 }
 
 void DataSketchesHll::merge(const DataSketchesHll& other) {
-    datasketches::hll_union u(MAX_HLL_LOG_K);
-    u.update(_sketch);
-    u.update(other._sketch);
-    _sketch = u.get_result(HLL_TGT_TYPE);
+    if (UNLIKELY(_sketch_union == nullptr)) {
+        _sketch_union = std::make_unique<datasketches::hll_union>(other.get_lg_config_k());
+    }
+    auto o_sketch = other.get_hll_sketch();
+    _sketch_union->update(*o_sketch);
+    this->mark_changed();
 }
 
 size_t DataSketchesHll::max_serialized_size() const {
-    return _sketch.get_max_updatable_serialization_bytes(HLL_LOG_K, HLL_TGT_TYPE);
+    if (_sketch_union == nullptr) {
+        return 0;
+    }
+    uint8_t log_k = get_lg_config_k();
+    datasketches::target_hll_type tgt_type = get_target_type();
+    return get_hll_sketch()->get_max_updatable_serialization_bytes(log_k, tgt_type);
 }
 
 size_t DataSketchesHll::serialize_size() const {
-    return _sketch.get_compact_serialization_bytes();
+    if (_sketch_union == nullptr) {
+        return 0;
+    }
+    return get_hll_sketch()->get_compact_serialization_bytes();
 }
 
 size_t DataSketchesHll::serialize(uint8_t* dst) const {
-    auto serialize_compact = _sketch.serialize_compact();
+    if (_sketch_union == nullptr) {
+        return 0;
+    }
+    auto serialize_compact = _sketch->serialize_compact();
     std::copy(serialize_compact.begin(), serialize_compact.end(), dst);
-    return _sketch.get_compact_serialization_bytes();
+    return get_hll_sketch()->get_compact_serialization_bytes();
 }
 
 bool DataSketchesHll::deserialize(const Slice& slice) {
-    // can be called only when _sketch is empty
-    DCHECK(_sketch.is_empty());
+    // can be called only when _sketch_union is empty
+    DCHECK(_sketch_union == nullptr);
 
     // check if input length is valid
     if (!is_valid(slice)) {
@@ -657,7 +671,11 @@ bool DataSketchesHll::deserialize(const Slice& slice) {
     }
 
     try {
-        _sketch = datasketches::hll_sketch::deserialize((uint8_t*)slice.data, slice.size);
+        auto sketch = std::make_unique<datasketches::hll_sketch>(
+                datasketches::hll_sketch::deserialize((uint8_t*)slice.data, slice.size));
+        _sketch_union = std::make_unique<datasketches::hll_union>(sketch->get_lg_config_k());
+        _sketch_union->update(*sketch);
+        this->mark_changed();
     } catch (std::logic_error& e) {
         LOG(WARNING) << "DataSketchesHll deserialize error: " << e.what();
         return false;
@@ -667,11 +685,18 @@ bool DataSketchesHll::deserialize(const Slice& slice) {
 }
 
 int64_t DataSketchesHll::estimate_cardinality() const {
-    return _sketch.get_estimate();
+    if (_sketch_union == nullptr) {
+        return 0;
+    }
+    return _sketch_union->get_estimate();
 }
 
 std::string DataSketchesHll::to_string() const {
-    return _sketch.to_string();
+    if (_sketch_union == nullptr) {
+        return "";
+    }
+
+    return get_hll_sketch()->to_string();
 }
 
 } // namespace starrocks

--- a/be/src/types/hll.h
+++ b/be/src/types/hll.h
@@ -177,35 +177,50 @@ private:
     }
 };
 
-const static datasketches::target_hll_type HLL_TGT_TYPE = datasketches::HLL_6;
-
 class DataSketchesHll {
 public:
-    DataSketchesHll() = default;
-
-    DataSketchesHll(const DataSketchesHll& other) : _sketch(other._sketch) {}
-
-    DataSketchesHll& operator=(const DataSketchesHll& other) {
-        if (this != &other) {
-            this->_sketch = other._sketch;
-        }
-        return *this;
+    static const datasketches::target_hll_type DEFAULT_HLL_TGT_TYPE = datasketches::HLL_6;
+    DataSketchesHll(uint8_t log_k, datasketches::target_hll_type tgt_type) : _tgt_type(tgt_type) {
+        this->_sketch_union = std::make_unique<datasketches::hll_union>(log_k);
     }
+    DataSketchesHll(const DataSketchesHll& other) = delete;
+    DataSketchesHll& operator=(const DataSketchesHll& other) = delete;
 
-    DataSketchesHll(DataSketchesHll&& other) noexcept : _sketch(std::move(other._sketch)) {}
-
+    DataSketchesHll(DataSketchesHll&& other) noexcept
+            : _sketch_union(std::move(other._sketch_union)), _tgt_type(other._tgt_type) {}
     DataSketchesHll& operator=(DataSketchesHll&& other) noexcept {
         if (this != &other) {
-            this->_sketch = std::move(other._sketch);
+            this->_sketch_union = std::move(other._sketch_union);
+            this->_tgt_type = other._tgt_type;
         }
         return *this;
     }
-
-    explicit DataSketchesHll(uint64_t hash_value) { this->_sketch.update(hash_value); }
 
     explicit DataSketchesHll(const Slice& src);
 
     ~DataSketchesHll() = default;
+
+    /**
+     * Returns sketch's configured lg_k value.
+     * @return Configured lg_k value.
+     */
+    uint8_t get_lg_config_k() const {
+        if (UNLIKELY(_sketch_union == nullptr)) {
+            return DEFAULT_HLL_LOG_K;
+        }
+        return _sketch_union->get_lg_config_k();
+    }
+
+    /**
+     * Returns the sketch's target HLL mode (from #target_hll_type).
+     * @return The sketch's target HLL mode.
+     */
+    datasketches::target_hll_type get_target_type() const {
+        if (UNLIKELY(_sketch_union == nullptr)) {
+            return DEFAULT_HLL_TGT_TYPE;
+        }
+        return _sketch_union->get_target_type();
+    }
 
     // Add a hash value to this HLL value
     // NOTE: input must be a hash_value
@@ -227,13 +242,6 @@ public:
 
     int64_t estimate_cardinality() const;
 
-    static std::string empty() {
-        static DataSketchesHll hll;
-        std::string buf;
-        hll.serialize((uint8_t*)buf.c_str());
-        return buf;
-    }
-
     // No need to check is_valid for datasketches HLL,
     // return ture for compatibility.
     static bool is_valid(const Slice& slice);
@@ -244,10 +252,23 @@ public:
     uint64_t serialize_size() const;
 
     // common interface
-    void clear() { _sketch.reset(); }
+    void clear() { _sketch_union->reset(); }
+
+    datasketches::hll_sketch* get_hll_sketch() const {
+        if (_is_changed) {
+            _sketch = std::make_unique<datasketches::hll_sketch>(_sketch_union->get_result(_tgt_type));
+            _is_changed = false;
+        }
+        return _sketch.get();
+    }
+    inline void mark_changed() { _is_changed = true; }
 
 private:
-    datasketches::hll_sketch _sketch{HLL_LOG_K, HLL_TGT_TYPE};
+    std::unique_ptr<datasketches::hll_union> _sketch_union = nullptr;
+    datasketches::target_hll_type _tgt_type = DEFAULT_HLL_TGT_TYPE;
+    // lazy value of union state
+    mutable std::unique_ptr<datasketches::hll_sketch> _sketch = nullptr;
+    mutable bool _is_changed = true;
 };
 
 } // namespace starrocks

--- a/be/src/types/hll.h
+++ b/be/src/types/hll.h
@@ -179,10 +179,13 @@ private:
 
 class DataSketchesHll {
 public:
+    // default lg_k value for HLL
     static const datasketches::target_hll_type DEFAULT_HLL_TGT_TYPE = datasketches::HLL_6;
-    DataSketchesHll(uint8_t log_k, datasketches::target_hll_type tgt_type) : _tgt_type(tgt_type) {
+
+    explicit DataSketchesHll(uint8_t log_k, datasketches::target_hll_type tgt_type) : _tgt_type(tgt_type) {
         this->_sketch_union = std::make_unique<datasketches::hll_union>(log_k);
     }
+
     DataSketchesHll(const DataSketchesHll& other) = delete;
     DataSketchesHll& operator=(const DataSketchesHll& other) = delete;
 
@@ -200,10 +203,7 @@ public:
 
     ~DataSketchesHll() = default;
 
-    /**
-     * Returns sketch's configured lg_k value.
-     * @return Configured lg_k value.
-     */
+    // Returns sketch's configured lg_k value.
     uint8_t get_lg_config_k() const {
         if (UNLIKELY(_sketch_union == nullptr)) {
             return DEFAULT_HLL_LOG_K;
@@ -211,10 +211,7 @@ public:
         return _sketch_union->get_lg_config_k();
     }
 
-    /**
-     * Returns the sketch's target HLL mode (from #target_hll_type).
-     * @return The sketch's target HLL mode.
-     */
+    // Returns the sketch's target HLL mode (from #target_hll_type).
     datasketches::target_hll_type get_target_type() const {
         if (UNLIKELY(_sketch_union == nullptr)) {
             return DEFAULT_HLL_TGT_TYPE;
@@ -226,6 +223,7 @@ public:
     // NOTE: input must be a hash_value
     void update(uint64_t hash_value);
 
+    // merge with other HLL value
     void merge(const DataSketchesHll& other);
 
     // Return max size of serialized binary
@@ -254,6 +252,7 @@ public:
     // common interface
     void clear() { _sketch_union->reset(); }
 
+    // get hll_sketch object which is lazy initialized
     datasketches::hll_sketch* get_hll_sketch() const {
         if (_is_changed) {
             _sketch = std::make_unique<datasketches::hll_sketch>(_sketch_union->get_result(_tgt_type));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -242,6 +242,7 @@ public class FunctionSet {
     // Aggregate functions:
     public static final String APPROX_COUNT_DISTINCT = "approx_count_distinct";
     public static final String APPROX_COUNT_DISTINCT_HLL_SKETCH = "approx_count_distinct_hll_sketch";
+    public static final String DS_HLL_COUNT_DISTINCT = "ds_hll_count_distinct";
     public static final String APPROX_TOP_K = "approx_top_k";
     public static final String AVG = "avg";
     public static final String COUNT = "count";
@@ -601,7 +602,7 @@ public class FunctionSet {
                     .add(FunctionSet.NOW)
                     .add(FunctionSet.UTC_TIMESTAMP)
                     .add(FunctionSet.MD5_SUM)
-                    .add(FunctionSet.APPROX_COUNT_DISTINCT_HLL_SKETCH)
+                    .add(FunctionSet.DS_HLL_COUNT_DISTINCT)
                     .add(FunctionSet.MD5_SUM_NUMERIC)
                     .add(FunctionSet.BITMAP_EMPTY)
                     .add(FunctionSet.HLL_EMPTY)
@@ -934,10 +935,17 @@ public class FunctionSet {
     }
 
     /**
-     * Adds a builtin to this database. The function must not already exist.
+     * Adds a builtin scalar function to this database. The function must not already exist.
      */
     public void addBuiltin(Function fn) {
         addBuiltInFunction(fn);
+    }
+
+    /**
+     * Adds a builtin aggregate function to this database. The function must not already exist.
+     */
+    public void addBuiltin(AggregateFunction aggFunc) {
+        addBuiltInFunction(aggFunc);
     }
 
     // Populate all the aggregate builtins in the globalStateMgr.
@@ -1027,10 +1035,17 @@ public class FunctionSet {
                     Lists.newArrayList(t), Type.BIGINT, Type.VARBINARY,
                     true, false, true));
 
-            //APPROX_COUNT_DISTINCT_HLL_SKETCH
-            //compute approx count distinct use DataSketches HyperLogLog
-            addBuiltin(AggregateFunction.createBuiltin(APPROX_COUNT_DISTINCT_HLL_SKETCH,
-                    Lists.newArrayList(t), Type.BIGINT, Type.VARCHAR,
+            // ds_hll_count_distinct(col)
+            addBuiltin(AggregateFunction.createBuiltin(DS_HLL_COUNT_DISTINCT,
+                    Lists.newArrayList(t), Type.BIGINT, Type.VARBINARY,
+                    true, false, true));
+            // ds_hll_count_distinct(col, log_k)
+            addBuiltin(AggregateFunction.createBuiltin(DS_HLL_COUNT_DISTINCT,
+                    Lists.newArrayList(t, Type.INT), Type.BIGINT, Type.VARBINARY,
+                    true, false, true));
+            // ds_hll_count_distinct(col, log_k, tgt_type)
+            addBuiltin(AggregateFunction.createBuiltin(DS_HLL_COUNT_DISTINCT,
+                    Lists.newArrayList(t, Type.INT, Type.VARCHAR), Type.BIGINT, Type.VARBINARY,
                     true, false, true));
 
             // HLL_RAW
@@ -1454,5 +1469,4 @@ public class FunctionSet {
         }
         return builtinFunctions;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.DecimalLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -34,8 +35,13 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 
 import java.util.Optional;
+import java.util.Set;
 
 public class FunctionAnalyzer {
+    private static final Set<String> SUPPORTED_TGT_TYPES = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+    static {
+        SUPPORTED_TGT_TYPES.addAll(Lists.newArrayList("HLL_8", "HLL_6", "HLL_4"));
+    }
 
     public static void analyze(FunctionCallExpr functionCallExpr) {
         if (functionCallExpr.getFn() instanceof AggregateFunction) {
@@ -277,7 +283,7 @@ public class FunctionAnalyzer {
                 || fnName.getFunction().equals(FunctionSet.MAX)
                 || fnName.getFunction().equals(FunctionSet.NDV)
                 || fnName.getFunction().equals(FunctionSet.APPROX_COUNT_DISTINCT)
-                || fnName.getFunction().equals(FunctionSet.APPROX_COUNT_DISTINCT_HLL_SKETCH))
+                || fnName.getFunction().equals(FunctionSet.DS_HLL_COUNT_DISTINCT))
                 && !arg.getType().canApplyToNumeric()) {
             throw new SemanticException(Type.NOT_SUPPORT_AGG_ERROR_MSG);
         }
@@ -447,6 +453,39 @@ public class FunctionAnalyzer {
             if (rate < 0 || rate > 1) {
                 throw new SemanticException(
                         fnName + " second parameter'value should be between 0 and 1");
+            }
+        }
+
+        // ds_hll_count_distinct
+        if (fnName.getFunction().equals(FunctionSet.DS_HLL_COUNT_DISTINCT)) {
+            int argSize = functionCallExpr.getChildren().size();
+            if (argSize > 3) {
+                throw new SemanticException(fnName + " requires one/two/three parameters: ds_hll_count_distinct(col, <log_k>, " +
+                        "<tgt_type>)");
+            }
+
+            // check the first parameter: log_k
+            if (argSize >= 2) {
+                if (!(functionCallExpr.getChild(1) instanceof IntLiteral)) {
+                    throw new SemanticException(fnName + " 's second parameter's data type is wrong ");
+                }
+                long precision = ((LiteralExpr) functionCallExpr.getChild(1)).getLongValue();
+                if (precision < 4 || precision > 21) {
+                    throw new SemanticException(
+                            fnName + " second parameter'value should be between 4 and 21");
+                }
+            }
+
+            // check the second parameter: tgt_type
+            if (argSize == 3) {
+                if (!(functionCallExpr.getChild(2) instanceof StringLiteral)) {
+                    throw new SemanticException(fnName + " 's second parameter's data type is wrong ");
+                }
+                String tgtType = ((LiteralExpr) functionCallExpr.getChild(2)).getStringValue();
+                if (!SUPPORTED_TGT_TYPES.contains(tgtType)) {
+                    throw new SemanticException(
+                            fnName + " third  parameter'value should be in HLL_4/HLL_6/HLL_8");
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
@@ -70,7 +70,7 @@ public class PreAggregateTurnOnRule implements TreeRewriteRule {
                 .add(FunctionSet.NDV)
                 .add(FunctionSet.MULTI_DISTINCT_COUNT)
                 .add(FunctionSet.APPROX_COUNT_DISTINCT)
-                .add(FunctionSet.APPROX_COUNT_DISTINCT_HLL_SKETCH)
+                .add(FunctionSet.DS_HLL_COUNT_DISTINCT)
                 .add(FunctionSet.BITMAP_UNION_INT.toUpperCase()).build();
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
@@ -35,6 +35,7 @@ public class SyntaxSugars {
         FUNCTION_PARSER = ImmutableMap.<String, Function<FunctionCallExpr, FunctionCallExpr>>builder()
                 .put(FunctionSet.ILIKE, SyntaxSugars::ilike)
                 .put(FunctionSet.STRUCT, SyntaxSugars::struct)
+                .put(FunctionSet.APPROX_COUNT_DISTINCT_HLL_SKETCH, SyntaxSugars::hllSketchCount)
                 .build();
     }
 
@@ -69,5 +70,12 @@ public class SyntaxSugars {
      */
     private static FunctionCallExpr struct(FunctionCallExpr call) {
         return new FunctionCallExpr(FunctionSet.ROW, call.getChildren());
+    }
+
+    /*
+     * approx_count_distinct_hll_sketch(col) -> ds_hll_count_distinct(col)
+     */
+    private static FunctionCallExpr hllSketchCount(FunctionCallExpr call) {
+        return new FunctionCallExpr(FunctionSet.DS_HLL_COUNT_DISTINCT, call.getChildren());
     }
 }

--- a/test/sql/test_agg_function/R/test_hll_sketch_count.sql
+++ b/test/sql/test_agg_function/R/test_hll_sketch_count.sql
@@ -1,0 +1,75 @@
+-- name: test_ds_hll_count_distinct
+CREATE TABLE t1 (
+  id BIGINT NOT NULL,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10) NOT NULL 
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 100000));
+-- result:
+-- !result
+select ds_hll_count_distinct(id), ds_hll_count_distinct(province), ds_hll_count_distinct(age), ds_hll_count_distinct(dt) from t1 order by 1, 2;
+-- result:
+100090	100140	100	1
+-- !result
+select ds_hll_count_distinct(id, 4), ds_hll_count_distinct(province, 4), ds_hll_count_distinct(age, 4), ds_hll_count_distinct(dt, 4) from t1 order by 1, 2;
+-- result:
+94302	83035	106	1
+-- !result
+select ds_hll_count_distinct(id, 10), ds_hll_count_distinct(province, 10), ds_hll_count_distinct(age, 10), ds_hll_count_distinct(dt, 10) from t1 order by 1, 2;
+-- result:
+99844	101905	96	1
+-- !result
+select ds_hll_count_distinct(id, 21), ds_hll_count_distinct(province, 21), ds_hll_count_distinct(age, 21), ds_hll_count_distinct(dt, 21) from t1 order by 1, 2;
+-- result:
+99995	100001	100	1
+-- !result
+select ds_hll_count_distinct(id, 10, "HLL_4"), ds_hll_count_distinct(province, 10, "HLL_4"), ds_hll_count_distinct(age, 10, "HLL_4"), ds_hll_count_distinct(dt, 10, "HLL_4") from t1 order by 1, 2;
+-- result:
+99844	101905	96	1
+-- !result
+select ds_hll_count_distinct(id, 10, "HLL_6"), ds_hll_count_distinct(province, 10, "HLL_6"), ds_hll_count_distinct(age, 10, "HLL_6"), ds_hll_count_distinct(dt, 10, "HLL_6") from t1 order by 1, 2;
+-- result:
+99844	101905	96	1
+-- !result
+select ds_hll_count_distinct(id, 10, "HLL_8"), ds_hll_count_distinct(province, 10, "HLL_8"), ds_hll_count_distinct(age, 10, "HLL_8"), ds_hll_count_distinct(dt, 10, "HLL_8") from t1 order by 1, 2;
+-- result:
+99844	101905	96	1
+-- !result
+INSERT INTO t1 values (1, 'a', 1, '2024-07-22'), (2, 'b', 1, '2024-07-23'), (3, NULL, NULL, '2024-07-24');
+-- result:
+-- !result
+select id, province, ds_hll_count_distinct(id), ds_hll_count_distinct(province), ds_hll_count_distinct(age), ds_hll_count_distinct(dt) from t1 group by 1, 2 order by 1, 2 limit 3;
+-- result:
+1	1	1	1	1	1
+1	a	1	1	1	1
+2	2	1	1	1	1
+-- !result
+select id, province, ds_hll_count_distinct(id, 10), ds_hll_count_distinct(province, 10), ds_hll_count_distinct(age, 10), ds_hll_count_distinct(dt, 10) from t1 group by 1, 2 order by 1, 2 limit 3;
+-- result:
+1	1	1	1	1	1
+1	a	1	1	1	1
+2	2	1	1	1	1
+-- !result
+select id, province, ds_hll_count_distinct(id, 10, "HLL_4"), ds_hll_count_distinct(province, 10, "HLL_4"), ds_hll_count_distinct(age, 10, "HLL_4"), ds_hll_count_distinct(dt, 10, "HLL_4") from t1 group by 1, 2 order by 1, 2 limit 3;
+-- result:
+1	1	1	1	1	1
+1	a	1	1	1	1
+2	2	1	1	1	1
+-- !result
+select ds_hll_count_distinct(id, 1)  from t1 order by 1, 2;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: ds_hll_count_distinct second parameter'value should be between 4 and 21.")
+-- !result
+select ds_hll_count_distinct(id, 100)  from t1 order by 1, 2;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: ds_hll_count_distinct second parameter'value should be between 4 and 21.")
+-- !result
+select ds_hll_count_distinct(id, 10, "INVALID") from t1 order by 1, 2;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: ds_hll_count_distinct third  parameter'value should be in HLL_4/HLL_6/HLL_8.")
+-- !result

--- a/test/sql/test_agg_function/T/test_hll_sketch_count.sql
+++ b/test/sql/test_agg_function/T/test_hll_sketch_count.sql
@@ -1,0 +1,35 @@
+-- name: test_ds_hll_count_distinct
+CREATE TABLE t1 (
+  id BIGINT NOT NULL,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10) NOT NULL 
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4;
+
+-- init with 10w values
+insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 100000));
+
+-- without params
+select ds_hll_count_distinct(id), ds_hll_count_distinct(province), ds_hll_count_distinct(age), ds_hll_count_distinct(dt) from t1 order by 1, 2;
+
+-- with 1 param
+select ds_hll_count_distinct(id, 4), ds_hll_count_distinct(province, 4), ds_hll_count_distinct(age, 4), ds_hll_count_distinct(dt, 4) from t1 order by 1, 2;
+select ds_hll_count_distinct(id, 10), ds_hll_count_distinct(province, 10), ds_hll_count_distinct(age, 10), ds_hll_count_distinct(dt, 10) from t1 order by 1, 2;
+select ds_hll_count_distinct(id, 21), ds_hll_count_distinct(province, 21), ds_hll_count_distinct(age, 21), ds_hll_count_distinct(dt, 21) from t1 order by 1, 2;
+
+-- with 2 params
+select ds_hll_count_distinct(id, 10, "HLL_4"), ds_hll_count_distinct(province, 10, "HLL_4"), ds_hll_count_distinct(age, 10, "HLL_4"), ds_hll_count_distinct(dt, 10, "HLL_4") from t1 order by 1, 2;
+select ds_hll_count_distinct(id, 10, "HLL_6"), ds_hll_count_distinct(province, 10, "HLL_6"), ds_hll_count_distinct(age, 10, "HLL_6"), ds_hll_count_distinct(dt, 10, "HLL_6") from t1 order by 1, 2;
+select ds_hll_count_distinct(id, 10, "HLL_8"), ds_hll_count_distinct(province, 10, "HLL_8"), ds_hll_count_distinct(age, 10, "HLL_8"), ds_hll_count_distinct(dt, 10, "HLL_8") from t1 order by 1, 2;
+
+INSERT INTO t1 values (1, 'a', 1, '2024-07-22'), (2, 'b', 1, '2024-07-23'), (3, NULL, NULL, '2024-07-24');
+select id, province, ds_hll_count_distinct(id), ds_hll_count_distinct(province), ds_hll_count_distinct(age), ds_hll_count_distinct(dt) from t1 group by 1, 2 order by 1, 2 limit 3;
+select id, province, ds_hll_count_distinct(id, 10), ds_hll_count_distinct(province, 10), ds_hll_count_distinct(age, 10), ds_hll_count_distinct(dt, 10) from t1 group by 1, 2 order by 1, 2 limit 3;
+select id, province, ds_hll_count_distinct(id, 10, "HLL_4"), ds_hll_count_distinct(province, 10, "HLL_4"), ds_hll_count_distinct(age, 10, "HLL_4"), ds_hll_count_distinct(dt, 10, "HLL_4") from t1 group by 1, 2 order by 1, 2 limit 3;
+
+-- bad cases
+select ds_hll_count_distinct(id, 1)  from t1 order by 1, 2;
+select ds_hll_count_distinct(id, 100)  from t1 order by 1, 2;
+select ds_hll_count_distinct(id, 10, "INVALID") from t1 order by 1, 2;


### PR DESCRIPTION
## Why I'm doing:
`HLL_SKETCH` is very useful for high precision ndv compute. The PR(https://github.com/StarRocks/starrocks/pull/20836) has supported hll_sketch aggregation, but there are some limitions:
1.  HLLSketch's `precision` and `hll_type` cannot be configurable for different scences.
2. There is a performance throttle for high cardinality compute in `merge`: 

```
+   88.79%     0.00%  pip_wg_executor  [.] starrocks::Thread::supervise_thread
+   88.79%     0.00%  pip_wg_executor  [.] starrocks::ThreadPool::dispatch_thread
+   88.79%     0.00%  pip_wg_executor  [.] starrocks::pipeline::GlobalDriverExecutor::_worker_thread
+   88.79%     0.00%  pip_wg_executor  [.] starrocks::pipeline::PipelineDriver::process                                                                                                                                                                                                                                                                           ▒
+   88.79%     0.00%  pip_wg_executor  [.] starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk
-   88.79%     0.00%  pip_wg_executor  [.] starrocks::Aggregator::compute_batch_agg_states
     starrocks::Aggregator::compute_batch_agg_states                                                                                                                                                                                                                                                                                                              ▒
   - starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::DataSketchesHll, false>, false, true, starrocks::AggNonNullPred<starrocks::DataSketchesHll> >::merge_batch                                                                                                     ▒
      - 88.77% starrocks::HllSketchAggregateFunction<(starrocks::LogicalType)17, starrocks::Slice>::merge                                                                                                                                                                                                                                                         ▒
         + 88.76% starrocks::DataSketchesHll::merge                                                                                                                                                                                                                                                                                                               ▒
-   88.79%     0.00%  pip_wg_executor  [.] starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::DataSketchesHll, false>, false, true, starrocks::AggNonNullPred<starrocks::DataSketchesHll> >::merge_batch                                                               ▒
   - starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::DataSketchesHll, false>, false, true, starrocks::AggNonNullPred<starrocks::DataSketchesHll> >::merge_batch                                                                                                     ▒
      - 88.77% starrocks::HllSketchAggregateFunction<(starrocks::LogicalType)17, starrocks::Slice>::merge                                                                                                                                                                                                                                                         ▒
         - 88.76% starrocks::DataSketchesHll::merge                                                                                                                                                                                                                                                                                                               ▒
            - 44.77% datasketches::hll_union_alloc<std::allocator<unsigned char> >::union_impl                                                                                                                                                                                                                                                                    ▒
               - datasketches::HllArray<std::allocator<unsigned char> >::copyAs                                                                                                                                                                                                                                                                                   ▒
                    31.51% datasketches::Hll8Array<std::allocator<unsigned char> >::mergeHll                                                                                                                                                                                                                                                                      ▒
                    12.78% datasketches::HllArray<std::allocator<unsigned char> >::hipAndKxQIncrementalUpdate                                                                                                                                                                                                                                                     ▒
            - 41.25% datasketches::HllSketchImplFactory<std::allocator<unsigned char> >::convertToHll6                                                                                                                                                                                                                                                            ▒
                 10.63% datasketches::Hll6Array<std::allocator<unsigned char> >::internalCouponUpdate                                                                                                                                                                                                                                                             ▒
                 9.18% datasketches::HllArray<std::allocator<unsigned char> >::hipAndKxQIncrementalUpdate                                                                                                                                                                                                                                                         ▒
              1.77% datasketches::Hll6Array<std::allocator<unsigned char> >::internalCouponUpdate                                                                                                                                                                                                                                                                 ▒
              0.93% __memmove_evex_unaligned_erms                                                                                                                                                                                                                                                                                                                 ▒
+   88.77%     0.00%  pip_wg_executor  [.] starrocks::HllSketchAggregateFunction<(starrocks::LogicalType)17, starrocks::Slice>::merge                                                                                                                                                                                                                             ▒
+   88.77%     0.00%  pip_wg_executor  [.] starrocks::DataSketchesHll::merge                                                                                                                                                                                                                                                                                      ◆
+   41.56%    20.98%  pip_wg_executor  [.] datasketches::HllSketchImplFactory<std::allocator<unsigned char> >::convertToHll6                                                                                                                                                                                                                                      ▒
+   21.96%    20.54%  pip_wg_executor  [.] datasketches::HllArray<std::allocator<unsigned char> >::hipAndKxQIncrementalUpdate                                                                                                                                                                                                                                     ▒
+   12.71%    12.39%  pip_wg_executor  [.] datasketches::Hll6Array<std::allocator<unsigned char> >::internalCouponUpdate
```

`merge` function is heavy since it will copy `hllsketch` into `hll_union` each call:
```
void DataSketchesHll::merge(const DataSketchesHll& other) {
    datasketches::hll_union u(MAX_HLL_LOG_K);
    u.update(_sketch);
    u.update(other._sketch);
    _sketch = u.get_result(HLL_TGT_TYPE);
}
```
## What I'm doing:
- Add an alias name `ds_hll_count_distinct` to be better syntax meanings(original function name is also kept either)
- Support configurable `hll_sketch` with different `precision` and `hll_type`:
![image](https://github.com/user-attachments/assets/98363c9e-2a41-4449-b990-df6fa1808841)
- Optimize `merge` performance by using `hll_union` as state rather than `hllsketch` to avoid copying in `merge`  call.

aggregate mode | Tables | After(ms) | Before(ms)
-- | -- | -- | --
force_streaming | t1 | 7377 | 8930
force_streaming | t2 | 7660 | 9526
force_streaming | t3 | 13425 | timeout(5min)
force_streaming | t4 | 7830 | 16568
auto | t1 | 4821 | 4626
auto | t2 | 7880 | 8834
auto | t3 | 1366 | 1546
auto | t4 | 784 | 797

</byte-sheet-html-origin><!--EndFragment-->
Fixes [#issue](https://github.com/StarRocks/starrocks/issues/49000)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
