### PR TITLE
[BugFix] fix pk memory usage error

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1527,6 +1527,9 @@ Status PrimaryIndex::get(const Column& key_col, std::vector<uint64_t>* rowids) c
 }
 
 std::size_t PrimaryIndex::memory_usage() const {
+    if (_persistent_index) {
+        return _persistent_index->memory_usage();
+    }
     return _memory_usage.load();
 }
 
@@ -1609,13 +1612,7 @@ Status PrimaryIndex::pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dum
 }
 
 void PrimaryIndex::_calc_memory_usage() {
-    size_t memory_usage = 0;
-    if (_persistent_index) {
-        memory_usage = _persistent_index->memory_usage();
-    } else {
-        memory_usage = _pkey_to_rssid_rowid ? _pkey_to_rssid_rowid->memory_usage() : 0;
-    }
-    _memory_usage.store(memory_usage);
+    _memory_usage.store(_pkey_to_rssid_rowid ? _pkey_to_rssid_rowid->memory_usage() : 0);
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -146,12 +146,15 @@ public:
         config::write_buffer_size = MaxN * (sizeof(int) * 2) / MaxUpsert;
         config::lake_publish_version_slow_log_ms = 0;
         config::enable_pindex_minor_compaction = false;
+        _old_enable_pk_strict_memcheck = config::enable_pk_strict_memcheck;
+        config::enable_pk_strict_memcheck = false;
     }
 
     void TearDown() override {
         (void)fs::remove_all(kTestGroupPath);
         config::l0_max_mem_usage = _old_l0_size;
         config::write_buffer_size = _old_memtable_size;
+        config::enable_pk_strict_memcheck = _old_enable_pk_strict_memcheck;
     }
 
     std::pair<ChunkPtr, std::vector<uint32_t>> gen_upsert_data(bool is_upsert) {
@@ -317,6 +320,7 @@ protected:
 
     int64_t _old_l0_size = 0;
     int64_t _old_memtable_size = 0;
+    bool _old_enable_pk_strict_memcheck = false;
 };
 
 TEST_P(LakePrimaryKeyConsistencyTest, test_local_pk_consistency) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix PK memory usage error introduced by PR #44034. PrimaryIndex::memory_usage() should return persistent index's memory usage.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
