### PR TITLE
[Refactor] refactor getRemoteFiles into a async way

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
@@ -118,6 +118,9 @@ public class AsyncTaskQueue<T> {
                 // unless we try to fetch it.
                 if (taskException.get() != null || taskQueueSize.get() == 0) {
                     hasMoreOutput = false;
+                    if (taskException.get() != null) {
+                        throw new RuntimeException(taskException.get());
+                    }
                     return;
                 }
                 outputQueueCondition.await();
@@ -147,13 +150,12 @@ public class AsyncTaskQueue<T> {
             expectedSize = maxSize - outputs.size();
             triggerTasks();
         }
-        if (taskException.get() != null) {
-            throw new RuntimeException(taskException.get());
-        }
         return outputs;
     }
 
     public boolean hasMoreOutput() {
+        // update end of stream state
+        tryGetOutputs(null, 0);
         return hasMoreOutput;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
@@ -1,0 +1,265 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * AsyncTaskQueue is a class that manages and executes asynchronous tasks
+ * <p>
+ * The class uses an Executor to run tasks concurrently. It maintains two queues:
+ * - outputQueue: stores the results of completed tasks.
+ * - taskQueue: stores the tasks that need to be executed.
+ * <p>
+ * The class also keeps track of the number of currently running tasks using an AtomicInteger.
+ * It provides methods to start tasks, retrieve outputs, and handle task exceptions.
+ * <p>
+ * Make sure there is a single consumer.
+ */
+
+/*
+ * Here is a code example:
+ * AsyncTaskQueue<String> asyncTaskQueue = new AsyncTaskQueue<>(executorService);
+ * asyncTaskQueue.setMaxRunningTaskCount(maxRunningTaskCount);
+ * asyncTaskQueue.setMaxOutputQueueSize(maxOutputQueueSize);
+ * asyncTaskQueue.start(tasks);
+ * while(asyncTaskQueue.hasMoreOutput()) {
+ *     List values = asyncTaskQueue.getOutputs();
+ * }
+ */
+
+public class AsyncTaskQueue<T> {
+
+    public interface Task<T> {
+        List<T> run() throws InterruptedException;
+
+        default List<Task<T>> moreTasks() {
+            return null;
+        }
+
+        default boolean isDone() {
+            return true;
+        }
+    }
+
+    public AsyncTaskQueue(Executor executor) {
+        this.executor = executor;
+    }
+
+    // output queue
+    ReentrantLock outputQueueLock = new ReentrantLock();
+    Condition outputQueueCondition = outputQueueLock.newCondition();
+    ArrayList<T> outputQueue = new ArrayList<>();
+    AtomicInteger outputQueueSize = new AtomicInteger();
+    boolean hasMoreOutput = true;
+
+    // task queue
+    ConcurrentLinkedDeque<Task<T>> taskQueue = new ConcurrentLinkedDeque<>();
+    AtomicInteger runningTaskCount = new AtomicInteger(0);
+    AtomicInteger taskQueueSize = new AtomicInteger(0);
+    AtomicReference<Exception> taskException = new AtomicReference<>(null);
+
+    // ---------------
+    int maxRunningTaskCount = Integer.MAX_VALUE;
+    int maxOutputQueueSize = Integer.MAX_VALUE;
+    Executor executor;
+
+    public void setMaxRunningTaskCount(int maxRunningTaskCount) {
+        this.maxRunningTaskCount = maxRunningTaskCount;
+    }
+
+    public void setMaxOutputQueueSize(int maxOutputQueueSize) {
+        this.maxOutputQueueSize = maxOutputQueueSize;
+    }
+
+    public void start(List<? extends Task<T>> tasks) {
+        taskQueue.addAll(tasks);
+        taskQueueSize.addAndGet(tasks.size());
+        // or we have to trigger tasks?
+        triggerTask();
+    }
+
+    public int computeOutputSize(T output) {
+        return 1;
+    }
+
+    private void tryGetOutputs(List<T> outputs, int maxSize) {
+        if (!hasMoreOutput) {
+            return;
+        }
+        try {
+            outputQueueLock.lock();
+            while (true) {
+                if (!outputQueue.isEmpty()) {
+                    break;
+                }
+                // which means any update on those variables should be
+                // protected by this lock. we are not sure about if there is more output
+                // unless we try to fetch it.
+                if (taskException.get() != null || taskQueueSize.get() == 0) {
+                    hasMoreOutput = false;
+                    return;
+                }
+                outputQueueCondition.await();
+            }
+            while (maxSize > 0 && !outputQueue.isEmpty()) {
+                T output = outputQueue.remove(outputQueue.size() - 1);
+                outputs.add(output);
+                int size = computeOutputSize(output);
+                maxSize -= size;
+                outputQueueSize.addAndGet(-size);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            outputQueueLock.unlock();
+        }
+    }
+
+    public List<T> getOutputs(int maxSize) {
+        List<T> outputs = new ArrayList<>();
+        int expectedSize = maxSize;
+        while (expectedSize > 0) {
+            tryGetOutputs(outputs, expectedSize);
+            if (!hasMoreOutput) {
+                break;
+            }
+            expectedSize = maxSize - outputs.size();
+            triggerTasks();
+        }
+        if (taskException.get() != null) {
+            throw new RuntimeException(taskException.get());
+        }
+        return outputs;
+    }
+
+    public boolean hasMoreOutput() {
+        return hasMoreOutput;
+    }
+
+    private void addOutputs(List<T> outputs) {
+        try {
+            outputQueueLock.lock();
+            outputQueue.addAll(outputs);
+            int size = 0;
+            for (T output : outputs) {
+                size += computeOutputSize(output);
+            }
+            outputQueueSize.addAndGet(size);
+            outputQueueCondition.signal();
+        } finally {
+            outputQueueLock.unlock();
+        }
+    }
+
+    private void updateTaskException(Exception e) {
+        if (taskException.compareAndSet(null, e)) {
+            // notify consumer an exception caught.
+            addOutputs(List.of());
+        }
+    }
+
+    // trigger a single task.
+    private boolean triggerTask() {
+        // don't trigger task when:
+        // 1. output queue is pretty full
+        // 2. no task to run.
+        // 3. a lot of tasks are running.
+        if (outputQueueSize.get() > maxOutputQueueSize || taskQueueSize.get() == 0 ||
+                runningTaskCount.get() > maxRunningTaskCount) {
+            return false;
+        }
+        // trigger a new task
+        // 1. add running count first to see if ok
+        // 2. fetch task from queue, and check if ok
+        // 3. submit this task, and check if ok
+        // 4. if not ok, dec running count.
+        boolean success = false;
+        try {
+            int count = runningTaskCount.incrementAndGet();
+            if (count > maxRunningTaskCount) {
+                return false;
+            }
+            Task task = taskQueue.poll();
+            if (task == null) {
+                return false;
+            }
+            executor.execute(new RunnableTask(task));
+            success = true;
+            return true;
+        } catch (RejectedExecutionException e) {
+            updateTaskException(e);
+        } finally {
+            if (!success) {
+                runningTaskCount.decrementAndGet();
+            }
+        }
+        return false;
+    }
+
+    // trigger enough tasks.
+    private void triggerTasks() {
+        for (int i = 0; i < maxRunningTaskCount; i++) {
+            if (!triggerTask()) {
+                break;
+            }
+        }
+    }
+
+    private class RunnableTask implements Runnable {
+        Task task;
+
+        RunnableTask(Task task) {
+            this.task = task;
+        }
+
+        @Override
+        public void run() {
+            if (taskException.get() == null) {
+                // run it only when there is no exception.
+                try {
+                    List<T> outputs = task.run();
+                    addOutputs(outputs);
+                    List<Task<T>> moreTasks = task.moreTasks();
+                    if (moreTasks != null) {
+                        taskQueueSize.addAndGet(moreTasks.size());
+                        taskQueue.addAll(moreTasks);
+                    }
+                    if (!task.isDone()) {
+                        taskQueueSize.addAndGet(1);
+                        taskQueue.addFirst(task);
+                    }
+                } catch (Exception e) {
+                    updateTaskException(e);
+                }
+            }
+            runningTaskCount.decrementAndGet();
+            // all tasks are done, notify the consumer.
+            if (taskQueueSize.decrementAndGet() == 0) {
+                addOutputs(List.of());
+            } else {
+                triggerTask();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -174,6 +174,11 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
+        return normal.getRemoteFilesAsync(table, params);
+    }
+
+    @Override
     public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers, ConnectContext connectContext) {
         return normal.prepareMetadata(item, tracers, connectContext);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -151,11 +151,18 @@ public interface ConnectorMetadata {
      * There are two ways of current connector table.
      * 1. Get the remote files information from hdfs or s3 according to table or partition.
      * 2. Get file scan tasks for iceberg/deltalake metadata by query predicate.
+     * <p>
+     * There is an implicit contract here:
+     * the order of remote file information in the list, must be identical to order of partition keys in params.
      *
      * @return the remote file information of the query to scan.
      */
     default List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
         return Lists.newArrayList();
+    }
+
+    default RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
+        return RemoteFileInfoDefaultSource.EMPTY;
     }
 
     default List<PartitionInfo> getRemotePartitions(Table table, List<String> partitionNames) {
@@ -169,8 +176,7 @@ public interface ConnectorMetadata {
      * @param tableName
      * @param snapshotId
      * @param serializedPredicate serialized predicate string of lake format expression
-     * @param metadataTableType metadata table type
-     *
+     * @param metadataTableType   metadata table type
      * @return table meta serialized specification
      */
     default SerializedMetaSpec getSerializedMetaSpec(String dbName, String tableName, long snapshotId,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class GetRemoteFilesParams {
     private List<PartitionKey> partitionKeys;
     private List<String> partitionNames;
+    private List<Object> partitionAttachments;
     private TableVersionRange tableVersionRange;
     private ScalarOperator predicate;
     private List<String> fieldNames;
@@ -32,12 +33,27 @@ public class GetRemoteFilesParams {
     private GetRemoteFilesParams(Builder builder) {
         this.partitionKeys = builder.partitionKeys;
         this.partitionNames = builder.partitionNames;
+        this.partitionAttachments = builder.partitionAttachments;
         this.tableVersionRange = builder.tableVersionRange;
         this.predicate = builder.predicate;
         this.fieldNames = builder.fieldNames;
         this.limit = builder.limit;
         this.useCache = builder.useCache;
         this.checkPartitionExistence = builder.checkPartitionExistence;
+    }
+
+    public GetRemoteFilesParams copy() {
+        return GetRemoteFilesParams.newBuilder()
+                .setPartitionKeys(partitionKeys)
+                .setPartitionNames(partitionNames)
+                .setPartitionAttachments(partitionAttachments)
+                .setTableVersionRange(tableVersionRange)
+                .setPredicate(predicate)
+                .setFieldNames(fieldNames)
+                .setLimit(limit)
+                .setUseCache(useCache)
+                .setCheckPartitionExistence(checkPartitionExistence)
+                .build();
     }
 
     // Getters
@@ -47,6 +63,10 @@ public class GetRemoteFilesParams {
 
     public List<String> getPartitionNames() {
         return partitionNames;
+    }
+
+    public List<Object> getPartitionAttachments() {
+        return partitionAttachments;
     }
 
     public TableVersionRange getTableVersionRange() {
@@ -69,6 +89,10 @@ public class GetRemoteFilesParams {
         return useCache;
     }
 
+    public void setUseCache(boolean useCache) {
+        this.useCache = useCache;
+    }
+
     public boolean isCheckPartitionExistence() {
         return checkPartitionExistence;
     }
@@ -76,6 +100,7 @@ public class GetRemoteFilesParams {
     public static class Builder {
         private List<PartitionKey> partitionKeys;
         private List<String> partitionNames;
+        private List<Object> partitionAttachments;
         private TableVersionRange tableVersionRange;
         private ScalarOperator predicate;
         private List<String> fieldNames;
@@ -85,6 +110,11 @@ public class GetRemoteFilesParams {
 
         public Builder setPartitionKeys(List<PartitionKey> partitionKeys) {
             this.partitionKeys = partitionKeys;
+            return this;
+        }
+
+        public Builder setPartitionAttachments(List partitionAttachments) {
+            this.partitionAttachments = partitionAttachments;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfo.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import com.starrocks.connector.hive.RemoteFileInputFormat;
@@ -24,6 +23,8 @@ public class RemoteFileInfo {
     private RemoteFileInputFormat format;
     private List<RemoteFileDesc> files = new ArrayList<>();
     private String fullPath;
+
+    private Object attachment;
 
     public RemoteFileInfo(RemoteFileInputFormat format, List<RemoteFileDesc> files, String fullPath) {
         this.format = format;
@@ -52,6 +53,14 @@ public class RemoteFileInfo {
 
     public String getFullPath() {
         return fullPath;
+    }
+
+    public Object getAttachment() {
+        return attachment;
+    }
+
+    public void setAttachment(Object attachment) {
+        this.attachment = attachment;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfoDefaultSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfoDefaultSource.java
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import java.util.List;
+
+public class RemoteFileInfoDefaultSource implements RemoteFileInfoSource {
+    public static RemoteFileInfoDefaultSource EMPTY = new RemoteFileInfoDefaultSource(List.of());
+    private List<RemoteFileInfo> data;
+    private int index = 0;
+
+    public RemoteFileInfoDefaultSource(List<RemoteFileInfo> data) {
+        this.data = data;
+    }
+
+    @Override
+    public RemoteFileInfo getOutput() {
+        index += 1;
+        return data.get(index - 1);
+    }
+
+    @Override
+    public boolean hasMoreOutput() {
+        return index < data.size();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfoSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfoSource.java
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface RemoteFileInfoSource {
+    RemoteFileInfo getOutput();
+
+    boolean hasMoreOutput();
+
+    default List<RemoteFileInfo> getAllOutputs() {
+        List<RemoteFileInfo> res = new ArrayList<>();
+        while (hasMoreOutput()) {
+            res.add(getOutput());
+        }
+        return res;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -158,7 +158,6 @@ public class RemoteFileOperations {
         }
 
         class MyAsyncTaskQueue extends AsyncTaskQueue<RemoteFileInfo> implements RemoteFileInfoSource {
-
             public MyAsyncTaskQueue(Executor executor) {
                 super(executor);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -200,7 +200,7 @@ public class RemoteFileOperations {
         for (int i = 0; i < partitions.size(); i++) {
             final Partition partition = partitions.get(i);
             final RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive);
-            final Object attachment = (attachments != null) ? attachments.get(i): null;
+            final Object attachment = (attachments != null) ? attachments.get(i) : null;
             pathKey.setScanContext(scanContext);
             tasks.add(() -> {
                 Map<RemotePathKey, List<RemoteFileDesc>> res = remoteFileIO.getRemoteFiles(pathKey);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector;
 
+import com.starrocks.catalog.Table;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -26,12 +27,16 @@ import java.util.concurrent.locks.ReentrantLock;
   And in this context, we maintain fields can be shared and reused.
  */
 public class RemoteFileScanContext {
+    public RemoteFileScanContext(Table table) {
+        this.table = table;
+    }
+
+    public Table table = null;
     // ---- concurrent initialization -----
     public AtomicBoolean init = new AtomicBoolean(false);
     public ReentrantLock lock = new ReentrantLock();
 
     // ---- hudi related fields -----
-    public String hudiTableLocation = null;
     public HoodieTableFileSystemView hudiFsView = null;
     public HoodieTimeline hudiTimeline = null;
     public HoodieInstant hudiLastInstant = null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCacheUpdateProcessor.java
@@ -340,13 +340,12 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
     }
 
     public void invalidateTable(String dbName, String tableName, Table table) {
-        String tableLocation;
         if (table == null) {
-            LOG.warn("table [{}.{}] origin location is null", dbName, tableName);
+            LOG.warn("table [{}.{}] is null", dbName, tableName);
             try {
                 table = metastore.getTable(dbName, tableName);
             } catch (Exception e) {
-                LOG.error("Can't get table location from cache or hive metastore. ignore it");
+                LOG.error("Can't get table from cache or hive metastore. ignore it");
                 return;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCacheUpdateProcessor.java
@@ -16,7 +16,6 @@ package com.starrocks.connector.hive;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -99,7 +98,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
         if (table instanceof HiveMetaStoreTable) {
             HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
             metastore.refreshTable(hmsTbl.getDbName(), hmsTbl.getTableName(), onlyCachedPartitions);
-            refreshRemoteFiles(hmsTbl.getTableLocation(), Operator.UPDATE, getExistPaths(hmsTbl), onlyCachedPartitions);
+            refreshRemoteFiles(table, Operator.UPDATE, getExistPaths(hmsTbl), onlyCachedPartitions);
             if (isResourceMappingCatalog(catalogName) && table.isHiveTable()) {
                 processSchemaChange(dbName, (HiveTable) table);
             }
@@ -121,7 +120,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
                 List<String> updatedPaths = updatedPartitions.values().stream().map(Partition::getFullPath)
                         .map(path -> path.endsWith("/") ? path : path + "/")
                         .collect(Collectors.toList());
-                refreshRemoteFilesBackground(hmsTbl.getTableLocation(), updatedPaths, onlyCachedPartitions, executor);
+                refreshRemoteFilesBackground(table, updatedPaths, onlyCachedPartitions, executor);
 
                 LOG.info("{}.{}.{} partitions has updated, updated partition size is {}, " +
                                 "refresh partition and file success", hmsTbl.getCatalogName(), hmsTbl.getDbName(),
@@ -215,8 +214,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
             List<RemotePathKey> remotePathKeys = partitions.values().stream()
                     .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive))
                     .collect(Collectors.toList());
-            RemoteFileScanContext scanContext = new RemoteFileScanContext();
-            scanContext.hudiTableLocation = hmsTable.getTableLocation();
+            RemoteFileScanContext scanContext = new RemoteFileScanContext(table);
             remotePathKeys.forEach(path -> {
                 path.setScanContext(scanContext);
                 remoteFileIO.get().updateRemoteFiles(path);
@@ -245,13 +243,13 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
         }
     }
 
-    private void refreshRemoteFilesBackground(String tableLocation, List<String> updatePaths,
+    private void refreshRemoteFilesBackground(Table table, List<String> updatePaths,
                                               boolean onlyCachedPartitions, ExecutorService refreshExecutor) {
         if (remoteFileIO.isPresent()) {
             List<RemotePathKey> presentPathKey = updatePaths.stream().map(path -> RemotePathKey.of(path, isRecursive))
                     .collect(Collectors.toList());
             if (onlyCachedPartitions) {
-                List<RemotePathKey> cachedPathKey = remoteFileIO.get().getPresentPathKeyInCache(tableLocation,
+                List<RemotePathKey> cachedPathKey = remoteFileIO.get().getPresentPathKeyInCache(table.getTableLocation(),
                         isRecursive);
                 presentPathKey = cachedPathKey.stream().filter(pathKey -> {
                     String pathWithSlash = pathKey.getPath().endsWith("/") ? pathKey.getPath() : pathKey.getPath() + "/";
@@ -259,16 +257,16 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
                 }).collect(Collectors.toList());
             }
 
-            refreshRemoteFilesImpl(tableLocation, presentPathKey, Lists.newArrayList(), refreshExecutor);
+            refreshRemoteFilesImpl(table, presentPathKey, Lists.newArrayList(), refreshExecutor);
         }
     }
 
-    private void refreshRemoteFiles(String tableLocation, Operator operator, List<String> existPaths,
+    private void refreshRemoteFiles(Table table, Operator operator, List<String> existPaths,
                                     boolean onlyCachedPartitions) {
         if (remoteFileIO.isPresent()) {
             List<RemotePathKey> presentPathKey;
             if (onlyCachedPartitions) {
-                presentPathKey = remoteFileIO.get().getPresentPathKeyInCache(tableLocation, isRecursive);
+                presentPathKey = remoteFileIO.get().getPresentPathKeyInCache(table.getTableLocation(), isRecursive);
             } else {
                 presentPathKey = existPaths.stream()
                         .map(path -> RemotePathKey.of(path, isRecursive))
@@ -284,16 +282,15 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
                     invalidateKeys.add(pathKey);
                 }
             });
-            refreshRemoteFilesImpl(tableLocation, updateKeys, invalidateKeys, executor);
+            refreshRemoteFilesImpl(table, updateKeys, invalidateKeys, executor);
         }
     }
 
-    private void refreshRemoteFilesImpl(String tableLocation, List<RemotePathKey> updateKeys,
+    private void refreshRemoteFilesImpl(Table table, List<RemotePathKey> updateKeys,
                                         List<RemotePathKey> invalidateKeys,
                                         ExecutorService refreshExecutor) {
         Preconditions.checkArgument(remoteFileIO.isPresent());
-        RemoteFileScanContext scanContext = new RemoteFileScanContext();
-        scanContext.hudiTableLocation = tableLocation;
+        RemoteFileScanContext scanContext = new RemoteFileScanContext(table);
         List<Future<?>> futures = Lists.newArrayList();
         updateKeys.forEach(pathKey -> {
             pathKey.setScanContext(scanContext);
@@ -310,7 +307,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
             try {
                 future.get();
             } catch (InterruptedException | ExecutionException e) {
-                LOG.error("Failed to update remote files on [{}]", tableLocation, e);
+                LOG.error("Failed to update remote files on [{}]", table.getTableLocation(), e);
                 throw new StarRocksConnectorException("Failed to update remote files", e);
             }
         }
@@ -326,7 +323,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
 
     public void refreshTableByEvent(HiveTable updatedHiveTable, HiveCommonStats commonStats, Partition partition) {
         ((CachingHiveMetastore) metastore).refreshTableByEvent(updatedHiveTable, commonStats, partition);
-        refreshRemoteFiles(updatedHiveTable.getTableLocation(), Operator.UPDATE, getExistPaths(updatedHiveTable), true);
+        refreshRemoteFiles(updatedHiveTable, Operator.UPDATE, getExistPaths(updatedHiveTable), true);
     }
 
     public void refreshPartitionByEvent(HivePartitionName hivePartitionName, HiveCommonStats commonStats, Partition partion) {
@@ -342,14 +339,12 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
         remoteFileIO.ifPresent(CachingRemoteFileIO::invalidateAll);
     }
 
-    public void invalidateTable(String dbName, String tableName, String originLocation) {
+    public void invalidateTable(String dbName, String tableName, Table table) {
         String tableLocation;
-        if (!Strings.isNullOrEmpty(originLocation)) {
-            tableLocation = originLocation;
-        } else {
+        if (table == null) {
             LOG.warn("table [{}.{}] origin location is null", dbName, tableName);
             try {
-                tableLocation = ((HiveMetaStoreTable) metastore.getTable(dbName, tableName)).getTableLocation();
+                table = metastore.getTable(dbName, tableName);
             } catch (Exception e) {
                 LOG.error("Can't get table location from cache or hive metastore. ignore it");
                 return;
@@ -359,7 +354,7 @@ public class HiveCacheUpdateProcessor implements CacheUpdateProcessor {
         metastore.invalidateTable(dbName, tableName);
 
         if (remoteFileIO.isPresent()) {
-            refreshRemoteFiles(tableLocation, Operator.DROP, Lists.newArrayList(), true);
+            refreshRemoteFiles(table, Operator.DROP, Lists.newArrayList(), true);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -165,11 +165,12 @@ public class HiveMetadata implements ConnectorMetadata {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         if (isResourceMappingCatalog(catalogName)) {
-            HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) GlobalStateMgr.getCurrentState()
+            Table table = GlobalStateMgr.getCurrentState()
                     .getMetadata().getTable(dbName, tableName);
+            HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
             if (hmsTable != null) {
                 cacheUpdateProcessor.ifPresent(processor -> processor.invalidateTable(
-                        hmsTable.getDbName(), hmsTable.getTableName(), hmsTable.getTableLocation()));
+                        hmsTable.getDbName(), hmsTable.getTableName(), table));
             }
         } else {
             HiveTable hiveTable = (HiveTable) getTable(dbName, tableName);
@@ -261,7 +262,9 @@ public class HiveMetadata implements ConnectorMetadata {
             useCache = false;
         }
 
-        return fileOps.getRemoteFiles(partitions.build(), RemoteFileOperations.Options.toUseCache(useCache));
+        GetRemoteFilesParams updatedParams = params.copy();
+        updatedParams.setUseCache(useCache);
+        return fileOps.getRemoteFiles(table, partitions.build(), updatedParams);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStatisticsProvider.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
@@ -146,9 +147,8 @@ public class HiveStatisticsProvider {
                 Lists.newArrayList(hmsOps.getPartition(hmsTbl.getDbName(), hmsTbl.getTableName(), Lists.newArrayList())) :
                 Lists.newArrayList(hmsOps.getPartitionByPartitionKeys(table, partitionKeys).values());
 
-        List<RemoteFileInfo> remoteFileInfos = fileOps.getRemoteFileInfoForStats(partitions,
-                RemoteFileOperations.Options.toUseHudiTableLocation(hmsTbl.getTableLocation()));
-
+        List<RemoteFileInfo> remoteFileInfos =
+                fileOps.getRemoteFileInfoForStats(table, partitions, GetRemoteFilesParams.newBuilder().build());
         long totalBytes = 0;
         for (RemoteFileInfo remoteFileInfo : remoteFileInfos) {
             for (RemoteFileDesc fileDesc : remoteFileInfo.getFiles()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -27,6 +27,7 @@ import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -135,8 +136,7 @@ public class HudiMetadata implements ConnectorMetadata {
         return hmsOps.tableExists(dbName, tblName);
     }
 
-    @Override
-    public List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
+    private List<Partition> buildGetRemoteFilesPartitions(Table table, GetRemoteFilesParams params) {
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
 
@@ -166,8 +166,19 @@ public class HudiMetadata implements ConnectorMetadata {
                 }
             }
         }
+        return partitions.build();
+    }
 
-        return fileOps.getRemoteFiles(table, partitions.build(), params);
+    @Override
+    public List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
+        List<Partition> partitions = buildGetRemoteFilesPartitions(table, params);
+        return fileOps.getRemoteFiles(table, partitions, params);
+    }
+
+    @Override
+    public RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
+        List<Partition> partitions = buildGetRemoteFilesPartitions(table, params);
+        return fileOps.getRemoteFilesAsync(table, partitions, params);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -167,8 +167,7 @@ public class HudiMetadata implements ConnectorMetadata {
             }
         }
 
-        return fileOps.getRemoteFiles(partitions.build(),
-                RemoteFileOperations.Options.toUseHudiTableLocation(hmsTbl.getTableLocation()));
+        return fileOps.getRemoteFiles(table, partitions.build(), params);
     }
 
     @Override
@@ -222,11 +221,12 @@ public class HudiMetadata implements ConnectorMetadata {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         if (isResourceMappingCatalog(catalogName)) {
-            HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) GlobalStateMgr.getCurrentState()
+            Table table = GlobalStateMgr.getCurrentState()
                     .getMetadata().getTable(dbName, tableName);
+            HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
             if (hmsTable != null) {
                 cacheUpdateProcessor.ifPresent(processor -> processor.invalidateTable(
-                        hmsTable.getDbName(), hmsTable.getTableName(), hmsTable.getTableLocation()));
+                        hmsTable.getDbName(), hmsTable.getTableName(), table));
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -69,7 +69,7 @@ public class HudiRemoteFileIO implements RemoteFileIO {
             HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(configuration);
             HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
             HoodieTableMetaClient metaClient =
-                    HoodieTableMetaClient.builder().setConf(configuration).setBasePath(ctx.hudiTableLocation).build();
+                    HoodieTableMetaClient.builder().setConf(configuration).setBasePath(ctx.table.getTableLocation()).build();
             // metaClient.reloadActiveTimeline();
             HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
             Option<HoodieInstant> lastInstant = timeline.lastInstant();
@@ -87,7 +87,7 @@ public class HudiRemoteFileIO implements RemoteFileIO {
     @Override
     public Map<RemotePathKey, List<RemoteFileDesc>> getRemoteFiles(RemotePathKey pathKey) {
         RemoteFileScanContext scanContext = pathKey.getScanContext();
-        String tableLocation = scanContext.hudiTableLocation;
+        String tableLocation = scanContext.table.getTableLocation();
         if (tableLocation == null) {
             throw new StarRocksConnectorException("Missing hudi table base location on %s", pathKey);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.SerializedMetaSpec;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.hive.HiveMetadata;
@@ -170,6 +171,12 @@ public class UnifiedMetadata implements ConnectorMetadata {
     public List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
         ConnectorMetadata metadata = metadataOfTable(table);
         return metadata.getRemoteFiles(table, params);
+    }
+
+    @Override
+    public RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
+        ConnectorMetadata metadata = metadataOfTable(table);
+        return metadata.getRemoteFilesAsync(table, params);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -778,6 +778,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // regexp predicate is less efficient than like predicates.
     public static final String LIKE_PREDICATE_CONSOLIDATE_MIN = "like_predicate_consolidate_min";
 
+    public static final String CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE = "connector_remote_file_async_queue_size";
+    public static final String CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE = "connector_remote_file_async_task_size";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1074,7 +1077,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Add a global shuffle between the connector sink fragment and its child fragment.
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
-
 
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
@@ -2109,6 +2111,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_PREDICATE_MOVE_AROUND)
     private boolean enablePredicateMoveAround = true;
 
+    @VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE, flag = VariableMgr.INVISIBLE)
+    private int connectorRemoteFileAsyncQueueSize = 1000;
+
+    @VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE, flag = VariableMgr.INVISIBLE)
+    private int connectorRemoteFileAsyncTaskSize = 4;
+
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
                         StringUtils.upperCase(chooseExecuteInstancesMode))
@@ -2215,6 +2223,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public int getPhasedSchedulerMaxConcurrency() {
         return phasedSchedulerMaxConcurrency;
     }
+
     public void setPhasedSchedulerMaxConcurrency(int phasedSchedulerMaxConcurrency) {
         this.phasedSchedulerMaxConcurrency = phasedSchedulerMaxConcurrency;
     }
@@ -2222,6 +2231,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean enablePhasedScheduler() {
         return enablePhasedScheduler;
     }
+
     public void setEnablePhasedScheduler(boolean enablePhasedScheduler) {
         this.enablePhasedScheduler = enablePhasedScheduler;
     }
@@ -2425,7 +2435,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
         SessionVariableConstants.ComputationFragmentSchedulingPolicy result =
                 Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
-                                   StringUtils.upperCase(computationFragmentSchedulingPolicy)).orNull();
+                        StringUtils.upperCase(computationFragmentSchedulingPolicy)).orNull();
         if (result == null) {
             String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ComputationFragmentSchedulingPolicy.values());
             throw new IllegalArgumentException("Legal values of computation_fragment_scheduling_policy are " + legalValues);
@@ -2435,7 +2445,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public SessionVariableConstants.ComputationFragmentSchedulingPolicy getComputationFragmentSchedulingPolicy() {
         return Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
-                StringUtils.upperCase(computationFragmentSchedulingPolicy))
+                        StringUtils.upperCase(computationFragmentSchedulingPolicy))
                 .or(SessionVariableConstants.ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY);
     }
 
@@ -4072,6 +4082,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCustomQueryId(String customQueryId) {
         this.customQueryId = customQueryId;
+    }
+
+    public int getConnectorRemoteFileAsyncQueueSize() {
+        return connectorRemoteFileAsyncQueueSize;
+    }
+
+    public int getConnectorRemoteFileAsyncTaskSize() {
+        return connectorRemoteFileAsyncTaskSize;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -54,6 +54,8 @@ import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.SerializedMetaSpec;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -792,6 +794,19 @@ public class MetadataMgr {
             }
         }
         return new ArrayList<>();
+    }
+
+    public RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
+        if (connectorMetadata.isPresent()) {
+            try {
+                return connectorMetadata.get().getRemoteFilesAsync(table, params);
+            } catch (Exception e) {
+                LOG.error("Failed to list remote file's metadata on catalog [{}], table [{}]", table.getCatalogName(), table, e);
+                throw e;
+            }
+        }
+        return RemoteFileInfoDefaultSource.EMPTY;
     }
 
     public List<PartitionInfo> getPartitions(String catalogName, Table table, List<String> partitionNames) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/AsyncTaskQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/AsyncTaskQueueTest.java
@@ -1,0 +1,129 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class AsyncTaskQueueTest {
+
+    public void runTest(ExecutorService executorService, int maxRunningTaskCount, int maxOutputQueueSize, int taskSize,
+                        int bufferSize,
+                        boolean throwException) {
+        int repeatNumber = 3;
+        int outputNumber = 20;
+        class MyTask implements AsyncTaskQueue.Task<String> {
+            int idx;
+            String name;
+            int repeat = repeatNumber;
+
+            public MyTask(int idx, String name) {
+                this.idx = idx;
+                this.name = name;
+            }
+
+            @Override
+            public List<String> run() throws InterruptedException {
+                repeat -= 1;
+                // Thread.sleep((taskSize - idx) * 10);
+                ArrayList<String> outputs = new ArrayList<>();
+                for (int i = 0; i < outputNumber; i++) {
+                    outputs.add(String.format("%s-%02d", name, i));
+                }
+                if (throwException && (idx == (taskSize - 1)) && repeat == 0) {
+                    throw new RuntimeException("");
+                }
+                return outputs;
+            }
+
+            @Override
+            public boolean isDone() {
+                return repeat == 0;
+            }
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        }
+
+        class MyAsyncTaskQueue extends AsyncTaskQueue<String> {
+
+            public MyAsyncTaskQueue(Executor executor) {
+                super(executor);
+            }
+
+            @Override
+            public int computeOutputSize(String output) {
+                return output.length();
+            }
+        }
+        AsyncTaskQueue<String> asyncTaskQueue = new MyAsyncTaskQueue(executorService);
+        asyncTaskQueue.setMaxRunningTaskCount(maxRunningTaskCount);
+        asyncTaskQueue.setMaxOutputQueueSize(maxOutputQueueSize);
+        List<MyTask> tasks = new ArrayList<>();
+        for (int i = 0; i < taskSize; i++) {
+            tasks.add(new MyTask(i, "mytask" + i));
+        }
+        asyncTaskQueue.start(tasks);
+        // int threads, int maxRunningTaskCount, int maxOutputQueueSize, int taskSize, int bufferSize
+        System.out.printf("a = %d, b = %d, c = %d, d= %d, e = %s\n", maxRunningTaskCount,
+                maxOutputQueueSize,
+                taskSize, bufferSize, throwException);
+        try {
+            List<String> ans = new ArrayList<>();
+            while (asyncTaskQueue.hasMoreOutput()) {
+                List<String> outputs = asyncTaskQueue.getOutputs(bufferSize);
+                ans.addAll(outputs);
+            }
+            Assert.assertEquals(repeatNumber * outputNumber * taskSize, ans.size());
+            Assert.assertTrue(!throwException);
+        } catch (Exception e) {
+            Assert.assertTrue(throwException);
+        }
+    }
+
+    @Test
+    public void testGenerateString() {
+        ExecutorService executorService =
+                Executors.newFixedThreadPool(4,
+                        new ThreadFactoryBuilder().setNameFormat("pull-hive-remote-files-%d").build());
+        for (int maxRunningTaskCount = 2; maxRunningTaskCount <= 8; maxRunningTaskCount += 2) {
+            for (int maxOutputQueueSize = 10; maxOutputQueueSize <= 40; maxOutputQueueSize += 10) {
+                for (int taskSize = 2; taskSize <= 8; taskSize += 2) {
+                    for (int bufferSize = 10; bufferSize <= 40; bufferSize += 10) {
+                        runTest(executorService, maxRunningTaskCount, maxOutputQueueSize, taskSize, bufferSize, false);
+                        runTest(executorService, maxRunningTaskCount, maxOutputQueueSize, taskSize, bufferSize, true);
+                    }
+                }
+            }
+        }
+        executorService.shutdown();
+    }
+
+    // @Test
+    public void stressTest() {
+        for (int i = 0; i < 1000; i++) {
+            testGenerateString();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -73,7 +73,7 @@ public class RemoteFileOperationsTest {
         Map<String, Partition> partitions = metastore.getPartitionsByNames("db1", "table1", partitionNames);
 
         List<RemoteFileInfo> remoteFileInfos =
-                ops.getRemoteFiles(Lists.newArrayList(partitions.values()), RemoteFileOperations.Options.DEFAULT);
+                ops.getRemoteFiles(null, Lists.newArrayList(partitions.values()), GetRemoteFilesParams.newBuilder().build());
         Assert.assertEquals(2, remoteFileInfos.size());
         Assert.assertTrue(remoteFileInfos.get(0).toString().contains("emoteFileInfo{format=ORC, files=["));
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileOperations;
@@ -186,7 +187,7 @@ public class HiveStatisticsProviderTest {
 
         List<String> partitionNames = Lists.newArrayList("col1=1", "col1=2");
         Map<String, Partition> partitions = metastore.getPartitionsByNames("db1", "table1", partitionNames);
-        fileOps.getRemoteFiles(Lists.newArrayList(partitions.values()), RemoteFileOperations.Options.DEFAULT);
+        fileOps.getRemoteFiles(hiveTable, Lists.newArrayList(partitions.values()), GetRemoteFilesParams.newBuilder().build());
         PartitionKey hivePartitionKey1 = PartitionUtil.createPartitionKey(
                 Lists.newArrayList("1"), hiveTable.getPartitionColumns());
         PartitionKey hivePartitionKey2 = PartitionUtil.createPartitionKey(


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- add `getRemoteFIlesAsync` returns `RemoteFileInfoSource` instead of list files
- by using `RemoteFileInfoSource`, you can fetch remote files in a incremental way
- `RemoteFileInfoDefaultSource` to be compatible with old way.

Fixes #issue

------------------

This is design arch of this `AsyncTaskQueue`  
- You can specify a) how large the output queue size is b)  how many tasks are running simultaneously. But they are all soft limits.
- Task will generate outputs, and output will be put into the output queue.
- A single consumer will fetch outputs from this output queue.

![image](https://github.com/user-attachments/assets/a1c8338a-0b25-4d9c-817a-1b4c2925ca4f)

and the way to use it is
- `start` is to put tasks into task queue, and will trigger a task to be scheduled
- `hasMoreOutput` is to tell if there is more output to be fetched
- `getOutputs(maxSize)` is to fetch `maxSize` outputs from output queue

```
 AsyncTaskQueue<String> asyncTaskQueue = new AsyncTaskQueue<>(executorService);
 asyncTaskQueue.setMaxRunningTaskCount(maxRunningTaskCount);
 asyncTaskQueue.setMaxOutputQueueSize(maxOutputQueueSize);
 asyncTaskQueue.start(tasks);
 while(asyncTaskQueue.hasMoreOutput()) {
     List values = asyncTaskQueue.getOutputs(10);
  }
```

The model works as following:
- `getOutputs` will get outputs from output queue. but also trigger tasks
-  tasks will put outputs into output queue. and if it's finished, it will try to trigger another task.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
