### PR TITLE
[BugFix] Fix partition live number not working

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -435,6 +435,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public TableProperty buildPartitionTTL() {
+        if (partitionTTLNumber != INVALID) {
+            return this;
+        }
         partitionTTLNumber = Integer.parseInt(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER,
                 String.valueOf(INVALID)));
         return this;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyTest.java
@@ -75,7 +75,6 @@ public class TablePropertyTest {
         in.close();
     }
 
-
     @Test
     public void testBuildDataCachePartitionDuration() throws IOException {
         // 1. Write objects to file
@@ -97,4 +96,27 @@ public class TablePropertyTest {
         in.close();
     }
 
+    @Test
+    public void testPartitionTTLNumberSerialization() throws IOException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER, "2");
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildPartitionLiveNumber();
+        tableProperty.buildPartitionTTL();
+        Assert.assertEquals(2, tableProperty.getPartitionTTLNumber());
+        tableProperty.write(out);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+        TableProperty readTableProperty = TableProperty.read(in);
+        Assert.assertEquals(2, readTableProperty.getPartitionTTLNumber());
+        in.close();
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
partition live number is not work, and the old partitions are not removed.
```
2024-07-30 13:25:52.630+08:00 WARN (DynamicPartitionScheduler|62) [DynamicPartitionScheduler.scheduleTTLPartition():523] database=12003, table=975173 have no ttl. remove it from scheduler
```

## What I'm doing:
partition live number is -1 when FE restarts, because `TableProperty.buildPartitionTTL` overwrites the real partition live number.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
