### PR TITLE
[BugFix] don't fill catalog and database name to cte relation in the hive catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ConnectorView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ConnectorView.java
@@ -18,6 +18,7 @@ import com.starrocks.analysis.ParseNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.common.ErrorType;
@@ -26,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -51,9 +53,11 @@ public abstract class ConnectorView extends Table {
         String sqlDialect = sessionVariable.getSqlDialect();
         QueryStatement queryStatement = doGetQueryStatement(sessionVariable);
         sessionVariable.setSqlDialect(sqlDialect);
-
+        List<String> cteRelationNames = queryStatement.getQueryRelation().getCteRelations()
+                .stream().map(CTERelation::getName)
+                .collect(Collectors.toList());
         List<TableRelation> tableRelations = AnalyzerUtils.collectTableRelations(queryStatement);
-        formatRelations(tableRelations);
+        formatRelations(tableRelations, cteRelationNames);
         return queryStatement;
     }
 
@@ -84,7 +88,7 @@ public abstract class ConnectorView extends Table {
         return null;
     }
 
-    protected abstract void formatRelations(List<TableRelation> tableRelations);
+    protected abstract void formatRelations(List<TableRelation> tableRelations, List<String> cteRelationNames);
 
     public String getInlineViewDef() {
         return inlineViewDef;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Strings;
 import com.starrocks.analysis.ParseNode;
+import com.starrocks.analysis.TableName;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.TableRelation;
@@ -59,8 +60,17 @@ public class HiveView extends ConnectorView {
         }
     }
 
-    public void formatRelations(List<TableRelation> tableRelations) {
+    public void formatRelations(List<TableRelation> tableRelations, List<String> cteRelationNames) {
         for (TableRelation tableRelation : tableRelations) {
+            TableName name = tableRelation.getName();
+
+            // do not fill catalog and database name to cte relation
+            if (Strings.isNullOrEmpty(name.getCatalog()) &&
+                    Strings.isNullOrEmpty(name.getDb()) &&
+                    cteRelationNames.contains(name.getTbl())) {
+                return;
+            }
+
             tableRelation.getName().setCatalog(catalogName);
             if (Strings.isNullOrEmpty(tableRelation.getName().getDb())) {
                 tableRelation.getName().setDb(dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -33,7 +33,7 @@ public class IcebergView extends ConnectorView {
     }
 
     @Override
-    protected void formatRelations(List<TableRelation> tableRelations) {
+    protected void formatRelations(List<TableRelation> tableRelations, List<String> cteRelationNames) {
         for (TableRelation tableRelation : tableRelations) {
             // iceberg view query statement with external catalog which created by starrocks must have catalog name
             if (Strings.isNullOrEmpty(tableRelation.getName().getCatalog())) {

--- a/test/sql/test_hive/R/test_hive_catalog
+++ b/test/sql/test_hive/R/test_hive_catalog
@@ -29,6 +29,10 @@ select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc a inne
 2	Bob	bj	2
 2	Bob	bj	2
 -- !result
+select * from hive_sql_test_${uuid0}.test_oss.test_hive_view;
+-- result:
+1
+-- !result
 drop catalog hive_sql_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_hive/T/test_hive_catalog
+++ b/test/sql/test_hive/T/test_hive_catalog
@@ -15,4 +15,8 @@ select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_parquet a 
 -- partition value is null and with runtime filter for orc
 select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc a inner join[shuffle] (select b.id as id from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc b inner join[shuffle] hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc c on b.city=c.city) d on a.id = d.id order by 1, 2, 3, 4;
 
+-- test hive view with cte
+-- view definition: CREATE VIEW `test_hive_view` AS with test_cte as (select `base_hive_table`.`k1` from `test_oss`.`base_hive_table`) select `test_cte`.`k1` from test_cte
+select * from hive_sql_test_${uuid0}.test_oss.test_hive_view;
+
 drop catalog hive_sql_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
we shouldn't fill catalog and database name to cte relation.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
