### PR TITLE
[BugFix]collect chunk io when pageindex didn't filter any page

### DIFF
--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -173,7 +173,7 @@ void ScalarColumnReader::collect_column_io_range(std::vector<io::SharedBufferedI
     const auto& column = _opts.row_group_meta->columns[_field->physical_column_index];
     if (type == ColumnIOType::PAGES) {
         const tparquet::ColumnMetaData& column_metadata = column.meta_data;
-        if (_offset_index_ctx != nullptr) {
+        if (_offset_index_ctx != nullptr && !_offset_index_ctx->page_selected.empty()) {
             // add dict page
             if (column_metadata.__isset.dictionary_page_offset) {
                 auto r = io::SharedBufferedInputStream::IORange(

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -484,4 +484,88 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
     EXPECT_EQ(total_row_nums, 10000);
 }
 
+TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), true),
+                         chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), true),
+                         chunk->num_columns());
+    chunk->append_column(
+            ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR), true),
+            chunk->num_columns());
+
+    const std::string small_page_file = "./be/test/formats/parquet/test_data/page_index_small_page.parquet";
+
+    Utils::SlotDesc min_max_slots[] = {
+            {"c0", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), 0},
+            {"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), 1},
+            {""},
+    };
+
+    auto ctx = _create_file_c0_c1_c2_context(small_page_file);
+    auto file = _create_file(small_page_file);
+    ctx->conjunct_ctxs_by_slot[0].clear();
+    ctx->conjunct_ctxs_by_slot[1].clear();
+    ctx->min_max_conjunct_ctxs.clear();
+    ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
+
+    std::vector<TExpr> t_conjuncts;
+    // c0: 1->20000, c0 > 500
+    ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 0, 500, &t_conjuncts);
+    // c1: 20000->1, c1 > 500
+    ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 1, 500, &t_conjuncts);
+
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->min_max_conjunct_ctxs);
+
+    std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0]};
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0, &ctx->conjunct_ctxs_by_slot[0]);
+
+    std::vector<TExpr> t_conjuncts_slot1{t_conjuncts[1]};
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot1, &ctx->conjunct_ctxs_by_slot[1]);
+
+    auto shared_buffer = std::make_shared<io::SharedBufferedInputStream>(file->stream(), small_page_file,
+                                                                         std::filesystem::file_size(small_page_file));
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                         std::filesystem::file_size(small_page_file), 100000, shared_buffer.get());
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
+
+    // two row groups.
+    EXPECT_EQ(file_reader->_row_group_readers.size(), 2);
+    std::vector<io::SharedBufferedInputStream::IORange> ranges;
+    int64_t end_offset = 0;
+
+    for (auto& r : file_reader->_row_group_readers) {
+        r->collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGE_INDEX);
+    }
+
+    // collect io of column index and offset index for active column,
+    // and offset index for lazy column
+    // and two group collect together. (2 + 2 + 1) * 2 = 10
+    EXPECT_EQ(ranges.size(), 10);
+
+    ranges.clear();
+    end_offset = 0;
+
+    file_reader->_row_group_readers[0]->collect_io_ranges(&ranges, &end_offset);
+    // only collect io of 1 chunk / column.
+    // three columns, 1 * 3 = 3
+    EXPECT_EQ(ranges.size(), 3);
+
+    EXPECT_EQ(shared_buffer->current_range_ref_sum(), 13);
+
+    // The second row group is not prepare yet
+
+    size_t total_row_nums = 0;
+    while (!status.is_end_of_file()) {
+        chunk->reset();
+        status = file_reader->get_next(&chunk);
+        chunk->check_or_die();
+        total_row_nums += chunk->num_rows();
+    }
+    EXPECT_EQ(total_row_nums, 19000);
+}
+
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing:
when page index don't filter any range, we don't set offset_index_ctx's page selected info,
so we should collect io of all the chunk.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
