### PR TITLE
[Enhancement] Show plan cost in explain verbose/costs (backport #49106)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -18,12 +18,14 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.plugin.AuditEvent;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.Explain;
 import com.starrocks.sql.ast.StatementBase;
@@ -174,6 +176,17 @@ public class ExecPlan {
 
     public String getExplainString(TExplainLevel level) {
         StringBuilder str = new StringBuilder();
+
+        if (level == TExplainLevel.VERBOSE || level == TExplainLevel.COSTS) {
+            if (FeConstants.showFragmentCost) {
+                final String prefix = "  ";
+                AuditEvent auditEvent = connectContext.getAuditEventBuilder().build();
+                str.append("PLAN COST").append("\n")
+                        .append(prefix).append("CPU: ").append(auditEvent.planCpuCosts).append("\n")
+                        .append(prefix).append("Memory: ").append(auditEvent.planMemCosts).append("\n\n");
+            }
+        }
+
         if (level == null) {
             str.append(Explain.toString(physicalPlan, outputColumns));
         } else {


### PR DESCRIPTION
CP from #49106.

## Why I'm doing:


We need know plan costs of classic queries to decide the resource group classifier field `plan_cpu_cost_range` and `plan_mem_cost_range`.

They are recorded in `fe.audit.log`. However, some platforms like BYOC doesn't support audit log.

Therefore, also show them in explain verbose / costs.

## What I'm doing:

Fixes #issue

```
+---------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                  |
+---------------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                       |
|   CPU: 1881002.0                                                                                                                |
|   Memory: 288001.0                                                                                                              |
|                                                                                                                                 |
| PLAN FRAGMENT 0(F01)                                                                                                            |
|   Fragment Cost: 35.99999999999999                                                                                              |
|   Output Exprs:16: count                                                                                                        |
|   Input Partition: UNPARTITIONED                                                                                                |
|   RESULT SINK                                                                                                                   |
|                                                                                                                                 |
|   4:AGGREGATE (merge finalize)                                                                                                  |
|   |  aggregate: count[([16: count, BIGINT, false]); args: TINYINT; result: BIGINT; args nullable: true; result nullable: false] |
|   |  cardinality: 1                                                                                                             |
|   |                                                                                                                             |
|   3:EXCHANGE                                                                                                                    |
|      distribution type: GATHER                                                                                                  |
|      cardinality: 1                                                                                                             |
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
<hr>This is an automatic backport of pull request #49106 done by [Mergify](https://mergify.com).
## Why I'm doing:

We need know plan costs of classic queries to decide the resource group classifier field `plan_cpu_cost_range` and `plan_mem_cost_range`.

They are recorded in `fe.audit.log`. However, some platforms like BYOC doesn't support audit log.

Therefore, also show them in explain verbose / costs.

## What I'm doing:

Fixes #issue

```
+---------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                  |
+---------------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                       |
|   CPU: 1881002.0                                                                                                                |
|   Memory: 288001.0                                                                                                              |
|                                                                                                                                 |
| PLAN FRAGMENT 0(F01)                                                                                                            |
|   Fragment Cost: 35.99999999999999                                                                                              |
|   Output Exprs:16: count                                                                                                        |
|   Input Partition: UNPARTITIONED                                                                                                |
|   RESULT SINK                                                                                                                   |
|                                                                                                                                 |
|   4:AGGREGATE (merge finalize)                                                                                                  |
|   |  aggregate: count[([16: count, BIGINT, false]); args: TINYINT; result: BIGINT; args nullable: true; result nullable: false] |
|   |  cardinality: 1                                                                                                             |
|   |                                                                                                                             |
|   3:EXCHANGE                                                                                                                    |
|      distribution type: GATHER                                                                                                  |
|      cardinality: 1                                                                                                             |
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


