### PR TITLE
[BugFix] Fix the bug that the backend of other clusters is added to the current cluster when synchronizing Olap external table metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -18,8 +18,6 @@ package com.starrocks.catalog;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
@@ -27,7 +25,6 @@ import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.meta.MetaContext;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.IndexDef;
@@ -63,19 +60,6 @@ import java.util.Map;
 public class ExternalOlapTable extends OlapTable {
     private static final Logger LOG = LogManager.getLogger(ExternalOlapTable.class);
 
-    private static final String JSON_KEY_HOST = "host";
-    private static final String JSON_KEY_PORT = "port";
-    private static final String JSON_KEY_USER = "user";
-    private static final String JSON_KEY_PASSWORD = "password";
-    private static final String JSON_KEY_TABLE_NAME = "table_name";
-    private static final String JSON_KEY_DB_ID = "db_id";
-    private static final String JSON_KEY_TABLE_ID = "table_id";
-    private static final String JSON_KEY_SOURCE_DB_NAME = "source_db_name";
-    private static final String JSON_KEY_SOURCE_DB_ID = "source_db_id";
-    private static final String JSON_KEY_SOURCE_TABLE_ID = "source_table_id";
-    private static final String JSON_KEY_SOURCE_TABLE_NAME = "source_table_name";
-    private static final String JSON_KEY_SOURCE_TABLE_TYPE = "source_table_type";
-
     private static final String PROPERTIES_HOST = "host";
     private static final String PROPERTIES_PORT = "port";
     private static final String PROPERTIES_USER = "user";
@@ -83,8 +67,8 @@ public class ExternalOlapTable extends OlapTable {
     private static final String PROPERTIES_DATABASE = "database";
     private static final String PROPERTIES_TABLE = "table";
 
-    public class ExternalTableInfo {
-        // remote doris cluster fe addr
+    public static class ExternalTableInfo {
+        // remote starrocks cluster fe addr
         @SerializedName("ht")
         private String host;
         @SerializedName("pt")
@@ -168,33 +152,6 @@ public class ExternalOlapTable extends OlapTable {
             this.tableType = tableType;
         }
 
-        public void toJsonObj(JsonObject obj) {
-            obj.addProperty(JSON_KEY_HOST, host);
-            obj.addProperty(JSON_KEY_PORT, port);
-            obj.addProperty(JSON_KEY_USER, user);
-            obj.addProperty(JSON_KEY_PASSWORD, password);
-            obj.addProperty(JSON_KEY_SOURCE_DB_NAME, dbName);
-            obj.addProperty(JSON_KEY_SOURCE_DB_ID, dbId);
-            obj.addProperty(JSON_KEY_SOURCE_TABLE_NAME, tableName);
-            obj.addProperty(JSON_KEY_SOURCE_TABLE_ID, tableId);
-            obj.addProperty(JSON_KEY_SOURCE_TABLE_TYPE, TableType.serialize(tableType));
-        }
-
-        public void fromJsonObj(JsonObject obj) {
-            host = obj.getAsJsonPrimitive(JSON_KEY_HOST).getAsString();
-            port = obj.getAsJsonPrimitive(JSON_KEY_PORT).getAsInt();
-            user = obj.getAsJsonPrimitive(JSON_KEY_USER).getAsString();
-            password = obj.getAsJsonPrimitive(JSON_KEY_PASSWORD).getAsString();
-            dbName = obj.getAsJsonPrimitive(JSON_KEY_SOURCE_DB_NAME).getAsString();
-            dbId = obj.getAsJsonPrimitive(JSON_KEY_SOURCE_DB_ID).getAsLong();
-            tableName = obj.getAsJsonPrimitive(JSON_KEY_SOURCE_TABLE_NAME).getAsString();
-            tableId = obj.getAsJsonPrimitive(JSON_KEY_SOURCE_TABLE_ID).getAsLong();
-            JsonPrimitive tableTypeJson = obj.getAsJsonPrimitive(JSON_KEY_SOURCE_TABLE_TYPE);
-            if (tableTypeJson != null) {
-                tableType = TableType.deserialize(tableTypeJson.getAsString());
-            }
-        }
-
         public void parseFromProperties(Map<String, String> properties) throws DdlException {
             if (properties == null) {
                 throw new DdlException("miss properties for external table, "
@@ -214,7 +171,7 @@ public class ExternalOlapTable extends OlapTable {
                         + "Please add properties('port'='3306') when create table");
             }
             try {
-                port = Integer.valueOf(portStr);
+                port = Integer.parseInt(portStr);
             } catch (Exception e) {
                 throw new DdlException("port of external table must be a number."
                         + "Please add properties('port'='3306') when create table");
@@ -252,6 +209,8 @@ public class ExternalOlapTable extends OlapTable {
 
     @SerializedName(value = "ef")
     private ExternalTableInfo externalTableInfo;
+
+    private SystemInfoService externalSystemInfoService;
 
     public ExternalOlapTable() {
         super();
@@ -325,6 +284,10 @@ public class ExternalOlapTable extends OlapTable {
 
     public boolean isSourceTableCloudNativeTableOrMaterializedView() {
         return isSourceTableCloudNativeTable() || isSourceTableCloudNativeMaterializedView();
+    }
+
+    public SystemInfoService getExternalSystemInfoService() {
+        return externalSystemInfoService;
     }
 
     @Override
@@ -460,7 +423,7 @@ public class ExternalOlapTable extends OlapTable {
         indexNameToId.clear();
 
         for (TIndexMeta indexMeta : meta.getIndexes()) {
-            List<Column> columns = new ArrayList();
+            List<Column> columns = new ArrayList<>();
             for (TColumnMeta columnMeta : indexMeta.getSchema_meta().getColumns()) {
                 Type type = Type.fromThrift(columnMeta.getColumnType());
                 Column column = new Column(columnMeta.getColumnName(), type, columnMeta.isAllowNull());
@@ -556,29 +519,19 @@ public class ExternalOlapTable extends OlapTable {
         }
         long endOfTabletMetaBuild = System.currentTimeMillis();
 
-        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        SystemInfoService systemInfoService = new SystemInfoService();
         for (TBackendMeta backendMeta : backendMetas) {
-            Backend backend = systemInfoService.getBackend(backendMeta.getBackend_id());
-            if (backend == null) {
-                backend = new Backend();
-                backend.setId(backendMeta.getBackend_id());
-                backend.setHost(backendMeta.getHost());
-                backend.setBePort(backendMeta.getBe_port());
-                backend.setHttpPort(backendMeta.getHttp_port());
-                backend.setBrpcPort(backendMeta.getRpc_port());
-                backend.setAlive(backendMeta.isAlive());
-                backend.setBackendState(BackendState.values()[backendMeta.getState()]);
-                systemInfoService.addBackend(backend);
-            } else {
-                backend.setId(backendMeta.getBackend_id());
-                backend.setHost(backendMeta.getHost());
-                backend.setBePort(backendMeta.getBe_port());
-                backend.setHttpPort(backendMeta.getHttp_port());
-                backend.setBrpcPort(backendMeta.getRpc_port());
-                backend.setAlive(backendMeta.isAlive());
-                backend.setBackendState(BackendState.values()[backendMeta.getState()]);
-            }
+            Backend backend = new Backend();
+            backend.setId(backendMeta.getBackend_id());
+            backend.setHost(backendMeta.getHost());
+            backend.setBePort(backendMeta.getBe_port());
+            backend.setHttpPort(backendMeta.getHttp_port());
+            backend.setBrpcPort(backendMeta.getRpc_port());
+            backend.setAlive(backendMeta.isAlive());
+            backend.setBackendState(BackendState.values()[backendMeta.getState()]);
+            systemInfoService.addBackend(backend);
         }
+        externalSystemInfoService = systemInfoService;
 
         lastExternalMeta = meta;
         LOG.info("TableMetaSyncer finish meta update. partition build cost: {}ms, " +

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -267,10 +267,9 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     }
 
     // return map of (BE id -> path hash) of normal replicas
-    public Multimap<Replica, Long> getNormalReplicaBackendPathMap() {
+    public Multimap<Replica, Long> getNormalReplicaBackendPathMap(SystemInfoService infoService) {
         Multimap<Replica, Long> map = LinkedHashMultimap.create();
         try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
-            SystemInfoService infoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
             for (Replica replica : replicas) {
                 if (replica.isBad()) {
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -255,7 +255,8 @@ public class OlapTableSink extends DataSink {
                 enableAutomaticPartition, automaticBucketSize, partitionIds);
         tSink.setPartition(partitionParam);
         tSink.setLocation(createLocation(dstTable, partitionParam, enableReplicatedStorage, warehouseId));
-        tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(warehouseId));
+        tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(warehouseId,
+                getSystemInfoService(dstTable)));
         tSink.setPartial_update_mode(this.partialUpdateMode);
         tSink.setAutomatic_bucket_size(automaticBucketSize);
         if (canUseColocateMVIndex(dstTable)) {
@@ -713,6 +714,14 @@ public class OlapTableSink extends DataSink {
                 WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
+    public static SystemInfoService getSystemInfoService(OlapTable table) {
+        if (table instanceof ExternalOlapTable) {
+            return ((ExternalOlapTable) table).getExternalSystemInfoService();
+        } else {
+            return GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        }
+    }
+
     public static TOlapTableLocationParam createLocation(OlapTable table, TOlapTablePartitionParam partitionParam,
                                                          boolean enableReplicatedStorage,
                                                          long warehouseId) throws UserException {
@@ -720,7 +729,7 @@ public class OlapTableSink extends DataSink {
         // replica -> path hash
         Multimap<Long, Long> allBePathsMap = HashMultimap.create();
         Map<Long, Long> bePrimaryMap = new HashMap<>();
-        SystemInfoService infoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        SystemInfoService infoService = getSystemInfoService(table);
         if (partitionParam.getPartitions() == null) {
             return locationParam;
         }
@@ -743,7 +752,7 @@ public class OlapTableSink extends DataSink {
                         // otherwise, there will be a 'unknown node id, id=xxx' error for stream load
                         LocalTablet localTablet = (LocalTablet) tablet;
                         Multimap<Replica, Long> bePathsMap =
-                                localTablet.getNormalReplicaBackendPathMap();
+                                localTablet.getNormalReplicaBackendPathMap(infoService);
                         if (bePathsMap.keySet().size() < quorum) {
                             throw new UserException(InternalErrorCode.REPLICA_FEW_ERR,
                                     String.format("Tablet lost replicas. Check if any backend is down or not. " +

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaTableSink.java
@@ -45,7 +45,8 @@ public class SchemaTableSink extends DataSink {
     protected TDataSink toThrift() {
         TDataSink tDataSink = new TDataSink(TDataSinkType.SCHEMA_TABLE_SINK);
         TSchemaTableSink sink = new TSchemaTableSink();
-        TNodesInfo info = GlobalStateMgr.getCurrentState().createNodesInfo(warehouseId);
+        TNodesInfo info = GlobalStateMgr.getCurrentState().createNodesInfo(warehouseId,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
         sink.setTable(tableName);
         sink.setNodes_info(info);
         tDataSink.setSchema_table_sink(sink);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -497,9 +497,8 @@ public class GlobalStateMgr {
         return journalObservable;
     }
 
-    public TNodesInfo createNodesInfo(long warehouseId) {
+    public TNodesInfo createNodesInfo(long warehouseId, SystemInfoService systemInfoService) {
         TNodesInfo nodesInfo = new TNodesInfo();
-        SystemInfoService systemInfoService = nodeMgr.getClusterInfo();
         if (RunMode.isSharedDataMode()) {
             List<Long> computeNodeIds = warehouseMgr.getAllComputeNodeIds(warehouseId);
             for (Long cnId : computeNodeIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2116,7 +2116,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setTablets(tablets);
 
         // build nodes
-        TNodesInfo nodesInfo = GlobalStateMgr.getCurrentState().createNodesInfo(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        TNodesInfo nodesInfo = GlobalStateMgr.getCurrentState().createNodesInfo(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
         result.setNodes(nodesInfo.nodes);
         result.setStatus(new TStatus(OK));
         return result;
@@ -2201,7 +2202,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     // otherwise, there will be a 'unknown node id, id=xxx' error for stream load
                     LocalTablet localTablet = (LocalTablet) tablet;
                     Multimap<Replica, Long> bePathsMap =
-                            localTablet.getNormalReplicaBackendPathMap();
+                            localTablet.getNormalReplicaBackendPathMap(
+                                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
                     if (bePathsMap.keySet().size() < quorum) {
                         throw new UserException(String.format("Tablet lost replicas. Check if any backend is down or not. " +
                                         "tablet_id: %s, replicas: %s. Check quorum number failed(buildTablets): " +
@@ -2454,7 +2456,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         // otherwise, there will be a 'unknown node id, id=xxx' error for stream load
                         LocalTablet localTablet = (LocalTablet) tablet;
                         Multimap<Replica, Long> bePathsMap =
-                                localTablet.getNormalReplicaBackendPathMap();
+                                localTablet.getNormalReplicaBackendPathMap(
+                                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
                         if (bePathsMap.keySet().size() < quorum) {
                             String errorMsg = String.format("Tablet lost replicas. Check if any backend is down or not. " +
                                             "tablet_id: %s, replicas: %s. Check quorum number failed" +
@@ -2479,7 +2482,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setTablets(tablets);
 
         // build nodes
-        TNodesInfo nodesInfo = GlobalStateMgr.getCurrentState().createNodesInfo(txnState.getWarehouseId());
+        TNodesInfo nodesInfo = GlobalStateMgr.getCurrentState().createNodesInfo(txnState.getWarehouseId(),
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
         result.setNodes(nodesInfo.nodes);
         result.setStatus(new TStatus(OK));
         return result;
@@ -2876,7 +2880,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     dictTable.getAutomaticBucketSize(), allPartitions);
             response.setPartition(partitionParam);
             response.setLocation(OlapTableSink.createLocation(dictTable, partitionParam, dictTable.enableReplicatedStorage()));
-            response.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(WarehouseManager.DEFAULT_WAREHOUSE_ID));
+            response.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()));
         } catch (UserException e) {
             SemanticException semanticException = new SemanticException("build DictQueryParams error in dict_query_expr.");
             semanticException.initCause(e);


### PR DESCRIPTION
## Why I'm doing:
PR #40982 remove the systemInfoMap from NodeMgr, so all the backends are added into the current cluster.

## What I'm doing:
Store the  external SystemInfoService into Olap External Table, and use it when loading into that table.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
