### PR TITLE
[Enhancement] Support Iceberg rest catalog with vended credential disabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.io.IcebergCachingFileIO;
+import com.starrocks.connector.share.iceberg.IcebergAwsClientFactory;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.hadoop.conf.Configuration;
@@ -38,6 +39,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTCatalog;
@@ -70,6 +72,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     // not the "https://api.tabular.io/ws"
     public static final String KEY_DISABLE_TABULAR_SUPPORT = "disable_tabular_support";
     public static final String KEY_CREDENTIAL_WITH_PREFIX = ICEBERG_CUSTOM_PROPERTIES_PREFIX + "credential";
+    public static final String KEY_DISABLE_VENDED_CREDENTIAL = "disable_vended_credential";
 
     private final Configuration conf;
     private final RESTCatalog delegate;
@@ -91,6 +94,13 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         if (!copiedProperties.containsKey(KEY_DISABLE_TABULAR_SUPPORT)) {
             copiedProperties.put("header.x-tabular-s3-access", "vended_credentials");
+        }
+
+        boolean disableVendedCredential = copiedProperties
+                .getOrDefault(KEY_DISABLE_VENDED_CREDENTIAL, "false")
+                .equalsIgnoreCase("true");
+        if (disableVendedCredential) {
+            copiedProperties.put(AwsProperties.CLIENT_FACTORY, IcebergAwsClientFactory.class.getName());
         }
 
         delegate = (RESTCatalog) CatalogUtil.loadCatalog(RESTCatalog.class.getName(), name, copiedProperties, conf);

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -346,7 +346,7 @@ under the License.
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.7</version>
+                <version>2.16.1</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf-rpc-core -->


### PR DESCRIPTION
## Why I'm doing:

Support rest catalog server with vended credential disabled.

## What I'm doing:

Introduce a new option named `disable_vended_credential` (default = false).

If disabled, the iceberg catalog will use credential provided in the `create catalog` statements. 

```sql
CREATE EXTERNAL CATALOG rest
PROPERTIES  
(  
"type" = "iceberg",  
"iceberg.catalog.type" = "rest",  
"iceberg.catalog.uri" = "http://localhost:8181",
"iceberg.catalog.disable_vended_credential" = "true",
"aws.s3.access_key"  =  "admin",
"aws.s3.secret_key"  =  "password",
"aws.s3.endpoint"  =  "http://localhost:9000",
"aws.s3.region" = "us-east-1",
"aws.s3.enable_path_style_access"="true"
);

```

Additionally, update the `commons-io` package to fix a method not found issue when using azure storage. 

`java.lang.NoSuchMethodError: 'void org.apache.commons.io.IOUtils.close(java.io.Closeable[])'`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
