### PR TITLE
[Enhancement] release the TaskRun.lock when archiving history

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -857,14 +857,7 @@ public class TaskManager implements MemoryTrackable {
     }
 
     public void removeExpiredTaskRuns() {
-        if (!taskRunManager.tryTaskRunLock()) {
-            return;
-        }
-        try {
-            taskRunManager.getTaskRunHistory().vacuum();
-        } finally {
-            taskRunManager.taskRunUnlock();
-        }
+        taskRunManager.getTaskRunHistory().vacuum();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -43,31 +43,29 @@ public class TaskRunHistory {
     // Thread-Safe history map:
     // QueryId -> TaskRunStatus
     // The same task-id may contain multi history task run status, so use query_id instead.
-    private final Map<String, TaskRunStatus> historyTaskRunMap =
-            Collections.synchronizedMap(Maps.newLinkedHashMap());
+    private final Map<String, TaskRunStatus> historyTaskRunMap = Maps.newLinkedHashMap();
     // TaskName -> TaskRunStatus
-    private final Map<String, TaskRunStatus> taskName2Status =
-            Collections.synchronizedMap(Maps.newLinkedHashMap());
+    private final Map<String, TaskRunStatus> taskName2Status = Maps.newLinkedHashMap();
 
     private final TaskRunHistoryTable historyTable = new TaskRunHistoryTable();
 
-    public void addHistory(TaskRunStatus status) {
+    public synchronized void addHistory(TaskRunStatus status) {
         historyTaskRunMap.put(status.getQueryId(), status);
         taskName2Status.put(status.getTaskName(), status);
     }
 
-    public TaskRunStatus getTaskByName(String taskName) {
+    public synchronized TaskRunStatus getTaskByName(String taskName) {
         return taskName2Status.get(taskName);
     }
 
-    public TaskRunStatus getTask(String queryId) {
+    public synchronized TaskRunStatus getTask(String queryId) {
         if (queryId == null) {
             return null;
         }
         return historyTaskRunMap.get(queryId);
     }
 
-    public void removeTaskByQueryId(String queryId) {
+    public synchronized void removeTaskByQueryId(String queryId) {
         if (queryId == null) {
             return;
         }
@@ -76,10 +74,14 @@ public class TaskRunHistory {
     }
 
     // Reserve historyTaskRunMap values to keep the last insert at the first.
-    public List<TaskRunStatus> getInMemoryHistory() {
+    public synchronized List<TaskRunStatus> getInMemoryHistory() {
         List<TaskRunStatus> historyRunStatus = new ArrayList<>(historyTaskRunMap.values());
         Collections.reverse(historyRunStatus);
         return historyRunStatus;
+    }
+
+    public synchronized long getTaskRunCount() {
+        return historyTaskRunMap.size();
     }
 
     public List<TaskRunStatus> lookupHistoryByTaskNames(String dbName, Set<String> taskNames) {
@@ -213,7 +215,4 @@ public class TaskRunHistory {
                 "size before GC:{}, size after GC:{}.", beforeSize, historyTaskRunMap.size());
     }
 
-    public long getTaskRunCount() {
-        return historyTaskRunMap.size();
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -211,8 +211,10 @@ public class TaskRunHistory {
 
         // Now remove outside of iteration
         idsToRemove.forEach(this::removeTaskByQueryId);
-        LOG.warn("Too much task metadata triggers forced task_run GC, " +
-                "size before GC:{}, size after GC:{}.", beforeSize, historyTaskRunMap.size());
+        synchronized (this) {
+            LOG.warn("Too much task metadata triggers forced task_run GC, " +
+                    "size before GC:{}, size after GC:{}.", beforeSize, historyTaskRunMap.size());
+        }
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -211,10 +211,8 @@ public class TaskRunHistory {
 
         // Now remove outside of iteration
         idsToRemove.forEach(this::removeTaskByQueryId);
-        synchronized (this) {
-            LOG.warn("Too much task metadata triggers forced task_run GC, " +
-                    "size before GC:{}, size after GC:{}.", beforeSize, historyTaskRunMap.size());
-        }
+        LOG.warn("Too much task metadata triggers forced task_run GC, " +
+                "size before GC:{}, size after GC:{}.", beforeSize, getTaskRunCount());
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -100,11 +100,13 @@ public class StatisticUtils {
         // but QeProcessorImpl::reportExecStatus will check query id,
         // So we must disable report query status from BE to FE
         context.getSessionVariable().setEnableProfile(false);
+        context.getSessionVariable().setEnableLoadProfile(false);
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setEnablePipelineEngine(true);
         context.getSessionVariable().setCboCteReuse(true);
         context.getSessionVariable().setCboCTERuseRatio(0);
+
         WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         Warehouse warehouse = manager.getBackgroundWarehouse();
         context.getSessionVariable().setWarehouseName(warehouse.getName());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Not hold the lock when archiving the history, it's not necessary at all
- Turn off the `enable_load_profile` for background DML

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
