### PR TITLE
[Enhancement] Starrocks becomes compatible with function cast(array as string) # 44768

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1722,8 +1722,6 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
 
         Expr* cast_element_expr = VectorizedCastExprFactory::from_thrift(pool, cast, allow_throw_exception);
         if (cast_element_expr == nullptr) {
-            LOG(WARNING) << strings::Substitute("Cannot cast $0 to $1.", array_field_type_cast_from.debug_string(),
-                                                array_field_type_cast_to.debug_string());
             return nullptr;
         }
         auto* child = new ColumnRef(cast);

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1703,6 +1703,38 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
                                                                             const TypeDescriptor& from_type,
                                                                             const TypeDescriptor& to_type,
                                                                             bool allow_throw_exception) {
+    if (to_type.is_string_type() && from_type.is_array_type()) {
+        LOG(INFO) << "Cast from array to varchar. ";
+        TypeDescriptor array_field_type_cast_to = TypeDescriptor::from_thrift(node.type);
+        TypeDescriptor array_field_type_cast_from = TypeDescriptor::from_thrift(node.child_type_desc);
+
+        while (from_type.is_array_type() && to_type.is_string_type()) {
+            array_field_type_cast_from = array_field_type_cast_from.children[0];
+        }
+
+        TExprNode cast;
+        cast.type = array_field_type_cast_to.to_thrift();
+        cast.child_type = to_thrift(array_field_type_cast_from.type);
+
+        //A new slot_id is created here, which has no practical meaning and is used for placeholders
+        cast.slot_ref.slot_id = 0;
+        cast.slot_ref.tuple_id = 0;
+
+        Expr* cast_element_expr = VectorizedCastExprFactory::from_thrift(pool, cast, allow_throw_exception);
+        if (cast_element_expr == nullptr) {
+            LOG(WARNING) << strings::Substitute("Cannot cast $0 to $1.", array_field_type_cast_from.debug_string(),
+                                                array_field_type_cast_to.debug_string());
+            return nullptr;
+        }
+        auto* child = new ColumnRef(cast);
+        cast_element_expr->add_child(child);
+        if (pool) {
+            pool->add(cast_element_expr);
+            pool->add(child);
+        }
+
+        return new CastArrayToString(cast_element_expr, node);
+    }
     if (from_type.is_array_type() && to_type.is_array_type()) {
         ASSIGN_OR_RETURN(auto child_cast,
                          create_cast_expr(pool, from_type.children[0], to_type.children[0], allow_throw_exception));

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1707,10 +1707,6 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
         TypeDescriptor array_field_type_cast_to = TypeDescriptor::from_thrift(node.type);
         TypeDescriptor array_field_type_cast_from = TypeDescriptor::from_thrift(node.child_type_desc);
 
-        while (from_type.is_array_type() && to_type.is_string_type()) {
-            array_field_type_cast_from = array_field_type_cast_from.children[0];
-        }
-
         TExprNode cast;
         cast.type = array_field_type_cast_to.to_thrift();
         cast.child_type = to_thrift(array_field_type_cast_from.type);
@@ -1730,7 +1726,7 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
             pool->add(child);
         }
 
-        return std::make_unique<CastArrayToString>(cast_element_expr, node);
+        return std::make_unique<CastArrayToString>(node);
     }
     if (from_type.is_array_type() && to_type.is_array_type()) {
         ASSIGN_OR_RETURN(auto child_cast,

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1704,7 +1704,6 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
                                                                             const TypeDescriptor& to_type,
                                                                             bool allow_throw_exception) {
     if (to_type.is_string_type() && from_type.is_array_type()) {
-        LOG(INFO) << "Cast from array to varchar. ";
         TypeDescriptor array_field_type_cast_to = TypeDescriptor::from_thrift(node.type);
         TypeDescriptor array_field_type_cast_from = TypeDescriptor::from_thrift(node.child_type_desc);
 

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1733,7 +1733,7 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
             pool->add(child);
         }
 
-        return new CastArrayToString(cast_element_expr, node);
+        return std::make_unique<CastArrayToString>(cast_element_expr, node);
     }
     if (from_type.is_array_type() && to_type.is_array_type()) {
         ASSIGN_OR_RETURN(auto child_cast,

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -54,18 +54,18 @@ private:
 
 // Cast array<ANY> to string
 class CastArrayToString final : public Expr {
-    public:
-        CastArrayToString(Expr* cast_element_expr, const TExprNode& node)
-                : Expr(node), _cast_element_expr(cast_element_expr) {}
+public:
+    CastArrayToString(Expr* cast_element_expr, const TExprNode& node)
+            : Expr(node), _cast_element_expr(cast_element_expr) {}
 
-        ~CastArrayToString() override = default;
+    ~CastArrayToString() override = default;
 
-        StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
-        Expr* clone(ObjectPool* pool) const override { return pool->add(new CastArrayToString(*this)); }
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastArrayToString(*this)); }
 
-    private:
-        Expr* _cast_element_expr;
+private:
+    Expr* _cast_element_expr;
 };
 
 // Cast string to array<ANY>

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -52,6 +52,22 @@ private:
                                        LogicalType to_type, bool allow_throw_exception);
 };
 
+// Cast array<ANY> to string
+class CastArrayToString final : public Expr {
+    public:
+        CastArrayToString(Expr* cast_element_expr, const TExprNode& node)
+                : Expr(node), _cast_element_expr(cast_element_expr) {}
+
+        ~CastArrayToString() override = default;
+
+        StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
+
+        Expr* clone(ObjectPool* pool) const override { return pool->add(new CastArrayToString(*this)); }
+
+    private:
+        Expr* _cast_element_expr;
+};
+
 // Cast string to array<ANY>
 class CastStringToArray final : public Expr {
 public:

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -55,15 +55,13 @@ private:
 // Cast array<ANY> to string
 class CastArrayToString final : public Expr {
 public:
-    CastArrayToString(const TExprNode& node)
-            : Expr(node) {}
+    CastArrayToString(const TExprNode& node) : Expr(node) {}
 
     ~CastArrayToString() override = default;
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new CastArrayToString(*this)); }
-
 };
 
 // Cast string to array<ANY>

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -60,7 +60,7 @@ class CastArrayToString final : public Expr {
 
         ~CastArrayToString() override = default;
 
-        StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
+        StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
         Expr* clone(ObjectPool* pool) const override { return pool->add(new CastArrayToString(*this)); }
 

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -55,8 +55,8 @@ private:
 // Cast array<ANY> to string
 class CastArrayToString final : public Expr {
 public:
-    CastArrayToString(Expr* cast_element_expr, const TExprNode& node)
-            : Expr(node), _cast_element_expr(cast_element_expr) {}
+    CastArrayToString(const TExprNode& node)
+            : Expr(node) {}
 
     ~CastArrayToString() override = default;
 
@@ -64,8 +64,6 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new CastArrayToString(*this)); }
 
-private:
-    Expr* _cast_element_expr;
 };
 
 // Cast string to array<ANY>

--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -138,7 +138,7 @@ Status CastStringToArray::open(RuntimeState* state, ExprContext* context, Functi
 }
 
 // Cast array<ANY> to string
-StatusOr<ColumnPtr> CastArrayToString::evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) {
+StatusOr<ColumnPtr> CastArrayToString::evaluate_checked(ExprContext* context, Chunk* ptr) {
     LOG(INFO) << "Converting array to string";
 
     ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));

--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -139,11 +139,11 @@ Status CastStringToArray::open(RuntimeState* state, ExprContext* context, Functi
 
 // Cast array<ANY> to string
 StatusOr<ColumnPtr> CastArrayToString::evaluate_checked(ExprContext* context, Chunk* ptr) {
-    LOG(INFO) << "Converting array to string";
+    VLOG(1) << "Converting array to string";
 
     ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
     if (ColumnHelper::count_nulls(column) == column->size()) {
-        LOG(WARNING) << "Returning null for converting array to string";
+        VLOG(1) << "Returning null for converting array to string";
         return ColumnHelper::create_const_null_column(column->size());
     }
     ColumnPtr cast_column = column->clone_shared();
@@ -160,7 +160,7 @@ StatusOr<ColumnPtr> CastArrayToString::evaluate_checked(ExprContext* context, Ch
         array_col = (ColumnHelper::as_column<ArrayColumn>(src_col));
         src_col = array_col->elements_column();
 
-        LOG(INFO) << "Returning string value. ";
+        VLOG(1) << "Returning string value. ";
         result->append(Slice(array_col->debug_string()));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1097,6 +1097,8 @@ public abstract class Type implements Cloneable {
             return true;
         } else if (from.isStringType() && to.isBitmapType()) {
             return true;
+        } else if (from.isArrayType() && to.isStringType()) {
+            return true;
         } else if (from.isScalarType() && to.isScalarType()) {
             return ScalarType.canCastTo((ScalarType) from, (ScalarType) to);
         } else if (from.isArrayType() && to.isArrayType()) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -376,17 +376,27 @@ public class SelectStmtTest {
                 "\n" +
                 "  RESULT SINK\n" +
                 "\n" +
-                "  4:AGGREGATE (merge finalize)\n" +
-                "  |  output: count(4: count)\n" +
+                "  6:AGGREGATE (merge finalize)\n" +
+                "  |  output: sum(4: count)\n" +
                 "  |  group by: 3: expr\n" +
                 "  |  \n" +
-                "  3:AGGREGATE (update serialize)\n" +
+                "  5:AGGREGATE (update serialize)\n" +
                 "  |  STREAMING\n" +
-                "  |  output: count(2: split)\n" +
+                "  |  output: sum(4: count)\n" +
                 "  |  group by: 3: expr\n" +
+                "  |  \n" +
+                "  4:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(CAST(2: split AS CHAR))\n" +
+                "  |  group by: 3: expr, 5: cast\n" +
+                "  |  \n" +
+                "  3:Project\n" +
+                "  |  <slot 2> : 2: split\n" +
+                "  |  <slot 3> : 3: expr\n" +
+                "  |  <slot 5> : CAST(murmur_hash3_32(CAST(2: split AS VARCHAR)) % 512 AS SMALLINT)\n" +
                 "  |  \n" +
                 "  2:AGGREGATE (update serialize)\n" +
-                "  |  group by: 2: split, 3: expr\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: 3: expr, 2: split\n" +
                 "  |  \n" +
                 "  1:Project\n" +
                 "  |  <slot 2> : split('a,b,c', ',')\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -702,4 +702,12 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "  |  <slot 9> : CAST(7: S_COMMENT AS ARRAY<ARRAY<VARCHAR(65533)>>)\n" +
                 "  |  limit: 1"));
     }
+
+    @Test
+    public void testCastArrayToString() throws Exception {
+        String sql = "select cast( S_ADDRESS as string) from supplier_nullable";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan, plan.contains("1:Project\n" +
+                "  |  <slot 9> : CAST(3: S_ADDRESS AS VARCHAR(65533))\n"));
+    }
 }

--- a/test/sql/test_cast/R/test_cast_array_to_string
+++ b/test/sql/test_cast/R/test_cast_array_to_string
@@ -1,0 +1,5 @@
+-- name: test_cast_array_to_string
+select cast([ as string);
+-- result:
+None
+-- !result

--- a/test/sql/test_cast/T/test_cast_array_to_string
+++ b/test/sql/test_cast/T/test_cast_array_to_string
@@ -1,0 +1,4 @@
+-- name: test_cast_array_to_string
+select cast([] as string);
+select cast([1, 2, 3] as string);
+select cast(cast([[[1,2],[]],[[1,2]],[]] as string);


### PR DESCRIPTION
sort_array, collect_set, cast(array as string) and nvl #44768

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5