### PR TITLE
[Enhancement] Add interface failure_handler_after_output_log to glog

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -247,11 +247,13 @@ if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.3.3" ]; then
 fi
 if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.4.0" ]; then
     patch -p1 < $TP_PATCH_DIR/glog-0.4.0-for-starrocks2.patch
-    patch -p1 < $TP_PATCH_DIR/glog-0.4.0-remove-unwind-dependency.patch 
+    patch -p1 < $TP_PATCH_DIR/glog-0.4.0-remove-unwind-dependency.patch
+    patch -p1 < $TP_PATCH_DIR/glog-0.4.0-add-handler-after-output-log.patch
     touch $PATCHED_MARK
 fi
 if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.7.1" ]; then
     patch -p1 < $TP_PATCH_DIR/glog-0.7.1.patch
+    patch -p1 < $TP_PATCH_DIR/glog-0.7.1-add-handler-after-output-log.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/patches/glog-0.4.0-add-handler-after-output-log.patch
+++ b/thirdparty/patches/glog-0.4.0-add-handler-after-output-log.patch
@@ -1,0 +1,48 @@
+diff --git a/src/glog/logging.h.in b/src/glog/logging.h.in
+index ff7c1c2..3a1df70 100644
+--- a/src/glog/logging.h.in
++++ b/src/glog/logging.h.in
+@@ -1662,6 +1662,8 @@ GOOGLE_GLOG_DLL_DECL void InstallFailureSignalHandler();
+ GOOGLE_GLOG_DLL_DECL void InstallFailureWriter(
+     void (*writer)(const char* data, int size));
+
++GOOGLE_GLOG_DLL_DECL void InstallFailureHandlerAfterOutputLog(void (*handler)());
++
+ @ac_google_end_namespace@
+
+ #endif // _LOGGING_H_
+diff --git a/src/signalhandler.cc b/src/signalhandler.cc
+index 961ee96..ec31c06 100644
+--- a/src/signalhandler.cc
++++ b/src/signalhandler.cc
+@@ -154,6 +154,8 @@ void WriteToStderr(const char* data, int size) {
+ // The writer function can be changed by InstallFailureWriter().
+ void (*g_failure_writer)(const char* data, int size) = WriteToStderr;
+
++void (*g_failure_handler_after_output_log)() = nullptr;
++
+ // Dumps time information.  We don't dump human-readable time information
+ // as localtime() is not guaranteed to be async signal safe.
+ void DumpTimeInfo() {
+@@ -347,6 +349,10 @@ void FailureSignalHandler(int signal_number,
+   // causes problems.
+   FlushLogFilesUnsafe(0);
+
++  if (g_failure_handler_after_output_log != nullptr) {
++      (*g_failure_handler_after_output_log)();
++  }
++
+   // Kill ourself by the default signal handler.
+   InvokeDefaultSignalHandler(signal_number);
+ }
+@@ -400,4 +406,10 @@ void InstallFailureWriter(void (*writer)(const char* data, int size)) {
+ #endif  // HAVE_SIGACTION
+ }
+
++void InstallFailureHandlerAfterOutputLog(void (*handler)()) {
++#if defined(HAVE_SIGACTION) || defined(OS_WINDOWS)
++    g_failure_handler_after_output_log = handler;
++#endif  // HAVE_SIGACTION
++}
++
+ _END_GOOGLE_NAMESPACE_

--- a/thirdparty/patches/glog-0.7.1-add-handler-after-output-log.patch
+++ b/thirdparty/patches/glog-0.7.1-add-handler-after-output-log.patch
@@ -1,0 +1,48 @@
+diff --git a/src/glog/logging.h b/src/glog/logging.h
+index 8b90782..c4a569d 100644
+--- a/src/glog/logging.h
++++ b/src/glog/logging.h
+@@ -1740,6 +1740,8 @@ GLOG_EXPORT bool IsFailureSignalHandlerInstalled();
+ GLOG_EXPORT void InstallFailureWriter(void (*writer)(const char* data,
+                                                      size_t size));
+
++GLOG_EXPORT void InstallFailureHandlerAfterOutputLog(void (*handler)());
++
+ // Dump stack trace as a string.
+ GLOG_EXPORT std::string GetStackTrace();
+
+diff --git a/src/signalhandler.cc b/src/signalhandler.cc
+index c5bae59..96df08d 100644
+--- a/src/signalhandler.cc
++++ b/src/signalhandler.cc
+@@ -166,6 +166,8 @@ void WriteToStderr(const char* data, size_t size) {
+ // The writer function can be changed by InstallFailureWriter().
+ void (*g_failure_writer)(const char* data, size_t size) = WriteToStderr;
+
++void (*g_failure_handler_after_output_log)() = nullptr;
++
+ // Dumps time information.  We don't dump human-readable time information
+ // as localtime() is not guaranteed to be async signal safe.
+ void DumpTimeInfo() {
+@@ -333,6 +335,10 @@ static void HandleSignal(int signal_number
+   // causes problems.
+   FlushLogFilesUnsafe(GLOG_INFO);
+
++  if (g_failure_handler_after_output_log != nullptr) {
++    (*g_failure_handler_after_output_log)();
++  }
++
+   // Kill ourself by the default signal handler.
+   InvokeDefaultSignalHandler(signal_number);
+ }
+@@ -399,4 +405,10 @@ void InstallFailureWriter(void (*writer)(const char* data, size_t size)) {
+ #endif  // HAVE_SIGACTION
+ }
+
++void InstallFailureHandlerAfterOutputLog(void (*handler)()) {
++#if defined(HAVE_SIGACTION) || defined(GLOG_OS_WINDOWS)
++  g_failure_handler_after_output_log = handler;
++#endif  // HAVE_SIGACTION
++}
++
+ }  // namespace google


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

In the function `HandleSignal` of glog, `DumpTimeInfo`, `DumpStackFrameInfo`, `DumpSignalInfo` all will invoke `failed_writer`.
If we release mem cache crash, the crash msg will not be dump completed, so i will add one callback function which will be call after output all the log.

```
static void HandleSignal(int signal_number) {

  // This is the first time we enter the signal handler.  We are going to
  // do some interesting stuff from here.
  // TODO(satorux): We might want to set timeout here using alarm(), but
  // mixing alarm() and sleep() can be a bad idea.

  // First dump time info.
  DumpTimeInfo();


  // Get the program counter from ucontext.
  void* pc = GetPC(ucontext);
  DumpStackFrameInfo("PC: ", pc);


#ifdef HAVE_STACKTRACE
  // Get the stack traces.
  void* stack[32];
  // +1 to exclude this function.
  const int depth = GetStackTrace(stack, ARRAYSIZE(stack), 1);
#  ifdef HAVE_SIGACTION
  DumpSignalInfo(signal_number, signal_info);
#  elif !defined(GLOG_OS_WINDOWS)
  (void)signal_info;
#  endif
  // Dump the stack traces.
  for (int i = 0; i < depth; ++i) {
    DumpStackFrameInfo("    ", stack[i]);
  }
#elif !defined(GLOG_OS_WINDOWS)
  (void)signal_info;
#endif

  // *** TRANSITION ***
  //
  // BEFORE this point, all code must be async-termination-safe!
  // (See WARNING above.)
  //
  // AFTER this point, we do unsafe things, like using LOG()!
  // The process could be terminated or hung at any time.  We try to
  // do more useful things first and riskier things later.

  // Flush the logs before we do anything in case 'anything'
  // causes problems.
  FlushLogFilesUnsafe(GLOG_INFO);

  if (g_failure_handler_after_output_log != nullptr) {
    (*g_failure_handler_after_output_log)();
  }

  // Kill ourself by the default signal handler.
  InvokeDefaultSignalHandler(signal_number);
}
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
