### PR TITLE
[Enhancement] add mem limit for partition top n

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -24,7 +24,9 @@
 #include "column/vectorized_fwd.h"
 #include "common/config.h"
 #include "common/status.h"
+#include "exec/aggregate/agg_profile.h"
 #include "exec/exec_node.h"
+#include "exec/limited_pipeline_chunk_buffer.h"
 #include "exec/pipeline/operator.h"
 #include "exec/spill/spiller.hpp"
 #include "exprs/anyval_util.h"
@@ -315,8 +317,8 @@ Status Aggregator::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(check_has_error());
 
-    _buffer_mem_manager = std::make_unique<pipeline::ChunkBufferMemoryManager>(
-            1, config::local_exchange_buffer_mem_limit_per_driver,
+    _limited_buffer = std::make_unique<LimitedPipelineChunkBuffer<AggStatistics>>(
+            _agg_stat, 1, config::local_exchange_buffer_mem_limit_per_driver,
             state->chunk_size() * config::streaming_agg_chunk_buffer_size);
 
     return Status::OK();
@@ -539,7 +541,7 @@ Status Aggregator::_reset_state(RuntimeState* state, bool reset_sink_complete) {
     _num_pass_through_rows = 0;
     _num_rows_returned = 0;
 
-    _buffer = {};
+    _limited_buffer->clear();
 
     _tmp_agg_states.assign(_tmp_agg_states.size(), nullptr);
     _streaming_selection.assign(_streaming_selection.size(), 0);
@@ -612,8 +614,8 @@ void Aggregator::close(RuntimeState* state) {
 
     _is_closed = true;
     // Clear the buffer
-    while (!_buffer.empty()) {
-        _buffer.pop();
+    if (_limited_buffer != nullptr) {
+        _limited_buffer->clear();
     }
 
     auto agg_close = [this, state]() {
@@ -659,45 +661,19 @@ void Aggregator::close(RuntimeState* state) {
 }
 
 bool Aggregator::is_chunk_buffer_empty() {
-    std::lock_guard<std::mutex> l(_buffer_mutex);
-    return _buffer.empty();
+    return _limited_buffer->is_empty();
 }
 
 ChunkPtr Aggregator::poll_chunk_buffer() {
-    ChunkPtr chunk;
-    {
-        std::lock_guard<std::mutex> l(_buffer_mutex);
-        if (_buffer.empty()) {
-            return nullptr;
-        }
-        chunk = _buffer.front();
-        _buffer.pop();
-    }
-    size_t mem_usage = chunk->memory_usage();
-    size_t num_rows = chunk->num_rows();
-    _buffer_mem_manager->update_memory_usage(-mem_usage, -num_rows);
-
-    COUNTER_ADD(_agg_stat->chunk_buffer_peak_memory, -mem_usage);
-    COUNTER_ADD(_agg_stat->chunk_buffer_peak_size, -1);
-
-    return chunk;
+    return _limited_buffer->pull();
 }
 
 void Aggregator::offer_chunk_to_buffer(const ChunkPtr& chunk) {
-    {
-        std::lock_guard<std::mutex> l(_buffer_mutex);
-        _buffer.push(chunk);
-    }
-
-    size_t mem_usage = chunk->memory_usage();
-    size_t num_rows = chunk->num_rows();
-    _buffer_mem_manager->update_memory_usage(mem_usage, num_rows);
-    COUNTER_ADD(_agg_stat->chunk_buffer_peak_memory, mem_usage);
-    COUNTER_ADD(_agg_stat->chunk_buffer_peak_size, 1);
+    _limited_buffer->push(chunk);
 }
 
 bool Aggregator::is_chunk_buffer_full() {
-    return _buffer_mem_manager->is_full();
+    return _limited_buffer->is_full();
 }
 
 bool Aggregator::should_expand_preagg_hash_tables(size_t prev_row_returned, size_t input_chunk_size, int64_t ht_mem,

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -32,6 +32,7 @@
 #include "exec/aggregate/agg_hash_variant.h"
 #include "exec/aggregate/agg_profile.h"
 #include "exec/chunk_buffer_memory_manager.h"
+#include "exec/limited_pipeline_chunk_buffer.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/spill_process_channel.h"
 #include "exprs/agg/aggregate_factory.h"
@@ -419,9 +420,7 @@ protected:
     // only used in pipeline engine
     std::atomic<bool> _is_sink_complete = false;
     // only used in pipeline engine
-    std::queue<ChunkPtr> _buffer;
-    std::unique_ptr<pipeline::ChunkBufferMemoryManager> _buffer_mem_manager;
-    std::mutex _buffer_mutex;
+    std::unique_ptr<LimitedPipelineChunkBuffer<AggStatistics>> _limited_buffer;
 
     // Certain aggregates require a finalize step, which is the final step of the
     // aggregate after consuming all input rows. The finalize step converts the aggregate

--- a/be/src/exec/chunk_buffer_memory_manager.h
+++ b/be/src/exec/chunk_buffer_memory_manager.h
@@ -60,6 +60,11 @@ public:
         _max_memory_usage = max_memory_usage;
     }
 
+    void clear() {
+        _memory_usage = 0;
+        _buffered_num_rows = 0;
+    }
+
 private:
     std::atomic<size_t> _max_memory_usage{128UL * 1024 * 1024 * 1024}; // 128GB
     size_t _max_memory_usage_per_driver = 128 * 1024 * 1024UL;         // 128MB

--- a/be/src/exec/limited_pipeline_chunk_buffer.h
+++ b/be/src/exec/limited_pipeline_chunk_buffer.h
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <queue>
+
+#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
+#include "exec/chunk_buffer_memory_manager.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks {
+template <class BufferMetrics>
+class LimitedPipelineChunkBuffer {
+public:
+    LimitedPipelineChunkBuffer(BufferMetrics* metrics, size_t max_dop, size_t max_memory_usage, size_t max_chunk_count)
+            : _metrics(metrics), _buffer_mem_manager(max_dop, max_memory_usage, max_chunk_count) {}
+
+    bool is_full() const { return _buffer_mem_manager.is_full(); }
+
+    void push(const ChunkPtr& chunk) {
+        size_t mem_usage = chunk->memory_usage();
+        size_t num_rows = chunk->num_rows();
+        {
+            std::lock_guard l(_buffer_mutex);
+            _buffer.push(chunk);
+        }
+        _element_size++;
+        _buffer_mem_manager.update_memory_usage(mem_usage, num_rows);
+        COUNTER_ADD(_metrics->chunk_buffer_peak_memory, mem_usage);
+        COUNTER_ADD(_metrics->chunk_buffer_peak_size, 1);
+    }
+
+    ChunkPtr pull() {
+        ChunkPtr chunk;
+        {
+            std::lock_guard l(_buffer_mutex);
+            if (_buffer.empty()) {
+                return nullptr;
+            }
+            chunk = _buffer.front();
+            _buffer.pop();
+        }
+        _element_size--;
+        size_t mem_usage = chunk->memory_usage();
+        size_t num_rows = chunk->num_rows();
+        _buffer_mem_manager.update_memory_usage(-mem_usage, -num_rows);
+
+        COUNTER_ADD(_metrics->chunk_buffer_peak_memory, -mem_usage);
+        COUNTER_ADD(_metrics->chunk_buffer_peak_size, -1);
+        return chunk;
+    }
+
+    bool is_empty() { return _element_size == 0; }
+
+    void clear() {
+        std::lock_guard l(_buffer_mutex);
+        _buffer = {};
+        _buffer_mem_manager.clear();
+        _element_size = 0;
+    }
+
+private:
+    std::atomic_size_t _element_size{};
+    std::mutex _buffer_mutex;
+    std::queue<ChunkPtr> _buffer;
+    BufferMetrics* _metrics;
+    pipeline::ChunkBufferMemoryManager _buffer_mem_manager;
+};
+} // namespace starrocks

--- a/be/src/exec/partition/partition_hash_variant.cpp
+++ b/be/src/exec/partition/partition_hash_variant.cpp
@@ -170,4 +170,14 @@ bool PartitionHashMapVariant::is_nullable() const {
         return std::decay_t<decltype(*hash_map_with_key)>::is_nullable;
     });
 }
+
+void PartitionHashMapVariant::set_passthrough() {
+    visit([](auto& hash_map_with_key) {
+        if (hash_map_with_key == nullptr) {
+            return;
+        }
+        hash_map_with_key->is_passthrough = true;
+    });
+}
+
 } // namespace starrocks

--- a/be/src/exec/partition/partition_hash_variant.h
+++ b/be/src/exec/partition/partition_hash_variant.h
@@ -200,5 +200,7 @@ struct PartitionHashMapVariant {
     size_t memory_usage() const;
 
     bool is_nullable() const;
+
+    void set_passthrough();
 };
 } // namespace starrocks

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -63,7 +63,11 @@ void AggregateStreamingSinkOperator::set_execute_mode(int performance_level) {
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO) {
         _aggregator->streaming_preaggregation_mode() = TStreamingPreaggregationMode::LIMITED_MEM;
     }
-    _limited_mem_state.limited_memory_size = _aggregator->hash_map_memory_usage();
+    if (_aggregator->hash_map_memory_usage() > config::streaming_agg_limited_memory_size) {
+        _limited_mem_state.limited_memory_size = config::streaming_agg_limited_memory_size;
+    } else {
+        _limited_mem_state.limited_memory_size = _aggregator->hash_map_memory_usage();
+    }
 }
 
 Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/hash_partition_context.cpp
+++ b/be/src/exec/pipeline/hash_partition_context.cpp
@@ -18,7 +18,7 @@
 
 namespace starrocks::pipeline {
 
-Status HashPartitionContext::prepare(RuntimeState* state) {
+Status HashPartitionContext::prepare(RuntimeState* state, RuntimeProfile* profile) {
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_partition_exprs, &_partition_exprs, state));
     RETURN_IF_ERROR(Expr::prepare(_partition_exprs, state));
     RETURN_IF_ERROR(Expr::open(_partition_exprs, state));
@@ -38,7 +38,7 @@ Status HashPartitionContext::prepare(RuntimeState* state) {
     }
 
     _chunks_partitioner = std::make_unique<ChunksPartitioner>(_has_nullable_key, _partition_exprs, _partition_types);
-    return _chunks_partitioner->prepare(state);
+    return _chunks_partitioner->prepare(state, profile);
 }
 
 Status HashPartitionContext::push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/hash_partition_context.h
+++ b/be/src/exec/pipeline/hash_partition_context.h
@@ -16,6 +16,7 @@
 
 #include "exec/partition/chunks_partitioner.h"
 #include "storage/chunk_helper.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks::pipeline {
 
@@ -29,7 +30,7 @@ class HashPartitionContext {
 public:
     HashPartitionContext(const std::vector<TExpr>& t_partition_exprs) : _t_partition_exprs(t_partition_exprs) {}
 
-    Status prepare(RuntimeState* state);
+    Status prepare(RuntimeState* state, RuntimeProfile* profile);
 
     // Add one chunk to partitioner
     Status push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk);

--- a/be/src/exec/pipeline/hash_partition_sink_operator.cpp
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.cpp
@@ -19,7 +19,7 @@ namespace starrocks::pipeline {
 Status HashPartitionSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     _partition_num = ADD_COUNTER(_unique_metrics, "PartitionNumber", TUnit::UNIT);
-    return _hash_partition_ctx->prepare(state);
+    return _hash_partition_ctx->prepare(state, _unique_metrics.get());
 }
 
 StatusOr<ChunkPtr> HashPartitionSinkOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -36,7 +36,7 @@ LocalPartitionTopnContext::LocalPartitionTopnContext(const std::vector<TExpr>& t
           _partition_limit(partition_limit),
           _topn_type(topn_type) {}
 
-Status LocalPartitionTopnContext::prepare(RuntimeState* state) {
+Status LocalPartitionTopnContext::prepare(RuntimeState* state, RuntimeProfile* runtime_profile) {
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_partition_exprs, &_partition_exprs, state));
     RETURN_IF_ERROR(Expr::prepare(_partition_exprs, state));
     RETURN_IF_ERROR(Expr::open(_partition_exprs, state));
@@ -56,7 +56,7 @@ Status LocalPartitionTopnContext::prepare(RuntimeState* state) {
     }
 
     _chunks_partitioner = std::make_unique<ChunksPartitioner>(_has_nullable_key, _partition_exprs, _partition_types);
-    return _chunks_partitioner->prepare(state);
+    return _chunks_partitioner->prepare(state, runtime_profile);
 }
 
 Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -48,7 +48,7 @@ public:
                               std::vector<bool> is_asc_order, std::vector<bool> is_null_first, std::string sort_keys,
                               int64_t offset, int64_t partition_limit, const TTopNType::type topn_type);
 
-    [[nodiscard]] Status prepare(RuntimeState* state);
+    Status prepare(RuntimeState* state, RuntimeProfile* runtime_profile);
 
     // Add one chunk to partitioner
     Status push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk);
@@ -69,6 +69,10 @@ public:
     StatusOr<ChunkPtr> pull_one_chunk();
 
     bool is_passthrough() const { return _chunks_partitioner->is_passthrough(); }
+
+    void set_passthrough() { _chunks_partitioner->set_passthrough(true); }
+
+    bool is_full() const { return _chunks_partitioner->is_passthrough_buffer_full(); }
 
     size_t num_partitions() const { return _partition_num; }
 

--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
@@ -26,7 +26,7 @@ LocalPartitionTopnSinkOperator::LocalPartitionTopnSinkOperator(OperatorFactory* 
 
 Status LocalPartitionTopnSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    return _partition_topn_ctx->prepare(state);
+    return _partition_topn_ctx->prepare(state, _unique_metrics.get());
 }
 
 StatusOr<ChunkPtr> LocalPartitionTopnSinkOperator::pull_chunk(RuntimeState* state) {
@@ -50,6 +50,11 @@ Status LocalPartitionTopnSinkOperator::set_finishing(RuntimeState* state) {
         return Status::OK();
     }
     return _partition_topn_ctx->transfer_all_chunks_from_partitioner_to_sorters(state);
+}
+
+// try to passthrough when memory usage is high.
+void LocalPartitionTopnSinkOperator::set_execute_mode(int performance_level) {
+    _partition_topn_ctx->set_passthrough();
 }
 
 OperatorPtr LocalPartitionTopnSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {

--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.h
@@ -39,7 +39,7 @@ public:
 
     bool has_output() const override { return false; }
 
-    bool need_input() const override { return true; }
+    bool need_input() const override { return !_partition_topn_ctx->is_full(); }
 
     bool is_finished() const override { return _is_finished; }
 
@@ -48,6 +48,9 @@ public:
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
     Status set_finishing(RuntimeState* state) override;
+
+    bool releaseable() const override { return true; }
+    void set_execute_mode(int performance_level) override;
 
 private:
     bool _is_finished = false;

--- a/test/sql/test_spill/R/test_spill_local_partition_top_n
+++ b/test/sql/test_spill/R/test_spill_local_partition_top_n
@@ -1,0 +1,40 @@
+-- name: test_spill_local_partition_top_n
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+insert into t0 values (null,null);
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+select count(*), sum(c0) from (select c0, rn from (select c0, row_number() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;
+-- result:
+1638401	335545139200
+-- !result
+select count(*), sum(c0) from (select c0, rn from (select c0, rank() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;
+-- result:
+1638401	335545139200
+-- !result
+select count(*), sum(c0) from (select c0, rn from (select c0, rank() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;
+-- result:
+1638401	335545139200
+-- !result

--- a/test/sql/test_spill/R/test_spill_random
+++ b/test/sql/test_spill/R/test_spill_random
@@ -210,3 +210,7 @@ select count(*), sum(rk) from (select rank() over (partition by c0, c1) as rk fr
 -- result:
 16384	16384
 -- !result
+select count(*), sum(c0) from (select c0, rn from (select c0, row_number() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;
+-- result:
+16384	33562624
+-- !result

--- a/test/sql/test_spill/T/test_spill_local_partition_top_n
+++ b/test/sql/test_spill/T/test_spill_local_partition_top_n
@@ -1,0 +1,19 @@
+-- name: test_spill_local_partition_top_n
+
+set enable_spill=true;
+set spill_mode="force";
+
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+insert into t0 select * from t0;
+insert into t0 select * from t0;
+insert into t0 values (null,null);
+
+set pipeline_dop = 1;
+
+select count(*), sum(c0) from (select c0, rn from (select c0, row_number() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;
+select count(*), sum(c0) from (select c0, rn from (select c0, rank() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;
+select count(*), sum(c0) from (select c0, rn from (select c0, rank() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;

--- a/test/sql/test_spill/T/test_spill_random
+++ b/test/sql/test_spill/T/test_spill_random
@@ -100,3 +100,5 @@ select count(*) from (select distinct c0, c1 from t5 limit 10) tb;
 -- test full sort
 select count(*), sum(rn) from (select row_number() over (partition by c0, c1) as rn from t0) tb;
 select count(*), sum(rk) from (select rank() over (partition by c0, c1) as rk from t0) tb;
+select count(*), sum(c0) from (select c0, rn from (select c0, row_number() over(partition by c0 order by c1) rn from t0) tb where rn <= 100 ) r;
+


### PR DESCRIPTION
## Why I'm doing:

when partition top n passthrough. we don't have a memory control for passthrough buffer. so when sink is slow the buffer memory usage will be very large

```
select sum(rn) from (select lo_orderkey, rn from (select lo_orderkey,row_number() over(partition by lo_orderkey) rn from lineorder) tb where rn <= 10 ) r;
```

baseline: (only for one column):

```
     - QueryExecutionWallTime: 20s558ms
     - QueryPeakMemoryUsagePerNode: 4.092 GB
     - QueryPeakScheduleTime: 382.596ms
     - QuerySpillBytes: 5.584 GB
```

patched

```
   - QueryExecutionWallTime: 23s798ms
     - QueryPeakMemoryUsagePerNode: 2.827 GB
     - QueryPeakScheduleTime: 514.502ms
     - QuerySpillBytes: 4.474 GB
```

## What I'm doing:

1. add a memory limit for local partition top N
2. support passthrough in advance in AUTO spill mode


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
