### PR TITLE
[Enhancement] Default set empty function for hll and bitmap in streamload

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -40,6 +40,7 @@ import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.SlotDescriptor;
@@ -48,6 +49,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Table;
@@ -61,6 +63,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.load.Load;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TBrokerRangeDesc;
 import com.starrocks.thrift.TBrokerScanRange;
@@ -290,6 +293,19 @@ public class StreamLoadScanNode extends LoadScanNode {
                     Column.DefaultValueType defaultValueType = column.getDefaultValueType();
                     if (defaultValueType == Column.DefaultValueType.CONST) {
                         expr = new StringLiteral(column.calculatedDefaultValue());
+                        if (expr.equals(ColumnDef.DefaultValueDef.EMPTY_VALUE.expr)) {
+                            if (column.getType().isHllType()) {
+                                expr = new FunctionCallExpr(new FunctionName(FunctionSet.HLL_EMPTY), Lists.newArrayList());
+                                Function fn = Expr.getBuiltinFunction(FunctionSet.HLL_EMPTY, new Type[] {}, Function.CompareMode.IS_IDENTICAL);
+                                expr.setFn(fn);
+                                expr.setType(fn.getReturnType());
+                            } else if (column.getType().isBitmapType()) {
+                                expr = new FunctionCallExpr(new FunctionName(FunctionSet.BITMAP_EMPTY), Lists.newArrayList());
+                                Function fn = Expr.getBuiltinFunction(FunctionSet.BITMAP_EMPTY, new Type[] {}, Function.CompareMode.IS_IDENTICAL);
+                                expr.setFn(fn);
+                                expr.setType(fn.getReturnType());
+                            }
+                        }
                     } else if (defaultValueType == Column.DefaultValueType.VARY) {
                         if (SUPPORTED_DEFAULT_FNS.contains(column.getDefaultExpr().getExpr())) {
                             expr = column.getDefaultExpr().obtainExpr();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
@@ -40,6 +40,7 @@ import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.SlotDescriptor;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
@@ -58,6 +59,7 @@ import com.starrocks.load.Load;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.parser.AstBuilder;
 import com.starrocks.sql.parser.ParsingException;
@@ -153,6 +155,26 @@ public class StreamLoadScanNodeTest {
         v1.setIsKey(false);
         v1.setIsAllowNull(true);
         v1.setAggregationType(AggregateType.HLL_UNION, false);
+        v1.setDefaultValue(((StringLiteral) ColumnDef.DefaultValueDef.EMPTY_VALUE.expr).getValue());
+
+        columns.add(v1);
+
+        return columns;
+    }
+
+    List<Column> getBitmapSchema() {
+        List<Column> columns = Lists.newArrayList();
+
+        Column k1 = new Column("k1", Type.BIGINT);
+        k1.setIsKey(true);
+        k1.setIsAllowNull(false);
+        columns.add(k1);
+
+        Column v1 = new Column("v1", Type.BITMAP);
+        v1.setIsKey(false);
+        v1.setIsAllowNull(true);
+        v1.setAggregationType(AggregateType.BITMAP_UNION, false);
+        v1.setDefaultValue(((StringLiteral) ColumnDef.DefaultValueDef.EMPTY_VALUE.expr).getValue());
 
         columns.add(v1);
 
@@ -787,5 +809,77 @@ public class StreamLoadScanNodeTest {
         List<ImportColumnDesc> columnExprs = Lists.newArrayList();
         columnExprs.add(new ImportColumnDesc("c3", new FunctionCallExpr("func", Lists.newArrayList())));
         Load.initColumns(table, columnExprs, null, null, null, null, null, null);
+    }
+
+    @Test
+    public void testHllColumnDefaultEmpty() throws UserException {
+        Analyzer analyzer = new Analyzer(globalStateMgr, connectContext);
+        DescriptorTable descTbl = analyzer.getDescTbl();
+
+        List<Column> columns = getHllSchema();
+        TupleDescriptor dstDesc = descTbl.createTupleDescriptor("DstTableDesc");
+        for (Column column : columns) {
+            SlotDescriptor slot = descTbl.addSlotDescriptor(dstDesc);
+            slot.setColumn(column);
+            slot.setIsMaterialized(true);
+            if (column.isAllowNull()) {
+                slot.setIsNullable(true);
+            } else {
+                slot.setIsNullable(false);
+            }
+        }
+
+        new Expectations() {{
+            globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+            result = new ScalarFunction(new FunctionName(FunctionSet.HLL_EMPTY), Lists.newArrayList(), Type.HLL,
+                false);
+        }};
+
+        TStreamLoadPutRequest request = getBaseRequest();
+        request.setFileType(TFileType.FILE_STREAM);
+        request.setColumns("k1,k2");
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
+
+        scanNode.init(analyzer);
+        scanNode.finalizeStats(analyzer);
+        scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+    }
+
+    @Test
+    public void testBitmapColumnDefaultEmpty() throws UserException {
+        Analyzer analyzer = new Analyzer(globalStateMgr, connectContext);
+        DescriptorTable descTbl = analyzer.getDescTbl();
+
+        List<Column> columns = getBitmapSchema();
+        TupleDescriptor dstDesc = descTbl.createTupleDescriptor("DstTableDesc");
+        for (Column column : columns) {
+            SlotDescriptor slot = descTbl.addSlotDescriptor(dstDesc);
+            slot.setColumn(column);
+            slot.setIsMaterialized(true);
+            if (column.isAllowNull()) {
+                slot.setIsNullable(true);
+            } else {
+                slot.setIsNullable(false);
+            }
+        }
+
+        new Expectations() {{
+            globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+            result = new ScalarFunction(new FunctionName(FunctionSet.BITMAP_EMPTY), Lists.newArrayList(), Type.BITMAP,
+                false);
+        }};
+
+        TStreamLoadPutRequest request = getBaseRequest();
+        request.setFileType(TFileType.FILE_STREAM);
+        request.setColumns("k1,k2");
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
+
+        scanNode.init(analyzer);
+        scanNode.finalizeStats(analyzer);
+        scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
when add hll or bitmap column to agg table, streamload task will throw 'HLL column must use hll_hash function...'

modify table and restart flink task can't done at same time, flink will failover.

## What I'm doing:
when streamload write columns doesn't contains hll or bitmap column, default set expr to hll_empty() or bitmap_empty() function, avoid set to null.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5