### PR TITLE
[BugFix] don't fill catalog and database name to cte relation in the hive catalog (backport #49253)

### DIFF
--- a/test/sql/test_hive/R/test_hive_catalog
+++ b/test/sql/test_hive/R/test_hive_catalog
@@ -26,6 +26,10 @@ select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc a inne
 2	Bob	bj	2
 2	Bob	bj	2
 -- !result
+select * from hive_sql_test_${uuid0}.test_oss.test_hive_view;
+-- result:
+1
+-- !result
 drop catalog hive_sql_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_hive/T/test_hive_catalog
+++ b/test/sql/test_hive/T/test_hive_catalog
@@ -14,4 +14,8 @@ select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_parquet a 
 -- partition value is null and with runtime filter for orc
 select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc a inner join[shuffle] (select b.id as id from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc b inner join[shuffle] hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc c on b.city=c.city) d on a.id = d.id order by 1, 2, 3, 4;
 
+-- test hive view with cte
+-- view definition: CREATE VIEW `test_hive_view` AS with test_cte as (select `base_hive_table`.`k1` from `test_oss`.`base_hive_table`) select `test_cte`.`k1` from test_cte
+select * from hive_sql_test_${uuid0}.test_oss.test_hive_view;
+
 drop catalog hive_sql_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

