### PR TITLE
[BugFix] Fix mv rewrite with avg function and having exprs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -859,11 +859,15 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         }
         // Copy group by keys as projection
         aggregationOperator.getGroupingKeys().forEach(c -> newProjection.put(c, c));
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(newProjection);
         // Copy original projection mappings.
         if (aggregationOperator.getProjection() != null) {
-            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(newProjection);
             aggregationOperator.getProjection().getColumnRefMap().forEach((k, v) ->
                     newProjection.put(k, rewriter.rewrite(v)));
+        }
+        ScalarOperator newPredicate = null;
+        if (aggregationOperator.getPredicate() != null) {
+            newPredicate = rewriter.rewrite(aggregationOperator.getPredicate());
         }
 
         // Make a new logical agg with new projections.
@@ -873,6 +877,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                 .setGroupingKeys(aggregationOperator.getGroupingKeys())
                 .setAggregations(newColumnRefToAggFuncMap)
                 .setProjection(new Projection(newProjection))
+                .setPredicate(newPredicate)
                 .build();
 
         return newAggOp;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
@@ -762,4 +762,41 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
         }
         connectContext.getSessionVariable().setEnableMaterializedViewRewritePartitionCompensate(true);
     }
+
+    @Test
+    public void testMVRewriteWithHaving() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `test_pt` (\n" +
+                "  `id` int(11) NULL,\n" +
+                "  `pt` date NOT NULL,\n" +
+                "  `gmv` int(11) NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`id`)\n" +
+                "PARTITION BY date_trunc('day', pt)\n" +
+                "DISTRIBUTED BY HASH(`pt`)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        executeInsertSql(connectContext, "insert into test_pt values(2,'2023-03-07',10), (2,'2023-03-08',10), (2," +
+                "'2023-03-11',10);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_pt_mv4` \n" +
+                        "PARTITION BY (`pt`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH ASYNC START(\"2024-03-08 03:00:00\") EVERY(INTERVAL 1 DAY)\n" +
+                        "PROPERTIES (\n" +
+                        "\"partition_refresh_number\" = \"1\"\n" +
+                        ")\n" +
+                        "AS SELECT `pt`, `id`, sum(gmv) AS `sum_gmv`, count(gmv) AS `count_gmv`\n" +
+                        "FROM `test`.`test_pt`\n" +
+                        "GROUP BY `pt`, `id`;",
+                () -> {
+                    String plan = getFragmentPlan("select pt, avg(gmv) as a from test_pt group by pt having a>0;");
+                    PlanTestBase.assertContains(plan, "     TABLE: test_pt_mv4\n" +
+                            "     PREAGGREGATION: ON\n" +
+                            "     partitions=0/0");
+                    PlanTestBase.assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                            "  |  output: sum(7: sum_gmv), sum(8: count_gmv)\n" +
+                            "  |  group by: 5: pt\n" +
+                            "  |  having: CAST(11: sum AS DOUBLE) / CAST(12: count AS DOUBLE) > 0.0");
+                });
+    }
 }

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg_part1
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg_part1
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_iceberg_part1
+-- name: test_mv_partition_compensate_iceberg_part1 @slow
 create external catalog mv_iceberg_${uuid0}
 properties
 (

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg_part2
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg_part2
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_iceberg_part2
+-- name: test_mv_partition_compensate_iceberg_part2 @slow
 create external catalog mv_iceberg_${uuid0}
 properties
 (

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_mysql
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_mysql
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_mysql
+-- name: test_mv_partition_compensate_mysql @slow
 shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
 -- result:
 0

--- a/test/sql/test_materialized_view/R/test_mv_rewrite_with_agg
+++ b/test/sql/test_materialized_view/R/test_mv_rewrite_with_agg
@@ -34,11 +34,11 @@ GROUP BY `pt`, `id`;
 -- result:
 -- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt';", "test_mv1")
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt;", "test_mv1")
 -- result:
 True
 -- !result
-function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt having a>0;';", "test_mv1")
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt having a>0;", "test_mv1")
 -- result:
 True
 -- !result
@@ -48,7 +48,7 @@ select pt,avg(gmv) as a from t1 group by pt order by 1;
 2023-03-08	3.0
 2023-03-11	10.0
 -- !result
-select pt,avg(gmv) as a from t1 group by pt having a>5.0 order by 1; 
+select pt,avg(gmv) as a from t1 group by pt having a>5.0 order by 1;
 -- result:
 2023-03-11	10.0
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_rewrite_with_agg
+++ b/test/sql/test_materialized_view/R/test_mv_rewrite_with_agg
@@ -1,0 +1,54 @@
+-- name: test_mv_rewrite_with_agg
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `id` int(11) NULL,
+  `pt` date NOT NULL,
+  `gmv` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+PARTITION BY date_trunc('day', pt)
+DISTRIBUTED BY HASH(`pt`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 values(2,'2023-03-07',1), (2,'2023-03-08',3), (2,'2023-03-11',10);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `test_mv1` 
+PARTITION BY (`pt`)
+DISTRIBUTED BY RANDOM
+REFRESH DEFERRED ASYNC START("2024-03-08 03:00:00") EVERY(INTERVAL 1 DAY)
+PROPERTIES (
+"partition_refresh_number" = "1"
+)
+AS SELECT `pt`, `id`, sum(gmv) AS `sum_gmv`, count(gmv) AS `count_gmv`
+FROM `t1`
+GROUP BY `pt`, `id`;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt';", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt having a>0;';", "test_mv1")
+-- result:
+True
+-- !result
+select pt,avg(gmv) as a from t1 group by pt order by 1;
+-- result:
+2023-03-07	1.0
+2023-03-08	3.0
+2023-03-11	10.0
+-- !result
+select pt,avg(gmv) as a from t1 group by pt having a>5.0 order by 1; 
+-- result:
+2023-03-11	10.0
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg_part1
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg_part1
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_iceberg_part1
+-- name: test_mv_partition_compensate_iceberg_part1 @slow
 create external catalog mv_iceberg_${uuid0}
 properties
 (

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg_part2
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg_part2
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_iceberg_part2
+-- name: test_mv_partition_compensate_iceberg_part2 @slow
 create external catalog mv_iceberg_${uuid0}
 properties
 (

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_mysql
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_mysql
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_mysql
+-- name: test_mv_partition_compensate_mysql @slow
 -- create mysql table
 shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
 shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t1 (num int, dt date) PARTITION BY range columns(dt) (PARTITION p20200614 VALUES LESS THAN ("2020-06-15"),PARTITION p20200617 VALUES LESS THAN ("2020-06-18"),PARTITION p20200620 VALUES LESS THAN ("2020-06-21"),PARTITION p20200623 VALUES LESS THAN ("2020-06-24"),PARTITION p20200701 VALUES LESS THAN ("2020-07-02"),PARTITION p20200704 VALUES LESS THAN ("2020-07-05"),PARTITION p20200707 VALUES LESS THAN ("2020-07-08"),PARTITION p20200710 VALUES LESS THAN ("2020-07-11"),PARTITION p20200715 VALUES LESS THAN ("2020-07-16"),PARTITION p20200718 VALUES LESS THAN ("2020-07-19"),PARTITION p20200721 VALUES LESS THAN ("2020-07-22"),PARTITION p20200724 VALUES LESS THAN ("2020-07-31"));'

--- a/test/sql/test_materialized_view/T/test_mv_rewrite_with_agg
+++ b/test/sql/test_materialized_view/T/test_mv_rewrite_with_agg
@@ -27,7 +27,7 @@ FROM `t1`
 GROUP BY `pt`, `id`;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 
-function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt';", "test_mv1")
-function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt having a>0;';", "test_mv1")
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt;", "test_mv1")
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt having a>0;", "test_mv1")
 select pt,avg(gmv) as a from t1 group by pt order by 1;
-select pt,avg(gmv) as a from t1 group by pt having a>5.0 order by 1; 
+select pt,avg(gmv) as a from t1 group by pt having a>5.0 order by 1;

--- a/test/sql/test_materialized_view/T/test_mv_rewrite_with_agg
+++ b/test/sql/test_materialized_view/T/test_mv_rewrite_with_agg
@@ -1,0 +1,33 @@
+-- name: test_mv_rewrite_with_agg
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE `t1` (
+  `id` int(11) NULL,
+  `pt` date NOT NULL,
+  `gmv` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+PARTITION BY date_trunc('day', pt)
+DISTRIBUTED BY HASH(`pt`)
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t1 values(2,'2023-03-07',1), (2,'2023-03-08',3), (2,'2023-03-11',10);
+
+
+CREATE MATERIALIZED VIEW `test_mv1` 
+PARTITION BY (`pt`)
+DISTRIBUTED BY RANDOM
+REFRESH DEFERRED ASYNC START("2024-03-08 03:00:00") EVERY(INTERVAL 1 DAY)
+PROPERTIES (
+"partition_refresh_number" = "1"
+)
+AS SELECT `pt`, `id`, sum(gmv) AS `sum_gmv`, count(gmv) AS `count_gmv`
+FROM `t1`
+GROUP BY `pt`, `id`;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt';", "test_mv1")
+function: print_hit_materialized_view("select pt,avg(gmv) as a from t1 group by pt having a>0;';", "test_mv1")
+select pt,avg(gmv) as a from t1 group by pt order by 1;
+select pt,avg(gmv) as a from t1 group by pt having a>5.0 order by 1; 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger_and_nested_mvs
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger_and_nested_mvs
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_event_trigger_and_nested_mvs
+-- name: test_mv_refresh_with_event_trigger_and_nested_mvs @slow
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger_and_nested_mvs
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger_and_nested_mvs
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_event_trigger_and_nested_mvs
+-- name: test_mv_refresh_with_event_trigger_and_nested_mvs @slow
 
 create database db_${uuid0};
 use db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

```
CREATE MATERIALIZED VIEW `test_pt_mv4` 
PARTITION BY (`pt`)
DISTRIBUTED BY RANDOM
REFRESH ASYNC START("2024-03-08 03:00:00") EVERY(INTERVAL 1 DAY)
PROPERTIES (
"partition_refresh_number" = "1"
)
AS SELECT `pt`, `id`, sum(gmv) AS `sum_gmv`, count(gmv) AS `count_gmv`
FROM `test`.`test_pt`
GROUP BY `pt`, `id`;


explain select pt,avg(gmv) as a from test_pt group by pt having a>0; 
ERROR: only found column statistics: {5: pt, 14: sum, 15: count}, but missing statistic of 
```
## What I'm doing:
- Fix mv rewrite with avg function and having exprs(ignore having exprs before)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
