### PR TITLE
[BugFix] fix concurrent issue between primary index unload and compaction

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4885,8 +4885,8 @@ StatusOr<EditVersion> PersistentIndex::_major_compaction_impl(
     return new_l2_version;
 }
 
-void PersistentIndex::modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
-                                         const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta) {
+Status PersistentIndex::modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
+                                           const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta) {
     // delete input l2 versions, and add output l2 version
     std::vector<EditVersion> new_l2_versions;
     std::vector<bool> new_l2_version_merged;
@@ -4906,6 +4906,12 @@ void PersistentIndex::modify_l2_versions(const std::vector<EditVersion>& input_l
             new_l2_version_merged.push_back(index_meta.l2_version_merged(i));
         }
     }
+    // Check all input l2 has been removed. If not, that means index has been rebuilt.
+    if (new_l2_versions.size() + input_l2_versions.size() != index_meta.l2_versions_size() + 1) {
+        return Status::Aborted(
+                fmt::format("PersistentIndex has been rebuilt, abort this compaction task. path : {} meta : {}", _path,
+                            index_meta.ShortDebugString()));
+    }
     // rebuild l2 versions in meta
     index_meta.clear_l2_versions();
     index_meta.clear_l2_version_merged();
@@ -4915,6 +4921,7 @@ void PersistentIndex::modify_l2_versions(const std::vector<EditVersion>& input_l
     for (const bool merge : new_l2_version_merged) {
         index_meta.add_l2_version_merged(merge);
     }
+    return Status::OK();
 }
 
 Status PersistentIndex::TEST_major_compaction(PersistentIndexMetaPB& index_meta) {
@@ -4936,7 +4943,7 @@ Status PersistentIndex::TEST_major_compaction(PersistentIndexMetaPB& index_meta)
     }
     // 2. merge l2 files to new l2 file
     ASSIGN_OR_RETURN(EditVersion new_l2_version, _major_compaction_impl(l2_versions, l2_vec));
-    modify_l2_versions(l2_versions, new_l2_version, index_meta);
+    RETURN_IF_ERROR(modify_l2_versions(l2_versions, new_l2_version, index_meta));
     // delete useless files
     RETURN_IF_ERROR(_reload(index_meta));
     RETURN_IF_ERROR(_delete_expired_index_file(
@@ -4998,7 +5005,7 @@ Status PersistentIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, s
         }
         PersistentIndexMetaPB index_meta;
         RETURN_IF_ERROR(TabletMetaManager::get_persistent_index_meta(data_dir, tablet_id, &index_meta));
-        modify_l2_versions(l2_versions, new_l2_version, index_meta);
+        RETURN_IF_ERROR(modify_l2_versions(l2_versions, new_l2_version, index_meta));
         RETURN_IF_ERROR(TabletMetaManager::write_persistent_index_meta(data_dir, tablet_id, index_meta));
         // reload new l2 versions
         RETURN_IF_ERROR(_reload(index_meta));

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4908,9 +4908,8 @@ Status PersistentIndex::modify_l2_versions(const std::vector<EditVersion>& input
     }
     // Check all input l2 has been removed. If not, that means index has been rebuilt.
     if (new_l2_versions.size() + input_l2_versions.size() != index_meta.l2_versions_size() + 1) {
-        return Status::Aborted(
-                fmt::format("PersistentIndex has been rebuilt, abort this compaction task. path : {} meta : {}", _path,
-                            index_meta.ShortDebugString()));
+        return Status::Aborted(fmt::format("PersistentIndex has been rebuilt, abort this compaction task. meta : {}",
+                                           index_meta.ShortDebugString()));
     }
     // rebuild l2 versions in meta
     index_meta.clear_l2_versions();

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -806,8 +806,8 @@ public:
 
     void reset_cancel_major_compaction();
 
-    static void modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
-                                   const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta);
+    static Status modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
+                                     const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta);
 
     Status pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1184,14 +1184,13 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     _set_schema(pkey_schema);
 
     // load persistent index if enable persistent index meta
-    size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
 
-    if (tablet->get_enable_persistent_index() && (fix_size <= 128)) {
+    if (tablet->get_enable_persistent_index()) {
         // TODO
         // PersistentIndex and tablet data are currently stored in the same directory
         // We may need to support the separation of PersistentIndex and Tablet data
         DCHECK(_persistent_index == nullptr);
-        _persistent_index = std::make_unique<PersistentIndex>(tablet->schema_hash_path());
+        _persistent_index = std::make_shared<PersistentIndex>(tablet->schema_hash_path());
         return _persistent_index->load_from_tablet(tablet);
     }
 
@@ -1555,8 +1554,14 @@ std::unique_ptr<PrimaryIndex> TEST_create_primary_index(const Schema& pk_schema)
 }
 
 Status PrimaryIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, std::shared_timed_mutex* mutex) {
-    if (_persistent_index != nullptr) {
-        return _persistent_index->major_compaction(data_dir, tablet_id, mutex);
+    // `_persistent_index` could be reset when call `unload()`, so we need to fetch reference first.
+    std::shared_ptr<PersistentIndex> pindex;
+    {
+        std::lock_guard<std::mutex> lg(_lock);
+        pindex = _persistent_index;
+    }
+    if (pindex != nullptr) {
+        return pindex->major_compaction(data_dir, tablet_id, mutex);
     } else {
         return Status::OK();
     }
@@ -1574,13 +1579,11 @@ Status PrimaryIndex::reset(Tablet* tablet, EditVersion version, PersistentIndexM
     auto pkey_schema = ChunkHelper::convert_schema(tablet_schema_ptr, pk_columns);
     _set_schema(pkey_schema);
 
-    size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
-
-    if (tablet->get_enable_persistent_index() && (fix_size <= 128)) {
+    if (tablet->get_enable_persistent_index()) {
         if (_persistent_index != nullptr) {
             _persistent_index.reset();
         }
-        _persistent_index = std::make_unique<PersistentIndex>(tablet->schema_hash_path());
+        _persistent_index = std::make_shared<PersistentIndex>(tablet->schema_hash_path());
         RETURN_IF_ERROR(_persistent_index->reset(tablet, version, index_meta));
     } else {
         if (_pkey_to_rssid_rowid != nullptr) {

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -199,7 +199,7 @@ protected:
     std::atomic<bool> _loaded{false};
     Status _status;
     int64_t _tablet_id = 0;
-    std::unique_ptr<PersistentIndex> _persistent_index;
+    std::shared_ptr<PersistentIndex> _persistent_index;
 
 private:
     size_t _key_size = 0;

--- a/be/test/storage/lake/local_pk_index_manager_test.cpp
+++ b/be/test/storage/lake/local_pk_index_manager_test.cpp
@@ -349,4 +349,75 @@ TEST_F(LocalPkIndexManagerTest, test_major_compaction) {
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), 3, txn_id).status());
 }
 
+TEST_F(LocalPkIndexManagerTest, test_major_compaction_with_unload) {
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("UpdateManager::pick_tablets_to_do_pk_index_major_compaction:1",
+                                          [](void* arg) { *(double*)arg = 1.0; });
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+
+    Chunk chunk0({c0, c1}, _schema);
+    auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
+
+    int64_t txn_id = next_id();
+    std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSERT_OK(writer->open());
+
+    // write segment #1
+    ASSERT_OK(writer->write(chunk0));
+    ASSERT_OK(writer->finish());
+
+    // write txnlog
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(_tablet_metadata->id());
+    txn_log->set_txn_id(txn_id);
+    auto op_write = txn_log->mutable_op_write();
+    for (auto& f : writer->files()) {
+        op_write->mutable_rowset()->add_segments(std::move(f.path));
+    }
+    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+    op_write->mutable_rowset()->set_data_size(writer->data_size());
+    op_write->mutable_rowset()->set_overlapped(false);
+
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    writer->close();
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
+    auto stores = StorageEngine::instance()->get_stores();
+    ASSERT_TRUE(stores.size() > 0);
+    ASSERT_OK(FileSystem::Default()->path_exists(stores[0]->get_persistent_index_path() + "/" +
+                                                 std::to_string(_tablet_metadata->id())));
+    auto local_pk_index_manager = std::make_unique<LocalPkIndexManager>();
+    ASSERT_OK(local_pk_index_manager->init());
+    local_pk_index_manager->schedule(
+            [&]() { return local_pk_index_manager->pick_tablets_to_do_pk_index_major_compaction(_update_mgr.get()); });
+    // LocalPkIndexManager use the global update manager to do major compaction.
+    // But we are using _update_mgr constructed in ut, so we have to call pk_index_major_compaction explicitly.
+    std::vector<TabletAndScore> pick_tablets =
+            local_pk_index_manager->pick_tablets_to_do_pk_index_major_compaction(_update_mgr.get());
+    for (auto& tablet_score : pick_tablets) {
+        auto tablet_id = tablet_score.first;
+        auto* data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
+        if (data_dir == nullptr) {
+            continue;
+        }
+        std::vector<std::thread> jobs;
+        jobs.emplace_back([&]() { _update_mgr->pk_index_major_compaction(tablet_id, data_dir); });
+        jobs.emplace_back([&]() { _update_mgr->unload_primary_index(tablet_id); });
+        for (auto& job : jobs) {
+            job.join();
+        }
+    }
+
+    SyncPoint::GetInstance()->ClearCallBack("UpdateManager::pick_tablets_to_do_pk_index_major_compaction:1");
+    SyncPoint::GetInstance()->DisableProcessing();
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -3279,7 +3279,7 @@ TEST_P(PersistentIndexTest, pindex_major_compact_meta) {
     input_l2_versions.emplace_back(1, 0);
     input_l2_versions.emplace_back(1, 1);
     input_l2_versions.emplace_back(3, 0);
-    PersistentIndex::modify_l2_versions(input_l2_versions, input_l2_versions.back(), index_meta);
+    ASSERT_TRUE(PersistentIndex::modify_l2_versions(input_l2_versions, input_l2_versions.back(), index_meta).ok());
 
     // check result
     ASSERT_EQ(index_meta.l2_versions_size(), index_meta.l2_version_merged_size());
@@ -3293,6 +3293,11 @@ TEST_P(PersistentIndexTest, pindex_major_compact_meta) {
             ASSERT_FALSE(index_meta.l2_version_merged(i));
         }
     }
+
+    // rebuild index
+    index_meta.clear_l2_versions();
+    index_meta.clear_l2_version_merged();
+    ASSERT_FALSE(PersistentIndex::modify_l2_versions(input_l2_versions, input_l2_versions.back(), index_meta).ok());
 }
 
 INSTANTIATE_TEST_SUITE_P(PersistentIndexTest, PersistentIndexTest,


### PR DESCRIPTION
## Why I'm doing:
When Primary Index call `unload` because of full clone or something else, there could be a background index compaction task was still running. Here is a concurrency safe issue.

## What I'm doing:
1. Check if all input l2 has been removed. If not, that means index has been rebuilt, we need to abort this index compaction task,
2. Using `std::shared_ptr` instead of `std::unique_ptr`, so running index compaction task could finish safely.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
