### PR TITLE
[Enhancement]speed up transform phase for complex expr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
@@ -91,6 +91,10 @@ public class Subquery extends Expr {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
         if (!super.equals(o)) {
             return false;
         }
@@ -98,7 +102,7 @@ public class Subquery extends Expr {
         if (((Subquery) o).getQueryStatement() == null) {
             return false;
         } else {
-            return o.equals(queryStatement);
+            return ((Subquery) o).getQueryStatement().equals(queryStatement);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -921,4 +921,27 @@ public class Utils {
         return downcast(obj, klass)
                 .orElseThrow(() -> new IllegalArgumentException("Cannot cast " + obj.getClass() + " to " + klass));
     }
+
+    // this method is useful when map is small, but key is very complex  like compound predicate with 1000 OR
+    // in which case key's hashCode() can be super slow because of bad time complexity
+    // so we can use equals' short-circuit logic to help us find whether key is in map quickly
+    // which means key's type is not same as map's key's types
+    public static <K, V> V getValueIfExists(Map<K, V> map, K key) {
+        V value = null;
+
+        if (map.size() < 4) {
+            for (Map.Entry<K, V> entry : map.entrySet()) {
+                if (entry.getKey().equals(key)) {
+                    value = entry.getValue();
+                    break;
+                }
+            }
+        } else {
+            if (map.containsKey(key)) {
+                value = map.get(key);
+            }
+        }
+
+        return value;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -937,9 +937,7 @@ public class Utils {
                 }
             }
         } else {
-            if (map.containsKey(key)) {
-                value = map.get(key);
-            }
+            value = map.get(key);
         }
 
         return value;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReplaceSubqueryRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReplaceSubqueryRewriteRule.java
@@ -57,7 +57,7 @@ public class ReplaceSubqueryRewriteRule extends TopDownScalarOperatorRewriteRule
         // so columnRef operator's equals()' short-circuit can benefit complex ScalarOperator like one thousand or predicate
         // if use Map::containsKey, these complex ScalarOperator's hashCode can be super slow
         SubqueryOperator subqueryOperator = Utils.getValueIfExists(subqueryPlaceholders, scalarOperator);
-        if(subqueryOperator != null) {
+        if (subqueryOperator != null) {
             LogicalApplyOperator applyOperator = subqueryOperator.getApplyOperator();
             builder = new OptExprBuilder(applyOperator, Arrays.asList(builder, subqueryOperator.getRootBuilder()),
                     builder.getExpressionMapping());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -293,7 +293,8 @@ public final class SqlToScalarOperatorTranslator {
         @Override
         public ScalarOperator visit(ParseNode node, Context context) {
             Expr expr = (Expr) node;
-            if (expressionMapping.get(expr) != null && !expr.isConstant()) {
+            if (!expressionMapping.getExpressionToColumns().isEmpty() && expressionMapping.get(expr) != null &&
+                    !expr.isConstant()) {
                 return expressionMapping.get(expr);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -72,6 +72,7 @@ import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.SubqueryUtils;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.logical.LogicalApplyOperator;
@@ -293,9 +294,12 @@ public final class SqlToScalarOperatorTranslator {
         @Override
         public ScalarOperator visit(ParseNode node, Context context) {
             Expr expr = (Expr) node;
-            if (!expressionMapping.getExpressionToColumns().isEmpty() && expressionMapping.get(expr) != null &&
+            if (!expressionMapping.getExpressionToColumns().isEmpty() &&
                     !expr.isConstant()) {
-                return expressionMapping.get(expr);
+                ScalarOperator res = Utils.getValueIfExists(expressionMapping.getExpressionToColumns(), expr);
+                if (res != null) {
+                    return res;
+                }
             }
 
             return node.accept(this, context);


### PR DESCRIPTION
## Why I'm doing:
expr with 1000 Or can be super slow in transform phase because compound predicate's hashCode() with top down or bottom up rule rewrite's time complexity is huge

## What I'm doing:
avoid calling compound predicate's hashCode() if possible, which always happen is map's contains(). And thos maps's key always not be Compound predicate, so we can use equals() to replace contains()

before this pr:
-- Transformer[1] 4s650ms
After this pr:
-- Transformer[1] 1s395ms


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
