### PR TITLE
[Enhancement] Support release block cache and some other thread pool before core dump

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -103,6 +103,8 @@ public:
 
     ThreadPool* get_thread_pool(int type) const;
 
+    void stop_task_worker_pool(TaskWorkerType type) const;
+
     DISALLOW_COPY_AND_MOVE(Impl);
 
 private:
@@ -595,6 +597,43 @@ void AgentServer::Impl::update_max_thread_by_type(int type, int new_val) {
     LOG_IF(ERROR, !st.ok()) << st;
 }
 
+#define STOP_IF_NOT_NULL(worker_pool) \
+    if (worker_pool != nullptr) {     \
+        worker_pool->stop();          \
+    }
+
+void AgentServer::Impl::stop_task_worker_pool(TaskWorkerType type) const {
+    switch (type) {
+    case TaskWorkerType::PUSH:
+        STOP_IF_NOT_NULL(_push_workers);
+        break;
+    case TaskWorkerType::PUBLISH_VERSION:
+        STOP_IF_NOT_NULL(_publish_version_workers);
+        break;
+    case TaskWorkerType::DELETE:
+        STOP_IF_NOT_NULL(_delete_workers);
+        break;
+    case TaskWorkerType::REPORT_TASK:
+        STOP_IF_NOT_NULL(_report_task_workers);
+        break;
+    case TaskWorkerType::REPORT_DISK_STATE:
+        STOP_IF_NOT_NULL(_report_disk_state_workers);
+        break;
+    case TaskWorkerType::REPORT_OLAP_TABLE:
+        STOP_IF_NOT_NULL(_report_tablet_workers);
+        break;
+    case TaskWorkerType::REPORT_WORKGROUP:
+        STOP_IF_NOT_NULL(_report_workgroup_workers);
+        STOP_IF_NOT_NULL(_report_resource_usage_workers);
+        break;
+    case TaskWorkerType::REPORT_DATACACHE_METRICS:
+        STOP_IF_NOT_NULL(_report_datacache_metrics_workers);
+        break;
+    default:
+        break;
+    }
+}
+
 ThreadPool* AgentServer::Impl::get_thread_pool(int type) const {
     // TODO: more thread pools.
     ThreadPool* ret = nullptr;
@@ -699,6 +738,10 @@ void AgentServer::update_max_thread_by_type(int type, int new_val) {
 
 ThreadPool* AgentServer::get_thread_pool(int type) const {
     return _impl->get_thread_pool(type);
+}
+
+void AgentServer::stop_task_worker_pool(TaskWorkerType type) const {
+    return _impl->stop_task_worker_pool(type);
 }
 
 void AgentServer::init_or_die() {

--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <vector>
 
+#include "agent/agent_common.h"
 #include "gutil/macros.h"
 
 namespace starrocks {
@@ -76,6 +77,8 @@ public:
     //
     // Returns nullptr if `type` is not a valid value of `TTaskType::type`.
     ThreadPool* get_thread_pool(int type) const;
+
+    void stop_task_worker_pool(TaskWorkerType type) const;
 
     DISALLOW_COPY_AND_MOVE(AgentServer);
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -112,6 +112,11 @@ TaskWorkerPool<AgentTaskRequest>::TaskWorkerPool(ExecEnv* env, int worker_count)
 template <class AgentTaskRequest>
 TaskWorkerPool<AgentTaskRequest>::~TaskWorkerPool() {
     stop();
+    for (uint32_t i = 0; i < _worker_count; ++i) {
+        if (_worker_threads[i].joinable()) {
+            _worker_threads[i].join();
+        }
+    }
     delete _worker_thread_condition_variable;
 }
 
@@ -124,16 +129,8 @@ void TaskWorkerPool<AgentTaskRequest>::start() {
 
 template <class AgentTaskRequest>
 void TaskWorkerPool<AgentTaskRequest>::stop() {
-    if (_stopped) {
-        return;
-    }
     _stopped = true;
     _worker_thread_condition_variable->notify_all();
-    for (uint32_t i = 0; i < _worker_count; ++i) {
-        if (_worker_threads[i].joinable()) {
-            _worker_threads[i].join();
-        }
-    }
 }
 
 template <class AgentTaskRequest>

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -169,6 +169,7 @@ void StarCacheWrapper::record_read_cache(size_t size, int64_t lateny_us) {
 }
 
 Status StarCacheWrapper::shutdown() {
+    // TODO: starcache implement shutdown to release memory
     return Status::OK();
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1383,7 +1383,7 @@ CONF_mBool(skip_lake_pk_preload, "false");
 // Reduce core file size by not dumping jemalloc retain pages
 CONF_mBool(enable_core_file_size_optimization, "true");
 // Current supported modules:
-// 1. data_cache (storage_page_cache, block_cache)
+// 1. data_cache (data cache for shared-nothing table, data cache for external table, data cache for shared-data table)
 // 2. connector_scan_executor
 // 3. non_pipeline_scan_thread_pool
 // 4. pipeline_prepare_thread_pool

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1383,7 +1383,7 @@ CONF_mBool(skip_lake_pk_preload, "false");
 // Reduce core file size by not dumping jemalloc retain pages
 CONF_mBool(enable_core_file_size_optimization, "true");
 // Current supported modules:
-// 1. mem_cache (storage_page_cache, block_cache)
+// 1. data_cache (storage_page_cache, block_cache)
 // 2. connector_scan_executor
 // 3. non_pipeline_scan_thread_pool
 // 4. pipeline_prepare_thread_pool
@@ -1394,7 +1394,7 @@ CONF_mBool(enable_core_file_size_optimization, "true");
 // 9. wg_driver_executor
 // use commas to separate:
 // * means release all above
-CONF_mString(try_release_resource_before_core_dump, "mem_cache");
+CONF_mString(try_release_resource_before_core_dump, "data_cache");
 
 // Experimental feature, this configuration will be removed after testing is complete.
 CONF_mBool(lake_enable_alter_struct, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1389,9 +1389,13 @@ CONF_mBool(enable_core_file_size_optimization, "true");
 // 4. pipeline_prepare_thread_pool
 // 5. pipeline_sink_io_thread_pool
 // 6. query_rpc_thread_pool
+// 7. publish_version_worker_pool
+// 8. olap_scan_executor
+// 9. wg_driver_executor
+// 10. block_cache
 // use commas to separate:
 // * means release all above
-CONF_mString(try_release_resource_before_core_dump, "storage_page_cache");
+CONF_mString(try_release_resource_before_core_dump, "storage_page_cache,block_cache");
 
 // Experimental feature, this configuration will be removed after testing is complete.
 CONF_mBool(lake_enable_alter_struct, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1383,7 +1383,7 @@ CONF_mBool(skip_lake_pk_preload, "false");
 // Reduce core file size by not dumping jemalloc retain pages
 CONF_mBool(enable_core_file_size_optimization, "true");
 // Current supported modules:
-// 1. storage_page_cache
+// 1. mem_cache (storage_page_cache, block_cache)
 // 2. connector_scan_executor
 // 3. non_pipeline_scan_thread_pool
 // 4. pipeline_prepare_thread_pool
@@ -1392,10 +1392,9 @@ CONF_mBool(enable_core_file_size_optimization, "true");
 // 7. publish_version_worker_pool
 // 8. olap_scan_executor
 // 9. wg_driver_executor
-// 10. block_cache
 // use commas to separate:
 // * means release all above
-CONF_mString(try_release_resource_before_core_dump, "storage_page_cache,block_cache");
+CONF_mString(try_release_resource_before_core_dump, "mem_cache");
 
 // Experimental feature, this configuration will be removed after testing is complete.
 CONF_mBool(lake_enable_alter_struct, "true");

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -844,11 +844,11 @@ void ExecEnv::try_release_resource_before_core_dump() {
         LOG(INFO) << "stop worker group driver executor";
     }
     auto* storage_page_cache = StoragePageCache::instance();
-    if (storage_page_cache != nullptr && need_release("mem_cache")) {
+    if (storage_page_cache != nullptr && need_release("data_cache")) {
         storage_page_cache->set_capacity(0);
         LOG(INFO) << "release storage page cache memory";
     }
-    if (_block_cache != nullptr && need_release("mem_cache")) {
+    if (_block_cache != nullptr && need_release("data_cache")) {
         // TODO: Currently, block cache don't support shutdown now,
         //  so here will temporary use update_mem_quota instead to release memory.
         (void)_block_cache->update_mem_quota(0, false);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -815,6 +815,10 @@ void ExecEnv::try_release_resource_before_core_dump() {
         _connector_scan_executor->close();
         LOG(INFO) << "close connector scan executor";
     }
+    if (_scan_executor != nullptr && need_release("olap_scan_executor")) {
+        _scan_executor->close();
+        LOG(INFO) << "close olap scan executor";
+    }
     if (_thread_pool != nullptr && need_release("non_pipeline_scan_thread_pool")) {
         _thread_pool->shutdown();
         LOG(INFO) << "shutdown non-pipeline scan thread pool";
@@ -831,10 +835,24 @@ void ExecEnv::try_release_resource_before_core_dump() {
         _query_rpc_pool->shutdown();
         LOG(INFO) << "shutdown query rpc thread pool";
     }
+    if (_agent_server != nullptr && need_release("publish_version_worker_pool")) {
+        _agent_server->stop_task_worker_pool(TaskWorkerType::PUBLISH_VERSION);
+        LOG(INFO) << "stop task worker pool for publish version";
+    }
+    if (_wg_driver_executor != nullptr && need_release("wg_driver_executor")) {
+        _wg_driver_executor->close();
+        LOG(INFO) << "stop worker group driver executor";
+    }
     auto* storage_page_cache = StoragePageCache::instance();
     if (storage_page_cache != nullptr && need_release("storage_page_cache")) {
         storage_page_cache->set_capacity(0);
         LOG(INFO) << "release storage page cache memory";
+    }
+    if (_block_cache != nullptr && need_release("block_cache")) {
+        // TODO: Currently, block cache don't support shutdown now,
+        //  so here will temporary use update_mem_quota instead to release memory.
+        (void) _block_cache->update_mem_quota(0, false);
+        LOG(INFO) << "release block cache";
     }
 }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -844,11 +844,11 @@ void ExecEnv::try_release_resource_before_core_dump() {
         LOG(INFO) << "stop worker group driver executor";
     }
     auto* storage_page_cache = StoragePageCache::instance();
-    if (storage_page_cache != nullptr && need_release("storage_page_cache")) {
+    if (storage_page_cache != nullptr && need_release("mem_cache")) {
         storage_page_cache->set_capacity(0);
         LOG(INFO) << "release storage page cache memory";
     }
-    if (_block_cache != nullptr && need_release("block_cache")) {
+    if (_block_cache != nullptr && need_release("mem_cache")) {
         // TODO: Currently, block cache don't support shutdown now,
         //  so here will temporary use update_mem_quota instead to release memory.
         (void)_block_cache->update_mem_quota(0, false);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -851,7 +851,7 @@ void ExecEnv::try_release_resource_before_core_dump() {
     if (_block_cache != nullptr && need_release("block_cache")) {
         // TODO: Currently, block cache don't support shutdown now,
         //  so here will temporary use update_mem_quota instead to release memory.
-        (void) _block_cache->update_mem_quota(0, false);
+        (void)_block_cache->update_mem_quota(0, false);
         LOG(INFO) << "release block cache";
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* Support release block cache and some other thread pool before core dump.
* Make `TaskWorkerPool::stop` can called repeatedly. `stop` no longer requires wait to prevent it from getting stuck for a long time. This can also increase the exit speed.
* Function `Recycle resource before coredump` support more thread pool.


TODO: Currently, block cache don't support shutdown now, so here will temporary use update_mem_quota instead to release memory.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
