### PR TITLE
[Enhancement] Improve load json array not set strip_outer_array error message

### DIFF
--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -50,6 +50,17 @@ Status JsonDocumentStreamParser::get_current(simdjson::ondemand::object* row) no
     try {
         if (_doc_stream_itr != _doc_stream.end()) {
             simdjson::ondemand::document_reference doc = *_doc_stream_itr;
+            if (doc.type() == simdjson::ondemand::json_type::array) {
+                auto err_msg = fmt::format(
+                        "The value is array type in json document stream, you can set strip_outer_array=true to parse "
+                        "each element of the array as individual rows, value: {}",
+                        JsonFunctions::to_json_string(doc, MAX_RAW_JSON_LEN));
+                return Status::DataQualityError(err_msg);
+            } else if (doc.type() != simdjson::ondemand::json_type::object) {
+                auto err_msg = fmt::format("The value should be object type in json document stream, value: {}",
+                                           JsonFunctions::to_json_string(doc, MAX_RAW_JSON_LEN));
+                return Status::DataQualityError(err_msg);
+            }
 
             _curr = doc.get_object();
             *row = _curr;
@@ -194,9 +205,15 @@ Status JsonDocumentStreamParserWithRoot::get_current(simdjson::ondemand::object*
     RETURN_IF_ERROR(JsonFunctions::extract_from_object(*row, _root_paths, &val));
 
     try {
-        if (val.type() != simdjson::ondemand::json_type::object) {
+        if (val.type() == simdjson::ondemand::json_type::array) {
+            auto err_msg = fmt::format(
+                    "The value is array type in json document stream with json root, you can set strip_outer_array=true"
+                    " to parse each element of the array as individual rows, value: {}",
+                    JsonFunctions::to_json_string(val, MAX_RAW_JSON_LEN));
+            return Status::DataQualityError(err_msg);
+        } else if (val.type() != simdjson::ondemand::json_type::object) {
             auto err_msg =
-                    fmt::format("the value should be object type in json document stream with json root, value: {}",
+                    fmt::format("The value should be object type in json document stream with json root, value: {}",
                                 JsonFunctions::to_json_string(val, MAX_RAW_JSON_LEN));
             return Status::DataQualityError(err_msg);
         }
@@ -231,8 +248,14 @@ Status JsonArrayParserWithRoot::get_current(simdjson::ondemand::object* row) noe
     RETURN_IF_ERROR(JsonFunctions::extract_from_object(*row, _root_paths, &val));
 
     try {
-        if (val.type() != simdjson::ondemand::json_type::object) {
-            auto err_msg = fmt::format("the value should be object type in json array with json root, value: {}",
+        if (val.type() == simdjson::ondemand::json_type::array) {
+            auto err_msg = fmt::format(
+                    "The value is array type in json array with json root, you can set strip_outer_array=true to parse "
+                    "each element of the array as individual rows, value: {}",
+                    JsonFunctions::to_json_string(val, MAX_RAW_JSON_LEN));
+            return Status::DataQualityError(err_msg);
+        } else if (val.type() != simdjson::ondemand::json_type::object) {
+            auto err_msg = fmt::format("The value should be object type in json array with json root, value: {}",
                                        JsonFunctions::to_json_string(val, MAX_RAW_JSON_LEN));
             return Status::DataQualityError(err_msg);
         }

--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -563,4 +563,92 @@ PARALLEL_TEST(JsonParserTest, test_big_json) {
     ASSERT_TRUE(st.is_end_of_file());
 }
 
+PARALLEL_TEST(JsonParserTest, test_document_stream_parser_invalid_type_array) {
+    std::string input = R"(   [{"key":1},{"key":2}]   )";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    simdjson::ondemand::parser simdjson_parser;
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
+    auto st = parser->parse(input.data(), size, padded_size);
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_TRUE(st.message().find("The value is array type in json document stream, you can set strip_outer_array=true "
+                                  "to parse each element of the array as individual rows, "
+                                  "value: [{\"key\":1},{\"key\":2}]") != std::string::npos);
+}
+
+PARALLEL_TEST(JsonParserTest, test_document_stream_parser_invalid_type_not_object) {
+    std::string input = R"(   1   )";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    simdjson::ondemand::parser simdjson_parser;
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
+    auto st = parser->parse(input.data(), size, padded_size);
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_TRUE(st.message().find("The value should be object type in json document stream, value: 1") !=
+                std::string::npos);
+}
+
+PARALLEL_TEST(JsonParserTest, test_document_stream_parser_with_jsonroot_invalid_type_array) {
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key0": [{"key1":1},{"key1":2}]}    {"key0":[{"key1":3},{"key1":4}]}  )";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    std::vector<SimpleJsonPath> jsonroot;
+    ASSERT_OK(JsonFunctions::parse_json_paths("$.key0", &jsonroot));
+
+    simdjson::ondemand::parser simdjson_parser;
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
+    auto st = parser->parse(input.data(), size, padded_size);
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+    st = parser->get_current(&row);
+    ASSERT_TRUE(
+            st.message().find("The value is array type in json document stream with json root, you can set "
+                              "strip_outer_array=true to parse each element of the array as individual rows, value: "
+                              "[{\"key1\":1},{\"key1\":2}]") != std::string::npos);
+}
+
+PARALLEL_TEST(JsonParserTest, test_array_parser_with_jsonroot_invalid_type_array) {
+    // json array with ' ', '/t', '\n'
+    std::string input = R"([   {"key0": [{"key1":1},{"key1":2}]},    {"key0": [{"key1":3},{"key1":4}]} ])";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    std::vector<SimpleJsonPath> jsonroot;
+    ASSERT_OK(JsonFunctions::parse_json_paths("$.key0", &jsonroot));
+
+    simdjson::ondemand::parser simdjson_parser;
+    std::unique_ptr<JsonParser> parser(new JsonArrayParserWithRoot(&simdjson_parser, jsonroot));
+    auto st = parser->parse(input.data(), size, padded_size);
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_TRUE(st.message().find(
+                        "The value is array type in json array with json root, you can set strip_outer_array=true to "
+                        "parse each element of the array as individual rows, value: [{\"key1\":1},{\"key1\":2}]") !=
+                std::string::npos);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
load json to table
```
create table t1(k1 int);

[{"k1":  1 }, {"k1": 2}]

"Message": "Failed to iterate document stream as object. error: INCORRECT_TYPE: The JSON element does not have the requested type."
```


## What I'm doing:
```
"Message": "The value is array type in json document stream, you can set strip_outer_array=true to parse each element of the array as individual rows, value: [{\"k1\":  1 }, {\"k1\": 2}]"
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
