### PR TITLE
[Enhancement] Show plan cost in explain verbose/costs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.planner.ExecGroup;
@@ -25,6 +26,7 @@ import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.plugin.AuditEvent;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.Explain;
 import com.starrocks.sql.ast.StatementBase;
@@ -62,7 +64,6 @@ public class ExecPlan {
     private volatile ProfilingExecPlan profilingPlan;
     private LogicalPlan logicalPlan;
     private ColumnRefFactory columnRefFactory;
-
 
     @VisibleForTesting
     public ExecPlan() {
@@ -153,6 +154,7 @@ public class ExecPlan {
     public void setExecGroups(List<ExecGroup> execGroups) {
         this.execGroups = execGroups;
     }
+
     public List<ExecGroup> getExecGroups() {
         return this.execGroups;
     }
@@ -188,6 +190,15 @@ public class ExecPlan {
 
     public String getExplainString(TExplainLevel level) {
         StringBuilder str = new StringBuilder();
+
+        if (level == TExplainLevel.VERBOSE || level == TExplainLevel.COSTS) {
+            if (FeConstants.showFragmentCost) {
+                AuditEvent auditEvent = connectContext.getAuditEventBuilder().build();
+                str.append("Plan CPU Cost:").append(auditEvent.planCpuCosts).append("\n");
+                str.append("Plan Memory Cost:").append(auditEvent.planMemCosts).append("\n\n");
+            }
+        }
+
         if (level == null) {
             str.append(Explain.toString(physicalPlan, outputColumns));
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -195,7 +195,7 @@ public class ExecPlan {
             if (FeConstants.showFragmentCost) {
                 final String prefix = "  ";
                 AuditEvent auditEvent = connectContext.getAuditEventBuilder().build();
-                str.append("Plan Cost").append("\n")
+                str.append("PLAN COST").append("\n")
                         .append(prefix).append("CPU: ").append(auditEvent.planCpuCosts).append("\n")
                         .append(prefix).append("Memory: ").append(auditEvent.planMemCosts).append("\n\n");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -193,9 +193,11 @@ public class ExecPlan {
 
         if (level == TExplainLevel.VERBOSE || level == TExplainLevel.COSTS) {
             if (FeConstants.showFragmentCost) {
+                final String prefix = "  ";
                 AuditEvent auditEvent = connectContext.getAuditEventBuilder().build();
-                str.append("Plan CPU Cost: ").append(auditEvent.planCpuCosts).append("\n");
-                str.append("Plan Memory Cost: ").append(auditEvent.planMemCosts).append("\n\n");
+                str.append("Plan Cost").append("\n")
+                        .append(prefix).append("CPU: ").append(auditEvent.planCpuCosts).append("\n")
+                        .append(prefix).append("Memory: ").append(auditEvent.planMemCosts).append("\n\n");
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -194,8 +194,8 @@ public class ExecPlan {
         if (level == TExplainLevel.VERBOSE || level == TExplainLevel.COSTS) {
             if (FeConstants.showFragmentCost) {
                 AuditEvent auditEvent = connectContext.getAuditEventBuilder().build();
-                str.append("Plan CPU Cost:").append(auditEvent.planCpuCosts).append("\n");
-                str.append("Plan Memory Cost:").append(auditEvent.planMemCosts).append("\n\n");
+                str.append("Plan CPU Cost: ").append(auditEvent.planCpuCosts).append("\n");
+                str.append("Plan Memory Cost: ").append(auditEvent.planMemCosts).append("\n\n");
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2322,11 +2322,11 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "     partition exprs: [4: t1a, VARCHAR, true]\n" +
                     "     cardinality: 9000");
             System.out.println(plan);
-            assertContains(plan, "Plan Cost\n" +
+            assertContains(plan, "PLAN COST\n" +
                     "  CPU: 1881002.0\n" +
                     "  Memory: 288001.0");
 
-            assertContains(getCostExplain(sql), "Plan Cost\n" +
+            assertContains(getCostExplain(sql), "PLAN COST\n" +
                     "  CPU: 1881002.0\n" +
                     "  Memory: 288001.0");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2296,31 +2296,43 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
     @Test
     public void testPlanCost() throws Exception {
-        String plan = getVerboseExplain("select t1a, v1 " +
-                "from t0 join [broadcast] test_all_type " +
-                "join [shuffle] (select 1 as v1_c1 where abs(1) = 2) v1 on t1a=v1 and t1a=v1_c1");
-        assertContains(plan, "  11:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  equal join conjunct: [4: t1a, VARCHAR, true] = [16: cast, VARCHAR, false]\n" +
-                "  |  build runtime filters:\n" +
-                "  |  - filter_id = 1, build_expr = (16: cast), remote = true\n" +
-                "  |  output columns: 1, 4\n" +
-                "  |  cardinality: 9000\n" +
-                "  |  \n" +
-                "  |----10:EXCHANGE\n" +
-                "  |       distribution type: SHUFFLE\n" +
-                "  |       partition exprs: [16: cast, VARCHAR, false]\n" +
-                "  |       cardinality: 1\n" +
-                "  |    \n" +
-                "  6:EXCHANGE\n" +
-                "     distribution type: SHUFFLE\n" +
-                "     partition exprs: [4: t1a, VARCHAR, true]\n" +
-                "     cardinality: 9000");
+        final boolean prevShowFragmentCost = FeConstants.showFragmentCost;
+        try {
+            FeConstants.showFragmentCost = true;
 
-        AuditEvent event = connectContext.getAuditEventBuilder().build();
-        Assert.assertTrue("planMemCosts should be > 1, but: " + event.planMemCosts, event.planMemCosts > 1);
-        Assert.assertTrue("planCpuCosts should be > 1, but: " + event.planCpuCosts, event.planCpuCosts > 1);
+            String sql = "select t1a, v1 " +
+                    "from t0 join [broadcast] test_all_type " +
+                    "join [shuffle] (select 1 as v1_c1 where abs(1) = 2) v1 on t1a=v1 and t1a=v1_c1";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  11:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                    "  |  equal join conjunct: [4: t1a, VARCHAR, true] = [16: cast, VARCHAR, false]\n" +
+                    "  |  build runtime filters:\n" +
+                    "  |  - filter_id = 1, build_expr = (16: cast), remote = true\n" +
+                    "  |  output columns: 1, 4\n" +
+                    "  |  cardinality: 9000\n" +
+                    "  |  \n" +
+                    "  |----10:EXCHANGE\n" +
+                    "  |       distribution type: SHUFFLE\n" +
+                    "  |       partition exprs: [16: cast, VARCHAR, false]\n" +
+                    "  |       cardinality: 1\n" +
+                    "  |    \n" +
+                    "  6:EXCHANGE\n" +
+                    "     distribution type: SHUFFLE\n" +
+                    "     partition exprs: [4: t1a, VARCHAR, true]\n" +
+                    "     cardinality: 9000");
+            assertContains(plan, "Plan CPU Cost:1881002.0\n" +
+                    "Plan Memory Cost:288001.0");
 
+            assertContains(getCostExplain(sql), "Plan CPU Cost:1881002.0\n" +
+                    "Plan Memory Cost:288001.0");
+
+            AuditEvent event = connectContext.getAuditEventBuilder().build();
+            Assert.assertTrue("planMemCosts should be > 1, but: " + event.planMemCosts, event.planMemCosts > 1);
+            Assert.assertTrue("planCpuCosts should be > 1, but: " + event.planCpuCosts, event.planCpuCosts > 1);
+        } finally {
+            FeConstants.showFragmentCost = prevShowFragmentCost;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2321,11 +2321,11 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "     distribution type: SHUFFLE\n" +
                     "     partition exprs: [4: t1a, VARCHAR, true]\n" +
                     "     cardinality: 9000");
-            assertContains(plan, "Plan CPU Cost:1881002.0\n" +
-                    "Plan Memory Cost:288001.0");
+            assertContains(plan, "Plan CPU Cost: 1881002.0\n" +
+                    "Plan Memory Cost: 288001.0");
 
-            assertContains(getCostExplain(sql), "Plan CPU Cost:1881002.0\n" +
-                    "Plan Memory Cost:288001.0");
+            assertContains(getCostExplain(sql), "Plan CPU Cost: 1881002.0\n" +
+                    "Plan Memory Cost: 288001.0");
 
             AuditEvent event = connectContext.getAuditEventBuilder().build();
             Assert.assertTrue("planMemCosts should be > 1, but: " + event.planMemCosts, event.planMemCosts > 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2321,11 +2321,14 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "     distribution type: SHUFFLE\n" +
                     "     partition exprs: [4: t1a, VARCHAR, true]\n" +
                     "     cardinality: 9000");
-            assertContains(plan, "Plan CPU Cost: 1881002.0\n" +
-                    "Plan Memory Cost: 288001.0");
+            System.out.println(plan);
+            assertContains(plan, "Plan Cost\n" +
+                    "  CPU: 1881002.0\n" +
+                    "  Memory: 288001.0");
 
-            assertContains(getCostExplain(sql), "Plan CPU Cost: 1881002.0\n" +
-                    "Plan Memory Cost: 288001.0");
+            assertContains(getCostExplain(sql), "Plan Cost\n" +
+                    "  CPU: 1881002.0\n" +
+                    "  Memory: 288001.0");
 
             AuditEvent event = connectContext.getAuditEventBuilder().build();
             Assert.assertTrue("planMemCosts should be > 1, but: " + event.planMemCosts, event.planMemCosts > 1);


### PR DESCRIPTION
## Why I'm doing:

We need know plan costs of classic queries to decide the resource group classifier field `plan_cpu_cost_range` and `plan_mem_cost_range`.

They are recorded in `fe.audit.log`. However, some platforms like BYOC doesn't support audit log.

Therefore, also show them in explain verbose / costs.

## What I'm doing:

Fixes #issue

```
+---------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                  |
+---------------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                       |
|   CPU: 1881002.0                                                                                                                |
|   Memory: 288001.0                                                                                                              |
|                                                                                                                                 |
| PLAN FRAGMENT 0(F01)                                                                                                            |
|   Fragment Cost: 35.99999999999999                                                                                              |
|   Output Exprs:16: count                                                                                                        |
|   Input Partition: UNPARTITIONED                                                                                                |
|   RESULT SINK                                                                                                                   |
|                                                                                                                                 |
|   4:AGGREGATE (merge finalize)                                                                                                  |
|   |  aggregate: count[([16: count, BIGINT, false]); args: TINYINT; result: BIGINT; args nullable: true; result nullable: false] |
|   |  cardinality: 1                                                                                                             |
|   |                                                                                                                             |
|   3:EXCHANGE                                                                                                                    |
|      distribution type: GATHER                                                                                                  |
|      cardinality: 1                                                                                                             |
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
