### PR TITLE
[BugFix] Should use AggRewriteInfo.NOT_REWRITE other than throw exception when mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -355,7 +355,10 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
                 int foundIndex = 0;
 
                 CallOperator newAggCall = ctx.aggColRefToPushDownAggMap.get(origAggColRef);
-                Preconditions.checkState(newAggCall != null, "newAggCall is null");
+                if (newAggCall == null) {
+                    logMVRewrite(mvRewriteContext, "newAggCall is null");
+                    return AggRewriteInfo.NOT_REWRITE;
+                }
                 if (ctx.isRewrittenByEquivalent(newAggCall)) {
                     newAggregate = ctx.aggToFinalAggMap.get(newAggCall);
                     if (newAggregate == null) {
@@ -377,8 +380,11 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
                                 }
                             }
                         }
-                        Preconditions.checkState(foundIndex != -1,
-                                "no aggregate functions found: " + newAggregate.getChildren());
+                        if (foundIndex == -1) {
+                            logMVRewrite(mvRewriteContext,
+                                    "no aggregate functions found: " + newAggregate.getChildren());
+                            return AggRewriteInfo.NOT_REWRITE;
+                        }
                     }
                 } else {
                     ScalarOperator newArg0 = remapping.get(origAggColRef);
@@ -398,14 +404,19 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
                     Type[] argTypes = newArgs.stream().map(ScalarOperator::getType).toArray(Type[]::new);
                     Function newFunc = Expr.getBuiltinFunction(rollupFuncName, argTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-                    Preconditions.checkState(newFunc != null,
-                            "Get rollup function is null, rollupFuncName:", rollupFuncName);
+                    if (newFunc == null) {
+                        logMVRewrite(mvRewriteContext, "Get rollup function is null, rollupFuncName:", rollupFuncName);
+                        return AggRewriteInfo.NOT_REWRITE;
+                    }
                     newAggregate = new CallOperator(rollupFuncName, newFunc.getReturnType(), newArgs, newFunc);
                     realAggregate = newAggregate;
                 }
 
                 // rewrite it with remapping and final aggregate should use the new input as its argument.
-                Preconditions.checkState(realAggregate != null, "realAggregate is null");
+                if (realAggregate == null) {
+                    logMVRewrite(mvRewriteContext, "realAggregate is null");
+                    return AggRewriteInfo.NOT_REWRITE;
+                }
                 realAggregate = replaceAggFuncArgument(remapping, origAggColRef, realAggregate, foundIndex);
 
                 ColumnRefOperator newAggColRef = queryColumnRefFactory.create(realAggregate,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -511,6 +511,9 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
 
         MatchMode matchMode = getMatchMode(queryTables, mvTables);
 
+        if (matchMode == MatchMode.NOT_MATCH && mvTables.stream().noneMatch(queryTables::contains)) {
+            return null;
+        }
         // Check whether mv can be applicable for the query.
         if (!isMVApplicable(mvExpression, matchMode, queryExpression)) {
             return null;


### PR DESCRIPTION
## Why I'm doing:
`test_pt` in sql like below failed to transform to it's mv
```sql
        SELECT
            sum(gmv)
        FROM
           test_pt
        WHERE
           id IN (
                SELECT upper(id)
                FROM
                   test_pt2
                WHERE
                    pt = '2023-03-07'
                group by upper(id)
            )
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
