### PR TITLE
[BugFix] Fix plan and alter concurrent issue

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -315,7 +315,7 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
     int64_t leaf_size = 0;
     for (const auto& path : *paths) {
         auto& root = path->path();
-        int32_t index = _tablet->field_index_with_max_version(root);
+        int32_t index = _tablet_schema->field_index(root);
         auto field = schema->get_field_by_name(root);
         if (index >= 0 && field != nullptr) {
             auto res = path->convert_by_index(field.get(), index);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -431,6 +431,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 {
 
     private void onFinished(Database db, OlapTable targetTable) throws AlterCancelException {
         try {
+            targetTable.setState(OlapTableState.UPDATING_META);
             if (allPartitionOptimized && optimizeClause.getDistributionDesc() != null) {
                 this.distributionInfo = optimizeClause.getDistributionDesc().toDistributionInfo(targetTable.getColumns());
                 targetTable.setDefaultDistributionInfo(distributionInfo);
@@ -657,6 +658,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 {
         this.allPartitionOptimized = replayedJob.allPartitionOptimized;
         this.optimizeOperation = replayedJob.optimizeOperation;
 
+        targetTable.setState(OlapTableState.UPDATING_META);
         Set<Tablet> sourceTablets = Sets.newHashSet();
         for (long id : replayedJob.getTmpPartitionIds()) {
             Partition partition = targetTable.getPartition(id);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2775,7 +2775,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             // for now table's state can only be NORMAL
-            Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL, olapTable.getState().name());
+            Preconditions.checkState(olapTable.getState() == OlapTableState.UPDATING_META, olapTable.getState().name());
             SchemaChangeJobV2 schemaChangeJob = new SchemaChangeJobV2(jobId, db.getId(), olapTable.getId(),
                     olapTable.getName(), 1000);
             // update base index schema

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2768,14 +2768,14 @@ public class SchemaChangeHandler extends AlterHandler {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.WRITE);
         try {
-            olapTable.setState(OlapTableState.UPDATING_META);
             LOG.debug("indexSchemaMap:{}, indexes:{}", indexSchemaMap, indexes);
             if (olapTable.getState() == OlapTableState.ROLLUP) {
                 throw new DdlException("Table[" + olapTable.getName() + "] is doing ROLLUP job");
             }
 
             // for now table's state can only be NORMAL
-            Preconditions.checkState(olapTable.getState() == OlapTableState.UPDATING_META, olapTable.getState().name());
+            Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL, olapTable.getState().name());
+            olapTable.setState(OlapTableState.UPDATING_META);
             SchemaChangeJobV2 schemaChangeJob = new SchemaChangeJobV2(jobId, db.getId(), olapTable.getId(),
                     olapTable.getName(), 1000);
             // update base index schema

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2768,6 +2768,7 @@ public class SchemaChangeHandler extends AlterHandler {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.WRITE);
         try {
+            olapTable.setState(OlapTableState.UPDATING_META);
             LOG.debug("indexSchemaMap:{}, indexes:{}", indexSchemaMap, indexes);
             if (olapTable.getState() == OlapTableState.ROLLUP) {
                 throw new DdlException("Table[" + olapTable.getName() + "] is doing ROLLUP job");
@@ -2845,6 +2846,7 @@ public class SchemaChangeHandler extends AlterHandler {
             LOG.info("finished modify table's add or drop column(field). table: {}, is replay: {}", olapTable.getName(),
                     isReplay);
         } finally {
+            olapTable.setState(OlapTableState.NORMAL);
             locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.WRITE);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -835,6 +835,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     }
 
     private void onFinished(OlapTable tbl) {
+        tbl.setState(OlapTableState.UPDATING_META);
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         // 
         // partition visible version won't update in schema change, so we need make global

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -178,7 +178,13 @@ public class OlapTable extends Table {
          * doing alter operation.
          * This state is an in-memory state and no need to persist.
          */
-        WAITING_STABLE
+        WAITING_STABLE,
+        /* This state means table is updating table meta during alter operation(SCHEMA_CHANGE
+         * or ROLLUP).
+         * The query plan which is generate during this state is invalid because the meta
+         * during the creation of the logical plan and the physical plan might be inconsistent. 
+        */
+        UPDATING_META
     }
 
     @SerializedName(value = "state")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/OptimisticVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/OptimisticVersion.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql;
 
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.OlapTable.OlapTableState;
 
 /**
  * Generate a monotonic version for optimistic lock.
@@ -36,6 +37,6 @@ public class OptimisticVersion {
      */
     public static boolean validateTableUpdate(OlapTable olapTable, long candidateVersion) {
         long schemaUpdate = olapTable.lastSchemaUpdateTime.get();
-        return schemaUpdate < candidateVersion;
+        return olapTable.getState() != OlapTableState.UPDATING_META && schemaUpdate < candidateVersion;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -348,8 +348,8 @@ public class StatementPlanner {
                 updatedTables.clear();
                 int idx = 0;
                 for (OlapTable tbl : olapTables) {
-                    if (tablesLastSchemaUpdateTime.get(idx) != tbl.lastSchemaUpdateTime.get() ||
-                            tbl.getState() == OlapTableState.UPDATING_META) {
+                    if (tbl.getState() == OlapTableState.UPDATING_META || 
+                            tablesLastSchemaUpdateTime.get(idx) != tbl.lastSchemaUpdateTime.get()) {
                         isSchemaValid = false;
                         updatedTables.add(tbl.getName());
                         break;


### PR DESCRIPTION
## Why I'm doing:
Alter operation will modify table meta under db lock, and when alter operation and query are concurrent, if query is not hold the lock, we will check `lastSchemaUpdateTime` to make sure there are no alter operation during create query plan. However, using `lastSchemaUpdateTime` is not enough, the following is one case:
1. start to create logic plan at time t1.
2. start to alter table at time t2
3. modify table meta at time t3, but alter is not finished totally
4. start to create physical plan at time t4
5. create plan finished at time t5
6. alter operation finished at t6
7. t1 < t2 < t3 < t4 < t5 < t6

Because the modify table meta is not an atomic operation and we only update `lastSchemaUpdateTime` after alter operation is finished. So the meta of logic plan and physical plan maybe inconsistent.

## What I'm doing:
1. Add a new state `UPDATING_META`. When we start to modify table meta, the table state will be set as `UPDATING_META`
2. We will check the table state after creating exec plan. If the table state is UPDATING_META, we consider this plan is invalid
3. Keep the first `lastSchemaUpdateTime` before release lock. Because alter operation maybe finished during analyze and creating exec plan.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8244

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
