### PR TITLE
[BugFix] mkdir $STARROCKS_HOME/meta in bin/start_fe.sh

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -55,6 +55,15 @@ jvm_arch() {
     echo $jvm_arch
 }
 
+read_var_from_conf() {
+    local var_name=$1
+    local conf_file=$2
+    local var_line=`grep $var_name $conf_file | sed 's/[[:blank:]]*=[[:blank:]]*/=/g' | sed 's/^[[:blank:]]*//g' | grep ^$var_name=`
+    if [[ $var_line == *"="* ]]; then
+        eval "$var_line"
+    fi
+}
+
 export_env_from_conf() {
     while read line; do
         envline=`echo $line | sed 's/[[:blank:]]*=[[:blank:]]*/=/g' | sed 's/^[[:blank:]]*//g' | egrep "^[[:upper:]]([[:upper:]]|_|[[:digit:]])*="`

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -176,6 +176,9 @@ if [ ! -d $LOG_DIR ]; then
     mkdir -p $LOG_DIR
 fi
 
+read_var_from_conf meta_dir $STARROCKS_HOME/conf/fe.conf
+mkdir -p ${meta_dir:-"$STARROCKS_HOME/meta"}
+
 # add libs to CLASSPATH
 for f in $STARROCKS_HOME/lib/*.jar; do
   CLASSPATH=$f:${CLASSPATH};

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -18,7 +18,7 @@
 #####################################################################
 ## The uppercase properties are read and exported by bin/start_fe.sh.
 ## To see all Frontend configurations,
-## see fe/src/com/starrocks/common/Config.java
+## see fe/fe-core/src/main/java/com/starrocks/common/Config.java
 
 # the output dir of stderr/stdout/gc
 LOG_DIR = ${STARROCKS_HOME}/log


### PR DESCRIPTION
## Why I'm doing:
When I run `./bin/start_fe.sh` after running `build.sh`, it reports an error:

```
2024-07-25 16:57:39.027Z ERROR (main|1) [MetaHelper.checkMetaDir():166] meta dir /data/starrocks/output/fe/meta does not exist
2024-07-25 16:57:39.031Z ERROR (main|1) [StarRocksFE.start():185] StarRocksFE start failed
com.starrocks.common.InvalidMetaDirException: null
        at com.starrocks.leader.MetaHelper.checkMetaDir(MetaHelper.java:167) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:120) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:83) ~[starrocks-fe.jar:?]
```

This is because we have not created `meta` directory.

## What I'm doing:

Add `mkdir $STARROCKS_HOME/meta` command in bin/start_fe.sh


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
