### PR TITLE
[Enhancement] agg push down rewriter supports rewriting to mv when no group-by in query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -244,12 +244,6 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
                 return visit(optExpression, context);
             }
 
-            // no-group-by don't push down
-            if (aggOp.getGroupingKeys().isEmpty()) {
-                logMVRewrite(mvRewriteContext, "No group by can't push down");
-                return visit(optExpression, context);
-            }
-
             context = new AggregatePushDownContext();
             context.setAggregator(aggOp);
             return context;
@@ -322,7 +316,7 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
     // 3. return input AggRewriteInfo as return value if you want to rewrite upper nodes.
     private class PostVisitor extends OptExpressionVisitor<AggRewriteInfo, AggRewriteInfo> {
         private boolean isInvalid(OptExpression optExpression, AggregatePushDownContext context) {
-            return context.isEmpty() || context.groupBys.isEmpty() || optExpression.getOp().hasLimit();
+            return context.isEmpty() || optExpression.getOp().hasLimit();
         }
 
         // Default visit method do nothing but just pass the AggRewriteInfo to its parent


### PR DESCRIPTION
## Why I'm doing:
sql like 
```sql
select sum(gmv) from test_pt
where id in (
    select id from test_alias
);
```
that without group-by in query should be able to be rewritten to mv
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
