### PR TITLE
[BugFix] Fix oom problem in complex type prune

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ComplexTypeAccessGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ComplexTypeAccessGroup.java
@@ -14,25 +14,19 @@
 
 package com.starrocks.catalog;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
+// Record ColumnRefOperator's each ComplexTypeAccessPaths
+// We have to use HashSet to deduplicate same ComplexTypeAccessPaths, it can avoid oom problem
 public class ComplexTypeAccessGroup {
-    private final List<ComplexTypeAccessPaths> accessPaths = new ArrayList<>();
-
-    public int size() {
-        return accessPaths.size();
-    }
-
-    public ComplexTypeAccessPaths get(int idx) {
-        return accessPaths.get(idx);
-    }
+    private final Set<ComplexTypeAccessPaths> accessPaths = new HashSet<>();
 
     public void addAccessPaths(ComplexTypeAccessPaths complexTypeAccessPaths) {
         accessPaths.add(complexTypeAccessPaths);
     }
 
-    public List<ComplexTypeAccessPaths> getAccessGroup() {
+    public Set<ComplexTypeAccessPaths> getAccessGroup() {
         return accessPaths;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ComplexTypeAccessPath.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ComplexTypeAccessPath.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.catalog;
 
+import java.util.Objects;
+
 public class ComplexTypeAccessPath {
     private final ComplexTypeAccessPathType accessPathType;
 
@@ -35,5 +37,26 @@ public class ComplexTypeAccessPath {
 
     public String getStructSubfieldName() {
         return this.structSubfieldName;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ComplexTypeAccessPath)) {
+            return false;
+        }
+
+        ComplexTypeAccessPath that = (ComplexTypeAccessPath) o;
+        return accessPathType == that.accessPathType &&
+                Objects.equals(structSubfieldName, that.structSubfieldName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(accessPathType);
+        result = 31 * result + Objects.hashCode(structSubfieldName);
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ComplexTypeAccessPaths.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ComplexTypeAccessPaths.java
@@ -14,12 +14,16 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+
+import java.util.Objects;
 
 public class ComplexTypeAccessPaths {
     private final ImmutableList<ComplexTypeAccessPath> accessPaths;
 
     public ComplexTypeAccessPaths(ImmutableList<ComplexTypeAccessPath> accessPaths) {
+        Preconditions.checkNotNull(accessPaths, "accessPaths can't be null");
         this.accessPaths = accessPaths;
     }
 
@@ -37,5 +41,23 @@ public class ComplexTypeAccessPaths {
 
     public ImmutableList<ComplexTypeAccessPath> getAccessPaths() {
         return accessPaths;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ComplexTypeAccessPaths)) {
+            return false;
+        }
+
+        ComplexTypeAccessPaths that = (ComplexTypeAccessPaths) o;
+        return Objects.equals(accessPaths, that.accessPaths);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(accessPaths);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
@@ -94,6 +94,7 @@ public class PruneComplexTypeUtil {
         public void addAccessPaths(ColumnRefOperator columnRefOperator,
                                    ComplexTypeAccessPaths curAccessPaths,
                                    ComplexTypeAccessGroup visitedAccessGroup) {
+            // We should copy it first to avoid ConcurrentModificationException
             ImmutableList<ComplexTypeAccessPaths> accessGroup = ImmutableList.<ComplexTypeAccessPaths>builder().addAll(
                     visitedAccessGroup.getAccessGroup()).build();
             for (ComplexTypeAccessPaths complexTypeAccessPaths : accessGroup) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
@@ -94,10 +94,10 @@ public class PruneComplexTypeUtil {
         public void addAccessPaths(ColumnRefOperator columnRefOperator,
                                    ComplexTypeAccessPaths curAccessPaths,
                                    ComplexTypeAccessGroup visitedAccessGroup) {
-            int size = visitedAccessGroup.size();
-            // We should we below loop to avoid ConcurrentModificationException
-            for (int i = 0; i < size; i++) {
-                addAccessPaths(columnRefOperator, concatAccessPaths(curAccessPaths, visitedAccessGroup.get(i)));
+            ImmutableList<ComplexTypeAccessPaths> accessGroup = ImmutableList.<ComplexTypeAccessPaths>builder().addAll(
+                    visitedAccessGroup.getAccessGroup()).build();
+            for (ComplexTypeAccessPaths complexTypeAccessPaths : accessGroup) {
+                addAccessPaths(columnRefOperator, concatAccessPaths(curAccessPaths, complexTypeAccessPaths));
             }
         }
 


### PR DESCRIPTION
## Why I'm doing:
Reproduce oom:
```sql
create table hive.temp.complex_test as select 1 as id, [1,2,3] as a, named_struct('a',2,'b',4) as b;

select hive.temp.complex_test.a from hive.temp.complex_test 
LEFT JOIN (SELECT a FROM hive.temp.complex_test)t1
ON hive.temp.complex_test.a = t1.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t2
ON hive.temp.complex_test.a = t2.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t3
ON hive.temp.complex_test.a = t3.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t4
ON hive.temp.complex_test.a = t4.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t5
ON hive.temp.complex_test.a = t5.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t6
ON hive.temp.complex_test.a = t6.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t7
ON hive.temp.complex_test.a = t7.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t8
ON hive.temp.complex_test.a = t8.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t9
ON hive.temp.complex_test.a = t9.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t10
ON hive.temp.complex_test.a = t10.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t11
ON hive.temp.complex_test.a = t11.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t12
ON hive.temp.complex_test.a = t12.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t13
ON hive.temp.complex_test.a = t13.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t14
ON hive.temp.complex_test.a = t14.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t15
ON hive.temp.complex_test.a = t15.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t16
ON hive.temp.complex_test.a = t16.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t17
ON hive.temp.complex_test.a = t17.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t18
ON hive.temp.complex_test.a = t18.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t19
ON hive.temp.complex_test.a = t19.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t20
ON hive.temp.complex_test.a = t20.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t21
ON hive.temp.complex_test.a = t21.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t22
ON hive.temp.complex_test.a = t22.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t23
ON hive.temp.complex_test.a = t23.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t24
ON hive.temp.complex_test.a = t24.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t25
ON hive.temp.complex_test.a = t25.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t26
ON hive.temp.complex_test.a = t26.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t27
ON hive.temp.complex_test.a = t27.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t28
ON hive.temp.complex_test.a = t28.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t29
ON hive.temp.complex_test.a = t29.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t30
ON hive.temp.complex_test.a = t30.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t31
ON hive.temp.complex_test.a = t31.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t32
ON hive.temp.complex_test.a = t32.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t33
ON hive.temp.complex_test.a = t33.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t34
ON hive.temp.complex_test.a = t34.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t35
ON hive.temp.complex_test.a = t35.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t36
ON hive.temp.complex_test.a = t36.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t37
ON hive.temp.complex_test.a = t37.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t38
ON hive.temp.complex_test.a = t38.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t39
ON hive.temp.complex_test.a = t39.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t40
ON hive.temp.complex_test.a = t40.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t41
ON hive.temp.complex_test.a = t41.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t42
ON hive.temp.complex_test.a = t42.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t43
ON hive.temp.complex_test.a = t43.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t44
ON hive.temp.complex_test.a = t44.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t45
ON hive.temp.complex_test.a = t45.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t46
ON hive.temp.complex_test.a = t46.a

LEFT JOIN (SELECT a FROM hive.temp.complex_test)t47
ON hive.temp.complex_test.a = t47.a

```

## What I'm doing:

Using HashSet to duplicate same ComplexTypeAccessPaths for each ColumnRefOperator

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
