### PR TITLE
[BugFix] fix last_refresh status of mv task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -440,7 +440,7 @@ public class ShowMaterializedViewStatus {
             status.setMvRefreshEndTime(mvRefreshFinishTime);
 
             long totalProcessDuration = lastJobTaskRunStatus.stream()
-                    .map(x -> x.calculateRefreshProcessDuration())
+                    .map(TaskRunStatus::calculateRefreshProcessDuration)
                     .collect(Collectors.summingLong(Long::longValue));
             status.setTotalProcessDuration(totalProcessDuration);
             status.setErrorCode(String.valueOf(lastTaskRunStatus.getErrorCode()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -646,18 +646,18 @@ public class TaskManager implements MemoryTrackable {
         Consumer<TaskRunStatus> addResult = task ->
                 mvNameRunStatusMap.computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList()).add(task);
 
-        // pending task runs
-        List<TaskRun> pendingTaskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
-        pendingTaskRuns.stream()
-                .map(TaskRun::getStatus)
-                .filter(taskRunFilter)
-                .forEach(addResult);
-
         // running
         taskRunScheduler.getCopiedRunningTaskRuns().stream()
                 .map(TaskRun::getStatus)
                 .filter(taskRunFilter)
                 .filter(duplicateFilter)
+                .forEach(addResult);
+
+        // pending task runs
+        List<TaskRun> pendingTaskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
+        pendingTaskRuns.stream()
+                .map(TaskRun::getStatus)
+                .filter(taskRunFilter)
                 .forEach(addResult);
 
         // history

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -639,6 +639,7 @@ public class TaskManager implements MemoryTrackable {
         Predicate<TaskRunStatus> taskRunFilter = (task) ->
                 Objects.nonNull(task)
                         && task.getSource() == Constants.TaskSource.MV
+                        && task.getState() != Constants.TaskRunState.MERGED
                         && (dbName == null || task.getDbName().equals(dbName))
                         && (CollectionUtils.isEmpty(taskNames) || taskNames.contains(task.getTaskName()));
         Consumer<TaskRunStatus> addResult = task -> {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -49,10 +49,11 @@ public class TaskRunExecutor {
             return false;
         }
 
+        // Synchronously update the status, to make sure they can be persisted
+        status.setState(Constants.TaskRunState.RUNNING);
+        status.setProcessStartTime(System.currentTimeMillis());
+
         CompletableFuture<Constants.TaskRunState> future = CompletableFuture.supplyAsync(() -> {
-            status.setState(Constants.TaskRunState.RUNNING);
-            // set process start time
-            status.setProcessStartTime(System.currentTimeMillis());
             try {
                 boolean isSuccess = taskRun.executeTaskRun();
                 if (isSuccess) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -131,7 +131,6 @@ public class TaskRunHistoryTable {
             }).collect(Collectors.joining(", "));
 
             String sql = insert + values;
-            System.err.println(sql);
             RepoExecutor.getInstance().executeDML(sql);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -377,15 +377,14 @@ public class TaskRunStatus implements Writable {
 
     public long calculateRefreshProcessDuration() {
         if (finishTime > processStartTime) {
-            return finishTime - processStartTime;
-        } else {
-            return 0L;
-        }
-    }
-
-    public long calculateRefreshDuration() {
-        if (finishTime > createTime) {
-            return finishTime - createTime;
+            // NOTE:
+            // It's mostly because of tech debt, before this pr, the processStartTime can be persisted as 0 .
+            // In this case to avoid return a weird duration we choose the createTime as startTime
+            if (processStartTime > 0) {
+                return finishTime - processStartTime;
+            } else {
+                return finishTime - createTime;
+            }
         } else {
             return 0L;
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. The `TaskRunStatus.processStartTime` should be updated before persistence, otherwise it will lose and become 0 after restarting
2. If the `processStartTime == 0`, the `last_refresh_duration` of MV is weird, should be fixed
3. Display `RUNNING` task before `PENDING` tasks
4. Skip show `MERGED` task as last refresh

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
