### PR TITLE
[Enhancement] suppport fast cancel for query context

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -102,6 +102,9 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
     }
 
     _query_ctx = exec_env->query_context_mgr()->get_or_register(query_id);
+    if (_query_ctx == nullptr) {
+        return Status::Cancelled("Query terminates prematurely");
+    }
     _query_ctx->set_exec_env(exec_env);
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -100,6 +100,7 @@ FragmentContextManager* QueryContext::fragment_mgr() {
 }
 
 void QueryContext::cancel(const Status& status) {
+    _is_cancelled = true;
     _fragment_mgr->cancel(status);
 }
 
@@ -337,6 +338,16 @@ QueryContextManager::~QueryContextManager() {
     }
 }
 
+#define RETURN_NULL_IF_CTX_CANCELLED(query_ctx) \
+    if (query_ctx->is_cancelled()) {            \
+        return nullptr;                         \
+    }                                           \
+    query_ctx->increment_num_fragments();       \
+    if (query_ctx->is_cancelled()) {            \
+        query_ctx->rollback_inc_fragments();    \
+        return nullptr;                         \
+    }
+
 QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
     size_t i = _slot_idx(query_id);
     auto& mutex = _mutexes[i];
@@ -348,7 +359,7 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         // lookup query context in context_map
         auto it = context_map.find(query_id);
         if (it != context_map.end()) {
-            it->second->increment_num_fragments();
+            RETURN_NULL_IF_CTX_CANCELLED(it->second);
             return it->second.get();
         }
     }
@@ -358,13 +369,13 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         auto it = context_map.find(query_id);
         auto sc_it = sc_map.find(query_id);
         if (it != context_map.end()) {
-            it->second->increment_num_fragments();
+            RETURN_NULL_IF_CTX_CANCELLED(it->second);
             return it->second.get();
         } else {
             // lookup query context for the second chance in sc_map
             if (sc_it != sc_map.end()) {
                 auto ctx = std::move(sc_it->second);
-                ctx->increment_num_fragments();
+                RETURN_NULL_IF_CTX_CANCELLED(ctx);
                 sc_map.erase(sc_it);
                 auto* raw_ctx_ptr = ctx.get();
                 context_map.emplace(query_id, std::move(ctx));


### PR DESCRIPTION
## Why I'm doing:

when not all fragments arrived to BE. BE need wait query time out secs to release the query-ctx. 

part of #47868

## What I'm doing:

add a fast cancel for query context. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
