### PR TITLE
[BugFix] Fix incorrect compaction status show in JSON format

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3283,7 +3283,7 @@ void TabletUpdates::get_compaction_status(std::string* json_result) {
     rapidjson::Value last_version_value;
     std::string last_version_str =
             strings::Substitute("$0_$1", last_version.major_number(), last_version.minor_number());
-    rowsets_count.SetString(last_version_str.c_str(), last_version_str.size(), root.GetAllocator());
+    last_version_value.SetString(last_version_str.c_str(), last_version_str.size(), root.GetAllocator());
     root.AddMember("last_version", last_version_value, root.GetAllocator());
 
     rapidjson::Document rowset_details;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1201,7 +1201,7 @@ TEST_F(TabletUpdatesTest, compaction_score_enough_normal) {
 }
 
 // NOLINTNEXTLINE
-void TabletUpdatesTest::test_horizontal_compaction(bool enable_persistent_index) {
+void TabletUpdatesTest::test_horizontal_compaction(bool enable_persistent_index, bool show_status) {
     auto orig = config::vertical_compaction_max_columns_per_group;
     config::vertical_compaction_max_columns_per_group = 5;
     DeferOp unset_config([&] { config::vertical_compaction_max_columns_per_group = orig; });
@@ -1234,6 +1234,12 @@ void TabletUpdatesTest::test_horizontal_compaction(bool enable_persistent_index)
     // the time interval is not enough after last compaction
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
     EXPECT_TRUE(best_tablet->verify().ok());
+
+    if (show_status) {
+        std::string json_result;
+        best_tablet->updates()->get_compaction_status(&json_result);
+        EXPECT_TRUE(json_result.find("\"last_version\": \"4_1\"") != std::string::npos);
+    }
 }
 
 // NOLINTNEXTLINE
@@ -3702,6 +3708,10 @@ TEST_F(TabletUpdatesTest, test_compaction_apply_retry) {
     _tablet->updates()->reset_error();
     _tablet->updates()->check_for_apply();
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+TEST_F(TabletUpdatesTest, test_get_compaction_status) {
+    test_horizontal_compaction(false, true);
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -793,7 +793,7 @@ public:
     void test_compaction_score_not_enough(bool enable_persistent_index);
     void test_compaction_score_enough_duplicate(bool enable_persistent_index);
     void test_compaction_score_enough_normal(bool enable_persistent_index);
-    void test_horizontal_compaction(bool enable_persistent_index);
+    void test_horizontal_compaction(bool enable_persistent_index, bool show_status = false);
     void test_vertical_compaction(bool enable_persistent_index);
     void test_horizontal_compaction_with_rows_mapper(bool enable_persistent_index);
     void test_vertical_compaction_with_rows_mapper(bool enable_persistent_index);


### PR DESCRIPTION
Currently, compaction status for primary key table will always return `NULL`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
