### PR TITLE
[BugFix] Fix decimal type for pushing down aggregate on grouping-set

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -333,7 +333,7 @@ public class GroupingSetsTest extends PlanTestBase {
     }
 
     @Test
-    public void testPushDownGroupingSetNormal2() throws Exception {
+    public void testPushDownGroupingSetDecimal() throws Exception {
         connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
         try {
             String sql = "select t1b, t1c, t1d, sum(id_decimal) " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -164,6 +164,7 @@ public class GroupingSetsTest extends PlanTestBase {
                 "  5:EXCHANGE"));
         connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
     }
+
     @Test
     public void testRollupToUnionRewrite1() throws Exception {
         connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
@@ -180,9 +181,9 @@ public class GroupingSetsTest extends PlanTestBase {
                 "  |  <slot 15> : 15: sum\n" +
                 "  |  <slot 18> : 0"));
         Assert.assertTrue(plan.contains("  7:Project\n" +
-                        "  |  <slot 8> : 8: sum\n" +
-                        "  |  <slot 9> : NULL\n" +
-                        "  |  <slot 12> : 1"));
+                "  |  <slot 8> : 8: sum\n" +
+                "  |  <slot 9> : NULL\n" +
+                "  |  <slot 12> : 1"));
         connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
     }
 
@@ -326,6 +327,23 @@ public class GroupingSetsTest extends PlanTestBase {
                     "  0:OlapScanNode");
             assertContains(plan, "  7:REPEAT_NODE\n" +
                     "  |  repeat: repeat 3 lines [[], [14], [14], [14]]\n");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
+    @Test
+    public void testPushDownGroupingSetNormal2() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        try {
+            String sql = "select t1b, t1c, t1d, sum(id_decimal) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            String plan = getCostExplain(sql);
+            assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  aggregate: sum[([10: id_decimal, DECIMAL64(10,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
+            assertContains(plan, "  3:AGGREGATE (merge finalize)\n" +
+                    "  |  aggregate: sum[([11: sum, DECIMAL128(38,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -339,12 +339,13 @@ public class GroupingSetsTest extends PlanTestBase {
             String sql = "select t1b, t1c, t1d, sum(id_decimal) " +
                     "   from test_all_type group by rollup(t1b, t1c, t1d)";
             String plan = getCostExplain(sql);
-            assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+            System.out.println(plan);
+            assertContains(plan, "  8:AGGREGATE (update serialize)\n" +
                     "  |  STREAMING\n" +
-                    "  |  aggregate: sum[([10: id_decimal, DECIMAL64(10,2), true]); args: DECIMAL64; " +
+                    "  |  aggregate: sum[([13: sum, DECIMAL128(38,2), true]); args: DECIMAL128; " +
                     "result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
-            assertContains(plan, "  3:AGGREGATE (merge finalize)\n" +
-                    "  |  aggregate: sum[([11: sum, DECIMAL128(38,2), true]); args: DECIMAL64; " +
+            assertContains(plan, "  10:AGGREGATE (merge finalize)\n" +
+                    "  |  aggregate: sum[([17: sum, DECIMAL128(38,2), true]); args: DECIMAL128; " +
                     "result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -341,9 +341,11 @@ public class GroupingSetsTest extends PlanTestBase {
             String plan = getCostExplain(sql);
             assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
                     "  |  STREAMING\n" +
-                    "  |  aggregate: sum[([10: id_decimal, DECIMAL64(10,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
+                    "  |  aggregate: sum[([10: id_decimal, DECIMAL64(10,2), true]); args: DECIMAL64; " +
+                    "result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
             assertContains(plan, "  3:AGGREGATE (merge finalize)\n" +
-                    "  |  aggregate: sum[([11: sum, DECIMAL128(38,2), true]); args: DECIMAL64; result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
+                    "  |  aggregate: sum[([11: sum, DECIMAL128(38,2), true]); args: DECIMAL64; " +
+                    "result: DECIMAL128(38,2); args nullable: true; result nullable: true]");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
         }


### PR DESCRIPTION
## Why I'm doing:

When pushing down aggregate function on grouping-set, `DECIMAL`'s scale and precision will be lost.

Because builtin functions don't store the scale and precision, we must reset the scale and precision after getting a function from builtin functions.

## What I'm doing:


Fixes https://github.com/StarRocks/StarRocksTest/issues/8289.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
