### PR TITLE
[BugFix] Fix lake table upgrade downgrade

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -47,7 +47,8 @@ Rowset::Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int
           _index(rowset_index),
           _tablet_metadata(std::move(tablet_metadata)) {
     auto rowset_id = _tablet_metadata->rowsets(rowset_index).id();
-    if (_tablet_metadata->rowset_to_schema().empty()) {
+    if (_tablet_metadata->rowset_to_schema().empty() ||
+        _tablet_metadata->rowset_to_schema().find(rowset_id) == _tablet_metadata->rowset_to_schema().end()) {
         _tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
     } else {
         auto schema_id = _tablet_metadata->rowset_to_schema().at(rowset_id);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -608,8 +608,6 @@ StatusOr<TabletSchemaPtr> TabletManager::get_output_rowset_schema(std::vector<ui
         } else {
             return Status::InternalError(fmt::format("can not find output rowset schema, id {}", rowset_it->second));
         }
-    } else {
-        return Status::InternalError(fmt::format("input rowset {} not exist in rowset_to_schema", input_id));
     }
     return tablet_schema;
 }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -154,6 +154,7 @@ public:
             RETURN_IF_ERROR(_index_entry->value().commit(_metadata, &_builder));
             _tablet.update_mgr()->index_cache().update_object_size(_index_entry, _index_entry->value().memory_usage());
         }
+        _metadata->GetReflection()->MutableUnknownFields(_metadata.get())->Clear();
         RETURN_IF_ERROR(_builder.finalize(_max_txn_id));
         _has_finalized = true;
         return Status::OK();
@@ -365,6 +366,7 @@ public:
     }
 
     Status finish() override {
+        _metadata->GetReflection()->MutableUnknownFields(_metadata.get())->Clear();
         _metadata->set_version(_new_version);
         return _tablet.put_metadata(_metadata);
     }


### PR DESCRIPTION
## Why I'm doing:
We add new field `rowset_to_schema` into `TableMetadataPB` to support add/drop field for struct column. However, when we downgrade to old version and ingestion some data. The new generated `TableMetadataPB` will also keep the old `rowset_to_schema` content but not update it because protobuf will save these unknown field. So when we upgrade to new version again, we will read the old `rowset_to_schema`.

## What I'm doing:
1. If we don't find rowset id in `rowset_to_schema`, set the latest schema as rowset schema.
2. Clear unknown PB before save TableMetaPB

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
