### PR TITLE
[Enhancement][fe] Add ability to cast ROW and ARRAY datatype for Trino

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
@@ -69,13 +69,6 @@ public class TrinoParserNotSupportTest extends TrinoTestBase {
         getFragmentPlan(sql);
     }
 
-    // refer to https://trino.io/docs/current/language/types.html#row
-    @Test
-    public void testCastRowDataType() {
-        String sql = "select CAST(ROW(1, 2e0) AS ROW(x BIGINT, y DOUBLE))";
-        analyzeFail(sql, "does not support the type ROW(x BIGINT, y DOUBLE)");
-    }
-
     // refer to https://trino.io/docs/current/sql/select.html#tablesample
     @Test
     public void testSampleTable() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1214,4 +1214,16 @@ public class TrinoQueryTest extends TrinoTestBase {
         sql = "select rand(10, 100);";
         assertPlanContains(sql, "<slot 2> : floor(random() * 90.0 + 10.0)");
     }
+
+    @Test
+    public void testCastRowDataType() throws Exception {
+        String sql = "select CAST(ROW(1, 2e0) AS ROW(x BIGINT, y DOUBLE))";
+        assertPlanContains(sql, "CAST(row(1, 2.0) AS struct<X bigint(20), Y double>)");
+    }
+
+    @Test
+    public void testCastArrayDataType() throws Exception {
+        String sql = "select cast(ARRAY[1] as array(int))";
+        assertPlanContains(sql, "CAST([1] AS ARRAY<INT>)");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Currently cast as row and cast as array not supported for trino dialect.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
