### PR TITLE
[Enhancement] Add memory limit for ByteBuffer allocation in data ingestion

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -417,6 +417,17 @@ struct StatusInstance {
 #define RETURN_IF_ERROR(stmt) RETURN_IF_ERROR_INTERNAL(stmt)
 #endif
 
+#define SET_STATUE_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)                                           \
+    do {                                                                                                    \
+        auto&& status__ = (stmt);                                                                           \
+        if (UNLIKELY(!status__.ok())) {                                                                     \
+            err_status = to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
+            return;                                                                                         \
+        }                                                                                                   \
+    } while (false)
+
+#define SET_STATUE_AND_RETURN_IF_ERROR(err_status, stmt) SET_STATUE_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)
+
 #define EXIT_IF_ERROR(stmt)                   \
     do {                                      \
         auto&& status__ = (stmt);             \

--- a/be/src/common/statusor.h
+++ b/be/src/common/statusor.h
@@ -733,4 +733,15 @@ inline std::ostream& operator<<(std::ostream& os, const StatusOr<T>& st) {
 // an lvalue StatusOr which you *don't* want to move out of cast appropriately.
 #define ASSIGN_OR_RETURN(lhs, rhs) ASSIGN_OR_RETURN_IMPL(VARNAME_LINENUM(value_or_err), lhs, rhs)
 
+#define ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR_IMPL(err_status, lhs, rhs) \
+    auto&& varname = (rhs);                                                 \
+    SET_STATUE_AND_RETURN_IF_ERROR(err_status, varname);                    \
+    lhs = std::move(varname).value();
+
+// ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR is basiclly the same as ASSIGN_OR_RETURN, except:
+// 1. return void if the status of rhs is NOT ok
+// 2. set the status of rhs into err_status before return
+#define ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(err_status, lhs, rhs) \
+    ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR_IMPL(err_status, lhs, rhs)
+
 } // namespace starrocks

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -681,7 +681,8 @@ Status JsonReader::_read_file_stream() {
     if (_file_stream_buffer->capacity < _file_stream_buffer->remaining() + simdjson::SIMDJSON_PADDING) {
         // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
         // Hence, a re-allocation is needed if the space is not enough.
-        auto buf = ByteBuffer::allocate_with_tracker(_file_stream_buffer->remaining() + simdjson::SIMDJSON_PADDING);
+        ASSIGN_OR_RETURN(auto buf, ByteBuffer::allocate_with_tracker(_file_stream_buffer->remaining() +
+                                                                     simdjson::SIMDJSON_PADDING));
         buf->put_bytes(_file_stream_buffer->ptr, _file_stream_buffer->remaining());
         buf->flip();
         std::swap(buf, _file_stream_buffer);

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -288,7 +288,8 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, StreamLoadContext* ct
         if (ctx->format == TFileFormatType::FORMAT_JSON) {
             // Allocate buffer in advance, since the json payload cannot be parsed in stream mode.
             // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
-            ctx->buffer = ByteBuffer::allocate_with_tracker(ctx->body_bytes + simdjson::SIMDJSON_PADDING);
+            ASSIGN_OR_RETURN(ctx->buffer,
+                             ByteBuffer::allocate_with_tracker(ctx->body_bytes + simdjson::SIMDJSON_PADDING));
         }
     } else {
 #ifndef BE_TEST
@@ -356,15 +357,24 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
     while ((len = evbuffer_get_length(evbuf)) > 0) {
         if (ctx->buffer == nullptr) {
             // Initialize buffer.
-            ctx->buffer = ByteBuffer::allocate_with_tracker(
+            auto res = ByteBuffer::allocate_with_tracker(
                     ctx->format == TFileFormatType::FORMAT_JSON ? std::max(len, ctx->kDefaultBufferSize) : len);
+            if (!res.status().ok()) {
+                ctx->status = res.status();
+                return;
+            }
+            ctx->buffer = res.value();
 
         } else if (ctx->buffer->remaining() < len) {
             if (ctx->format == TFileFormatType::FORMAT_JSON) {
                 // For json format, we need build a complete json before we push the buffer to the pipe.
                 // buffer capacity is not enough, so we try to expand the buffer.
-                ByteBufferPtr buf =
-                        ByteBuffer::allocate_with_tracker(BitUtil::RoundUpToPowerOfTwo(ctx->buffer->pos + len));
+                auto res = ByteBuffer::allocate_with_tracker(BitUtil::RoundUpToPowerOfTwo(ctx->buffer->pos + len));
+                if (!res.status().ok()) {
+                    ctx->status = res.status();
+                    return;
+                }
+                ByteBufferPtr buf = res.value();
                 buf->put_bytes(ctx->buffer->ptr, ctx->buffer->pos);
                 std::swap(buf, ctx->buffer);
 
@@ -379,7 +389,12 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
                     return;
                 }
 
-                ctx->buffer = ByteBuffer::allocate_with_tracker(std::max(len, ctx->kDefaultBufferSize));
+                auto res = ByteBuffer::allocate_with_tracker(std::max(len, ctx->kDefaultBufferSize));
+                if (!res.status().ok()) {
+                    ctx->status = res.status();
+                    return;
+                }
+                ctx->buffer = res.value();
             }
         }
 

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -357,16 +357,19 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
     while ((len = evbuffer_get_length(evbuf)) > 0) {
         if (ctx->buffer == nullptr) {
             // Initialize buffer.
-            ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(ctx->status, ctx->buffer, ByteBuffer::allocate_with_tracker(
-                    ctx->format == TFileFormatType::FORMAT_JSON ? std::max(len, ctx->kDefaultBufferSize) : len));
+            ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(
+                    ctx->status, ctx->buffer,
+                    ByteBuffer::allocate_with_tracker(ctx->format == TFileFormatType::FORMAT_JSON
+                                                              ? std::max(len, ctx->kDefaultBufferSize)
+                                                              : len));
 
         } else if (ctx->buffer->remaining() < len) {
             if (ctx->format == TFileFormatType::FORMAT_JSON) {
                 // For json format, we need build a complete json before we push the buffer to the pipe.
                 // buffer capacity is not enough, so we try to expand the buffer.
                 ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(
-                    ctx->status, ByteBufferPtr buf,
-                    ByteBuffer::allocate_with_tracker(BitUtil::RoundUpToPowerOfTwo(ctx->buffer->pos + len)));
+                        ctx->status, ByteBufferPtr buf,
+                        ByteBuffer::allocate_with_tracker(BitUtil::RoundUpToPowerOfTwo(ctx->buffer->pos + len)));
                 buf->put_bytes(ctx->buffer->ptr, ctx->buffer->pos);
                 std::swap(buf, ctx->buffer);
 
@@ -382,7 +385,8 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
                 }
 
                 ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(
-                    ctx->status, ctx->buffer,ByteBuffer::allocate_with_tracker(std::max(len, ctx->kDefaultBufferSize)));
+                        ctx->status, ctx->buffer,
+                        ByteBuffer::allocate_with_tracker(std::max(len, ctx->kDefaultBufferSize)));
             }
         }
 

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -529,9 +529,11 @@ void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
     while ((len = evbuffer_get_length(evbuf)) > 0) {
         if (ctx->buffer == nullptr) {
             // Initialize buffer.
-            ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(ctx->status, ctx->buffer,
-            ByteBuffer::allocate_with_tracker(
-                ctx->format == TFileFormatType::FORMAT_JSON ? std::max(len, ctx->kDefaultBufferSize) : len));
+            ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(
+                    ctx->status, ctx->buffer,
+                    ByteBuffer::allocate_with_tracker(ctx->format == TFileFormatType::FORMAT_JSON
+                                                              ? std::max(len, ctx->kDefaultBufferSize)
+                                                              : len));
 
         } else if (ctx->buffer->remaining() < len) {
             if (ctx->format == TFileFormatType::FORMAT_JSON) {
@@ -545,8 +547,9 @@ void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
                     ctx->status = Status::MemoryLimitExceeded(err_msg);
                     return;
                 }
-                ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(ctx->status, ByteBufferPtr buf,
-                            ByteBuffer::allocate_with_tracker(BitUtil::RoundUpToPowerOfTwo(data_sz)));
+                ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(
+                        ctx->status, ByteBufferPtr buf,
+                        ByteBuffer::allocate_with_tracker(BitUtil::RoundUpToPowerOfTwo(data_sz)));
                 buf->put_bytes(ctx->buffer->ptr, ctx->buffer->pos);
                 std::swap(buf, ctx->buffer);
 
@@ -561,8 +564,9 @@ void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
                     return;
                 }
 
-                ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(ctx->status, ctx->buffer,
-                                    ByteBuffer::allocate_with_tracker(std::max(len, ctx->kDefaultBufferSize)));
+                ASSIGN_OR_SET_STATUS_AND_RETURN_IF_ERROR(
+                        ctx->status, ctx->buffer,
+                        ByteBuffer::allocate_with_tracker(std::max(len, ctx->kDefaultBufferSize)));
             }
         }
 

--- a/be/src/runtime/routine_load/kafka_consumer_pipe.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe.h
@@ -67,7 +67,7 @@ public:
 
     Status append_json(const char* data, size_t size, char row_delimiter) {
         // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
-        auto buf = ByteBuffer::allocate_with_tracker(size + simdjson::SIMDJSON_PADDING);
+        ASSIGN_OR_RETURN(auto buf, ByteBuffer::allocate_with_tracker(size + simdjson::SIMDJSON_PADDING));
         buf->put_bytes(data, size);
         buf->flip();
         return append(std::move(buf));

--- a/be/src/runtime/stream_load/stream_load_pipe.cpp
+++ b/be/src/runtime/stream_load/stream_load_pipe.cpp
@@ -78,7 +78,7 @@ Status StreamLoadPipe::append(const char* data, size_t size) {
     // need to allocate a new chunk, min chunk is 64k
     size_t chunk_size = std::max(_min_chunk_size, size - pos);
     chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
-    _write_buf = ByteBuffer::allocate_with_tracker(chunk_size);
+    ASSIGN_OR_RETURN(_write_buf, ByteBuffer::allocate_with_tracker(chunk_size));
     _write_buf->put_bytes(data + pos, size - pos);
     return Status::OK();
 }
@@ -195,7 +195,7 @@ Status StreamLoadPipe::no_block_read(uint8_t* data, size_t* data_size, bool* eof
                         // put back the read data to the buf_queue, read the data in the next time
                         size_t chunk_size = bytes_read;
                         chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
-                        ByteBufferPtr write_buf = ByteBuffer::allocate_with_tracker(chunk_size);
+                        ASSIGN_OR_RETURN(ByteBufferPtr write_buf, ByteBuffer::allocate_with_tracker(chunk_size));
                         write_buf->put_bytes((char*)data, bytes_read);
                         write_buf->flip();
                         // error happens iff pipe is cancelled
@@ -293,7 +293,7 @@ StatusOr<ByteBufferPtr> CompressedStreamLoadPipeReader::read() {
     }
 
     if (_decompressed_buffer == nullptr) {
-        _decompressed_buffer = ByteBuffer::allocate_with_tracker(buffer_size);
+        ASSIGN_OR_RETURN(_decompressed_buffer, ByteBuffer::allocate_with_tracker(buffer_size));
     }
 
     ASSIGN_OR_RETURN(auto buf, StreamLoadPipeReader::read());
@@ -316,7 +316,7 @@ StatusOr<ByteBufferPtr> CompressedStreamLoadPipeReader::read() {
     while (!stream_end) {
         // buffer size grows exponentially
         buffer_size = buffer_size < MAX_DECOMPRESS_BUFFER_SIZE ? buffer_size * 2 : MAX_DECOMPRESS_BUFFER_SIZE;
-        auto piece = ByteBuffer::allocate_with_tracker(buffer_size);
+        ASSIGN_OR_RETURN(auto piece, ByteBuffer::allocate_with_tracker(buffer_size));
         RETURN_IF_ERROR(_decompressor->decompress(
                 reinterpret_cast<uint8_t*>(buf->ptr) + total_bytes_read, buf->remaining() - total_bytes_read,
                 &bytes_read, reinterpret_cast<uint8_t*>(piece->ptr), piece->capacity, &bytes_written, &stream_end));
@@ -332,7 +332,7 @@ StatusOr<ByteBufferPtr> CompressedStreamLoadPipeReader::read() {
         if (_decompressed_buffer->remaining() < pieces_size) {
             // align to 1024 bytes.
             auto sz = ALIGN_UP(_decompressed_buffer->pos + pieces_size, 1024);
-            _decompressed_buffer = ByteBuffer::reallocate(_decompressed_buffer, sz);
+            ASSIGN_OR_RETURN(_decompressed_buffer, ByteBuffer::reallocate_with_tracker(_decompressed_buffer, sz));
         }
         for (const auto& piece : pieces) {
             _decompressed_buffer->put_bytes(piece->ptr, piece->pos);

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -43,8 +43,8 @@
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
-#include "testutil/sync_point.h"
 #include "storage/utils.h"
+#include "testutil/sync_point.h"
 
 namespace starrocks {
 

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -41,7 +41,10 @@
 #include "common/logging.h"
 #include "gutil/strings/fastmem.h"
 #include "runtime/current_thread.h"
+#include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
+#include "testutil/sync_point.h"
+#include "storage/utils.h"
 
 namespace starrocks {
 
@@ -61,25 +64,30 @@ struct MemTrackerDeleter {
 };
 
 struct ByteBuffer {
-    static ByteBufferPtr allocate(size_t size) {
-        ByteBufferPtr ptr(new ByteBuffer(size));
-        return ptr;
-    }
-
-    static ByteBufferPtr allocate(size_t size, MemTracker* tracker) {
+    static StatusOr<ByteBufferPtr> allocate_with_tracker(size_t size) {
+        auto tracker = CurrentThread::mem_tracker();
         if (tracker == nullptr) {
-            return allocate(size);
+            return Status::InternalError("current thread memory tracker Not Found when allocate ByteBuffer");
         }
+#ifndef BE_TEST
+        // check limit before allocation
+        TRY_CATCH_BAD_ALLOC(ByteBufferPtr ptr(new ByteBuffer(size), MemTrackerDeleter(tracker)); return ptr;);
+#else
         ByteBufferPtr ptr(new ByteBuffer(size), MemTrackerDeleter(tracker));
-        return ptr;
+        Status ret = Status::OK();
+        TEST_SYNC_POINT_CALLBACK("ByteBuffer::allocate_with_tracker", &ret);
+        if (ret.ok()) {
+            return ptr;
+        } else {
+            return ret;
+        }
+#endif
     }
 
-    static ByteBufferPtr allocate_with_tracker(size_t size) { return allocate(size, CurrentThread::mem_tracker()); }
-
-    static ByteBufferPtr reallocate(const ByteBufferPtr& old_ptr, size_t new_size) {
+    static StatusOr<ByteBufferPtr> reallocate_with_tracker(const ByteBufferPtr& old_ptr, size_t new_size) {
         if (new_size <= old_ptr->capacity) return old_ptr;
 
-        ByteBufferPtr ptr(new ByteBuffer(new_size));
+        ASSIGN_OR_RETURN(ByteBufferPtr ptr, allocate_with_tracker(new_size));
         ptr->put_bytes(old_ptr->ptr, old_ptr->pos);
         return ptr;
     }

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -34,6 +34,7 @@
 
 #include "http/action/stream_load.h"
 
+#include <event2/buffer.h>
 #include <event2/http.h>
 #include <event2/http_struct.h>
 #include <gtest/gtest.h>
@@ -45,6 +46,7 @@
 #include "http/http_request.h"
 #include "runtime/exec_env.h"
 #include "runtime/stream_load/load_stream_mgr.h"
+#include "runtime/stream_load/stream_load_context.h"
 #include "runtime/stream_load/stream_load_executor.h"
 #include "testutil/sync_point.h"
 #include "util/brpc_stub_cache.h"
@@ -297,6 +299,87 @@ TEST_F(StreamLoadActionTest, plan_fail) {
 
     SyncPoint::GetInstance()->ClearCallBack("StreamLoadExecutor::execute_plan_fragment:1");
     SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_F(StreamLoadActionTest, huge_malloc) {
+    StreamLoadAction action(&_env, _limiter.get());
+    auto ctx = new StreamLoadContext(&_env);
+    ctx->ref();
+    ctx->body_sink = std::make_shared<StreamLoadPipe>();
+    HttpRequest request(_evhttp_req);
+    std::string content = "abc";
+
+    struct evhttp_request ev_req;
+    ev_req.remote_host = nullptr;
+    auto evb = evbuffer_new();
+    ev_req.input_buffer = evb;
+    request._ev_req = &ev_req;
+
+    request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
+    request._headers.emplace(HTTP_DB_KEY, "db");
+    request._headers.emplace(HTTP_LABEL_KEY, "123");
+    request._headers.emplace(HTTP_COLUMN_SEPARATOR, "|");
+    request.set_handler(&action);
+    request.set_handler_ctx(ctx);
+
+    evbuffer_add(evb, content.data(), content.size());
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
+                                          [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
+    SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.ok());
+
+    evbuffer_add(evb, content.data(), content.size());
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
+                                          [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
+    ctx->buffer = nullptr;
+    SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.ok());
+    ctx->buffer = nullptr;
+
+    evbuffer_add(evb, content.data(), content.size());
+    auto old_format = ctx->format;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
+                                          [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
+    ctx->format = TFileFormatType::FORMAT_JSON;
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
+    ctx->buffer = nullptr;
+    SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ctx->format = TFileFormatType::FORMAT_JSON;
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.ok());
+    ctx->buffer = nullptr;
+    ctx->format = old_format;
+
+    request.set_handler_ctx(nullptr);
+    request.set_handler(nullptr);
+    if (ctx->unref()) {
+        delete ctx;
+    }
+    evbuffer_free(evb);
 }
 
 } // namespace starrocks

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -340,14 +340,14 @@ TEST_F(StreamLoadActionTest, huge_malloc) {
     SyncPoint::GetInstance()->EnableProcessing();
     SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
                                           [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
     ctx->buffer = nullptr;
     SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
     SyncPoint::GetInstance()->DisableProcessing();
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.ok());
@@ -359,7 +359,7 @@ TEST_F(StreamLoadActionTest, huge_malloc) {
     SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
                                           [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
     ctx->format = TFileFormatType::FORMAT_JSON;
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
@@ -367,7 +367,7 @@ TEST_F(StreamLoadActionTest, huge_malloc) {
     SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
     SyncPoint::GetInstance()->DisableProcessing();
     ctx->format = TFileFormatType::FORMAT_JSON;
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.ok());

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -14,9 +14,11 @@
 
 #include "http/action/transaction_stream_load.h"
 
+#include <event2/buffer.h>
 #include <event2/http.h>
 #include <event2/http_struct.h>
 #include <gtest/gtest.h>
+#include <exception>
 #include <rapidjson/document.h>
 
 #include "gen_cpp/FrontendService_types.h"
@@ -750,6 +752,85 @@ TEST_F(TransactionStreamLoadActionTest, txn_not_same_load) {
         request._headers.emplace(HTTP_COLUMN_SEPARATOR, ",");
         ASSERT_EQ(-1, action.on_header(&request));
     }
+}
+
+TEST_F(TransactionStreamLoadActionTest, huge_malloc) {
+    TransactionStreamLoadAction action(&_env);
+    auto ctx = new StreamLoadContext(&_env);
+    ctx->ref();
+    ctx->body_sink = std::make_shared<StreamLoadPipe>();
+    HttpRequest request(_evhttp_req);
+    std::string content = "abc";
+
+    struct evhttp_request ev_req;
+    ev_req.remote_host = nullptr;
+    auto evb = evbuffer_new();
+    ev_req.input_buffer = evb;
+    request._ev_req = &ev_req;
+
+    request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
+    request._headers.emplace(HTTP_DB_KEY, "db");
+    request._headers.emplace(HTTP_LABEL_KEY, "123");
+    request._headers.emplace(HTTP_COLUMN_SEPARATOR, "|");
+
+    (_env._stream_context_mgr)->put("123", ctx);
+
+    evbuffer_add(evb, content.data(), content.size());
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
+                                          [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
+    SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.ok());
+
+    evbuffer_add(evb, content.data(), content.size());
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
+                                          [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
+    ctx->buffer = nullptr;
+    SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.ok());
+    ctx->buffer = nullptr;
+
+    evbuffer_add(evb, content.data(), content.size());
+    auto old_format = ctx->format;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
+                                          [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
+    ctx->format = TFileFormatType::FORMAT_JSON;
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
+    ctx->buffer = nullptr;
+    SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ctx->format = TFileFormatType::FORMAT_JSON;
+    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->status = Status::OK();
+    action.on_chunk_data(&request);
+    ASSERT_TRUE(ctx->status.ok());
+    ctx->buffer = nullptr;
+    ctx->format = old_format;
+
+    if (ctx->unref()) {
+        delete ctx;
+    }
+    evbuffer_free(evb);
 }
 
 } // namespace starrocks

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -18,7 +18,6 @@
 #include <event2/http.h>
 #include <event2/http_struct.h>
 #include <gtest/gtest.h>
-#include <exception>
 #include <rapidjson/document.h>
 
 #include "gen_cpp/FrontendService_types.h"
@@ -793,14 +792,14 @@ TEST_F(TransactionStreamLoadActionTest, huge_malloc) {
     SyncPoint::GetInstance()->EnableProcessing();
     SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
                                           [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
     ctx->buffer = nullptr;
     SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
     SyncPoint::GetInstance()->DisableProcessing();
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.ok());
@@ -812,7 +811,7 @@ TEST_F(TransactionStreamLoadActionTest, huge_malloc) {
     SyncPoint::GetInstance()->SetCallBack("ByteBuffer::allocate_with_tracker",
                                           [](void* arg) { *((Status*)arg) = Status::MemoryLimitExceeded("TestFail"); });
     ctx->format = TFileFormatType::FORMAT_JSON;
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.is_mem_limit_exceeded());
@@ -820,7 +819,7 @@ TEST_F(TransactionStreamLoadActionTest, huge_malloc) {
     SyncPoint::GetInstance()->ClearCallBack("ByteBuffer::allocate_with_tracker");
     SyncPoint::GetInstance()->DisableProcessing();
     ctx->format = TFileFormatType::FORMAT_JSON;
-    ctx->buffer = std::move(ByteBufferPtr (new ByteBuffer(1)));
+    ctx->buffer = std::move(ByteBufferPtr(new ByteBuffer(1)));
     ctx->status = Status::OK();
     action.on_chunk_data(&request);
     ASSERT_TRUE(ctx->status.ok());

--- a/be/test/runtime/stream_load_pipe_test.cpp
+++ b/be/test/runtime/stream_load_pipe_test.cpp
@@ -148,7 +148,7 @@ PARALLEL_TEST(StreamLoadPipeTest, append_buffer) {
     StreamLoadPipe pipe(66, 64);
 
     auto appender = [&pipe] {
-        auto buf = ByteBuffer::allocate(64);
+        auto buf = ByteBuffer::allocate_with_tracker(64).value();
         int k = 0;
         for (int j = 0; j < 64; ++j) {
             char c = '0' + (k++ % 10);
@@ -185,7 +185,7 @@ PARALLEL_TEST(StreamLoadPipeTest, append_and_read_buffer) {
     StreamLoadPipe pipe(66, 64);
 
     auto appender = [&pipe] {
-        auto buf = ByteBuffer::allocate(64);
+        auto buf = ByteBuffer::allocate_with_tracker(64).value();
         int k = 0;
         for (int j = 0; j < 64; ++j) {
             char c = '0' + (k++ % 10);

--- a/be/test/util/byte_buffer_test2.cpp
+++ b/be/test/util/byte_buffer_test2.cpp
@@ -29,7 +29,7 @@ public:
 };
 
 TEST_F(ByteBufferTest, normal) {
-    auto buf = ByteBuffer::allocate(4);
+    auto buf = ByteBuffer::allocate_with_tracker(4).value();
     ASSERT_EQ(0, buf->pos);
     ASSERT_EQ(4, buf->limit);
     ASSERT_EQ(4, buf->capacity);


### PR DESCRIPTION
## Why I'm doing:
ByteBuffer may allocate huge chunk of memory and cause BE OOM in this case.

## What I'm doing:
limit the memory allocation using the current thread tracker.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/8102

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
