### PR TITLE
[Enhancement] Dump mem image before be exit to check mem leak

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -33,6 +33,7 @@ OPTS=$(getopt \
     -l 'logconsole' \
     -l 'meta_tool' \
     -l numa: \
+    -l 'check_mem_leak' \
 -- "$@")
 
 eval set -- "$OPTS"
@@ -43,6 +44,7 @@ RUN_BE=0
 RUN_NUMA="-1"
 RUN_LOG_CONSOLE=0
 RUN_META_TOOL=0
+RUN_CHECK_MEM_LEAK=0
 
 while true; do
     case "$1" in
@@ -52,6 +54,7 @@ while true; do
         --logconsole) RUN_LOG_CONSOLE=1 ; shift ;;
         --numa) RUN_NUMA=$2; shift 2 ;;
         --meta_tool) RUN_META_TOOL=1 ; shift ;;
+        --check_mem_leak) RUN_CHECK_MEM_LEAK=1 ; shift ;;
         --) shift ;  break ;;
         *) echo "Internal error" ; exit 1 ;;
     esac
@@ -80,7 +83,11 @@ fi
 # export JEMALLOC_CONF="junk:true,tcache:false,prof:true"
 # Set JEMALLOC_CONF environment variable if not already set
 if [[ -z "$JEMALLOC_CONF" ]]; then
-    export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"
+    if [ ${RUN_CHECK_MEM_LEAK} -eq 1 ] ; then
+      export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:true,prof_leak:true,lg_prof_sample:0,prof_final:true"
+    else
+      export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"
+    fi
 else
     echo "JEMALLOC_CONF from conf is '$JEMALLOC_CONF'"
 fi


### PR DESCRIPTION
## Why I'm doing:

With the help of jemalloc's mem_leak logic, the memory image is output, which is convenient for users and tests to check memory leaks.

## What I'm doing:

How to usage:

1. ./bin/start_be.sh --daemon --check_mem_leak
2. kill starrocks_be (without -9)
3. When be exit, will output one heap profile
```
<jemalloc>: Leak approximation summary: ~33504584 bytes, ~21783 objects, >= 4201 contexts
<jemalloc>: Run jeprof on dump output for leak detail

jeprof.1747309.0.f.heap
```
4. convert the file to pdf
```
./bin/jeprof --show_bytes --nodefraction=0.000000001 --edgefraction=0.000000001 --pdf lib/starrocks_be.debuginfo jeprof.1747309.0.f.heap >b.pdf
```

![image](https://github.com/user-attachments/assets/8248647c-c720-4b1a-9cf6-1f0cfea638da)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
