### PR TITLE
[Enhancement]shared buffer should always peek successfully to avoid more copy

### DIFF
--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -269,7 +269,6 @@ StatusOr<int64_t> SharedBufferedInputStream::read(void* data, int64_t count) {
 
 StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
     ASSIGN_OR_RETURN(auto ret, find_shared_buffer(_offset, count));
-    // if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
     const uint8_t* buf = nullptr;
     RETURN_IF_ERROR(get_bytes(&buf, _offset, count, ret));
     return std::string_view((const char*)buf, count);
@@ -278,7 +277,7 @@ StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
 StatusOr<std::string_view> SharedBufferedInputStream::peek_shared_buffer(int64_t count,
                                                                          SharedBufferPtr* shared_buffer) {
     ASSIGN_OR_RETURN(auto ret, find_shared_buffer(_offset, count));
-    // if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
+    if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
     const uint8_t* buf = ret->buffer.data() + _offset - ret->offset;
     if (shared_buffer) {
         *shared_buffer = ret;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -269,7 +269,7 @@ StatusOr<int64_t> SharedBufferedInputStream::read(void* data, int64_t count) {
 
 StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
     ASSIGN_OR_RETURN(auto ret, find_shared_buffer(_offset, count));
-    if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
+    // if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
     const uint8_t* buf = nullptr;
     RETURN_IF_ERROR(get_bytes(&buf, _offset, count, ret));
     return std::string_view((const char*)buf, count);
@@ -278,7 +278,7 @@ StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
 StatusOr<std::string_view> SharedBufferedInputStream::peek_shared_buffer(int64_t count,
                                                                          SharedBufferPtr* shared_buffer) {
     ASSIGN_OR_RETURN(auto ret, find_shared_buffer(_offset, count));
-    if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
+    // if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
     const uint8_t* buf = ret->buffer.data() + _offset - ret->offset;
     if (shared_buffer) {
         *shared_buffer = ret;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
