### PR TITLE
[BugFix] fix column overflow when handle too large partial update

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -321,6 +321,8 @@ CONF_mInt64(update_compaction_result_bytes, "1073741824");
 CONF_mInt32(update_compaction_delvec_file_io_amp_ratio, "2");
 // This config defines the maximum percentage of data allowed per compaction
 CONF_mDouble(update_compaction_ratio_threshold, "0.5");
+// This config controls max memory that we can use for partial update.
+CONF_mInt64(partial_update_memory_limit_per_worker, "2147483648"); // 2GB
 
 CONF_mInt32(repair_compaction_interval_seconds, "600"); // 10 min
 CONF_Int32(manual_compaction_threads, "4");

--- a/be/src/storage/rowset/horizontal_update_rowset_writer.cpp
+++ b/be/src/storage/rowset/horizontal_update_rowset_writer.cpp
@@ -58,7 +58,7 @@ Status HorizontalUpdateRowsetWriter::add_chunk(const Chunk& chunk) {
         RETURN_IF_ERROR(_update_file_writer->finalize(&segment_size, &index_size, &footer_position));
         {
             std::lock_guard<std::mutex> l(_lock);
-            _num_rows_upt += _update_file_writer->num_rows_written();
+            _num_rows_upt += chunk.num_rows();
             _num_uptfile++;
             _total_update_row_size += static_cast<int64_t>(chunk.bytes_usage());
         }
@@ -105,7 +105,6 @@ Status HorizontalUpdateRowsetWriter::flush() {
         RETURN_IF_ERROR(_update_file_writer->finalize(&segment_size, &index_size, &footer_position));
         {
             std::lock_guard<std::mutex> l(_lock);
-            _num_rows_upt += _update_file_writer->num_rows_written();
             _num_uptfile++;
         }
         _update_file_writer.reset();

--- a/be/src/storage/rowset/horizontal_update_rowset_writer.cpp
+++ b/be/src/storage/rowset/horizontal_update_rowset_writer.cpp
@@ -58,11 +58,14 @@ Status HorizontalUpdateRowsetWriter::add_chunk(const Chunk& chunk) {
         RETURN_IF_ERROR(_update_file_writer->finalize(&segment_size, &index_size, &footer_position));
         {
             std::lock_guard<std::mutex> l(_lock);
-            _num_rows_upt += chunk.num_rows();
             _num_uptfile++;
-            _total_update_row_size += static_cast<int64_t>(chunk.bytes_usage());
         }
         ASSIGN_OR_RETURN(_update_file_writer, _create_update_file_writer());
+    }
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        _num_rows_upt += chunk.num_rows();
+        _total_update_row_size += static_cast<int64_t>(chunk.bytes_usage());
     }
 
     return _update_file_writer->append_chunk(chunk);

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -228,8 +228,9 @@ public:
     size_t data_disk_size() const { return rowset_meta()->total_disk_size(); }
     bool empty() const { return rowset_meta()->empty(); }
     int64_t num_rows() const override { return rowset_meta()->num_rows(); }
+    int64_t num_rows_upt() const { return rowset_meta()->num_rows_upt(); }
     size_t total_row_size() const { return rowset_meta()->total_row_size(); }
-    size_t total_update_row_size() const { return rowset_meta()->total_update_row_size(); }
+    int64_t total_update_row_size() const { return rowset_meta()->total_update_row_size(); }
     Version version() const { return rowset_meta()->version(); }
     RowsetId rowset_id() const override { return rowset_meta()->rowset_id(); }
     std::string rowset_id_str() const { return rowset_meta()->rowset_id().to_string(); }

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -98,6 +98,8 @@ public:
 
     int64_t num_rows() const { return _rowset_meta_pb->num_rows(); }
 
+    int64_t num_rows_upt() const { return _rowset_meta_pb->num_rows_upt(); }
+
     void set_num_rows(int64_t num_rows) { _rowset_meta_pb->set_num_rows(num_rows); }
 
     int64_t total_row_size() { return _rowset_meta_pb->total_row_size(); }

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -165,6 +165,7 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
         _rowset_meta_pb->set_num_delete_files(_num_delfile);
         _rowset_meta_pb->set_num_update_files(_num_uptfile);
         _rowset_meta_pb->set_total_update_row_size(_total_update_row_size);
+        _rowset_meta_pb->set_num_rows_upt(_num_rows_upt);
         if (_num_segment <= 1) {
             _rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
         }

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -31,6 +31,16 @@ class Segment;
 class RandomAccessFile;
 class ColumnIterator;
 
+struct StreamChunkContainer {
+    Chunk* chunk_ptr = nullptr;
+    // [start_rowid, end_rowid) is range of this chunk_ptr
+    uint32_t start_rowid = 0;
+    uint32_t end_rowid = 0;
+
+    // whether this container contains this rowid.
+    bool contains(uint32_t rowid) { return start_rowid <= rowid && rowid < end_rowid; }
+};
+
 struct RowsetSegmentStat {
     int64_t num_rows_written = 0;
     int64_t total_row_size = 0;
@@ -215,7 +225,7 @@ private:
 
     Status _update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs, const Schema& partial_schema,
                                        Rowset* rowset, OlapReaderStatistics* stats, MemTracker* tracker,
-                                       ChunkPtr* source_chunk);
+                                       StreamChunkContainer container);
 
 private:
     int64_t _tablet_id = 0;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -175,6 +175,8 @@ message RowsetMetaPB {
     optional uint32 max_compact_input_rowset_id = 61;
     // global transaction id
     optional int64 gtid = 62;
+    // total number of upt file's rows.
+    optional int64 num_rows_upt = 63;
 }
 
 enum DataFileType {


### PR DESCRIPTION
## Why I'm doing:
In current implementation, when handle partial column update, we will try to build the column to be updated with segment granularity, it will lead to overflow. E.g.
1. If we have a `ARRAY` column to be update, In the beginning, because the data in the table does not contain arrays yet, we will slice the segment file with a size of 1GB, so a segment file may contain a large number of rows. We can assume that there are 500w rows in a tablet.
2. And in a `ArraryColumn` struct, we store offset of array using uint32_t , that means we can only have 4,294,967,295 items in a `ArraryColumn`.
3. When items in one array is larger than 900, which is large than 4,294,967,295, so overflow happens.

## What I'm doing:
Processing updates involving large amounts of data in batches, each batch will be limit by `partial_update_memory_limit_per_worker`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
