### PR TITLE
[BugFix] Fix partition prune for delta lake when partition column type is tinyint/boolean

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2007,6 +2007,15 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         for expect in expects:
             tools.assert_true(str(res["result"]).find(expect) == -1, "assert expect %s is found in plan" % (expect))
 
+    def assert_explain_verbose_contains(self, query, *expects):
+        """
+        assert explain verbose result contains expect string
+        """
+        sql = "explain verbose %s" % (query)
+        res = self.execute_sql(sql, True)
+        for expect in expects:
+            tools.assert_true(str(res["result"]).find(expect) > 0, "assert expect %s is not found in plan" % (expect))
+
     def assert_explain_costs_contains(self, query, *expects):
         """
         assert explain costs result contains expect string

--- a/test/sql/test_deltalake/R/test_deltalake_partition_prune
+++ b/test/sql/test_deltalake/R/test_deltalake_partition_prune
@@ -1,0 +1,49 @@
+-- name: test_deltalake_partition_prune
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = true', 'partitions=1/2')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = false', 'partitions=1/2')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_tinyint where col_tinyint = 3', 'partitions=1/3')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_smallint where col_smallint = 3', 'partitions=1/3')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_int where col_int = 3', 'partitions=1/3')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_bigint where col_long = 3', 'partitions=1/3')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_date where col_date = '2024-04-27'", "partitions=1/4")
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp where col_timestamp = '2023-01-01 01:01:01'", "partitions=1/3")
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_string where col_string = 'value2'", "partitions=1/3")
+-- result:
+None
+-- !result
+drop catalog delta_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_deltalake/T/test_deltalake_partition_prune
+++ b/test/sql/test_deltalake/T/test_deltalake_partition_prune
@@ -1,0 +1,36 @@
+-- name: test_deltalake_partition_prune
+
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+-- test partition prune with boolean type
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = true', 'partitions=1/2')
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = false', 'partitions=1/2')
+
+-- test partition prune with tinyint type
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_tinyint where col_tinyint = 3', 'partitions=1/3')
+
+-- test partition prune with smallint type
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_smallint where col_smallint = 3', 'partitions=1/3')
+
+-- test partition prune with int type
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_int where col_int = 3', 'partitions=1/3')
+
+-- test partition prune with bigint type
+function: assert_explain_verbose_contains('select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_bigint where col_long = 3', 'partitions=1/3')
+
+-- test partition prune with date type
+function: assert_explain_verbose_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_date where col_date = '2024-04-27'", "partitions=1/4")
+
+-- test partition prune with timestamp type
+function: assert_explain_verbose_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp where col_timestamp = '2023-01-01 01:01:01'", "partitions=1/3")
+
+-- test partition prune with string type
+function: assert_explain_verbose_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_string where col_string = 'value2'", "partitions=1/3")
+
+drop catalog delta_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
When partition column type is boolean/tinyint, can not partition prune
## What I'm doing:
support covert sr predicate with tinyint/boolean type to delta lake predicate expression 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
