### PR TITLE
[Enhancement] shorten FE plan time in some corner case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -153,7 +153,7 @@ public class Utils {
             return new LinkedList<>();
         }
 
-        LinkedList<ColumnRefOperator> list = new LinkedList<>();
+        List<ColumnRefOperator> list = new LinkedList<>();
         if (OperatorType.VARIABLE.equals(root.getOpType())) {
             list.add((ColumnRefOperator) root);
             return list;
@@ -163,8 +163,8 @@ public class Utils {
         if (childs.isEmpty()) {
             return list;
         }
-        
-        list = (LinkedList<ColumnRefOperator>) extractColumnRef(childs.get(0));
+
+        list = extractColumnRef(childs.get(0));
         for (int i = 1; i < childs.size(); i++) {
             list.addAll(extractColumnRef(childs.get(i)));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -171,10 +171,6 @@ public class Utils {
     }
 
     public static int countColumnRef(ScalarOperator root) {
-        return countColumnRef(root, 0);
-    }
-
-    private static int countColumnRef(ScalarOperator root, int count) {
         if (null == root) {
             return 0;
         }
@@ -183,8 +179,9 @@ public class Utils {
             return 1;
         }
 
+        int count = 0;
         for (ScalarOperator child : root.getChildren()) {
-            count += countColumnRef(child, count);
+            count += countColumnRef(child);
         }
 
         return count;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -149,7 +149,7 @@ public class Utils {
     }
 
     public static List<ColumnRefOperator> extractColumnRef(ScalarOperator root) {
-        if (null == root || !root.isVariable()) {
+        if (null == root) {
             return new LinkedList<>();
         }
 
@@ -160,7 +160,11 @@ public class Utils {
         }
 
         for (ScalarOperator child : root.getChildren()) {
-            list.addAll(extractColumnRef(child));
+            if (list.isEmpty()) {
+                list = (LinkedList<ColumnRefOperator>) extractColumnRef(child);
+            } else {
+                list.addAll(extractColumnRef(child));
+            }
         }
 
         return list;
@@ -171,7 +175,7 @@ public class Utils {
     }
 
     private static int countColumnRef(ScalarOperator root, int count) {
-        if (null == root || !root.isVariable()) {
+        if (null == root) {
             return 0;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -153,23 +153,7 @@ public class Utils {
             return new LinkedList<>();
         }
 
-        List<ColumnRefOperator> list = new LinkedList<>();
-        if (OperatorType.VARIABLE.equals(root.getOpType())) {
-            list.add((ColumnRefOperator) root);
-            return list;
-        }
-
-        List<ScalarOperator> childs = root.getChildren();
-        if (childs.isEmpty()) {
-            return list;
-        }
-
-        list = extractColumnRef(childs.get(0));
-        for (int i = 1; i < childs.size(); i++) {
-            list.addAll(extractColumnRef(childs.get(i)));
-        }
-
-        return list;
+        return root.getColumnRefs();
     }
 
     public static int countColumnRef(ScalarOperator root) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -159,12 +159,14 @@ public class Utils {
             return list;
         }
 
-        for (ScalarOperator child : root.getChildren()) {
-            if (list.isEmpty()) {
-                list = (LinkedList<ColumnRefOperator>) extractColumnRef(child);
-            } else {
-                list.addAll(extractColumnRef(child));
-            }
+        List<ScalarOperator> childs = root.getChildren();
+        if (childs.isEmpty()) {
+            return list;
+        }
+        
+        list = (LinkedList<ColumnRefOperator>) extractColumnRef(childs.get(0));
+        for (int i = 1; i < childs.size(); i++) {
+            list.addAll(extractColumnRef(childs.get(i)));
         }
 
         return list;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -38,8 +38,8 @@ public class CompoundPredicateOperator extends PredicateOperator {
     //      AND         AND
     //     /   \       /  \
     // subT1   a+1  And  subT5
-    //               /   \
-    //             subT3  a+1
+    //             /   \
+    //          subT3  a+1
     private int compoundTreeLeafNodeNumber;
     private Set<ScalarOperator> compoundTreeUniqueLeaves;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ExtractCommonPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ExtractCommonPredicateRule.java
@@ -50,7 +50,7 @@ public class ExtractCommonPredicateRule extends TopDownScalarOperatorRewriteRule
         List<List<ScalarOperator>> orAndPredicates = Lists.newArrayList();
 
         for (ScalarOperator or : orLists) {
-            orAndPredicates.add(Lists.newArrayList(Utils.extractConjuncts(or)));
+            orAndPredicates.add(Utils.extractConjuncts(or));
         }
 
         // extract common predicate

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
@@ -254,9 +254,13 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
             }
             result.add(newOp);
         });
-        CompoundPredicateOperator res =
-                (CompoundPredicateOperator) (isIn ? Utils.compoundOr(result) : Utils.compoundAnd(result));
-        return visitCompoundPredicate(res, context);
+
+        ScalarOperator res = isIn ? Utils.compoundOr(result) : Utils.compoundAnd(result);
+        if (res instanceof CompoundPredicateOperator) {
+            return visitCompoundPredicate((CompoundPredicateOperator) res, context);
+        } else {
+            return res;
+        }
     }
 
     // rewrite collection element to subfiled

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
@@ -145,9 +145,9 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
     @Nullable
     private Optional<ScalarOperator> getOptimizedCompoundTree(CompoundPredicateOperator parent) {
         // reset node first So we can apply NormalizePredicateRule to one tree many times
-        parent.setCompoundTreeUniqueLeaves(Sets.newLinkedHashSet());
+        parent.setCompoundTreeUniqueLeaves(null);
         parent.setCompoundTreeLeafNodeNumber(0);
-        Set<ScalarOperator> compoundTreeUniqueLeaves = parent.getCompoundTreeUniqueLeaves();
+        Set<ScalarOperator> compoundTreeUniqueLeaves = null;
 
         for (ScalarOperator child : parent.getChildren()) {
             if (child != null) {
@@ -157,12 +157,19 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
                         (parent.isOr() && OperatorType.COMPOUND.equals(child.getOpType()) &&
                                 ((CompoundPredicateOperator) child).isOr())) {
                     CompoundPredicateOperator compoundChild = (CompoundPredicateOperator) (child);
-                    compoundTreeUniqueLeaves.addAll(compoundChild.getCompoundTreeUniqueLeaves());
+                    if (compoundTreeUniqueLeaves == null) {
+                        compoundTreeUniqueLeaves = compoundChild.getCompoundTreeUniqueLeaves();
+                    } else {
+                        compoundTreeUniqueLeaves.addAll(compoundChild.getCompoundTreeUniqueLeaves());
+                    }
                     parent.setCompoundTreeLeafNodeNumber(
                             compoundChild.getCompoundTreeLeafNodeNumber() + parent.getCompoundTreeLeafNodeNumber());
                 } else {
                     // child is leaf node in compound tree
                     // we cache CompoundPredicate's hash value to eliminate duplicate calculations
+                    if (compoundTreeUniqueLeaves == null) {
+                        compoundTreeUniqueLeaves = Sets.newLinkedHashSet();
+                    }
                     compoundTreeUniqueLeaves.add(new HashCachedScalarOperator(child));
                     parent.setCompoundTreeLeafNodeNumber(1 + parent.getCompoundTreeLeafNodeNumber());
                 }
@@ -176,6 +183,7 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
                 }
             }
         }
+        parent.setCompoundTreeUniqueLeaves(compoundTreeUniqueLeaves);
 
         // this tree can be optimized
         if (compoundTreeUniqueLeaves.size() != parent.getCompoundTreeLeafNodeNumber()) {
@@ -246,8 +254,9 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
             }
             result.add(newOp);
         });
-
-        return isIn ? Utils.compoundOr(result) : Utils.compoundAnd(result);
+        CompoundPredicateOperator res =
+                (CompoundPredicateOperator) (isIn ? Utils.compoundOr(result) : Utils.compoundAnd(result));
+        return visitCompoundPredicate(res, context);
     }
 
     // rewrite collection element to subfiled

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRuleTest.java
@@ -118,4 +118,28 @@ public class NormalizePredicateRuleTest {
 
         assertTrue(result.isConstantTrue());
     }
+
+    @Test
+    public void testCompound1() {
+        NormalizePredicateRule rule = new NormalizePredicateRule();
+        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
+
+        InPredicateOperator inOp = new InPredicateOperator(
+                true,
+                ConstantOperator.createInt(1),
+                new ColumnRefOperator(0, Type.INT, "col1", true),
+                new ColumnRefOperator(0, Type.INT, "col1", true)
+        );
+
+        CompoundPredicateOperator compoundPredicateOperator =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, inOp,
+                        new BinaryPredicateOperator(BinaryType.GE,
+                                ConstantOperator.createInt(1),
+                                new ColumnRefOperator(1, Type.INT, "test1", true))
+                );
+
+        ScalarOperatorRewriter operatorRewriter = new ScalarOperatorRewriter();
+        ScalarOperator res =
+                operatorRewriter.rewrite(compoundPredicateOperator, Lists.newArrayList(new NormalizePredicateRule()));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
1. extractColumnRef's implement is not effective, time complexity is O(N^2), N is Tree's node number, so remove "
root.isVariable()"

2. There exist one pattern in some rule "create new set or list, add all child's set or list into my set or list, return my set or list". Usually rule's input opeator is tend to be Left -deep tree, if one bottom up rule has this pattern and tree is left-deep tree, we don't need to create a new set or list for the first child which is deep in  Left -deep tree. Instead, we can just use first child's set or list

3.  fix a bug reported by https://github.com/StarRocks/starrocks/issues/44933

some evidence from IDEA profiler：
![image](https://github.com/user-attachments/assets/c180aec6-381d-4cc3-9964-3109ee623eef)
![image](https://github.com/user-attachments/assets/dce4cda5-347d-4034-a13c-7dbf278825a3)
![image](https://github.com/user-attachments/assets/df2a78f1-4ffe-4959-984f-d5e528ac1515)


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
