### PR TITLE
[Enhancement] marginal improve performance of RuntimeProfile.addCounter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -803,6 +803,7 @@ public class RuntimeProfile {
     }
 
     public static void removeRedundantMinMaxMetrics(RuntimeProfile profile) {
+        List<String> toRemove = Lists.newArrayList();
         for (String name : profile.counterMap.keySet()) {
             Counter counter = profile.getCounter(name);
             Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
@@ -813,12 +814,13 @@ public class RuntimeProfile {
 
             if (Objects.equals(minCounter.getValue(), maxCounter.getValue()) &&
                     Objects.equals(minCounter.getValue(), counter.getValue())) {
-                profile.removeCounter(MERGED_INFO_PREFIX_MIN + name);
-                profile.removeCounter(MERGED_INFO_PREFIX_MAX + name);
+                toRemove.add(MERGED_INFO_PREFIX_MIN + name);
+                toRemove.add(MERGED_INFO_PREFIX_MAX + name);
             }
         }
 
         profile.getChildList().forEach(pair -> removeRedundantMinMaxMetrics(pair.first));
+        toRemove.forEach(profile::removeCounter);
     }
 
     interface ProfileFormatter {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1144,10 +1144,15 @@ public class DefaultCoordinator extends Coordinator {
     // build execution profile  from every BE's report
     @Override
     public RuntimeProfile buildQueryProfile(boolean needMerge) {
-        if (isShortCircuit) {
-            return shortCircuitExecutor.buildQueryProfile(needMerge);
+        lock();
+        try {
+            if (isShortCircuit) {
+                return shortCircuitExecutor.buildQueryProfile(needMerge);
+            }
+            return queryProfile.buildQueryProfile(needMerge);
+        } finally {
+            unlock();
         }
-        return queryProfile.buildQueryProfile(needMerge);
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Change `RuntimeProfile ConcurrentHashMap` into `HashMap`, since it's more performant 
- Optimize `RuntimeProfile.addCounters` , as it's the bottleneck

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/febaf68d-d0b6-4132-9e64-0e343046696b">



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
