### PR TITLE
[Refactor] make hashjoiner use predeclarations

### DIFF
--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -32,7 +32,6 @@ class ExprContext;
 class ColumnRef;
 class RuntimeFilterBuildDescriptor;
 
-static constexpr size_t kHashJoinKeyColumnOffset = 1;
 class HashJoinNode final : public ExecNode {
 public:
     HashJoinNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -18,6 +18,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "exec/mor_processor.h"
+#include "exec/pipeline/scan/morsel.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/runtime_filter_bank.h"

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/mor_processor.h"
 
+#include "exec/hash_joiner.h"
+
 namespace starrocks {
 
 Status IcebergMORProcessor::init(RuntimeState* runtime_state, const MORParams& params) {

--- a/be/src/exec/mor_processor.h
+++ b/be/src/exec/mor_processor.h
@@ -16,7 +16,7 @@
 
 #include <atomic>
 
-#include "exec/hash_joiner.h"
+#include "exec/pipeline/hashjoin/hash_joiner_fwd.h"
 #include "exprs/expr_context.h"
 #include "runtime/descriptors.h"
 #include "util/runtime_profile.h"

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -22,6 +22,7 @@
 #include "exec/cross_join_node.h"
 #include "exec/exchange_node.h"
 #include "exec/exec_node.h"
+#include "exec/hash_join_node.h"
 #include "exec/multi_olap_table_sink.h"
 #include "exec/olap_scan_node.h"
 #include "exec/pipeline/adaptive/event.h"

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -17,11 +17,14 @@
 #include <numeric>
 #include <utility>
 
+#include "exec/hash_joiner.h"
+#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
 #include "exec/pipeline/query_context.h"
 #include "exprs/runtime_filter_bank.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_filter_worker.h"
 #include "util/race_detect.h"
+
 namespace starrocks::pipeline {
 
 HashJoinBuildOperator::HashJoinBuildOperator(OperatorFactory* factory, int32_t id, const string& name,
@@ -165,6 +168,10 @@ Status HashJoinBuildOperator::set_finishing(RuntimeState* state) {
     _join_builder->enter_probe_phase();
 
     return Status::OK();
+}
+
+bool HashJoinBuildOperator::is_finished() const {
+    return _is_finished || _join_builder->is_finished();
 }
 
 HashJoinBuildOperatorFactory::HashJoinBuildOperatorFactory(

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -18,12 +18,13 @@
 
 #include <atomic>
 
-#include "exec/hash_joiner.h"
-#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
+#include "exec/pipeline/hashjoin/hash_joiner_fwd.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_fwd.h"
+#include "exec/pipeline/spill_process_channel.h"
 #include "exprs/expr.h"
 #include "runtime/descriptors.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 
@@ -48,7 +49,7 @@ public:
     bool need_input() const override { return !is_finished(); }
 
     Status set_finishing(RuntimeState* state) override;
-    bool is_finished() const override { return _is_finished || _join_builder->is_finished(); }
+    bool is_finished() const override;
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/pipeline/hashjoin/hash_join_probe_operator.h"
 
+#include "exec/hash_joiner.h"
+#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
 #include "runtime/current_thread.h"
 
 namespace starrocks::pipeline {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -14,8 +14,7 @@
 
 #pragma once
 
-#include "exec/hash_joiner.h"
-#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
+#include "exec/pipeline/hashjoin/hash_joiner_fwd.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/operator_with_dependency.h"
 #include "exec/pipeline/pipeline_fwd.h"

--- a/be/src/exec/pipeline/hashjoin/hash_joiner_fwd.h
+++ b/be/src/exec/pipeline/hashjoin/hash_joiner_fwd.h
@@ -1,0 +1,30 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace starrocks {
+static inline constexpr size_t kHashJoinKeyColumnOffset = 1;
+class HashJoiner;
+class JoinHashTable;
+using HashJoinerPtr = std::shared_ptr<HashJoiner>;
+
+namespace pipeline {
+class HashJoinerFactory;
+using HashJoinerFactoryPtr = std::shared_ptr<HashJoinerFactory>;
+} // namespace pipeline
+
+} // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -21,8 +21,9 @@
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exec/hash_join_node.h"
-#include "exec/join_hash_map.h"
+#include "exec/hash_joiner.h"
 #include "exec/pipeline/hashjoin/hash_join_build_operator.h"
+#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/spill/options.h"
 #include "exec/spill/spiller.h"
@@ -222,6 +223,14 @@ void SpillableHashJoinBuildOperator::set_execute_mode(int performance_level) {
     if (!_is_finished) {
         _join_builder->set_spill_strategy(spill::SpillStrategy::SPILL_ALL);
     }
+}
+
+void SpillableHashJoinBuildOperator::set_spill_strategy(spill::SpillStrategy strategy) {
+    _join_builder->set_spill_strategy(strategy);
+}
+
+spill::SpillStrategy SpillableHashJoinBuildOperator::spill_strategy() const {
+    return _join_builder->spill_strategy();
 }
 
 std::function<StatusOr<ChunkPtr>()> SpillableHashJoinBuildOperator::_convert_hash_map_to_chunk() {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -21,6 +21,7 @@
 
 #include "column/vectorized_fwd.h"
 #include "exec/pipeline/hashjoin/hash_join_build_operator.h"
+#include "exec/pipeline/hashjoin/hash_joiner_fwd.h"
 #include "exec/spill/spiller.h"
 #include "exprs/expr_context.h"
 
@@ -52,8 +53,8 @@ public:
     size_t estimated_memory_reserved() override;
 
 private:
-    void set_spill_strategy(spill::SpillStrategy strategy) { _join_builder->set_spill_strategy(strategy); }
-    spill::SpillStrategy spill_strategy() const { return _join_builder->spill_strategy(); }
+    void set_spill_strategy(spill::SpillStrategy strategy);
+    spill::SpillStrategy spill_strategy() const;
 
     std::function<StatusOr<ChunkPtr>()> _convert_hash_map_to_chunk();
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -22,8 +22,8 @@
 
 #include "common/config.h"
 #include "exec/hash_joiner.h"
-#include "exec/join_hash_map.h"
 #include "exec/pipeline/hashjoin/hash_join_probe_operator.h"
+#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/spill/executor.h"
 #include "exec/spill/partition.h"
@@ -456,6 +456,10 @@ StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* stat
     }
 
     return nullptr;
+}
+
+bool SpillableHashJoinProbeOperator::spilled() const {
+    return _join_builder->spiller()->spilled();
 }
 
 void SpillableHashJoinProbeOperator::_acquire_next_partitions() {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -17,7 +17,6 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -26,6 +25,8 @@
 #include "exec/hash_join_components.h"
 #include "exec/pipeline/hashjoin/hash_join_probe_operator.h"
 #include "exec/spill/partition.h"
+#include "exec/spill/spill_components.h"
+#include "exec/spill/spiller_factory.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
 
@@ -79,7 +80,7 @@ public:
     void set_probe_spiller(std::shared_ptr<spill::Spiller> spiller) { _probe_spiller = std::move(spiller); }
 
 private:
-    bool spilled() const { return _join_builder->spiller()->spilled(); }
+    bool spilled() const;
 
     SpillableHashJoinProbeOperator* as_mutable() const { return const_cast<SpillableHashJoinProbeOperator*>(this); }
 

--- a/be/src/exec/pipeline/pipeline_fwd.h
+++ b/be/src/exec/pipeline/pipeline_fwd.h
@@ -50,4 +50,9 @@ class DriverExecutor;
 using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
 class GlobalDriverExecutor;
 class ExecStateReporter;
+class PipelineBuilderContext;
 } // namespace starrocks::pipeline
+
+namespace starrocks {
+using OperatorFactoryPtr = pipeline::OpFactoryPtr;
+}

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -18,7 +18,7 @@
 #include <utility>
 
 #include "common/statusor.h"
-#include "exec/hash_join_node.h"
+#include "exec/pipeline/hashjoin/hash_joiner_fwd.h"
 #include "exprs/expr_context.h"
 #include "exprs/predicate.h"
 #include "exprs/runtime_filter_bank.h"

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/source_operator.h"
 #include "exec/query_cache/cache_operator.h"
 #include "exec/query_cache/lane_arbiter.h"

--- a/be/src/exec/query_cache/multilane_operator.h
+++ b/be/src/exec/query_cache/multilane_operator.h
@@ -21,6 +21,7 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "exec/pipeline/operator.h"
+#include "exec/pipeline/pipeline_fwd.h"
 #include "exec/query_cache/lane_arbiter.h"
 #include "runtime/runtime_state.h"
 

--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -14,7 +14,15 @@
 
 #include "table_function_table_sink.h"
 
+#include "common/logging.h"
+#include "connector/file_chunk_sink.h"
+#include "connector/hive_chunk_sink.h"
+#include "exec/data_sink.h"
+#include "exec/hdfs_scanner_text.h"
+#include "exec/pipeline/sink/connector_sink_operator.h"
 #include "exprs/expr.h"
+#include "formats/column_evaluator.h"
+#include "formats/csv/csv_file_writer.h"
 #include "glog/logging.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"

--- a/be/src/runtime/table_function_table_sink.h
+++ b/be/src/runtime/table_function_table_sink.h
@@ -14,14 +14,7 @@
 
 #pragma once
 
-#include "common/logging.h"
-#include "connector/file_chunk_sink.h"
-#include "connector/hive_chunk_sink.h"
 #include "exec/data_sink.h"
-#include "exec/hdfs_scanner_text.h"
-#include "exec/pipeline/sink/connector_sink_operator.h"
-#include "formats/column_evaluator.h"
-#include "formats/csv/csv_file_writer.h"
 
 namespace starrocks {
 


### PR DESCRIPTION
## Why I'm doing:

1. Avoid runtime filters that rely on hash_join_node.h. This will cause all operators to rely on hash_join related code.
2. Use predeclaration for hash_joiners.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
