### PR TITLE
[Enhancement] Release mem of page cache and execute purge dirty page before core dump

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -161,6 +161,15 @@ static void dontdump_unused_pages() {
 static void failure_writer(const char* data, int size) {
     dump_trace_info();
     [[maybe_unused]] auto wt = write(STDERR_FILENO, data, size);
+
+    if (config::enable_core_file_size_optimization) {
+        // TODO: If page cache releases crash due to memory problem,
+        //  the stack of be.out will be incomplete.
+        //  Glog needs to add a new interface to first write the log of stach and then optimize core file size.
+        //  I will and the interface later.
+        release_cache_mem();
+        dontdump_unused_pages();
+    }
 }
 
 static void failure_function() {

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -160,10 +160,6 @@ static void dontdump_unused_pages() {
 
 static void failure_writer(const char* data, int size) {
     dump_trace_info();
-    if (config::enable_core_file_size_optimization) {
-        release_cache_mem();
-        dontdump_unused_pages();
-    }
     [[maybe_unused]] auto wt = write(STDERR_FILENO, data, size);
 }
 

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -159,20 +159,20 @@ static void dontdump_unused_pages() {
 }
 
 static void failure_writer(const char* data, int size) {
+    dump_trace_info();
     if (config::enable_core_file_size_optimization) {
         release_cache_mem();
         dontdump_unused_pages();
     }
-    dump_trace_info();
     [[maybe_unused]] auto wt = write(STDERR_FILENO, data, size);
 }
 
 static void failure_function() {
+    dump_trace_info();
     if (config::enable_core_file_size_optimization) {
         release_cache_mem();
         dontdump_unused_pages();
     }
-    dump_trace_info();
     std::abort();
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Release mem of page cache before core dump to reduce the core files size of be.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
