### PR TITLE
[BugFix] Fix subpartitions with tablet pruing bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1112,6 +1112,9 @@ public class OlapScanNode extends ScanNode {
         return selectedIndexId;
     }
 
+    /**
+     * Get partition id -> tablets map, note that the partition id is unrolled partition id which may be subpartition id.
+     */
     public Map<Long, List<Long>> getPartitionToScanTabletMap() {
         return partitionToScanTabletMap;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -837,19 +837,28 @@ public class PlanFragmentBuilder {
                             .getBackendIdByHost(FrontendOptions.getLocalHostAddress());
                 }
 
-                List<Long> selectedNonEmptyPartitionIds = node.getSelectedPartitionId().stream().filter(p -> {
-                    List<Long> selectTabletIds = scanNode.getPartitionToScanTabletMap().get(p);
-                    return selectTabletIds != null && !selectTabletIds.isEmpty();
-                }).collect(Collectors.toList());
-                scanNode.setSelectedPartitionIds(selectedNonEmptyPartitionIds);
-
+                // Filter out empty partitions from all selected partitions, original selected partition ids may be
+                // only parent partition ids if table contains subpartitions, use the real sub partition ids instead.
+                // eg:
+                // partition        : 10001 -> (tablet_1)
+                //  subpartition1   : 10002 -> (tablet_2)
+                //  subpartition2   : 10004 -> (tablet_3)
+                // original selected partition id with tablet ids: 10001 -> (tablet_2)
+                // after:
+                // selected partition ids   : 10002
+                // selected tablet ids      : tablet_2
+                // total tablets num        : 1
+                List<Long> selectedNonEmptyPartitionIds = Lists.newArrayList();
                 for (Long partitionId : scanNode.getSelectedPartitionIds()) {
                     final Partition partition = referenceTable.getPartition(partitionId);
-
                     for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                        Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
                         List<Long> selectTabletIds = scanNode.getPartitionToScanTabletMap()
                                 .get(physicalPartition.getId());
+                        if (CollectionUtils.isEmpty(selectTabletIds)) {
+                            continue;
+                        }
+                        selectedNonEmptyPartitionIds.add(physicalPartition.getId());
+                        Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
                         Preconditions.checkState(selectTabletIds != null && !selectTabletIds.isEmpty());
                         final MaterializedIndex selectedTable = physicalPartition.getIndex(selectedIndexId);
                         List<Long> allTabletIds = selectedTable.getTabletIdsInOrder();
@@ -863,6 +872,7 @@ public class PlanFragmentBuilder {
                         scanNode.addScanRangeLocations(partition, physicalPartition, selectedTable, tablets, localBeId);
                     }
                 }
+                scanNode.setSelectedPartitionIds(selectedNonEmptyPartitionIds);
                 scanNode.setTotalTabletsNum(totalTabletsNum);
             } catch (UserException e) {
                 throw new StarRocksPlannerException(

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2091,3 +2091,21 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         tools.assert_true(res["status"], "show schema change task error")
         ans = res["result"]
         tools.assert_true(len(ans) == expect_num, "The number of partitions is %s" % len(ans))
+
+    def wait_table_rowcount_not_empty(self, table, time_out=300):
+        times = 0
+        rc = 0
+        sql = 'show partitions from ' + table
+        while times < time_out and times < time_out:
+            result = self.execute_sql(sql, True)
+            log.info(sql)
+            log.info(result)
+            if len(result["result"]) > 0:
+                rc = int(result["result"][0][-4])
+                log.info(rc)
+                if rc > 0:
+                    break
+            time.sleep(1)
+            times += 1
+        tools.assert_true(rc > 0, "wait row count > 0 error, timeout 300s")
+

--- a/test/sql/test_random_distribution/R/test_random_distribution_tablet_prune
+++ b/test/sql/test_random_distribution/R/test_random_distribution_tablet_prune
@@ -1,0 +1,32 @@
+-- name: test_random_distribution_tablet_prune @slow
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+DISTRIBUTED BY RANDOM 
+PROPERTIES(
+	'bucket_size' = '100'
+);
+-- result:
+-- !result
+insert into t1 select generate_series, "2020-06-18" from table(generate_series(1, 100));
+-- result:
+-- !result
+insert into t1 select generate_series, "2020-06-18" from table(generate_series(1, 100));
+-- result:
+-- !result
+insert into t1 select generate_series, "2020-06-18" from table(generate_series(1, 100));
+-- result:
+-- !result
+function: wait_table_rowcount_not_empty("t1")
+-- result:
+None
+-- !result
+select count(*) from t1 limit 1;
+-- result:
+300
+-- !result
+select * from t1 limit 1;
+-- result:
+1	2020-06-18
+-- !result

--- a/test/sql/test_random_distribution/T/test_random_distribution_tablet_prune
+++ b/test/sql/test_random_distribution/T/test_random_distribution_tablet_prune
@@ -1,0 +1,19 @@
+-- name: test_random_distribution_tablet_prune @slow
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+DISTRIBUTED BY RANDOM 
+PROPERTIES(
+	'bucket_size' = '100'
+);
+
+insert into t1 select generate_series, "2020-06-18" from table(generate_series(1, 100));
+insert into t1 select generate_series, "2020-06-18" from table(generate_series(1, 100));
+insert into t1 select generate_series, "2020-06-18" from table(generate_series(1, 100));
+
+-- wait until row counts are updated
+function: wait_table_rowcount_not_empty("t1")
+
+select count(*) from t1 limit 1;
+select * from t1 limit 1;


### PR DESCRIPTION
## Why I'm doing:
- Table with subpartitions may return empty after `LimitPruneTabletsRule` rule.

```
mysql> select count(1) from t1;
+-----------+
| count(1)  |
+-----------+
| 109396015 |
+-----------+
1 row in set (0.36 sec)

mysql> select * from t1 limit 1;
Empty set (0.25 sec)
```


Bad plan:
```
mysql> explain verbose select * from t1 limit 1;

|   0:OlapScanNode                                                                                                                                                                                                        |
|      table: t1, rollup: t1                                                                                                                                                                              |
|      preAggregation: on                                                                                                                                                                                                 |
|      dict_col=type                                                                                                                                                                                                      |
|      partitionsRatio=1/1, tabletsRatio=1/0           <-                                                                                                                                                                   |
|      tabletList=12023                                                                                                                                                                                                   |
|      actualRows=0, avgRowSize=323.28174                                                                                                                                                                                 |
|      limit: 1                                                                                                                                                                                                           |
|      cardinality: 1                                                                                                                                                                                                     |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
33 rows in set (0.24 sec)


```
## What I'm doing:
- Filter out empty partitions from all selected partitions, original selected partition ids may be only parent partition ids if table contains subpartitions, use the real sub partition ids instead.
```
                // Filter out empty partitions from all selected partitions, original selected partition ids may be
                // only parent partition ids if table contains subpartitions, use the real sub partition ids instead.
                // eg:
                // partition        : 10001 -> (tablet_1)
                //  subpartition1   : 10002 -> (tablet_2)
                //  subpartition2   : 10004 -> (tablet_3)
                // original selected partition id with tablet ids: 10001 -> (tablet_2)
                // after:
                // selected partition ids   : 10002
                // selected tablet ids      : tablet_1
                // total tablets num        : 1
                List<Long> selectedNonEmptyPartitionIds = Lists.newArrayList();
```

After:
```
|   0:OlapScanNode                           |
|      table: t1, rollup: t1                 |
|      preAggregation: on                    |
|      partitionsRatio=1/1, tabletsRatio=1/1 |
|      tabletList=23033                      |
|      actualRows=100, avgRowSize=2.0        |
|      limit: 1                              |
|      cardinality: 1                        |
+--------------------------------------------+
32 rows in set (0.01 sec)


```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
