### PR TITLE
[BugFix]deal with pageindex before collect_io_range of data page

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -650,7 +650,7 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.conjunct_ctxs_by_slot = fd_scanner_ctx.conjunct_ctxs_by_slot;
     _group_reader_param.timezone = fd_scanner_ctx.timezone;
     _group_reader_param.stats = fd_scanner_ctx.stats;
-    _group_reader_param.sb_stream = nullptr;
+    _group_reader_param.sb_stream = _sb_stream;
     _group_reader_param.chunk_size = _chunk_size;
     _group_reader_param.file = _file;
     _group_reader_param.file_metadata = _file_metadata.get();
@@ -709,38 +709,10 @@ Status FileReader::_init_group_readers() {
 
     if (!_row_group_readers.empty()) {
         // prepare first row group
-        RETURN_IF_ERROR(_prepare_cur_row_group());
+        RETURN_IF_ERROR(_row_group_readers[_cur_row_group_idx]->prepare());
     }
 
     return Status::OK();
-}
-
-Status FileReader::_prepare_cur_row_group() {
-    auto& r = _row_group_readers[_cur_row_group_idx];
-    // we need deal with page index first, so that it can work on collect_io_range
-    RETURN_IF_ERROR(r->deal_with_pageindex());
-    // if coalesce read enabled, we have to
-    // 0. clear last group memory
-    // 1. allocate shared buffered input stream and
-    // 2. collect io ranges of every row group reader.
-    // 3. set io ranges to the stream.
-    if (config::parquet_coalesce_read_enable && _sb_stream != nullptr) {
-        std::vector<io::SharedBufferedInputStream::IORange> ranges;
-        int64_t end_offset = 0;
-        r->collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGES);
-        int32_t counter = _scanner_ctx->lazy_column_coalesce_counter->load(std::memory_order_relaxed);
-        if (counter >= 0 || !config::io_coalesce_adaptive_lazy_active) {
-            _scanner_ctx->stats->group_active_lazy_coalesce_together += 1;
-        } else {
-            _scanner_ctx->stats->group_active_lazy_coalesce_seperately += 1;
-        }
-        r->set_end_offset(end_offset);
-        RETURN_IF_ERROR(_sb_stream->set_io_ranges(ranges, counter >= 0));
-        _group_reader_param.sb_stream = _sb_stream;
-    }
-
-    // prepare row group
-    return r->prepare();
 }
 
 Status FileReader::get_next(ChunkPtr* chunk) {
@@ -766,7 +738,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
                 _cur_row_group_idx++;
                 if (_cur_row_group_idx < _row_group_size) {
                     // prepare new group
-                    RETURN_IF_ERROR(_prepare_cur_row_group());
+                    RETURN_IF_ERROR(_row_group_readers[_cur_row_group_idx]->prepare());
                 }
 
                 return Status::OK();

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -717,6 +717,8 @@ Status FileReader::_init_group_readers() {
 
 Status FileReader::_prepare_cur_row_group() {
     auto& r = _row_group_readers[_cur_row_group_idx];
+    // we need deal with page index first, so that it can work on collect_io_range
+    RETURN_IF_ERROR(r->deal_with_pageindex());
     // if coalesce read enabled, we have to
     // 0. clear last group memory
     // 1. allocate shared buffered input stream and

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -128,8 +128,6 @@ private:
     // Validate the magic bytes and get the length of metadata
     StatusOr<uint32_t> _parse_metadata_length(const std::vector<char>& footer_buff) const;
 
-    Status _prepare_cur_row_group();
-
     // get min/max value from row group stats
     Status _get_min_max_value(const SlotDescriptor* slot, const tparquet::ColumnMetaData* column_meta,
                               const ParquetField* field, std::vector<std::string>& min_values,

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -57,7 +57,7 @@ Status GroupReader::init() {
     return Status::OK();
 }
 
-Status GroupReader::deal_with_pageindex() {
+Status GroupReader::_deal_with_pageindex() {
     if (config::parquet_page_index_enable) {
         SCOPED_RAW_TIMER(&_param.stats->page_index_ns);
         _param.stats->rows_before_page_index += _row_group_metadata->num_rows;
@@ -74,6 +74,28 @@ Status GroupReader::deal_with_pageindex() {
 }
 
 Status GroupReader::prepare() {
+    // we need deal with page index first, so that it can work on collect_io_range,
+    // and pageindex's io has been collected in FileReader
+    RETURN_IF_ERROR(_deal_with_pageindex());
+
+    // if coalesce read enabled, we have to
+    // 1. allocate shared buffered input stream and
+    // 2. collect io ranges of every row group reader.
+    // 3. set io ranges to the stream.
+    if (config::parquet_coalesce_read_enable && _param.sb_stream != nullptr) {
+        std::vector<io::SharedBufferedInputStream::IORange> ranges;
+        int64_t end_offset = 0;
+        collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGES);
+        int32_t counter = _param.lazy_column_coalesce_counter->load(std::memory_order_relaxed);
+        if (counter >= 0 || !config::io_coalesce_adaptive_lazy_active) {
+            _param.stats->group_active_lazy_coalesce_together += 1;
+        } else {
+            _param.stats->group_active_lazy_coalesce_seperately += 1;
+        }
+        _set_end_offset(end_offset);
+        RETURN_IF_ERROR(_param.sb_stream->set_io_ranges(ranges, counter >= 0));
+    }
+
     RETURN_IF_ERROR(_rewrite_conjunct_ctxs_to_predicates(&_is_group_filtered));
     _init_read_chunk();
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -116,17 +116,19 @@ public:
     // init used to init column reader, and devide active/lazy
     // then we can use inited column collect io range.
     Status init();
-    // deal_with_pageindex need collect pageindex io range first, it will collect all row groups' io together,
-    // so it should be done in file reader. when reading the current row group, we need first deal_with_pageindex,
-    // and then we can collect io range based on pageindex.
-    Status deal_with_pageindex();
-    // we need load dict for dict_filter, so prepare should be after collec_io_range
     Status prepare();
     Status get_next(ChunkPtr* chunk, size_t* row_count);
     void close();
     void collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                            ColumnIOType type = ColumnIOType::PAGES);
-    void set_end_offset(int64_t value) { _end_offset = value; }
+
+private:
+    void _set_end_offset(int64_t value) { _end_offset = value; }
+
+    // deal_with_pageindex need collect pageindex io range first, it will collect all row groups' io together,
+    // so it should be done in file reader. when reading the current row group, we need first deal_with_pageindex,
+    // and then we can collect io range based on pageindex.
+    Status _deal_with_pageindex();
 
     void _use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path);
     Status _rewrite_conjunct_ctxs_to_predicates(bool* is_group_filtered);

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -113,8 +113,13 @@ public:
                 int64_t row_group_first_row);
     ~GroupReader() = default;
 
-    // init used to init column reader, init dict_filter_ctx and devide active/lazy
+    // init used to init column reader, and devide active/lazy
+    // then we can use inited column collect io range.
     Status init();
+    // deal_with_pageindex need collect pageindex io range first, it will collect all row groups' io together,
+    // so it should be done in file reader. when reading the current row group, we need first deal_with_pageindex,
+    // and then we can collect io range based on pageindex.
+    Status deal_with_pageindex();
     // we need load dict for dict_filter, so prepare should be after collec_io_range
     Status prepare();
     Status get_next(ChunkPtr* chunk, size_t* row_count);

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -297,7 +297,7 @@ void SharedBufferedInputStream::_update_estimated_mem_usage() {
     _estimated_mem_usage = std::max(mem_usage, _estimated_mem_usage);
 }
 
-int64_t SharedBufferedInputStream::current_range_ref_num() const {
+int64_t SharedBufferedInputStream::current_range_ref_sum() const {
     int64_t ref = 0;
     for (const auto& [_, sb] : _map) {
         ref += sb->ref_count;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -297,4 +297,12 @@ void SharedBufferedInputStream::_update_estimated_mem_usage() {
     _estimated_mem_usage = std::max(mem_usage, _estimated_mem_usage);
 }
 
+int64_t SharedBufferedInputStream::current_range_ref_num() const {
+    int64_t ref = 0;
+    for (const auto& [_, sb] : _map) {
+        ref += sb->ref_count;
+    }
+    return ref;
+}
+
 } // namespace starrocks::io

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -91,7 +91,8 @@ public:
     int64_t direct_io_bytes() const { return _direct_io_bytes; }
     int64_t direct_io_timer() const { return _direct_io_timer; }
     int64_t estimated_mem_usage() const { return _estimated_mem_usage; }
-    int64_t current_range_ref_num() const;
+    // each SharedBuffer may contain several ranges, the return the ref sum
+    int64_t current_range_ref_sum() const;
 
     StatusOr<std::string_view> peek(int64_t count) override;
     const std::string& filename() const override { return _filename; }

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -91,6 +91,7 @@ public:
     int64_t direct_io_bytes() const { return _direct_io_bytes; }
     int64_t direct_io_timer() const { return _direct_io_timer; }
     int64_t estimated_mem_usage() const { return _estimated_mem_usage; }
+    int64_t current_range_ref_num() const;
 
     StatusOr<std::string_view> peek(int64_t count) override;
     const std::string& filename() const override { return _filename; }

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -439,8 +439,11 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
     std::vector<TExpr> t_conjuncts_slot1{t_conjuncts[1]};
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot1, &ctx->conjunct_ctxs_by_slot[1]);
 
+    auto shared_buffer = std::make_shared<io::SharedBufferedInputStream>(file->stream(), small_page_file,
+                                                                         std::filesystem::file_size(small_page_file));
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(small_page_file), 100000);
+                                                    std::filesystem::file_size(small_page_file), 100000,
+                                                    shared_buffer.get());
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
@@ -466,6 +469,8 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
     // only collect io of 5 pages, 5001-6000, 6001-7000, 7001-8000, 8001-9000, 9001-10000 and a dict page.
     // three columns, (5 + 1) * 3 = 18
     EXPECT_EQ(ranges.size(), 18);
+
+    EXPECT_EQ(shared_buffer->current_range_ref_num(), 28);
 
     // The second row group is not prepare yet
 

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -441,9 +441,9 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
 
     auto shared_buffer = std::make_shared<io::SharedBufferedInputStream>(file->stream(), small_page_file,
                                                                          std::filesystem::file_size(small_page_file));
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(small_page_file), 100000,
-                                                    shared_buffer.get());
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(small_page_file), 100000, shared_buffer.get());
 
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -470,7 +470,7 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
     // three columns, (5 + 1) * 3 = 18
     EXPECT_EQ(ranges.size(), 18);
 
-    EXPECT_EQ(shared_buffer->current_range_ref_num(), 28);
+    EXPECT_EQ(shared_buffer->current_range_ref_sum(), 28);
 
     // The second row group is not prepare yet
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
we need deal with pageindex first, so that we can collect io based on pageindex.

Fixes #issue
introduced by 
#44666 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
