### PR TITLE
[BugFix] Only repair mv when table's version/version time are matched with mv's version map

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -540,10 +540,11 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                 if (partition == null || table.isTempPartition(partitionId)) {
                     continue;
                 }
-                // TODO(fixme): last version/version time is not kept in transaction state, use version - 1 for n
+                // TODO(fixme): last version/version time is not kept in transaction state, use version - 1 for last commit
+                //  version.
+                // TODO: we may add last version time to check mv's version map with base table's version time.
                 PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo(partition.getId(),  partition.getName(),
-                        partitionVersion.getValue() - 1, -1,
-                        partitionVersion.getValue(), finishedTimeMs);
+                        partitionVersion.getValue() - 1, partitionVersion.getValue(), finishedTimeMs);
                 partitionRepairInfos.add(partitionRepairInfo);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/listener/GlobalLoadJobListenerBus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/GlobalLoadJobListenerBus.java
@@ -83,8 +83,7 @@ public class GlobalLoadJobListenerBus {
         // only trigger the stream load transaction
         TransactionState.LoadJobSourceType sourceType = transactionState.getSourceType();
         if (!TransactionState.LoadJobSourceType.FRONTEND_STREAMING.equals(sourceType)
-                && !TransactionState.LoadJobSourceType.BACKEND_STREAMING.equals(sourceType)
-                && !TransactionState.LoadJobSourceType.INSERT_STREAMING.equals(sourceType)) {
+                && !TransactionState.LoadJobSourceType.BACKEND_STREAMING.equals(sourceType)) {
             return;
         }
         listeners.stream().forEach(listener -> listener.onStreamLoadTransactionFinish(transactionState));

--- a/fe/fe-core/src/main/java/com/starrocks/listener/GlobalLoadJobListenerBus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/GlobalLoadJobListenerBus.java
@@ -83,7 +83,8 @@ public class GlobalLoadJobListenerBus {
         // only trigger the stream load transaction
         TransactionState.LoadJobSourceType sourceType = transactionState.getSourceType();
         if (!TransactionState.LoadJobSourceType.FRONTEND_STREAMING.equals(sourceType)
-                && !TransactionState.LoadJobSourceType.BACKEND_STREAMING.equals(sourceType)) {
+                && !TransactionState.LoadJobSourceType.BACKEND_STREAMING.equals(sourceType)
+                && !TransactionState.LoadJobSourceType.INSERT_STREAMING.equals(sourceType)) {
             return;
         }
         listeners.stream().forEach(listener -> listener.onStreamLoadTransactionFinish(transactionState));

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
@@ -44,20 +44,36 @@ public class LoadJobMVListener implements LoadJobListener {
 
     public static final LoadJobMVListener INSTANCE = new LoadJobMVListener();
 
+    private static boolean isTriggerOnTransactionFinish(TransactionState transactionState) {
+        if (transactionState.getSourceType() == TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public void onStreamLoadTransactionFinish(TransactionState transactionState) {
+        if (!isTriggerOnTransactionFinish(transactionState)) {
+            return;
+        }
         // how to handle stream load transaction?
         triggerToRefreshRelatedMVs(transactionState, false);
     }
 
     @Override
     public void onLoadJobTransactionFinish(TransactionState transactionState) {
+        if (!isTriggerOnTransactionFinish(transactionState)) {
+            return;
+        }
         triggerToRefreshRelatedMVs(transactionState, false);
     }
 
     @Override
     public void onDMLStmtJobTransactionFinish(TransactionState transactionState, Database db, Table table) {
         if (table != null && table.isMaterializedView()) {
+            return;
+        }
+        if (!isTriggerOnTransactionFinish(transactionState)) {
             return;
         }
         triggerToRefreshRelatedMVs(db, table);

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
@@ -105,7 +105,7 @@ public class LoadJobMVListener implements LoadJobListener {
                 LOG.warn("failed to get transaction tableId {} when pending refresh.", tableId);
                 return;
             }
-            if (!isTriggerIfBaseTableIsMV) {
+            if (!isTriggerIfBaseTableIsMV && table.isMaterializedView()) {
                 LOG.info("Skip to trigger refresh related materialized views in publish version phase because " +
                         "base table {} is a materialized view.", table.getName());
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -134,10 +134,10 @@ public class MVMetaVersionRepairer {
             if (curBasePartitionInfo.getId() != info.getPartitionId()
                     || curBasePartitionInfo.getVersion() != info.getLastVersion()) {
                 LOG.info("Base table {} partition {} version not match, id {}(mv)/{}(table), " +
-                                "version {}(mv)/{}(table), version time {}(mv)/{}(table), skip to repair",
+                                "version {}(mv)/{}(table), version time {}(mv), skip to repair",
                         table.getName(), info.getPartitionName(), curBasePartitionInfo.getId(),
                         info.getPartitionId(), curBasePartitionInfo.getVersion(), info.getLastVersion(),
-                        curBasePartitionInfo.getLastRefreshTime(), info.getLastVersionTime());
+                        curBasePartitionInfo.getLastRefreshTime());
                 continue;
             }
             needToUpdatePartitionInfos.add(info);

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -131,12 +131,13 @@ public class MVMetaVersionRepairer {
                 continue;
             }
             MaterializedView.BasePartitionInfo curBasePartitionInfo = partitionInfoMap.get(info.getPartitionName());
-            if (curBasePartitionInfo.getVersion() != info.getCurVersion() ||
-                    curBasePartitionInfo.getLastRefreshTime() != info.getCurVersionTime()) {
-                LOG.info("Base table {} partition {} version not match, cur version {}(mv)/{}(table), " +
-                                "version time {}(mv)/{}(table), skip to repair", table.getName(), info.getPartitionName(),
-                        curBasePartitionInfo.getVersion(), info.getCurVersion(), curBasePartitionInfo.getLastRefreshTime(),
-                        info.getCurVersionTime());
+            if (curBasePartitionInfo.getId() != info.getPartitionId()
+                    || curBasePartitionInfo.getVersion() != info.getLastVersion()) {
+                LOG.info("Base table {} partition {} version not match, id {}(mv)/{}(table), " +
+                                "version {}(mv)/{}(table), version time {}(mv)/{}(table), skip to repair",
+                        table.getName(), info.getPartitionName(), curBasePartitionInfo.getId(),
+                        info.getPartitionId(), curBasePartitionInfo.getVersion(), info.getLastVersion(),
+                        curBasePartitionInfo.getLastRefreshTime(), info.getLastVersionTime());
                 continue;
             }
             needToUpdatePartitionInfos.add(info);

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -88,8 +88,13 @@ public class MVMetaVersionRepairer {
         MaterializedView.AsyncRefreshContext asyncRefreshContext = mv.getRefreshScheme().getAsyncRefreshContext();
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVersionMap =
                 asyncRefreshContext.getBaseTableVisibleVersionMap();
+        List<MVRepairHandler.PartitionRepairInfo> needToUpdatePartitionInfos =
+                filterToRepairPartitionInfos(mv, table, baseTableVersionMap, partitionRepairInfos);
+        if (needToUpdatePartitionInfos.isEmpty()) {
+            return;
+        }
         // repair base table's version map directly
-        Map<String, MaterializedView.BasePartitionInfo> changedVersions = toBasePartitionInfoMap(partitionRepairInfos);
+        Map<String, MaterializedView.BasePartitionInfo> changedVersions = toBasePartitionInfoMap(needToUpdatePartitionInfos);
         baseTableVersionMap.computeIfAbsent(table.getId(), k -> Maps.newHashMap())
                 .putAll(changedVersions);
         LOG.info("repair base table {} version changes for mv {}, changed versions:{}",
@@ -100,13 +105,52 @@ public class MVMetaVersionRepairer {
         MVVersionManager.updateEditLogAfterVersionMetaChanged(mv, maxChangedTableRefreshTime);
     }
 
+    /**
+     * Only repair partition infos which version and version time are matched with base table's version map.
+     * @param mv mv to repair
+     * @param table base table that has been changed(schema change or compactions)
+     * @param baseTableVersionMap base table's version map in mv's version map
+     * @param partitionRepairInfos partition infos to repair
+     * @return partition infos that need to be updated
+     */
+    private static List<MVRepairHandler.PartitionRepairInfo> filterToRepairPartitionInfos(
+            MaterializedView mv,
+            Table table,
+            Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVersionMap,
+            List<MVRepairHandler.PartitionRepairInfo> partitionRepairInfos) {
+        List<MVRepairHandler.PartitionRepairInfo> needToUpdatePartitionInfos = Lists.newArrayList();
+        for (MVRepairHandler.PartitionRepairInfo info : partitionRepairInfos) {
+            if (!baseTableVersionMap.containsKey(table.getId())) {
+                LOG.info("Base table {} not found in mv {}'s version map, skip to repair", table.getName(), mv.getName());
+                continue;
+            }
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = baseTableVersionMap.get(table.getId());
+            if (!partitionInfoMap.containsKey(info.getPartitionName())) {
+                LOG.info("Partition {} not found in base table {}'s version map, skip to repair", info.getPartitionName(),
+                        table.getName());
+                continue;
+            }
+            MaterializedView.BasePartitionInfo curBasePartitionInfo = partitionInfoMap.get(info.getPartitionName());
+            if (curBasePartitionInfo.getVersion() != info.getCurVersion() ||
+                    curBasePartitionInfo.getLastRefreshTime() != info.getCurVersionTime()) {
+                LOG.info("Base table {} partition {} version not match, cur version {}(mv)/{}(table), " +
+                                "version time {}(mv)/{}(table), skip to repair", table.getName(), info.getPartitionName(),
+                        curBasePartitionInfo.getVersion(), info.getCurVersion(), curBasePartitionInfo.getLastRefreshTime(),
+                        info.getCurVersionTime());
+                continue;
+            }
+            needToUpdatePartitionInfos.add(info);
+        }
+        return needToUpdatePartitionInfos;
+    }
+
     private static Map<String, MaterializedView.BasePartitionInfo> toBasePartitionInfoMap(
             List<MVRepairHandler.PartitionRepairInfo> partitionRepairInfos) {
         Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = Maps.newHashMap();
         for (MVRepairHandler.PartitionRepairInfo partitionRepairInfo : partitionRepairInfos) {
             MaterializedView.BasePartitionInfo basePartitionInfo = new MaterializedView.BasePartitionInfo(
-                    partitionRepairInfo.getPartitionId(), partitionRepairInfo.getVersion(),
-                    partitionRepairInfo.getVersionTime());
+                    partitionRepairInfo.getPartitionId(), partitionRepairInfo.getNewVersion(),
+                    partitionRepairInfo.getNewVersionTime());
             partitionInfoMap.put(partitionRepairInfo.getPartitionName(), basePartitionInfo);
         }
         return partitionInfoMap;

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
@@ -31,42 +31,45 @@ import java.util.Map;
 
 public interface MVRepairHandler {
 
-    public class PartitionRepairInfo {
-        private long partitionId; // partition id
-        private String partitionName; // partition name
-        private long version; // partition visible version
-        private long versionTime; // partition visible version time
+    class PartitionRepairInfo {
+        private final long partitionId; // partition id
+        private final String partitionName; // partition name
+        private final long curVersion; // new commit partition visible version
+        private final long curVersionTime; // new commit partition visible version time
+        private final long newVersion; // new commit partition visible version
+        private final long newVersionTime; // new commit partition visible version time
+
+        public PartitionRepairInfo(Partition partition, long newVersion, long newVersionTime) {
+            this.partitionId = partition.getId();
+            this.partitionName = partition.getName();
+            this.curVersion = partition.getVisibleVersion();
+            this.curVersionTime = partition.getVisibleVersionTime();
+            this.newVersion = newVersion;
+            this.newVersionTime = newVersionTime;
+        }
 
         public long getPartitionId() {
             return partitionId;
-        }
-
-        public void setPartitionId(long partitionId) {
-            this.partitionId = partitionId;
         }
 
         public String getPartitionName() {
             return partitionName;
         }
 
-        public void setPartitionName(String partitionName) {
-            this.partitionName = partitionName;
+        public long getNewVersion() {
+            return newVersion;
         }
 
-        public long getVersion() {
-            return version;
+        public long getNewVersionTime() {
+            return newVersionTime;
         }
 
-        public void setVersion(long version) {
-            this.version = version;
+        public long getCurVersion() {
+            return curVersion;
         }
 
-        public long getVersionTime() {
-            return versionTime;
-        }
-
-        public void setVersionTime(long versionTime) {
-            this.versionTime = versionTime;
+        public long getCurVersionTime() {
+            return curVersionTime;
         }
     }
 
@@ -105,11 +108,8 @@ public interface MVRepairHandler {
                     if (partition == null || olapTable.isTempPartition(partitionId)) {
                         continue;
                     }
-                    PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo();
-                    partitionRepairInfo.setPartitionId(partitionId);
-                    partitionRepairInfo.setPartitionName(partition.getName());
-                    partitionRepairInfo.setVersion(partitionCommitInfo.getVersion());
-                    partitionRepairInfo.setVersionTime(partitionCommitInfo.getVersionTime());
+                    PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo(partition,
+                            partitionCommitInfo.getVersion(), partitionCommitInfo.getVersionTime());
                     partitionRepairInfos.add(partitionRepairInfo);
                 }
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
@@ -35,14 +35,12 @@ public interface MVRepairHandler {
         private final long partitionId; // partition id
         private final String partitionName; // partition name
         private final long lastVersion; // last commit partition visible version
-        private final long lastVersionTime; // last commit partition visible version time
         private final long newVersion; // new commit partition visible version
         private final long newVersionTime; // new commit partition visible version time
 
         public PartitionRepairInfo(long partitionId,
                                    String partitionName,
                                    long lastVersion,
-                                   long lastVersionTime,
                                    long newVersion,
                                    long newVersionTime) {
             this.partitionId = partitionId;
@@ -50,7 +48,6 @@ public interface MVRepairHandler {
             this.newVersion = newVersion;
             this.newVersionTime = newVersionTime;
             this.lastVersion = lastVersion;
-            this.lastVersionTime = lastVersionTime;
         }
 
         public long getPartitionId() {
@@ -71,10 +68,6 @@ public interface MVRepairHandler {
 
         public long getLastVersion() {
             return lastVersion;
-        }
-
-        public long getLastVersionTime() {
-            return lastVersionTime;
         }
     }
 
@@ -113,9 +106,11 @@ public interface MVRepairHandler {
                     if (partition == null || olapTable.isTempPartition(partitionId)) {
                         continue;
                     }
-                    // TODO(fixme): last version/version time is not kept in transaction state, use version - 1 for n
+                    // TODO(fixme): last version/version time is not kept in transaction state, use version - 1 for last commit
+                    //  version.
+                    // TODO: we may add last version time to check mv's version map with base table's version time.
                     PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo(partition.getId(),
-                            partition.getName(), partitionCommitInfo.getVersion()  - 1, -1,
+                            partition.getName(), partitionCommitInfo.getVersion()  - 1,
                             partitionCommitInfo.getVersion(), partitionCommitInfo.getVersionTime());
                     partitionRepairInfos.add(partitionRepairInfo);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
@@ -16,6 +16,7 @@ package com.starrocks.planner.mv;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.mv.MVMetaVersionRepairer;
 import com.starrocks.mv.MVRepairHandler;
@@ -67,6 +68,10 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         String mvName = (String) obj;
                         starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
                                 "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        Table m1 = getTable("test", "m1");
+                        Assert.assertTrue(m1 != null);
+                        Partition curPartition = m1.getPartition("p1");
+
                         MaterializedView mv1 = getMv("test", mvName);
                         Set<String> mvNames = mv1.getPartitionNames();
                         Assert.assertEquals("[p1]", mvNames.toString());
@@ -86,13 +91,10 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         MaterializedView.BasePartitionInfo basePartitionInfo = value.get(baseTablePartitionName);
 
                         // repair base table version changes
-                        MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
-                                new MVRepairHandler.PartitionRepairInfo();
                         long currentTs = System.currentTimeMillis();
-                        partitionRepairInfo.setVersionTime(currentTs);
-                        partitionRepairInfo.setPartitionName(baseTablePartitionName);
-                        partitionRepairInfo.setVersion(100L);
-                        partitionRepairInfo.setPartitionId(basePartitionInfo.getId());
+                        // p1 has been refreshed, use curPartition as its partition
+                        MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
+                                new MVRepairHandler.PartitionRepairInfo(curPartition, 100L, currentTs);
 
                         Database db = GlobalStateMgr.getCurrentState().getDb("test");
                         Table baseTable = getTable("test", "m1");
@@ -141,29 +143,154 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         Assert.assertEquals(0, baseTableVisibleVersionMap.size());
 
                         // repair base table version changes
-                        MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
-                                new MVRepairHandler.PartitionRepairInfo();
+                        Table m1 = getTable("test", "m1");
+                        Assert.assertTrue(m1 != null);
+                        Partition curPartition = m1.getPartition("p1");
                         long currentTs = System.currentTimeMillis();
-                        partitionRepairInfo.setVersionTime(currentTs);
-                        partitionRepairInfo.setPartitionName("p1");
-                        partitionRepairInfo.setVersion(100L);
-                        partitionRepairInfo.setPartitionId(1000L);
+                        MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
+                                new MVRepairHandler.PartitionRepairInfo(curPartition, 100L, currentTs);
 
                         Database db = GlobalStateMgr.getCurrentState().getDb("test");
                         Table baseTable = getTable("test", "m1");
                         MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
 
-                        // check mv version map after
+                        // Since mv has not refreshed, not repair it since mv's version map has not contained the old version
+                        baseTableVisibleVersionMap = asyncRefreshContext.getBaseTableVisibleVersionMap();
+                        Assert.assertEquals(0, baseTableVisibleVersionMap.size());
+                    });
+        });
+    }
+
+    @Test
+    public void testRepairBaseTableVersionChanges3() {
+        starRocksAssert.withTable(m1, () -> {
+            cluster.runSql("test", "insert into m1 values (1,1,1,1,1), (4,2,1,1,1);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (k1) " +
+                            " DISTRIBUTED BY HASH(k1) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " PROPERTIES (\n" +
+                            " 'transparent_mv_rewrite_mode' = 'true'" +
+                            " ) " +
+                            " AS SELECT k1, k2, v1, v2 from m1;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        MaterializedView mv1 = getMv("test", mvName);
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1]", mvNames.toString());
+                        MaterializedView.AsyncRefreshContext asyncRefreshContext =
+                                mv1.getRefreshScheme().getAsyncRefreshContext();
+                        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                                asyncRefreshContext.getBaseTableVisibleVersionMap();
+                        System.out.println(baseTableVisibleVersionMap);
+
+                        // repair base table version changes
+                        Table m1 = getTable("test", "m1");
+                        Assert.assertTrue(m1 != null);
+
+                        // check mv version map before
+                        Assert.assertEquals(1, baseTableVisibleVersionMap.size());
+                        Long baseTableId = baseTableVisibleVersionMap.keySet().iterator().next();
+                        Map<String, MaterializedView.BasePartitionInfo> value =
+                                baseTableVisibleVersionMap.values().iterator().next();
+                        Assert.assertEquals(1, value.size());
+                        String baseTablePartitionName = value.keySet().iterator().next();
+                        MaterializedView.BasePartitionInfo basePartitionInfo = value.get(baseTablePartitionName);
+                        Partition p1 = m1.getPartition("p1");
+                        Assert.assertEquals(basePartitionInfo.getVersion(), p1.getVisibleVersion());
+                        Assert.assertEquals(basePartitionInfo.getLastRefreshTime(), p1.getVisibleVersionTime());
+
+                        Partition p2 = m1.getPartition("p2");
+                        long currentTs = System.currentTimeMillis();
+                        // p1 has been refreshed, but p2 has been compaction or fast schema changed, use curPartition as its
+                        // partition
+                        MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
+                                new MVRepairHandler.PartitionRepairInfo(p2, 100L, currentTs);
+
+                        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                        Table baseTable = getTable("test", "m1");
+                        MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
+
                         baseTableVisibleVersionMap = asyncRefreshContext.getBaseTableVisibleVersionMap();
                         Assert.assertEquals(1, baseTableVisibleVersionMap.size());
-                        Map<String, MaterializedView.BasePartitionInfo> newValue =
+                        Assert.assertEquals(baseTableId, baseTableVisibleVersionMap.keySet().iterator().next());
+                        Map<String, MaterializedView.BasePartitionInfo> basePartitionInfoMap = baseTableVisibleVersionMap.get(m1.getId());
+                        Assert.assertEquals(1, basePartitionInfoMap.size());
+                        System.out.println(basePartitionInfoMap);
+                        // p2 should not be in the version map
+                        Assert.assertFalse(basePartitionInfoMap.containsKey("p2"));
+                    });
+        });
+    }
+
+    @Test
+    public void testRepairBaseTableVersionChanges4() {
+        starRocksAssert.withTable(m1, () -> {
+            cluster.runSql("test", "insert into m1 values (1,1,1,1,1), (4,2,1,1,1);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (k1) " +
+                            " DISTRIBUTED BY HASH(k1) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " PROPERTIES (\n" +
+                            " 'transparent_mv_rewrite_mode' = 'true'" +
+                            " ) " +
+                            " AS SELECT k1, k2, v1, v2 from m1;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        MaterializedView mv1 = getMv("test", mvName);
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1]", mvNames.toString());
+                        MaterializedView.AsyncRefreshContext asyncRefreshContext =
+                                mv1.getRefreshScheme().getAsyncRefreshContext();
+                        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                                asyncRefreshContext.getBaseTableVisibleVersionMap();
+                        System.out.println(baseTableVisibleVersionMap);
+
+                        // repair base table version changes
+                        Table m1 = getTable("test", "m1");
+                        Assert.assertTrue(m1 != null);
+
+                        // check mv version map before
+                        Assert.assertEquals(1, baseTableVisibleVersionMap.size());
+                        Long baseTableId = baseTableVisibleVersionMap.keySet().iterator().next();
+                        Map<String, MaterializedView.BasePartitionInfo> value =
                                 baseTableVisibleVersionMap.values().iterator().next();
-                        Assert.assertEquals(1, newValue.size());
-                        Assert.assertEquals("p1", newValue.keySet().iterator().next());
-                        MaterializedView.BasePartitionInfo newBasePartitionInfo = newValue.get("p1");
-                        Assert.assertEquals(100L, newBasePartitionInfo.getVersion());
-                        Assert.assertEquals(currentTs, newBasePartitionInfo.getLastRefreshTime());
-                        Assert.assertEquals(1000L, newBasePartitionInfo.getId());
+                        Assert.assertEquals(1, value.size());
+                        String baseTablePartitionName = value.keySet().iterator().next();
+                        MaterializedView.BasePartitionInfo basePartitionInfo = value.get(baseTablePartitionName);
+                        Partition p1 = m1.getPartition("p1");
+                        long lastRefreshVersion = p1.getVisibleVersion();
+                        long lastRefreshVersionTime = p1.getVisibleVersionTime();
+                        Assert.assertEquals(basePartitionInfo.getVersion(), lastRefreshVersion);
+                        Assert.assertEquals(basePartitionInfo.getLastRefreshTime(), lastRefreshVersionTime);
+
+                        long currentTs = System.currentTimeMillis();
+                        // p1 has been refreshed, but p2 has been compaction or fast schema changed, use curPartition as its
+                        // partition
+                        // p1 has been updated, so the version of p1 should be updated
+                        p1.setVisibleVersion(lastRefreshVersion + 1, lastRefreshVersionTime + 1);
+                        MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
+                                new MVRepairHandler.PartitionRepairInfo(p1, 100L, currentTs);
+
+                        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                        Table baseTable = getTable("test", "m1");
+                        MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
+
+                        baseTableVisibleVersionMap = asyncRefreshContext.getBaseTableVisibleVersionMap();
+                        Assert.assertEquals(1, baseTableVisibleVersionMap.size());
+                        Assert.assertEquals(baseTableId, baseTableVisibleVersionMap.keySet().iterator().next());
+                        Map<String, MaterializedView.BasePartitionInfo> basePartitionInfoMap = baseTableVisibleVersionMap.get(m1.getId());
+                        Assert.assertEquals(1, basePartitionInfoMap.size());
+                        System.out.println(basePartitionInfoMap);
+                        basePartitionInfo = basePartitionInfoMap.get("p1");
+                        // p1 should not been updated since it has been updated
+                        Assert.assertEquals(basePartitionInfo.getVersion(), lastRefreshVersion);
+                        Assert.assertEquals(basePartitionInfo.getLastRefreshTime(), lastRefreshVersionTime);
+                        Assert.assertFalse(basePartitionInfoMap.containsKey("p2"));
                     });
         });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
@@ -52,6 +52,13 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
         );
     }
 
+    private MVRepairHandler.PartitionRepairInfo toPartitionInfo(Partition partition, long version,
+                                                                long versionTime) {
+        return new MVRepairHandler.PartitionRepairInfo(partition.getId(), partition.getName(),
+                partition.getVisibleVersion(), partition.getVisibleVersionTime(),
+                version, versionTime);
+    }
+
     @Test
     public void testRepairBaseTableVersionChanges1() {
         starRocksAssert.withTable(m1, () -> {
@@ -94,7 +101,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         long currentTs = System.currentTimeMillis();
                         // p1 has been refreshed, use curPartition as its partition
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
-                                new MVRepairHandler.PartitionRepairInfo(curPartition, 100L, currentTs);
+                                toPartitionInfo(curPartition, 100L, currentTs);
 
                         Database db = GlobalStateMgr.getCurrentState().getDb("test");
                         Table baseTable = getTable("test", "m1");
@@ -148,7 +155,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         Partition curPartition = m1.getPartition("p1");
                         long currentTs = System.currentTimeMillis();
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
-                                new MVRepairHandler.PartitionRepairInfo(curPartition, 100L, currentTs);
+                                toPartitionInfo(curPartition, 100L, currentTs);
 
                         Database db = GlobalStateMgr.getCurrentState().getDb("test");
                         Table baseTable = getTable("test", "m1");
@@ -207,7 +214,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         // p1 has been refreshed, but p2 has been compaction or fast schema changed, use curPartition as its
                         // partition
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
-                                new MVRepairHandler.PartitionRepairInfo(p2, 100L, currentTs);
+                                toPartitionInfo(p2, 100L, currentTs);
 
                         Database db = GlobalStateMgr.getCurrentState().getDb("test");
                         Table baseTable = getTable("test", "m1");
@@ -274,7 +281,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         // p1 has been updated, so the version of p1 should be updated
                         p1.setVisibleVersion(lastRefreshVersion + 1, lastRefreshVersionTime + 1);
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
-                                new MVRepairHandler.PartitionRepairInfo(p1, 100L, currentTs);
+                                toPartitionInfo(p1, 100L, currentTs);
 
                         Database db = GlobalStateMgr.getCurrentState().getDb("test");
                         Table baseTable = getTable("test", "m1");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
@@ -55,8 +55,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
     private MVRepairHandler.PartitionRepairInfo toPartitionInfo(Partition partition, long version,
                                                                 long versionTime) {
         return new MVRepairHandler.PartitionRepairInfo(partition.getId(), partition.getName(),
-                partition.getVisibleVersion(), partition.getVisibleVersionTime(),
-                version, versionTime);
+                partition.getVisibleVersion(), version, versionTime);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
@@ -75,8 +75,8 @@ public class MVRepairHandlerTest {
                 PartitionRepairInfo partitionRepairInfo = partitionRepairInfos.get(0);
                 Assert.assertEquals(partition.getId(), partitionRepairInfo.getPartitionId());
                 Assert.assertEquals(partition.getName(), partitionRepairInfo.getPartitionName());
-                Assert.assertEquals(100, partitionRepairInfo.getVersion());
-                Assert.assertEquals(100, partitionRepairInfo.getVersionTime());
+                Assert.assertEquals(100, partitionRepairInfo.getNewVersion());
+                Assert.assertEquals(100, partitionRepairInfo.getNewVersionTime());
             }
         };
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_event_trigger_with_stream_load
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_event_trigger_with_stream_load
@@ -1,0 +1,94 @@
+-- name: test_mv_event_trigger_with_stream_load
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+DROP TABLE IF EXISTS tab1;
+-- result:
+-- !result
+DROP TABLE IF EXISTS tab2;
+-- result:
+-- !result
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `mv1`
+REFRESH ASYNC
+AS
+select k1, k2, sum(v1), sum(v2), sum(v3) from tab1 group by k1, k2;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("db_${uuid0}", "mv1")
+-- result:
+None
+-- !result
+select * from mv1 order by k1;
+-- result:
+100	k2_100	100	100	100
+200	k2_200	200	200	200
+300	k3_300	300	300	300
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_condition_update_1.csv -XPUT -H label:db_${uuid0}_label_1 -H column_separator:, -H merge_condition:k1 ${url}/api/db_${uuid0}/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Fail",
+    "Message": "Merge condition column k1 should not be primary key!"
+}
+-- !result
+function: wait_async_materialized_view_finish("db_${uuid0}", "mv1")
+-- result:
+None
+-- !result
+select * from mv1 order by k1;
+-- result:
+100	k2_100	100	100	100
+200	k2_200	200	200	200
+300	k3_300	300	300	300
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_condition_update_1.csv -XPUT -H label:db_${uuid0}_label_2 -H column_separator:, -H merge_condition:v1 ${url}/api/db_${uuid0}/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+function: wait_async_materialized_view_finish("db_${uuid0}", "mv1")
+-- result:
+None
+-- !result
+select * from mv1 order by k1;
+-- result:
+100	k2_100	111	100	100
+200	k2_200	200	200	200
+300	k3_300	300	300	300
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_event_trigger_with_stream_load
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_event_trigger_with_stream_load
@@ -1,0 +1,42 @@
+-- name: test_mv_event_trigger_with_stream_load
+create database db_${uuid0};
+use db_${uuid0};
+
+DROP TABLE IF EXISTS tab1;
+DROP TABLE IF EXISTS tab2;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+
+CREATE MATERIALIZED VIEW `mv1`
+REFRESH ASYNC
+AS
+select k1, k2, sum(v1), sum(v2), sum(v3) from tab1 group by k1, k2;
+
+function: wait_async_materialized_view_finish("db_${uuid0}", "mv1")
+select * from mv1 order by k1;
+
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_condition_update_1.csv -XPUT -H label:db_${uuid0}_label_1 -H column_separator:, -H merge_condition:k1 ${url}/api/db_${uuid0}/tab1/_stream_load
+function: wait_async_materialized_view_finish("db_${uuid0}", "mv1")
+select * from mv1 order by k1;
+
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_condition_update_1.csv -XPUT -H label:db_${uuid0}_label_2 -H column_separator:, -H merge_condition:v1 ${url}/api/db_${uuid0}/tab1/_stream_load
+function: wait_async_materialized_view_finish("db_${uuid0}", "mv1")
+select * from mv1 order by k1;
+
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:


1. #48883 will repair mv's partition version no matter the base table's partition has already refreshed which will cause
wrong version mapping between mv and base table.
2. Stream Load will not trigger related mv since changed.

## What I'm doing:
- Only repair partition infos which version and version time are matched with base table's version map.
- Fix stream load trigger related mvs bug.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
