### PR TITLE
[Enhancement] optimize schema scan execution

### DIFF
--- a/be/src/exec/pipeline/pipeline.cpp
+++ b/be/src/exec/pipeline/pipeline.cpp
@@ -19,6 +19,7 @@
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_driver.h"
 #include "exec/pipeline/scan/connector_scan_operator.h"
+#include "exec/pipeline/scan/schema_scan_operator.h"
 #include "exec/pipeline/stream_pipeline_driver.h"
 #include "runtime/runtime_state.h"
 
@@ -102,7 +103,8 @@ void Pipeline::instantiate_drivers(RuntimeState* state) {
         if (auto* scan_operator = driver->source_scan_operator()) {
             scan_operator->set_workgroup(workgroup);
             scan_operator->set_query_ctx(query_ctx->get_shared_ptr());
-            if (dynamic_cast<ConnectorScanOperator*>(scan_operator) != nullptr) {
+            if (dynamic_cast<ConnectorScanOperator*>(scan_operator) != nullptr ||
+                dynamic_cast<SchemaScanOperator*>(scan_operator) != nullptr) {
                 scan_operator->set_scan_executor(state->exec_env()->connector_scan_executor());
             } else {
                 scan_operator->set_scan_executor(state->exec_env()->scan_executor());

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -47,10 +47,12 @@ public:
     virtual Status prepare(RuntimeState* state);
 
     virtual void close(RuntimeState* state) = 0;
-    
+
     // Start the ChunkSource for some heavy operations like RPC calls
     // The difference between prepare() is, the start() is executed in IO-ThreadPool instead of Exec-ThreadPool,
     // which is more suitable for blocking network operations.
+    // The start() itself should use std::once to make sure it's idempotent and called once, since the io-thread would
+    // call it multiple times
     virtual Status start(RuntimeState* state) { return {}; }
 
     // Return true if eos is not reached

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -47,6 +47,11 @@ public:
     virtual Status prepare(RuntimeState* state);
 
     virtual void close(RuntimeState* state) = 0;
+    
+    // Start the ChunkSource for some heavy operations like RPC calls
+    // The difference between prepare() is, the start() is executed in IO-ThreadPool instead of Exec-ThreadPool,
+    // which is more suitable for blocking network operations.
+    virtual Status start(RuntimeState* state) { return {}; }
 
     // Return true if eos is not reached
     // Return false if eos is reached or error occurred

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -411,6 +411,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(this);
 
             auto& chunk_source = _chunk_sources[chunk_source_index];
+            RETURN_IF_ERROR(chunk_source->start(state));
             SCOPED_SET_CUSTOM_COREDUMP_MSG(chunk_source->get_custom_coredump_msg());
 
             [[maybe_unused]] std::string category;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -411,7 +411,6 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(this);
 
             auto& chunk_source = _chunk_sources[chunk_source_index];
-            RETURN_IF_ERROR(chunk_source->start(state));
             SCOPED_SET_CUSTOM_COREDUMP_MSG(chunk_source->get_custom_coredump_msg());
 
             [[maybe_unused]] std::string category;
@@ -431,6 +430,10 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
             int64_t prev_scan_rows = chunk_source->get_scan_rows();
             int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
+
+            // kick start this chunk source
+            RETURN_IF_ERROR(chunk_source->start(state));
+
             auto status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
 
             if (!status.ok() && !status.is_end_of_file()) {

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -432,7 +432,12 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
 
             // kick start this chunk source
-            RETURN_IF_ERROR(chunk_source->start(state));
+            auto start_status = chunk_source->start(state);
+            if (!start_status.ok()) {
+                LOG(ERROR) << "start chunk_source failed, fragment_instance_id="
+                           << print_id(state->fragment_instance_id()) << ", error=" << start_status.to_string();
+                _set_scan_status(start_status);
+            }
 
             auto status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
 

--- a/be/src/exec/pipeline/scan/schema_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.cpp
@@ -15,6 +15,7 @@
 #include "exec/pipeline/scan/schema_chunk_source.h"
 
 #include <boost/algorithm/string.hpp>
+#include <mutex>
 
 #include "exec/schema_scanner.h"
 #include "exec/workgroup/work_group.h"
@@ -85,7 +86,9 @@ Status SchemaChunkSource::prepare(RuntimeState* state) {
 }
 
 Status SchemaChunkSource::start(RuntimeState* state) {
-    return _schema_scanner->start(state);
+    Status st = Status::OK();
+    std::call_once(_start_once, [&]() { st = _schema_scanner->start(state); });
+    return st;
 }
 
 void SchemaChunkSource::close(RuntimeState* state) {}

--- a/be/src/exec/pipeline/scan/schema_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.cpp
@@ -81,6 +81,10 @@ Status SchemaChunkSource::prepare(RuntimeState* state) {
     }
     _accumulator.set_desired_size(state->chunk_size());
 
+    return {};
+}
+
+Status SchemaChunkSource::start(RuntimeState* state) {
     return _schema_scanner->start(state);
 }
 

--- a/be/src/exec/pipeline/scan/schema_chunk_source.h
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.h
@@ -34,7 +34,7 @@ public:
                       const SchemaScanContextPtr& ctx);
 
     ~SchemaChunkSource() override;
-    
+
     // Prepare the ChunkSource state. Should not put any blocking RPC calls in it
     Status prepare(RuntimeState* state) override;
 
@@ -61,6 +61,8 @@ private:
     std::vector<int> _index_map;
 
     ChunkAccumulator _accumulator;
+
+    std::once_flag _start_once;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/scan/schema_chunk_source.h
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.h
@@ -34,8 +34,12 @@ public:
                       const SchemaScanContextPtr& ctx);
 
     ~SchemaChunkSource() override;
-
+    
+    // Prepare the ChunkSource state. Should not put any blocking RPC calls in it
     Status prepare(RuntimeState* state) override;
+
+    // Start the ChunkSource, may execute some RPC calls to fetch metadata from FE
+    Status start(RuntimeState* state) override;
 
     void close(RuntimeState* state) override;
 


### PR DESCRIPTION
## Why I'm doing:
1. Most SchemaScan will do some RPC calls in the `start()` function, which is executed in pipeline exec-thread
2. But pipeline exec-thread is not suitable for blocking operations, so we'd better move it into pipeline io-thread

## What I'm doing:
1. Introduce a `ChunkSource::start()` function to execute the blocking RPC in the pipeline io-threads
2. Use `ConnectorScanExecutor` to execute `SchemaScanOperator`, which has more threads than regular `ScanOperator`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
