### PR TITLE
[BugFix] Capture query context when use its mem_tracker out of its lifetime (backport #49123)

### DIFF
--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -3,6 +3,7 @@
 #include "runtime/runtime_filter_worker.h"
 
 #include <random>
+#include <utility>
 
 #include "exec/pipeline/query_context.h"
 #include "exprs/vectorized/runtime_filter_bank.h"
@@ -23,15 +24,23 @@
 
 namespace starrocks {
 
-static inline std::shared_ptr<MemTracker> get_mem_tracker(const PUniqueId& query_id, bool is_pipeline) {
+// Using a query-level mem_tracker beyond QueryContext's lifetime may access already destructed parent mem_tracker.
+// mem_trackers has a hierarchy: process->query_pool->resource_group->query, so when resource_group is dropped or
+// altered, resource_group-level mem_tracker would be destructed, such a dangling query-level mem_tracker would cause
+// BE's crash when it accesses its parent mem_tracker(i.e. resource_group-level mem_tracker). so we need capture
+// query context to prevent it from being destructed, and when a dropping resource_group is used by outstanding query
+// contexts, it would be delayed to be dropped until all its outstanding query contexts are destructed.
+static inline std::pair<pipeline::QueryContextPtr, std::shared_ptr<MemTracker>> get_mem_tracker(
+        const PUniqueId& query_id, bool is_pipeline) {
     if (is_pipeline) {
         TUniqueId tquery_id;
         tquery_id.lo = query_id.lo();
         tquery_id.hi = query_id.hi();
         auto query_ctx = ExecEnv::GetInstance()->query_context_mgr()->get(tquery_id);
-        return query_ctx == nullptr ? nullptr : query_ctx->mem_tracker();
+        auto mem_tracker = query_ctx == nullptr ? nullptr : query_ctx->mem_tracker();
+        return std::make_pair(query_ctx, mem_tracker);
     } else {
-        return nullptr;
+        return std::make_pair(nullptr, nullptr);
     }
 }
 
@@ -199,7 +208,7 @@ Status RuntimeFilterMerger::init(const TRuntimeFilterParams& params) {
 }
 
 void RuntimeFilterMerger::merge_runtime_filter(PTransmitRuntimeFilterParams& params) {
-    auto mem_tracker = get_mem_tracker(params.query_id(), params.is_pipeline());
+    auto [query_ctx, mem_tracker] = get_mem_tracker(params.query_id(), params.is_pipeline());
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker.get());
 
     DCHECK(params.is_partial());
@@ -628,7 +637,7 @@ static inline Status receive_total_runtime_filter_pipeline(
 }
 
 void RuntimeFilterWorker::_receive_total_runtime_filter(PTransmitRuntimeFilterParams& request) {
-    auto mem_tracker = get_mem_tracker(request.query_id(), request.is_pipeline());
+    auto [query_ctx, mem_tracker] = get_mem_tracker(request.query_id(), request.is_pipeline());
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker.get());
     // deserialize once, and all fragment instance shared that runtime filter.
     vectorized::JoinRuntimeFilter* rf = nullptr;
@@ -701,7 +710,7 @@ void RuntimeFilterWorker::_receive_total_runtime_filter(PTransmitRuntimeFilterPa
 
 void RuntimeFilterWorker::_process_send_broadcast_runtime_filter_event(
         PTransmitRuntimeFilterParams&& params, std::vector<TRuntimeFilterDestination>&& destinations, int timeout_ms) {
-    auto mem_tracker = get_mem_tracker(params.query_id(), params.is_pipeline());
+    auto [query_ctx, mem_tracker] = get_mem_tracker(params.query_id(), params.is_pipeline());
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker.get());
 
     std::random_device rd;


### PR DESCRIPTION
## Why I'm doing
RuntimeFilterWorker may handle a delay runtime filter of  a pre-maturely terminating query, so a query context is destructed before the using its query-level mem_tacker in RuntimeFilterWorker. when this mem_tracker is undergoing
desctruction, its parent mem_tracker (e.g. resource_group-level mem_tracker) would be accessed, however, the resource-group-level mem trackers has already been destructed when the resource group is dropped or altered.

Using query-level mem-tracker beyond query context's life time may lead to BE's crash as follows:
```
*** Aborted at 1722298201 (unix time) try "date -d @1722298201" if you are using GNU date ***
PC: @          0x80cfb60 (unknown)
*** SIGSEGV (@0x0) received by PID 41980 (TID 0x7f0a2fbea700) from PID 0; stack trace: ***
    @          0x5c32442 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f0da11847f2 os::Linux::chained_handler()
    @     0x7f0da118b5c6 JVM_handle_linux_signal
    @     0x7f0da1181683 signalHandler()
    @     0x7f0da064c630 (unknown)
    @          0x80cfb60 (unknown)
    @          0x4a588d8 starrocks::MemTracker::~MemTracker()
    @          0x2cb1e8a std::_Sp_counted_base<>::_M_release()
    @          0x4ac1d87 starrocks::RuntimeFilterWorker::_receive_total_runtime_filter()
    @          0x4ac4266 starrocks::RuntimeFilterWorker::execute()
    @          0x8146cb0 execute_native_thread_routine
    @     0x7f0da0644ea5 start_thread
    @     0x7f0d9fc5f98d __clone
    @                0x0 (unknown)
```

## What I'm doing:
We need capture query context to prevent it from being destructed, and when a dropping resource_group is used by outstanding query contexts, it would be delayed to be dropped until all its outstanding query contexts are destructed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
<hr>This is an automatic backport of pull request #49123 done by [Mergify](https://mergify.com).
## Why I'm doing
RuntimeFilterWorker may handle a delay runtime filter of  a pre-maturely terminating query, so a query context is destructed before the using its query-level mem_tacker in RuntimeFilterWorker. when this mem_tracker is undergoing
desctruction, its parent mem_tracker (e.g. resource_group-level mem_tracker) would be accessed, however, the resource-group-level mem trackers has already been destructed when the resource group is dropped or altered.

Using query-level mem-tracker beyond query context's life time may lead to BE's crash as follows:
```
*** Aborted at 1722298201 (unix time) try "date -d @1722298201" if you are using GNU date ***
PC: @          0x80cfb60 (unknown)
*** SIGSEGV (@0x0) received by PID 41980 (TID 0x7f0a2fbea700) from PID 0; stack trace: ***
    @          0x5c32442 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f0da11847f2 os::Linux::chained_handler()
    @     0x7f0da118b5c6 JVM_handle_linux_signal
    @     0x7f0da1181683 signalHandler()
    @     0x7f0da064c630 (unknown)
    @          0x80cfb60 (unknown)
    @          0x4a588d8 starrocks::MemTracker::~MemTracker()
    @          0x2cb1e8a std::_Sp_counted_base<>::_M_release()
    @          0x4ac1d87 starrocks::RuntimeFilterWorker::_receive_total_runtime_filter()
    @          0x4ac4266 starrocks::RuntimeFilterWorker::execute()
    @          0x8146cb0 execute_native_thread_routine
    @     0x7f0da0644ea5 start_thread
    @     0x7f0d9fc5f98d __clone
    @                0x0 (unknown)
```

## What I'm doing:
We need capture query context to prevent it from being destructed, and when a dropping resource_group is used by outstanding query contexts, it would be delayed to be dropped until all its outstanding query contexts are destructed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


