### PR TITLE
[Enhancement] Incremental expand JSON buffer size if JSON file is too large for stream load

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -363,8 +363,11 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
             if (ctx->format == TFileFormatType::FORMAT_JSON) {
                 // For json format, we need build a complete json before we push the buffer to the pipe.
                 // buffer capacity is not enough, so we try to expand the buffer.
-                ByteBufferPtr buf =
-                        ByteBuffer::allocate_with_tracker(BitUtil::RoundUpToPowerOfTwo(ctx->buffer->pos + len));
+                auto data_sz = ctx->buffer->pos + len;
+                // empirical method to expand memory size in incremental way, prevent from memory overhead.
+                size_t new_size = data_sz >= ctx->kJSONMaxBufferSize / 4 ?
+                                  data_sz + ctx->kJSONIncrementalBufferSize : BitUtil::RoundUpToPowerOfTwo(data_sz);
+                ByteBufferPtr buf = ByteBuffer::allocate_with_tracker(new_size);
                 buf->put_bytes(ctx->buffer->ptr, ctx->buffer->pos);
                 std::swap(buf, ctx->buffer);
 

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -271,6 +271,8 @@ public:
     static constexpr size_t kDefaultBufferSize = 64 * 1024;
     // max buffer size for JSON format is 4GB.
     static constexpr int64_t kJSONMaxBufferSize = 4294967296;
+    // incremental expand size for JSON format buffer.
+    static constexpr int64_t kJSONIncrementalBufferSize = 1073741824;
     ByteBufferPtr buffer = nullptr;
 
     TStreamLoadPutRequest request;


### PR DESCRIPTION
## Why I'm doing:
In stream load, JSON file must be completely read from http. But we can not know the size of the file advance and must allocate the memory dynamically. In current implementation, memory expand exponentially. This will cause OOM if the file size is too large.

## What I'm doing:
Expand the memory in a incremental way if the JSON file size is too large.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
