### PR TITLE
[BugFix] Fix orc search argument build failed for decimal type

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -161,12 +161,14 @@ Expr::Expr(TypeDescriptor type, bool is_slotref)
         case TYPE_VARBINARY:
             _node_type = (TExprNodeType::BINARY_LITERAL);
             break;
-        case TYPE_UNKNOWN:
-        case TYPE_STRUCT:
-        case TYPE_MAP:
         case TYPE_DECIMAL32:
         case TYPE_DECIMAL64:
         case TYPE_DECIMAL128:
+            _node_type = TExprNodeType::DECIMAL_LITERAL;
+            break;
+        case TYPE_UNKNOWN:
+        case TYPE_STRUCT:
+        case TYPE_MAP:
         case TYPE_JSON:
             break;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -149,6 +149,7 @@ set(EXEC_FILES
         ./exprs/utility_functions_test.cpp
         ./exprs/runtime_filter_test.cpp
         ./exprs/subfield_expr_test.cpp
+        ./exprs/vectorized_literal_test.cpp
         ./formats/csv/array_converter_test.cpp
         ./formats/csv/boolean_converter_test.cpp
         ./formats/csv/csv_file_writer_test.cpp

--- a/be/test/exprs/vectorized_literal_test.cpp
+++ b/be/test/exprs/vectorized_literal_test.cpp
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <column/column_helper.h>
+#include <gtest/gtest.h>
+
+#include "exprs/literal.h"
+
+namespace starrocks {
+class VectorizedLiteralTest : public ::testing::Test {
+public:
+    void SetUp() override {}
+};
+
+TEST_F(VectorizedLiteralTest, literal_test) {
+    TypeDescriptor type = TypeDescriptor::from_logical_type(TYPE_DECIMAL128, 10, 5, 2);
+    ColumnPtr column = ColumnHelper::create_const_decimal_column<TYPE_DECIMAL128>(10, 5, 2, 1);
+    VectorizedLiteral literal{std::move(column), type};
+    ASSERT_EQ(TExprNodeType::DECIMAL_LITERAL, literal.node_type());
+}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Fix error msg about:
sql is:
```sql
select * from ex_hive_tbl_subquery where col_decimal32_01 > (select col_decimal32_02 from ex_hive_tbl_subquery order by 1 limit 1) order by 1;
```

error msg is:
```bash
(1064, 'ORC reader read file hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/hive_extbl_test_decimalv3.db/hive_hdfs_decimal_subquery/000002_0_copy_1 failed. Reason is vector::_M_range_check: __n (which is 0) >= this->size() (which is 0).')
```

The reason is:
* This SQL will use nest loop join for none-eq join, and generate local runtime filter.
* It will use `CrossJoinNode::rewrite_runtime_filter()->RuntimeFilterHelper::rewrite_runtime_filter_in_cross_join_node()` to generate predicate for runtime filter
* Call `auto literal = pool->add(new VectorizedLiteral(std::move(col), right_child->type()));` to create DecimalLiteral, but this function didn't set expr's `TExprNodeType` for decimal type.
* In the orc search argument builder, it will call `translate_to_orc_literal()` to convert sr's literal to orc's literal.  It depends on `TExprNodeType`, but `TExprNodeType` was not set, so its value is random. Finally, we will see random errors.


## What I'm doing:
fix it


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
