### PR TITLE
[Enhancement] Optimize text based mv rewrite performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -442,12 +442,16 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @SerializedName(value = "inactiveReason")
     private String inactiveReason;
 
-    // for show create mv, constructing refresh job(insert into select)
+    // This is a normalized view define SQL by AstToSQLBuilder#toSQL, which is used for show create mv, constructing a refresh job
+    // (insert into select)
     @SerializedName(value = "viewDefineSql")
     private String viewDefineSql;
-
+    // This is a normalized view define SQL by AstToSQLBuilder#buildSimple.
     @SerializedName(value = "simpleDefineSql")
     private String simpleDefineSql;
+    // This is the original user's view define SQL which can be used to generate ast key in text based rewrite.
+    @SerializedName(value = "originalViewDefineSql")
+    private String originalViewDefineSql;
 
     // Deprecated field which is used to store single partition ref table exprs of the mv in old version.
     @Deprecated
@@ -613,6 +617,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public void setSimpleDefineSql(String simple) {
         this.simpleDefineSql = simple;
+    }
+
+    public String getOriginalViewDefineSql() {
+        return originalViewDefineSql;
+    }
+
+    public void setOriginalViewDefineSql(String originalViewDefineSql) {
+        this.originalViewDefineSql = originalViewDefineSql;
     }
 
     public String getTaskDefinition() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1986,7 +1986,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             }
             ConnectContext connectContext = new ConnectContext();
             connectContext.setDatabase(db.getOriginName());
-            this.defineQueryParseNode = MvUtils.getQueryAst(viewDefineSql, connectContext);
+            if (!Strings.isNullOrEmpty(originalViewDefineSql)) {
+                this.defineQueryParseNode = MvUtils.getQueryAst(originalViewDefineSql, connectContext);
+            } else {
+                this.defineQueryParseNode = MvUtils.getQueryAst(viewDefineSql, connectContext);
+            }
         }
         return this.defineQueryParseNode;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3218,6 +3218,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler {
         // set viewDefineSql
         materializedView.setViewDefineSql(stmt.getInlineViewDef());
         materializedView.setSimpleDefineSql(stmt.getSimpleViewDef());
+        materializedView.setOriginalViewDefineSql(stmt.getOriginalViewDefineSql());
         // set partitionRefTableExprs
         if (stmt.getPartitionRefTableExpr() != null) {
             //avoid to get a list of null inside

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -264,15 +264,14 @@ public class MaterializedViewAnalyzer {
             }
 
             // convert queryStatement to sql and set
+            statement.setInlineViewDef(AstToSQLBuilder.toSQL(queryStatement));
             statement.setSimpleViewDef(AstToSQLBuilder.buildSimple(queryStatement));
-            if (statement.getOrigStmt() != null) {
-                String originalViewDef = statement.getOrigStmt().originStmt;
-                Preconditions.checkArgument(originalViewDef != null,
-                        "MV's original view definition is null");
-                statement.setInlineViewDef(originalViewDef.substring(statement.getQueryStartIndex()));
-            } else {
-                statement.setInlineViewDef(AstToSQLBuilder.toSQL(queryStatement));
-            }
+            Preconditions.checkArgument(statement.getOrigStmt() != null, "MV's original statement is null");
+            String originalViewDef = statement.getOrigStmt().originStmt;
+            Preconditions.checkArgument(originalViewDef != null,
+                    "MV's original view definition is null");
+            statement.setOriginalViewDefineSql(originalViewDef.substring(statement.getQueryStartIndex()));
+
             // collect table from query statement
 
             if (!InternalCatalog.isFromDefault(statement.getTableName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -264,8 +264,15 @@ public class MaterializedViewAnalyzer {
             }
 
             // convert queryStatement to sql and set
-            statement.setInlineViewDef(AstToSQLBuilder.toSQL(queryStatement));
             statement.setSimpleViewDef(AstToSQLBuilder.buildSimple(queryStatement));
+            if (statement.getOrigStmt() != null) {
+                String originalViewDef = statement.getOrigStmt().originStmt;
+                Preconditions.checkArgument(originalViewDef != null,
+                        "MV's original view definition is null");
+                statement.setInlineViewDef(originalViewDef.substring(statement.getQueryStartIndex()));
+            } else {
+                statement.setInlineViewDef(AstToSQLBuilder.toSQL(queryStatement));
+            }
             // collect table from query statement
 
             if (!InternalCatalog.isFromDefault(statement.getTableName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -56,10 +56,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private final int queryStartIndex;
     private final List<String> sortKeys;
     private KeysType keysType = KeysType.DUP_KEYS;
-    // original view definition of the mv query without any rewrite which can be used in text based rewrite.
+    // view definition of the mv which has been rewritten by AstToSQLBuilder#toSQL
     protected String inlineViewDef;
     // simple view definition of the mv which has been rewritten by AstToSQLBuilder#buildSimple
     private String simpleViewDef;
+    // original view definition of the mv query without any rewrite which can be used in text based rewrite.
+    private String originalViewDefineSql;
     private List<BaseTableInfo> baseTableInfos;
 
     // Maintenance information
@@ -197,6 +199,14 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public void setSimpleViewDef(String simpleViewDef) {
         this.simpleViewDef = simpleViewDef;
+    }
+
+    public String getOriginalViewDefineSql() {
+        return originalViewDefineSql;
+    }
+
+    public void setOriginalViewDefineSql(String originalViewDefineSql) {
+        this.originalViewDefineSql = originalViewDefineSql;
     }
 
     public int getQueryStartIndex() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -53,10 +53,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private Map<String, String> properties;
     private QueryStatement queryStatement;
     private DistributionDesc distributionDesc;
+    private final int queryStartIndex;
     private final List<String> sortKeys;
     private KeysType keysType = KeysType.DUP_KEYS;
+    // original view definition of the mv query without any rewrite which can be used in text based rewrite.
     protected String inlineViewDef;
-
+    // simple view definition of the mv which has been rewritten by AstToSQLBuilder#buildSimple
     private String simpleViewDef;
     private List<BaseTableInfo> baseTableInfos;
 
@@ -87,7 +89,9 @@ public class CreateMaterializedViewStatement extends DdlStmt {
                                            ExpressionPartitionDesc expressionPartitionDesc,
                                            DistributionDesc distributionDesc, List<String> sortKeys,
                                            Map<String, String> properties,
-                                           QueryStatement queryStatement, NodePosition pos) {
+                                           QueryStatement queryStatement,
+                                           int queryStartIndex,
+                                           NodePosition pos) {
         super(pos);
         this.tableName = tableName;
         this.colWithComments = colWithComments;
@@ -99,6 +103,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.distributionDesc = distributionDesc;
         this.sortKeys = sortKeys;
         this.properties = properties;
+        this.queryStartIndex = queryStartIndex;
         this.queryStatement = queryStatement;
     }
 
@@ -192,6 +197,10 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public void setSimpleViewDef(String simpleViewDef) {
         this.simpleViewDef = simpleViewDef;
+    }
+
+    public int getQueryStartIndex() {
+        return queryStartIndex;
     }
 
     public QueryStatement getQueryStatement() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -45,6 +45,11 @@ public class CachingMvPlanContextBuilder {
 
     public static class AstKey {
         private final String sql;
+
+        /**
+         * Create a AstKey with parseNode(sub parse node)
+         * @param parseNode
+         */
         public AstKey(ParseNode parseNode) {
             this.sql = new AstToSQLBuilder.AST2SQLBuilderVisitor(true, false).visit(parseNode);
         }
@@ -167,9 +172,6 @@ public class CachingMvPlanContextBuilder {
             return;
         }
         try {
-            // initialize define query parse node each time
-            mv.initDefineQueryParseNode();
-
             // cache by ast
             ParseNode parseNode = mv.getDefineQueryParseNode();
             if (parseNode == null) {
@@ -187,11 +189,11 @@ public class CachingMvPlanContextBuilder {
      * @param parseNode: ast to query.
      * @return: null if parseNode is null or astToMvsMap doesn't contain this ast, otherwise return the mvs
      */
-    public Set<MaterializedView> getMvsByAst(ParseNode parseNode) {
-        if (parseNode == null) {
+    public Set<MaterializedView> getMvsByAst(AstKey ast) {
+        if (ast == null) {
             return null;
         }
-        return astToMvsMap.get(new AstKey(parseNode));
+        return astToMvsMap.get(ast);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -88,7 +88,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.catalog.MvRefreshArbiter.getMVTimelinessUpdateInfo;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.getMvPartialPartitionPredicates;
 
@@ -98,6 +97,7 @@ public class MvRewritePreprocessor {
     private final ColumnRefFactory queryColumnRefFactory;
     private final OptimizerContext context;
     private final ColumnRefSet requiredColumns;
+    private final QueryMaterializationContext queryMaterializationContext;
 
     public MvRewritePreprocessor(ConnectContext connectContext,
                                  ColumnRefFactory queryColumnRefFactory,
@@ -107,6 +107,7 @@ public class MvRewritePreprocessor {
         this.queryColumnRefFactory = queryColumnRefFactory;
         this.context = context;
         this.requiredColumns = requiredColumns;
+        this.queryMaterializationContext = context.getQueryMaterializationContext();
     }
 
     @VisibleForTesting
@@ -237,10 +238,11 @@ public class MvRewritePreprocessor {
             logMVParams(connectContext, queryTables);
 
             // use a new context rather than reuse the existed context to avoid cache conflict.
-            QueryMaterializationContext queryMaterializationContext = new QueryMaterializationContext();
             try {
                 // 1. get related mvs for all input tables
                 Set<MaterializedView> relatedMVs = getRelatedMVs(queryTables, context.getOptimizerConfig().isRuleBased());
+                // add into queryMaterializationContext for later use
+                this.queryMaterializationContext.addRelatedMVs(relatedMVs);
 
                 // 2. choose best related mvs by user's config or related mv limit
                 Set<MaterializedView> selectedRelatedMVs;
@@ -270,7 +272,6 @@ public class MvRewritePreprocessor {
                 if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
                     // it's safe used in the optimize context here since the query mv context is not shared across the
                     // connect-context.
-                    context.setQueryMaterializationContext(queryMaterializationContext);
                     connectContext.setQueryMVContext(queryMaterializationContext);
                 }
 
@@ -742,7 +743,7 @@ public class MvRewritePreprocessor {
             MvPlanContext mvPlanContext = mvWithPlanContext.getMvPlanContext();
             try {
                 // mv's partitions to refresh
-                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo(mv, true);
+                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "stale partitions {}", mvUpdateInfo);
                     continue;
@@ -766,7 +767,7 @@ public class MvRewritePreprocessor {
                 if (materializationContext == null) {
                     continue;
                 }
-                context.addCandidateMvs(materializationContext);
+                queryMaterializationContext.addValidCandidateMV(materializationContext);
                 logMVPrepare(connectContext, mv, "Prepare MV {} success", mv.getName());
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -177,12 +177,11 @@ public class Optimizer {
             // prepare for optimizer
             prepare(connectContext, columnRefFactory, logicOperatorTree);
 
-            // try text based mv rewrite first before mv rewrite prepare so can deduce mv prepare time if it can be rewritten.
-            logicOperatorTree = new TextMatchBasedRewriteRule(connectContext, stmt, optToAstMap)
-                    .transform(logicOperatorTree, context).get(0);
-
             // prepare for mv rewrite
             prepareMvRewrite(connectContext, logicOperatorTree, columnRefFactory, requiredColumns);
+
+            logicOperatorTree = new TextMatchBasedRewriteRule(connectContext, stmt, optToAstMap)
+                    .transform(logicOperatorTree, context).get(0);
 
             OptExpression result = optimizerConfig.isRuleBased() ?
                     optimizeByRule(logicOperatorTree, requiredProperty, requiredColumns) :

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -137,7 +137,7 @@ public class QueryMaterializationContext {
             return null;
         }
 
-        return (ScalarOperator) mvQueryContextCache.get(predicate, x -> {
+        return (ScalarOperator) getMvQueryContextCache().get(predicate, x -> {
             ScalarOperator rewritten = new ScalarOperatorRewriter()
                     .rewrite(predicate.clone(), ScalarOperatorRewriter.MV_SCALAR_REWRITE_RULES);
             return rewritten;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -18,8 +18,12 @@ package com.starrocks.sql.optimizer;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.api.client.util.Lists;
+import com.google.api.client.util.Sets;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.persist.gson.GsonUtils;
@@ -37,11 +41,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.starrocks.catalog.MvRefreshArbiter.getMVTimelinessUpdateInfo;
+
 /**
  * Store materialized view context during the query lifecycle which is seperated from per materialized view's context.
  */
 public class QueryMaterializationContext {
     protected static final Logger LOG = LogManager.getLogger(QueryMaterializationContext.class);
+
+    // MVs that are related to the query
+    private Set<MaterializedView> relatedMVs = Sets.newHashSet();
+    // MVs with context that are valid (SPJG pattern) candidates for materialization rewrite
+    private List<MaterializationContext> validCandidateMVs = Lists.newArrayList();
+    // MV with the cached timeliness update info which should be initialized once in one query context.
+    private Map<MaterializedView, MvUpdateInfo> mvTimelinessInfos = Maps.newHashMap();
 
     // used by view based mv rewrite
     // query's logical plan with view
@@ -54,10 +67,7 @@ public class QueryMaterializationContext {
     // 1. cache query predicates to its final predicate split per query because PredicateSplit's construct is expensive.
     // 2. cache query predicate to its canonized predicate to avoid one predicate's repeat canonized.
     // It can be be used for more situations later.
-    private final Cache<Object, Object> mvQueryContextCache = Caffeine.newBuilder()
-            .maximumSize(Config.mv_query_context_cache_max_size)
-            .recordStats()
-            .build();
+    private Cache<Object, Object> mvQueryContextCache = null;
 
     private final QueryCacheStats queryCacheStats = new QueryCacheStats();
 
@@ -88,20 +98,26 @@ public class QueryMaterializationContext {
     }
 
     public Cache<Object, Object> getMvQueryContextCache() {
+        if (mvQueryContextCache == null) {
+            mvQueryContextCache = Caffeine.newBuilder()
+                    .maximumSize(Config.mv_query_context_cache_max_size)
+                    .recordStats()
+                    .build();
+        }
         return mvQueryContextCache;
     }
 
     public PredicateSplit getPredicateSplit(Set<ScalarOperator> predicates,
                                             ReplaceColumnRefRewriter columnRefRewriter) {
         // Cache predicate split for predicates because it's time costing if there are too many materialized views.
-        Object cached = mvQueryContextCache.getIfPresent(predicates);
+        Object cached = getMvQueryContextCache().getIfPresent(predicates);
         if (cached != null) {
             return (PredicateSplit) cached;
         }
         ScalarOperator queryPredicate = rewriteOptExprCompoundPredicate(predicates, columnRefRewriter);
         PredicateSplit predicateSplit = PredicateSplit.splitPredicate(queryPredicate);
         if (predicateSplit != null) {
-            mvQueryContextCache.put(predicates, predicateSplit);
+            getMvQueryContextCache().put(predicates, predicateSplit);
         }
         return predicateSplit;
     }
@@ -148,8 +164,62 @@ public class QueryMaterializationContext {
         return viewScans;
     }
 
+    /**
+     * Add related mvs about this query.
+     * @param mvs: related mvs
+     */
+    public void addRelatedMVs(Set<MaterializedView> mvs) {
+        relatedMVs.addAll(mvs);
+    }
+
+    /**
+     * Add valid candidate materialized view for the query:
+     * @param mv mv with context that is valid (SPJG pattern) candidate for materialization rewrite
+     */
+    public void addValidCandidateMV(MaterializationContext mv) {
+        validCandidateMVs.add(mv);
+    }
+
+    /**
+     * Get or init the cached timeliness update info for the materialized view.
+     * @param mv intput mv
+     * @return MvUpdateInfo of the mv, null if mv is null or initialize fail
+     */
+    public MvUpdateInfo getOrInitMVTimelinessInfos(MaterializedView mv) {
+        if (mv == null) {
+            return null;
+        }
+        if (!mvTimelinessInfos.containsKey(mv)) {
+            MvUpdateInfo result = getMVTimelinessUpdateInfo(mv, true);
+            mvTimelinessInfos.put(mv, result);
+            return result;
+        } else {
+            return mvTimelinessInfos.get(mv);
+        }
+    }
+
+    /**
+     * All related mvs about this query which contains valid candidate mvs(SPJG) and other mvs(non SPGJ).
+     * @return
+     */
+    public Set<MaterializedView> getRelatedMVs() {
+        return relatedMVs;
+    }
+
+    /**
+     * Get all valid candidate materialized views for the query:
+     * - The materialized view is valid to rewrite by rule(SPJG)
+     * - The materialized view's refresh-ness is valid to rewrite.
+     */
+    public List<MaterializationContext> getValidCandidateMVs() {
+        return validCandidateMVs;
+    }
+
     // Invalidate all caches by hand to avoid memory allocation after query optimization.
     public void clear() {
+        if (mvQueryContextCache == null) {
+            return;
+        }
         if (ConnectContext.get() != null) {
             QueryDebugOptions debugOptions = ConnectContext.get().getSessionVariable().getQueryDebugOptions();
             if (debugOptions.isEnableQueryTraceLog()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -54,7 +55,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.catalog.MvRefreshArbiter.getMVTimelinessUpdateInfo;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty;
 
@@ -148,7 +148,8 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         Set<Table> queryTables = MvUtils.getAllTables(mvPlan).stream().collect(Collectors.toSet());
 
         // mv's to refresh partition info
-        MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo(mv, true);
+        QueryMaterializationContext queryMaterializationContext = context.getQueryMaterializationContext();
+        MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
         if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
             logMVRewrite(context, this, "Get mv to refresh partition info failed, and redirect to mv's defined query");
             return getOptExpressionByDefault(context, mv, mvPlanContext, olapScanOperator, queryTables);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1343,12 +1343,13 @@ public class MvUtils {
         }
     }
 
-    public static ParseNode getQueryAst(String query) {
+    public static ParseNode getQueryAst(String query, ConnectContext connectContext) {
         try {
             List<StatementBase> statementBases =
-                    com.starrocks.sql.parser.SqlParser.parse(query, new com.starrocks.qe.SessionVariable());
+                    com.starrocks.sql.parser.SqlParser.parse(query, connectContext.getSessionVariable());
             Preconditions.checkState(statementBases.size() == 1);
             StatementBase stmt = statementBases.get(0);
+            Analyzer.analyze(stmt, connectContext);
             return stmt;
         } catch (ParsingException parsingException) {
             LOG.warn("Parse query {} failed:{}", query, parsingException);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1796,6 +1796,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         String comment =
                 context.comment() == null ? null : ((StringLiteral) visit(context.comment().string())).getStringValue();
         QueryStatement queryStatement = (QueryStatement) visit(context.queryStatement());
+        int queryStartIndex = context.queryStatement().start.getStartIndex();
 
         RefreshSchemeClause refreshSchemeDesc = null;
         Map<String, String> properties = new HashMap<>();
@@ -1890,7 +1891,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 context.indexDesc() == null ? null : getIndexDefs(context.indexDesc()),
                 comment,
                 refreshSchemeDesc,
-                expressionPartitionDesc, distributionDesc, sortKeys, properties, queryStatement, createPos(context));
+                expressionPartitionDesc, distributionDesc, sortKeys, properties, queryStatement, queryStartIndex,
+                createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
@@ -218,8 +218,8 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
     public void testMvAstCache() {
         String query = "select user_id, time, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id, time " +
                 "order by user_id, time;";
-        ParseNode parseNode1 = MvUtils.getQueryAst(query);
-        ParseNode parseNode2 = MvUtils.getQueryAst(query);
+        ParseNode parseNode1 = MvUtils.getQueryAst(query, connectContext);
+        ParseNode parseNode2 = MvUtils.getQueryAst(query, connectContext);
         Assert.assertFalse(parseNode2.equals(parseNode1));
 
         CachingMvPlanContextBuilder.AstKey astKey1 = new CachingMvPlanContextBuilder.AstKey(parseNode1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
@@ -155,7 +155,7 @@ public class MvRewriteMetricsTest extends MvRewriteTestBase {
                 assertContains(pr, "TEXT_BASED_REWRITE: Rewrite Succeed");
 
                 Assert.assertTrue(mvMetric.counterQueryHitTotal.getValue() == 1);
-                Assert.assertTrue(mvMetric.counterQueryConsideredTotal.getValue() == 0);
+                Assert.assertTrue(mvMetric.counterQueryConsideredTotal.getValue() == 1);
                 Assert.assertTrue(mvMetric.counterQueryTextBasedMatchedTotal.getValue() == 1);
                 Assert.assertTrue(mvMetric.counterQueryMatchedTotal.getValue() == 0);
                 Assert.assertTrue(mvMetric.counterQueryMaterializedViewTotal.getValue() == 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
@@ -155,7 +155,6 @@ public class MvRewriteMetricsTest extends MvRewriteTestBase {
                 assertContains(pr, "TEXT_BASED_REWRITE: Rewrite Succeed");
 
                 Assert.assertTrue(mvMetric.counterQueryHitTotal.getValue() == 1);
-                Assert.assertTrue(mvMetric.counterQueryConsideredTotal.getValue() == 1);
                 Assert.assertTrue(mvMetric.counterQueryTextBasedMatchedTotal.getValue() == 1);
                 Assert.assertTrue(mvMetric.counterQueryMatchedTotal.getValue() == 0);
                 Assert.assertTrue(mvMetric.counterQueryMaterializedViewTotal.getValue() == 1);


### PR DESCRIPTION
## Why I'm doing:
- Text based mv rewrite may take expensive time in mv rewrite;


## What I'm doing:
1. Only do text based mv rewrite when query contains related mvs;
2. Use original view define instead  of `AstToSQLBuilder.toSQL` to cache mv's ast to avoid query doing normalization in query: 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
