### PR TITLE
[Enhancement] move the updateExecStatus out of Coordinator Lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -956,12 +956,12 @@ public class DefaultCoordinator extends Coordinator {
 
         queryProfile.updateProfile(execState, params);
 
+        if (!execState.updateExecStatus(params)) {
+            return;
+        }
+
         lock();
         try {
-            if (!execState.updateExecStatus(params)) {
-                return;
-            }
-
             queryProfile.updateLoadChannelProfile(params);
         } finally {
             unlock();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- `DefaultCoordinator::updateFragmentExecStatus` -> Lock -> `FragmentInstanceExecState::updateExecStatus`
- The `FragmentInstanceExecState#updateExecStatus` can be a bottleneck in case of many be nodes and concurrent queries
- Move it out of the DefaultCoordinator lock to allow for more concurrency

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
