### PR TITLE
[Refactor] fix clang-tidy warnings

### DIFF
--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -34,7 +34,7 @@ const Connector* ConnectorManager::get(const std::string& name) {
 }
 
 void ConnectorManager::put(const std::string& name, std::unique_ptr<Connector> connector) {
-    _connectors.emplace(std::make_pair(name, std::move(connector)));
+    _connectors.emplace(name, std::move(connector));
 }
 
 ConnectorManager* ConnectorManager::default_instance() {

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -724,7 +724,7 @@ StatusOr<ColumnPtr> JsonFunctions::json_array(FunctionContext* context, const Co
     ColumnBuilder<TYPE_JSON> result(rows);
     std::vector<ColumnViewer<TYPE_JSON>> viewers;
     for (auto& col : columns) {
-        viewers.emplace_back(ColumnViewer<TYPE_JSON>(col));
+        viewers.emplace_back(col);
     }
 
     for (int row = 0; row < rows; row++) {
@@ -764,7 +764,7 @@ StatusOr<ColumnPtr> JsonFunctions::json_object(FunctionContext* context, const C
     ColumnBuilder<TYPE_JSON> result(rows);
     std::vector<ColumnViewer<TYPE_JSON>> viewers;
     for (auto& col : columns) {
-        viewers.emplace_back(ColumnViewer<TYPE_JSON>(col));
+        viewers.emplace_back(col);
     }
 
     for (int row = 0; row < rows; row++) {

--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -141,7 +141,7 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
 
                 for (int h = 0; h < haystack.size;) {
                     auto char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(haystack.data[h])];
-                    v.emplace_back(Slice(haystack.data + h, char_size));
+                    v.emplace_back(haystack.data + h, char_size);
                     h += char_size;
                     ++offset;
                 }

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -2766,7 +2766,7 @@ static inline ColumnPtr concat_not_const(Columns const& columns) {
     std::vector<ColumnViewer<TYPE_VARCHAR>> list;
     list.reserve(columns.size());
     for (const ColumnPtr& col : columns) {
-        list.emplace_back(ColumnViewer<TYPE_VARCHAR>(col));
+        list.emplace_back(col);
     }
     const auto num_rows = columns[0]->size();
     auto dst_bytes_max_size = ColumnHelper::compute_bytes_size(columns.begin(), columns.end());
@@ -2919,7 +2919,7 @@ StatusOr<ColumnPtr> StringFunctions::concat_ws(FunctionContext* context, const C
     // skip only null
     for (int i = 1; i < columns.size(); ++i) {
         if (!columns[i]->only_null()) {
-            list.emplace_back(ColumnViewer<TYPE_VARCHAR>(columns[i]));
+            list.emplace_back(columns[i]);
         }
     }
 

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -73,7 +73,7 @@ public:
         auto it = _sender_id_to_channel.find(sender_id);
         if (it == _sender_id_to_channel.end()) {
             auto* channel = new PassThroughSenderChannel(_total_bytes);
-            _sender_id_to_channel.emplace(std::make_pair(sender_id, channel));
+            _sender_id_to_channel.emplace(sender_id, channel);
             return channel;
         } else {
             return it->second;
@@ -113,7 +113,7 @@ PassThroughChannel* PassThroughChunkBuffer::get_or_create_channel(const Key& key
     auto it = _key_to_channel.find(key);
     if (it == _key_to_channel.end()) {
         auto* channel = new PassThroughChannel();
-        _key_to_channel.emplace(std::make_pair(key, channel));
+        _key_to_channel.emplace(key, channel);
         return channel;
     } else {
         return it->second;
@@ -144,7 +144,7 @@ void PassThroughChunkBufferManager::open_fragment_instance(const TUniqueId& quer
         auto it = _query_id_to_buffer.find(query_id);
         if (it == _query_id_to_buffer.end()) {
             auto* buffer = new PassThroughChunkBuffer(query_id);
-            _query_id_to_buffer.emplace(std::make_pair(query_id, buffer));
+            _query_id_to_buffer.emplace(query_id, buffer);
         } else {
             it->second->ref();
         }

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -434,12 +434,12 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
     {
         const auto it = nodes_to_frag_insts.find(local);
         if (it != nodes_to_frag_insts.end()) {
-            targets.emplace_back(make_pair(it->first, it->second));
+            targets.emplace_back(it->first, it->second);
         }
     }
     for (const auto& it : nodes_to_frag_insts) {
         if (it.first != local) {
-            targets.emplace_back(make_pair(it.first, it.second));
+            targets.emplace_back(it.first, it.second);
         }
     }
 

--- a/be/src/storage/dictionary_cache_manager.cpp
+++ b/be/src/storage/dictionary_cache_manager.cpp
@@ -58,7 +58,7 @@ Status DictionaryCacheManager::refresh(const PProcessDictionaryCacheRequest* req
     std::vector<SlotId> value_slot_ids;
     for (int i = 0; i < schema->tuple_desc()->slots().size(); ++i) {
         const string& name = schema->tuple_desc()->slots()[i]->col_name();
-        col_names.emplace_back(std::string_view(name.data(), name.size()));
+        col_names.emplace_back(name.data(), name.size());
 
         if (i < request->key_size()) {
             key_slot_ids.emplace_back(schema->tuple_desc()->slots()[i]->id());

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -77,7 +77,7 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
 
     std::vector<Version> missed_versions;
     for (auto v = request.visible_version + 1; v <= request.src_visible_version; ++v) {
-        missed_versions.emplace_back(Version(v, v));
+        missed_versions.emplace_back(v, v);
     }
     if (UNLIKELY(missed_versions.empty())) {
         LOG(WARNING) << "Remote snapshot tablet skipped, no missing version"

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3308,7 +3308,7 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta, bool relo
                     index_meta.l2_versions(i).minor_number(), index_meta.l2_version_merged(i) ? MergeSuffix : "");
             ASSIGN_OR_RETURN(auto l2_rfile, _fs->new_random_access_file(l2_block_path));
             ASSIGN_OR_RETURN(auto l2_index, ImmutableIndex::load(std::move(l2_rfile), load_bf_or_not()));
-            _l2_versions.emplace_back(EditVersionWithMerge(index_meta.l2_versions(i), index_meta.l2_version_merged(i)));
+            _l2_versions.emplace_back(index_meta.l2_versions(i), index_meta.l2_version_merged(i));
             _l2_vec.emplace_back(std::move(l2_index));
         }
     }
@@ -4902,7 +4902,7 @@ void PersistentIndex::modify_l2_versions(const std::vector<EditVersion>& input_l
             }
         }
         if (!need_remove) {
-            new_l2_versions.emplace_back(EditVersion(index_meta.l2_versions(i)));
+            new_l2_versions.emplace_back(index_meta.l2_versions(i));
             new_l2_version_merged.push_back(index_meta.l2_version_merged(i));
         }
     }

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -135,7 +135,7 @@ public:
 
     template <LogicalType from_type, LogicalType to_type>
     void add_convert_type_mapping() {
-        _convert_type_set.emplace(std::make_pair(from_type, to_type));
+        _convert_type_set.emplace(from_type, to_type);
     }
 
 private:

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1569,8 +1569,7 @@ void StorageEngine::clear_rowset_delta_column_group_cache(const Rowset& rowset) 
         std::vector<DeltaColumnGroupKey> dcg_keys;
         dcg_keys.reserve(rowset.num_segments());
         for (auto i = 0; i < rowset.num_segments(); i++) {
-            dcg_keys.emplace_back(
-                    DeltaColumnGroupKey(rowset.rowset_meta()->tablet_id(), rowset.rowset_meta()->rowset_id(), i));
+            dcg_keys.emplace_back(rowset.rowset_meta()->tablet_id(), rowset.rowset_meta()->rowset_id(), i);
         }
         return dcg_keys;
     }());
@@ -1614,7 +1613,7 @@ void StorageEngine::add_schedule_apply_task(int64_t tablet_id, std::chrono::stea
     LOG(INFO) << "add tablet:" << tablet_id << ", next apply time:";
     {
         std::unique_lock<std::mutex> wl(_schedule_apply_mutex);
-        _schedule_apply_tasks.emplace(std::make_pair(time_point, tablet_id));
+        _schedule_apply_tasks.emplace(time_point, tablet_id);
     }
     _apply_tablet_changed_cv.notify_one();
 }

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -569,7 +569,7 @@ Status TabletReader::_to_seek_tuple(const TabletSchemaCSPtr& tablet_schema, cons
         int idx = sort_key_idxes.empty() ? i : sort_key_idxes[i];
         auto f = std::make_shared<Field>(ChunkHelper::convert_field(idx, tablet_schema->column(idx)));
         schema.append(f);
-        values.emplace_back(Datum());
+        values.emplace_back();
         if (input.is_null(i)) {
             continue;
         }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5009,7 +5009,7 @@ void TabletUpdates::_clear_rowset_del_vec_cache(const Rowset& rowset) {
         std::vector<TabletSegmentId> tsids;
         tsids.reserve(rowset.num_segments());
         for (auto i = 0; i < rowset.num_segments(); i++) {
-            tsids.emplace_back(TabletSegmentId{_tablet.tablet_id(), rowset.rowset_meta()->get_rowset_seg_id() + i});
+            tsids.emplace_back(_tablet.tablet_id(), rowset.rowset_meta()->get_rowset_seg_id() + i);
         }
         return tsids;
     }());
@@ -5020,7 +5020,7 @@ void TabletUpdates::_clear_rowset_delta_column_group_cache(const Rowset& rowset)
         std::vector<TabletSegmentId> tsids;
         tsids.reserve(rowset.num_segments());
         for (auto i = 0; i < rowset.num_segments(); i++) {
-            tsids.emplace_back(TabletSegmentId{_tablet.tablet_id(), rowset.rowset_meta()->get_rowset_seg_id() + i});
+            tsids.emplace_back(_tablet.tablet_id(), rowset.rowset_meta()->get_rowset_seg_id() + i);
         }
         return tsids;
     }());

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -961,10 +961,10 @@ std::vector<BitmapValue> BitmapValue::split_bitmap(size_t batch_size) const {
 
     switch (_type) {
     case EMPTY:
-        results.emplace_back(BitmapValue());
+        results.emplace_back();
         break;
     case SINGLE:
-        results.emplace_back(BitmapValue(*this));
+        results.emplace_back(*this);
         break;
     case SET: {
         std::vector values(_set->begin(), _set->end());


### PR DESCRIPTION
* eliminate emplace with temp object

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
