### PR TITLE
[Doc] put prop in H4 tag

### DIFF
--- a/docs/en/sql-reference/sql-statements/data-definition/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/data-definition/CREATE_TABLE.md
@@ -524,7 +524,7 @@ PROPERTIES (
 | dynamic_partition.prefix    | No       | The prefix added to the names of dynamic partitions. Default value: `p`. |
 | dynamic_partition.buckets   | No       | The number of buckets per dynamic partition. The default value is the same as the number of buckets determined by the reserved word `BUCKETS` or automatically set by StarRocks. |
 
-#### Specify the bucket size for tables configured with random bucketing
+#### Specify the bucket size (`bucket_size`) for tables configured with random bucketing
 
 Since v3.2, for tables configured with random bucketing, you can specify the bucket size by using the `bucket_size` parameter in `PROPERTIES` at table creation to enable the on-demand and dynamic increase of the number of buckets. Unit: B.
 

--- a/docs/zh/sql-reference/sql-statements/data-definition/CREATE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/data-definition/CREATE_TABLE.md
@@ -632,7 +632,7 @@ PROPERTIES (
 | `dynamic_partition.prefix`    | 否       | 动态分区的前缀名，默认值为 `p`。                             |
 | dynamic_partition.buckets     | 否       | 动态分区的分桶数量。默认与 BUCKETS 保留字指定的分桶数量、或者 StarRocks 自动设置的分桶数量保持一致。 |
 
-#### 设置随机分桶表中分桶大小
+#### 设置随机分桶表中分桶大小 (`bucket_size`)
 
 自 3.2 版本起，对于随机分桶的表，您可以在建表时在 `PROPERTIES` 中设置 `bucket_size` 参数来指定分桶大小，启用按需动态增加分桶数量。单位为 B。
 


### PR DESCRIPTION
Algolia search for `bucket_size` is not returning the CREATE TABLE page. It appears that content in `<code>` tags is not indexed by the Algolia crawler (and I don't think code blocks should be), unless the content in the `<code>` block is in an `<hx>` heading (H4 in this case). Reference: [Algolia discourse](https://discourse.algolia.com/t/experience-and-advice-for-dealing-with-indexing-of-code-in-software-documentation/8307/5)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5