### PR TITLE
[Enhancement][FlatJson] opitmize flat json compaction performance

### DIFF
--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -193,22 +193,23 @@ StatusOr<std::unique_ptr<ColumnAccessPath>> ColumnAccessPath::create(const TColu
 }
 
 StatusOr<std::unique_ptr<ColumnAccessPath>> ColumnAccessPath::create(const TAccessPathType::type& type,
-                                                                     const std::string& path, uint32_t index) {
+                                                                     const std::string& path, uint32_t index,
+                                                                     const std::string& prefix) {
     auto p = std::make_unique<ColumnAccessPath>();
     p->_type = type;
     p->_path = path;
     p->_column_index = index;
-    p->_absolute_path = path;
+    if (prefix != "") {
+        p->_absolute_path = prefix + "." + path;
+    } else {
+        p->_absolute_path = path;
+    }
     p->_value_type = TypeDescriptor(LogicalType::TYPE_JSON);
     p->_children.clear();
     return std::move(p);
 }
 
-ColumnAccessPath* insert_json_path_impl(const std::string& path, ColumnAccessPath* root) {
-    if (path.empty()) {
-        return root;
-    }
-
+std::pair<std::string, std::string> _split_path(const std::string& path) {
     size_t pos = 0;
     if (path.starts_with("\"")) {
         pos = path.find('\"', 1);
@@ -224,9 +225,18 @@ ColumnAccessPath* insert_json_path_impl(const std::string& path, ColumnAccessPat
         next = path.substr(pos + 1);
     }
 
+    return {key, next};
+}
+
+ColumnAccessPath* insert_json_path_impl(const std::string& path, ColumnAccessPath* root) {
+    if (path.empty()) {
+        return root;
+    }
+
+    auto [key, next] = _split_path(path);
     auto child = root->get_child(key);
     if (child == nullptr) {
-        auto n = ColumnAccessPath::create(TAccessPathType::FIELD, key, 0);
+        auto n = ColumnAccessPath::create(TAccessPathType::FIELD, key, 0, root->absolute_path());
         DCHECK(n.ok());
         root->children().emplace_back(std::move(n.value()));
         child = root->children().back().get();
@@ -238,7 +248,7 @@ void ColumnAccessPath::insert_json_path(ColumnAccessPath* root, LogicalType type
     auto leaf = insert_json_path_impl(path, root);
     leaf->_type = TAccessPathType::type::FIELD;
     leaf->_column_index = 0;
-    leaf->_absolute_path = path;
+    leaf->_absolute_path = root->absolute_path() + "." + path;
     leaf->_value_type = TypeDescriptor(type);
 }
 

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -46,11 +46,11 @@ public:
     Status init(const std::string& parent_path, const TColumnAccessPath& column_path, RuntimeState* state,
                 ObjectPool* pool);
 
-    // for test
     static StatusOr<std::unique_ptr<ColumnAccessPath>> create(const TAccessPathType::type& type,
-                                                              const std::string& path, uint32_t index);
+                                                              const std::string& path, uint32_t index,
+                                                              const std::string& prefix = "");
+    // the path doesn't contains root
     static void insert_json_path(ColumnAccessPath* root, LogicalType type, const std::string& path);
-    // end test
 
     const std::string& path() const { return _path; }
 
@@ -59,6 +59,10 @@ public:
     const std::vector<std::unique_ptr<ColumnAccessPath>>& children() const { return _children; }
 
     std::vector<std::unique_ptr<ColumnAccessPath>>& children() { return _children; }
+
+    void set_from_compaction(bool from_compaction) { _from_compaction = from_compaction; }
+
+    bool is_from_compaction() const { return _from_compaction; }
 
     bool is_key() const { return _type == TAccessPathType::type::KEY; }
 
@@ -104,6 +108,8 @@ private:
     uint32_t _column_index;
 
     bool _from_predicate;
+
+    bool _from_compaction = false;
 
     // the data type of the subfield
     TypeDescriptor _value_type;

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -476,10 +476,12 @@ std::string JsonColumn::debug_flat_paths() const {
     }
     std::ostringstream ss;
     ss << "[";
-    for (size_t i = 0; i < _flat_column_paths.size() - 1; i++) {
-        ss << _flat_column_paths[i] << ", ";
+    size_t i = 0;
+    for (; i < _flat_column_paths.size() - 1; i++) {
+        ss << _flat_column_paths[i] << "(" << type_to_string(_flat_column_types[i]) << "), ";
     }
-    ss << _flat_column_paths.back() << "]";
+    ss << _flat_column_paths[i] << "(" << type_to_string(_flat_column_types[i]) << ")";
+    ss << (has_remain() ? "]" : "}");
     return ss.str();
 }
 } // namespace starrocks

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1324,8 +1324,11 @@ CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
 // json flat flag
 CONF_mBool(enable_json_flat, "true");
 
-// extract flat json column when row_num * null_factor < null_row_num
-CONF_mDouble(json_flat_null_factor, "0.4");
+// enable compaction is base on flat json, not whole json
+CONF_mBool(enable_compaction_flat_json, "true");
+
+// extract flat json column when row_num * null_factor > null_row_num
+CONF_mDouble(json_flat_null_factor, "0.3");
 
 // extract flat json column when row_num * sparsity_factor < hit_row_num
 CONF_mDouble(json_flat_sparsity_factor, "0.9");

--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -167,6 +167,7 @@ Status Compaction::_merge_rowsets_horizontally(size_t segment_iterator_num, Stat
     TabletReaderParams reader_params;
     reader_params.reader_type = compaction_type();
     reader_params.profile = _runtime_profile.create_child("merge_rowsets");
+    reader_params.column_access_paths = &_column_access_paths;
 
     int64_t total_num_rows = 0;
     int64_t total_mem_footprint = 0;
@@ -253,6 +254,7 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
         TabletReaderParams reader_params;
         reader_params.reader_type = compaction_type();
         reader_params.profile = _runtime_profile.create_child("merge_rowsets");
+        reader_params.column_access_paths = &_column_access_paths;
 
         int64_t total_num_rows = 0;
         int64_t total_mem_footprint = 0;

--- a/be/src/storage/compaction.h
+++ b/be/src/storage/compaction.h
@@ -86,6 +86,8 @@ protected:
     Version _output_version;
 
     RuntimeProfile _runtime_profile;
+    // for flat json used
+    std::vector<std::unique_ptr<ColumnAccessPath>> _column_access_paths;
 
 private:
     // merge rows from vectorized reader and write into `_output_rs_writer`.

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -14,10 +14,12 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <sstream>
 #include <vector>
 
+#include "column/column_access_path.h"
 #include "storage/background_task.h"
 #include "storage/compaction_utils.h"
 #include "storage/olap_common.h"
@@ -309,6 +311,8 @@ protected:
     std::shared_lock<std::shared_mutex> _compaction_lock;
     MonotonicStopWatch _watch;
     MemTracker* _mem_tracker{nullptr};
+    // for flat json used
+    std::vector<std::unique_ptr<ColumnAccessPath>> _column_access_paths;
 };
 
 } // namespace starrocks

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -71,6 +71,7 @@ Status HorizontalCompactionTask::_horizontal_compact_data(Statistics* statistics
     reader_params.reader_type =
             compaction_type() == BASE_COMPACTION ? READER_BASE_COMPACTION : READER_CUMULATIVE_COMPACTION;
     reader_params.profile = _runtime_profile.create_child("merge_rowsets");
+    reader_params.column_access_paths = &_column_access_paths;
 
     int32_t chunk_size = CompactionUtils::get_read_chunk_size(
             config::compaction_memory_limit_per_worker, config::vector_chunk_size, _task_info.input_rows_num,

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <ostream>
 
+#include "column/column_access_path.h"
 #include "common/status.h"
 #include "compaction_task_context.h"
 #include "runtime/mem_tracker.h"
@@ -55,6 +56,8 @@ protected:
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
     CompactionTaskContext* _context;
     std::shared_ptr<const TabletSchema> _tablet_schema;
+    // for flat json used
+    std::vector<std::unique_ptr<ColumnAccessPath>> _column_access_paths;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -51,6 +51,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     reader_params.profile = nullptr;
     reader_params.use_page_cache = false;
     reader_params.lake_io_opts = {false, config::lake_compaction_stream_buffer_size_bytes};
+    reader_params.column_access_paths = &_column_access_paths;
     RETURN_IF_ERROR(reader.open(reader_params));
 
     ASSIGN_OR_RETURN(auto writer,

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -38,6 +38,7 @@
 #include "storage/tablet_schema_map.h"
 #include "storage/types.h"
 #include "storage/union_iterator.h"
+#include "util/json_flattener.h"
 
 namespace starrocks::lake {
 
@@ -106,6 +107,7 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         read_params.reader_type != ReaderType::READER_ALTER_TABLE && !is_compaction(read_params.reader_type)) {
         return Status::NotSupported("reader type not supported now");
     }
+    RETURN_IF_ERROR(init_compaction_column_paths(read_params));
 
     if (_need_split) {
         std::vector<BaseTabletSharedPtr> tablets;
@@ -175,6 +177,64 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         return init_collector(read_params);
     }
 
+    return Status::OK();
+}
+
+Status TabletReader::init_compaction_column_paths(const TabletReaderParams& read_params) {
+    if (!config::enable_compaction_flat_json || !is_compaction(read_params.reader_type) ||
+        read_params.column_access_paths == nullptr) {
+        return Status::OK();
+    }
+
+    if (!read_params.column_access_paths->empty()) {
+        VLOG(3) << "Lake Compaction flat json paths exists: " << read_params.column_access_paths->size();
+        return Status::OK();
+    }
+
+    DCHECK(is_compaction(read_params.reader_type) && read_params.column_access_paths != nullptr &&
+           read_params.column_access_paths->empty());
+    int num_readers = 0;
+    for (const auto& rowset : _rowsets) {
+        auto segments = rowset->get_segments();
+        std::for_each(segments.begin(), segments.end(),
+                      [&](const auto& segment) { num_readers += segment->num_rows() > 0 ? 1 : 0; });
+    }
+
+    std::vector<const ColumnReader*> readers;
+    for (size_t i = 0; i < _tablet_schema->num_columns(); i++) {
+        const auto& col = _tablet_schema->column(i);
+        auto col_name = std::string(col.name());
+        if (_schema.get_field_by_name(col_name) == nullptr || col.type() != LogicalType::TYPE_JSON) {
+            continue;
+        }
+        readers.clear();
+        for (const auto& rowset : _rowsets) {
+            for (const auto& segment : rowset->get_segments()) {
+                if (segment->num_rows() == 0) {
+                    continue;
+                }
+                auto reader = segment->column_with_uid(col.unique_id());
+                if (reader != nullptr && reader->column_type() == LogicalType::TYPE_JSON &&
+                    nullptr != reader->sub_readers() && !reader->sub_readers()->empty()) {
+                    readers.emplace_back(reader);
+                }
+            }
+        }
+        if (readers.size() == num_readers) {
+            // must all be flat json type
+            JsonPathDeriver deriver;
+            deriver.derived(readers);
+            auto paths = deriver.flat_paths();
+            auto types = deriver.flat_types();
+            VLOG(3) << "Lake Compaction flat json column: " << JsonFlatPath::debug_flat_json(paths, types, true);
+            ASSIGN_OR_RETURN(auto res, ColumnAccessPath::create(TAccessPathType::ROOT, std::string(col.name()), i));
+            for (size_t j = 0; j < paths.size(); j++) {
+                ColumnAccessPath::insert_json_path(res.get(), types[j], paths[j]);
+            }
+            res->set_from_compaction(true);
+            read_params.column_access_paths->emplace_back(std::move(res));
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -99,6 +99,7 @@ private:
     Status init_delete_predicates(const TabletReaderParams& read_params, DeletePredicates* dels);
 
     Status init_collector(const TabletReaderParams& read_params);
+    Status init_compaction_column_paths(const TabletReaderParams& read_params);
 
     static Status to_seek_tuple(const TabletSchema& tablet_schema, const OlapTuple& input, SeekTuple* tuple,
                                 MemPool* mempool);

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -163,6 +163,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     reader_params.chunk_size = chunk_size;
     reader_params.profile = nullptr;
     reader_params.use_page_cache = false;
+    reader_params.column_access_paths = &_column_access_paths;
     reader_params.lake_io_opts = {config::lake_enable_vertical_compaction_fill_data_cache,
                                   config::lake_compaction_stream_buffer_size_bytes};
     RETURN_IF_ERROR(reader.open(reader_params));

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -30,6 +31,7 @@
 #include "gutil/casts.h"
 #include "storage/rowset/column_writer.h"
 #include "types/constexpr.h"
+#include "types/logical_type.h"
 #include "util/json_flattener.h"
 
 namespace starrocks {
@@ -54,48 +56,82 @@ Status FlatJsonColumnCompactor::_compact_columns(std::vector<ColumnPtr>& json_da
     _flat_types = deriver.flat_types();
     _has_remain = deriver.has_remain_json();
 
+    VLOG(1) << "FlatJsonColumnCompactor compact_columns, json_datas size: " << json_datas.size()
+            << ", flat json: " << JsonFlatPath::debug_flat_json(_flat_paths, _flat_types, _has_remain);
+
     if (_flat_paths.empty()) {
         // write json directly
-        _is_flat = false;
-        _json_meta->mutable_json_meta()->set_has_remain(false);
-        _json_meta->mutable_json_meta()->set_is_flat(false);
+        return _merge_columns(json_datas);
+    }
+    return _flatten_columns(json_datas);
+}
 
-        for (auto& col : json_datas) {
-            JsonColumn* json_col;
-            NullColumnPtr null_col;
-            if (col->is_nullable()) {
-                auto nullable_column = down_cast<const NullableColumn*>(col.get());
-                json_col = down_cast<JsonColumn*>(nullable_column->data_column().get());
-                null_col = nullable_column->null_column();
-            } else {
-                json_col = down_cast<JsonColumn*>(col.get());
-            }
-
-            if (!json_col->is_flat_json()) {
-                RETURN_IF_ERROR(_json_writer->append(*col));
-            } else {
-                JsonMerger merger(json_col->flat_column_paths(), json_col->flat_column_types(), json_col->has_remain());
-                auto j = merger.merge(json_col->get_flat_fields());
-
-                if (col->is_nullable()) {
-                    auto n = NullableColumn::create(j, null_col);
-                    n->set_has_null(col->has_null());
-                    RETURN_IF_ERROR(_json_writer->append(*n));
-                } else {
-                    RETURN_IF_ERROR(_json_writer->append(*j));
-                }
-            }
-            col->resize_uninitialized(0);
-        }
-        return Status::OK();
+bool check_is_same_schema(JsonColumn* one, JsonColumn* two) {
+    if (one == nullptr || two == nullptr) {
+        return false;
     }
 
+    if (one->is_flat_json() && two->is_flat_json()) {
+        return one->flat_column_paths() == two->flat_column_paths() &&
+               one->flat_column_types() == two->flat_column_types() && one->has_remain() == two->has_remain();
+    }
+    return false;
+}
+
+Status FlatJsonColumnCompactor::_merge_columns(std::vector<ColumnPtr>& json_datas) {
+    VLOG(1) << "FlatJsonColumnCompactor merge_columns, json_datas: " << json_datas.size();
+    _is_flat = false;
+    _json_meta->mutable_json_meta()->set_has_remain(false);
+    _json_meta->mutable_json_meta()->set_is_flat(false);
+
+    JsonColumn* pre_col = nullptr;
+    std::unique_ptr<JsonMerger> merger = nullptr;
+    for (auto& col : json_datas) {
+        JsonColumn* json_col;
+        NullColumnPtr null_col;
+        if (col->is_nullable()) {
+            auto nullable_column = down_cast<const NullableColumn*>(col.get());
+            json_col = down_cast<JsonColumn*>(nullable_column->data_column().get());
+            null_col = nullable_column->null_column();
+        } else {
+            json_col = down_cast<JsonColumn*>(col.get());
+        }
+
+        if (!json_col->is_flat_json()) {
+            VLOG(1) << "FlatJsonColumnCompactor merge_columns direct write";
+            RETURN_IF_ERROR(_json_writer->append(*col));
+        } else {
+            VLOG(1) << "FlatJsonColumnCompactor merge_columns merge: " << json_col->debug_flat_paths();
+            if (!check_is_same_schema(pre_col, json_col)) {
+                merger = std::make_unique<JsonMerger>(json_col->flat_column_paths(), json_col->flat_column_types(),
+                                                      json_col->has_remain());
+                pre_col = json_col;
+            }
+            auto j = merger->merge(json_col->get_flat_fields());
+
+            if (col->is_nullable()) {
+                auto n = NullableColumn::create(j, null_col);
+                n->set_has_null(col->has_null());
+                RETURN_IF_ERROR(_json_writer->append(*n));
+            } else {
+                RETURN_IF_ERROR(_json_writer->append(*j));
+            }
+        }
+        col->resize_uninitialized(0);
+    }
+    return Status::OK();
+}
+
+Status FlatJsonColumnCompactor::_flatten_columns(std::vector<ColumnPtr>& json_datas) {
+    VLOG(1) << "FlatJsonColumnCompactor flatten_columns, json_datas: " << json_datas.size();
     _is_flat = true;
+
+    // init flattener first, the flat_paths/types will change in _init_flat_writers
+    JsonFlattener flattener(_flat_paths, _flat_types, _has_remain);
+    HyperJsonTransformer transformer(_flat_paths, _flat_types, _has_remain);
+
     RETURN_IF_ERROR(_init_flat_writers());
-
-    JsonFlattener flattener(deriver);
-    HyperJsonTransformer transformer(deriver);
-
+    JsonColumn* pre_col = nullptr;
     for (auto& col : json_datas) {
         JsonColumn* json_col;
         if (col->is_nullable()) {
@@ -106,13 +142,18 @@ Status FlatJsonColumnCompactor::_compact_columns(std::vector<ColumnPtr>& json_da
         }
 
         if (!json_col->is_flat_json()) {
+            VLOG(1) << "FlatJsonColumnCompactor flatten_columns flat json.";
             flattener.flatten(json_col);
             _flat_columns = flattener.mutable_result();
         } else {
-            transformer.init_compaction_task(json_col);
+            if (!check_is_same_schema(pre_col, json_col)) {
+                transformer.init_compaction_task(json_col->flat_column_paths(), json_col->flat_column_types(),
+                                                 json_col->has_remain());
+                pre_col = json_col;
+            }
+            VLOG(1) << "FlatJsonColumnCompactor flatten_columns hyper-transformer: " << json_col->debug_flat_paths();
             RETURN_IF_ERROR(transformer.trans(json_col->get_flat_fields()));
             _flat_columns = transformer.mutable_result();
-            transformer.reset();
         }
 
         // recode null column in 1st

--- a/be/src/storage/rowset/json_column_compactor.h
+++ b/be/src/storage/rowset/json_column_compactor.h
@@ -32,6 +32,10 @@ public:
 
 private:
     Status _compact_columns(std::vector<ColumnPtr>& json_datas);
+
+    Status _merge_columns(std::vector<ColumnPtr>& json_datas);
+
+    Status _flatten_columns(std::vector<ColumnPtr>& json_datas);
 };
 
 class JsonColumnCompactor final : public ColumnWriter {

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -50,14 +50,16 @@ public:
     JsonFlatColumnIterator(ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
                            std::vector<std::unique_ptr<ColumnIterator>> field_iters,
                            const std::vector<std::string>& target_paths, const std::vector<LogicalType>& target_types,
-                           const std::vector<std::string>& source_paths, const std::vector<LogicalType>& source_types)
+                           const std::vector<std::string>& source_paths, const std::vector<LogicalType>& source_types,
+                           bool need_remain)
             : _reader(reader),
               _null_iter(std::move(null_iter)),
               _flat_iters(std::move(field_iters)),
               _target_paths(std::move(target_paths)),
               _target_types(std::move(target_types)),
               _source_paths(std::move(source_paths)),
-              _source_types(std::move(source_types)){};
+              _source_types(std::move(source_types)),
+              _need_remain(need_remain){};
 
     ~JsonFlatColumnIterator() override {
         if (transformer != nullptr) {
@@ -101,6 +103,7 @@ private:
     std::vector<LogicalType> _target_types;
     std::vector<std::string> _source_paths;
     std::vector<LogicalType> _source_types;
+    bool _need_remain = false;
 
     std::vector<ColumnPtr> _source_column_modules;
     // to avoid create column with find type
@@ -119,20 +122,29 @@ Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
     }
 
     bool has_remain = _source_paths.size() != _flat_iters.size();
-    transformer = std::make_unique<HyperJsonTransformer>(_target_paths, _target_types, false);
-    {
-        SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
-        transformer->init_read_task(_source_paths, _source_types, has_remain);
+    VLOG(1) << "JsonFlatColumnIterator init, target: "
+            << JsonFlatPath::debug_flat_json(_target_paths, _target_types, _need_remain)
+            << ", source: " << JsonFlatPath::debug_flat_json(_source_paths, _source_types, has_remain);
 
-        for (int i = 0; i < _source_paths.size(); i++) {
-            auto column = ColumnHelper::create_column(TypeDescriptor(_source_types[i]), true);
-            _source_column_modules.emplace_back(column);
-        }
+    for (int i = 0; i < _source_paths.size(); i++) {
+        auto column = ColumnHelper::create_column(TypeDescriptor(_source_types[i]), true);
+        _source_column_modules.emplace_back(column);
     }
 
     DCHECK_EQ(_source_column_modules.size(), _source_paths.size());
     if (has_remain) {
         _source_column_modules.emplace_back(JsonColumn::create());
+    }
+
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
+        if (_need_remain) {
+            transformer = std::make_unique<HyperJsonTransformer>(_target_paths, _target_types, true);
+            transformer->init_compaction_task(_source_paths, _source_types, has_remain);
+        } else {
+            transformer = std::make_unique<HyperJsonTransformer>(_target_paths, _target_types, false);
+            transformer->init_read_task(_source_paths, _source_types, has_remain);
+        }
     }
 
     // update stats
@@ -268,10 +280,11 @@ Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<cons
 class JsonDynamicFlatIterator final : public ColumnIterator {
 public:
     JsonDynamicFlatIterator(std::unique_ptr<ScalarColumnIterator>& json_iter, std::vector<std::string> target_paths,
-                            std::vector<LogicalType> target_types)
+                            std::vector<LogicalType> target_types, bool need_remain)
             : _json_iter(std::move(json_iter)),
               _target_paths(std::move(target_paths)),
-              _target_types(std::move(target_types)){};
+              _target_types(std::move(target_types)),
+              _need_remain(need_remain){};
 
     ~JsonDynamicFlatIterator() override = default;
 
@@ -297,28 +310,39 @@ public:
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
 private:
-    Status _flat_json(Column* input, Column* output);
+    template <typename FUNC>
+    Status _dynamic_flat(Column* dst, FUNC read_fn);
 
 private:
     std::unique_ptr<ScalarColumnIterator> _json_iter;
     std::vector<std::string> _target_paths;
     std::vector<LogicalType> _target_types;
+    bool _need_remain = false;
 
     std::unique_ptr<JsonFlattener> _flattener;
 };
 
 Status JsonDynamicFlatIterator::init(const ColumnIteratorOptions& opts) {
     RETURN_IF_ERROR(ColumnIterator::init(opts));
+    RETURN_IF_ERROR(_json_iter->init(opts));
+
     for (auto& p : _target_paths) {
         opts.stats->dynamic_json_hits[p] += 1;
     }
 
     SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
-    _flattener = std::make_unique<JsonFlattener>(_target_paths, _target_types, false);
-    return _json_iter->init(opts);
+    _flattener = std::make_unique<JsonFlattener>(_target_paths, _target_types, _need_remain);
+    VLOG(1) << "JsonDynamicFlatIterator init, target: "
+            << JsonFlatPath::debug_flat_json(_target_paths, _target_types, _need_remain);
+    return Status::OK();
 }
 
-Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
+template <typename FUNC>
+Status JsonDynamicFlatIterator::_dynamic_flat(Column* output, FUNC read_fn) {
+    auto proxy = output->clone_empty();
+    RETURN_IF_ERROR(read_fn(_json_iter.get(), proxy.get()));
+    output->set_delete_state(proxy->delete_state());
+
     SCOPED_RAW_TIMER(&_opts.stats->json_flatten_ns);
     JsonColumn* json_data = nullptr;
 
@@ -328,7 +352,7 @@ Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
         auto* output_nullable = down_cast<NullableColumn*>(output);
         auto* output_null = down_cast<NullColumn*>(output_nullable->null_column().get());
 
-        auto* input_nullable = down_cast<NullableColumn*>(input);
+        auto* input_nullable = down_cast<NullableColumn*>(proxy.get());
         auto* input_null = down_cast<NullColumn*>(input_nullable->null_column().get());
 
         output_null->append(*input_null, 0, input_null->size());
@@ -341,31 +365,25 @@ Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
     }
 
     // 2. flat
-    _flattener->flatten(input);
+    _flattener->flatten(proxy.get());
     auto result = _flattener->mutable_result();
     json_data->set_flat_columns(_target_paths, _target_types, result);
     return Status::OK();
 }
 
 Status JsonDynamicFlatIterator::next_batch(size_t* n, Column* dst) {
-    auto proxy = dst->clone_empty();
-    RETURN_IF_ERROR(_json_iter->next_batch(n, proxy.get()));
-    dst->set_delete_state(proxy->delete_state());
-    return _flat_json(proxy.get(), dst);
+    auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(n, column); };
+    return _dynamic_flat(dst, read);
 }
 
 Status JsonDynamicFlatIterator::next_batch(const SparseRange<>& range, Column* dst) {
-    auto proxy = dst->clone_empty();
-    RETURN_IF_ERROR(_json_iter->next_batch(range, proxy.get()));
-    dst->set_delete_state(proxy->delete_state());
-    return _flat_json(proxy.get(), dst);
+    auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(range, column); };
+    return _dynamic_flat(dst, read);
 }
 
 Status JsonDynamicFlatIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
-    auto proxy = values->clone_empty();
-    RETURN_IF_ERROR(_json_iter->fetch_values_by_rowid(rowids, size, proxy.get()));
-    values->set_delete_state(proxy->delete_state());
-    return _flat_json(proxy.get(), values);
+    auto read = [&](ColumnIterator* iter, Column* column) { return iter->fetch_values_by_rowid(rowids, size, column); };
+    return _dynamic_flat(values, read);
 }
 
 Status JsonDynamicFlatIterator::seek_to_first() {
@@ -386,13 +404,12 @@ class JsonMergeIterator final : public ColumnIterator {
 public:
     JsonMergeIterator(ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
                       std::vector<std::unique_ptr<ColumnIterator>> all_iter, const std::vector<std::string>& src_paths,
-                      const std::vector<LogicalType>& src_types, bool is_merge)
+                      const std::vector<LogicalType>& src_types)
             : _reader(reader),
               _null_iter(std::move(null_iter)),
               _all_iter(std::move(all_iter)),
               _src_paths(std::move(src_paths)),
-              _src_types(std::move(src_types)),
-              _is_merge(is_merge){};
+              _src_types(std::move(src_types)){};
 
     ~JsonMergeIterator() override = default;
 
@@ -431,7 +448,6 @@ private:
     std::vector<ColumnPtr> _src_column_modules;
 
     std::unique_ptr<JsonMerger> _merger;
-    bool _is_merge;
 };
 
 Status JsonMergeIterator::init(const ColumnIteratorOptions& opts) {
@@ -444,15 +460,8 @@ Status JsonMergeIterator::init(const ColumnIteratorOptions& opts) {
         RETURN_IF_ERROR(iter->init(opts));
     }
 
-    if (_is_merge) {
-        for (auto& p : _src_paths) {
-            opts.stats->merge_json_hits[p] += 1;
-        }
-
-        SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
-        _merger = std::make_unique<JsonMerger>(_src_paths, _src_types, _all_iter.size() != _src_paths.size());
-    }
-
+    bool has_remain = _all_iter.size() != _src_paths.size();
+    VLOG(1) << "JsonMergeIterator init, source: " << JsonFlatPath::debug_flat_json(_src_paths, _src_types, has_remain);
     DCHECK(_all_iter.size() == _src_paths.size() || _all_iter.size() == _src_paths.size() + 1);
     for (int i = 0; i < _src_paths.size(); i++) {
         auto column = ColumnHelper::create_column(TypeDescriptor(_src_types[i]), true);
@@ -463,6 +472,12 @@ Status JsonMergeIterator::init(const ColumnIteratorOptions& opts) {
         // remain
         _src_column_modules.emplace_back(JsonColumn::create());
     }
+
+    for (auto& p : _src_paths) {
+        opts.stats->merge_json_hits[p] += 1;
+    }
+    SCOPED_RAW_TIMER(&_opts.stats->json_init_ns);
+    _merger = std::make_unique<JsonMerger>(_src_paths, _src_types, has_remain);
 
     return Status::OK();
 }
@@ -477,13 +492,9 @@ Status JsonMergeIterator::_merge(JsonColumn* dst, FUNC func) {
         all_columns.emplace_back(std::move(c));
     }
 
-    if (_is_merge) {
-        SCOPED_RAW_TIMER(&_opts.stats->json_merge_ns);
-        auto json = _merger->merge(all_columns);
-        dst->append(*json, 0, json->size());
-    } else {
-        dst->set_flat_columns(_src_paths, _src_types, all_columns);
-    }
+    SCOPED_RAW_TIMER(&_opts.stats->json_merge_ns);
+    auto json = _merger->merge(all_columns);
+    dst->append(*json, 0, json->size());
     dst->check_or_die();
     return Status::OK();
 }
@@ -586,21 +597,19 @@ Status JsonMergeIterator::get_row_ranges_by_zone_map(const std::vector<const Col
     return Status::OK();
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(ColumnReader* reader,
-                                                                    std::unique_ptr<ColumnIterator> null_iter,
-                                                                    std::vector<std::unique_ptr<ColumnIterator>> iters,
-                                                                    const std::vector<std::string>& target_paths,
-                                                                    const std::vector<LogicalType>& target_types,
-                                                                    const std::vector<std::string>& source_paths,
-                                                                    const std::vector<LogicalType>& source_types) {
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> iters, const std::vector<std::string>& target_paths,
+        const std::vector<LogicalType>& target_types, const std::vector<std::string>& source_paths,
+        const std::vector<LogicalType>& source_types, bool need_remain) {
     return std::make_unique<JsonFlatColumnIterator>(reader, std::move(null_iter), std::move(iters), target_paths,
-                                                    target_types, source_paths, source_types);
+                                                    target_types, source_paths, source_types, need_remain);
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
         std::unique_ptr<ScalarColumnIterator> json_iter, const std::vector<std::string>& target_paths,
-        const std::vector<LogicalType>& target_types) {
-    return std::make_unique<JsonDynamicFlatIterator>(json_iter, target_paths, target_types);
+        const std::vector<LogicalType>& target_types, bool need_remain) {
+    return std::make_unique<JsonDynamicFlatIterator>(json_iter, target_paths, target_types, need_remain);
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
@@ -608,14 +617,6 @@ StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
         std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& merge_paths,
         const std::vector<LogicalType>& merge_types) {
     return std::make_unique<JsonMergeIterator>(reader, std::move(null_iter), std::move(all_iters), merge_paths,
-                                               merge_types, true);
-}
-
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_direct_iterator(
-        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
-        std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& merge_paths,
-        const std::vector<LogicalType>& merge_types) {
-    return std::make_unique<JsonMergeIterator>(reader, std::move(null_iter), std::move(all_iters), merge_paths,
-                                               merge_types, false);
+                                               merge_types);
 }
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.h
+++ b/be/src/storage/rowset/json_column_iterator.h
@@ -22,26 +22,18 @@
 
 namespace starrocks {
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(ColumnReader* reader,
-                                                                    std::unique_ptr<ColumnIterator> null_iter,
-                                                                    std::vector<std::unique_ptr<ColumnIterator>> iters,
-                                                                    const std::vector<std::string>& target_paths,
-                                                                    const std::vector<LogicalType>& target_types,
-                                                                    const std::vector<std::string>& source_paths,
-                                                                    const std::vector<LogicalType>& source_types);
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> iters, const std::vector<std::string>& target_paths,
+        const std::vector<LogicalType>& target_types, const std::vector<std::string>& source_paths,
+        const std::vector<LogicalType>& source_types, bool need_remain = false);
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
         std::unique_ptr<ScalarColumnIterator> json_iter, const std::vector<std::string>& target_paths,
-        const std::vector<LogicalType>& target_types);
+        const std::vector<LogicalType>& target_types, bool need_remain = false);
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_merge_iterator(
         ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
         std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& merge_paths,
         const std::vector<LogicalType>& merge_types);
-
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_direct_iterator(
-        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
-        std::vector<std::unique_ptr<ColumnIterator>> all_iters, const std::vector<std::string>& all_paths,
-        const std::vector<LogicalType>& all_types);
-
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -92,6 +92,8 @@ Status FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
     _flat_types = deriver.flat_types();
     _has_remain = deriver.has_remain_json();
 
+    VLOG(1) << "FlatJsonColumnWriter flat_column flat json: "
+            << JsonFlatPath::debug_flat_json(_flat_paths, _flat_types, _has_remain);
     if (_flat_paths.empty()) {
         return Status::InternalError("doesn't have flat column.");
     }
@@ -281,6 +283,7 @@ Status FlatJsonColumnWriter::finish_current_page() {
 StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWriterOptions& opts,
                                                                   TypeInfoPtr type_info, WritableFile* wfile,
                                                                   std::unique_ptr<ScalarColumnWriter> json_writer) {
+    VLOG(1) << "Create Json Column Writer is_compaction: " << opts.is_compaction << ", need_flat : " << opts.need_flat;
     // compaction
     if (opts.is_compaction) {
         if (opts.need_flat) {

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -222,6 +222,9 @@ public:
 
     DISALLOW_COPY_AND_MOVE(Segment);
 
+    // for ut test
+    void set_num_rows(uint32_t num_rows) { _num_rows = num_rows; }
+
 private:
     friend struct SegmentZoneMapPruner;
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -15,8 +15,11 @@
 #include "storage/tablet_reader.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <utility>
+#include <vector>
 
+#include "column/column_access_path.h"
 #include "column/datum_convert.h"
 #include "common/status.h"
 #include "gen_cpp/tablet_schema.pb.h"
@@ -31,13 +34,17 @@
 #include "storage/delete_predicates.h"
 #include "storage/empty_iterator.h"
 #include "storage/merge_iterator.h"
+#include "storage/olap_common.h"
 #include "storage/predicate_parser.h"
+#include "storage/rowset/column_reader.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/seek_range.h"
 #include "storage/tablet.h"
 #include "storage/tablet_updates.h"
 #include "storage/types.h"
 #include "storage/union_iterator.h"
+#include "types/logical_type.h"
+#include "util/json_flattener.h"
 
 namespace starrocks {
 
@@ -127,8 +134,69 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         _reader_params = &read_params;
         return Status::OK();
     }
+
+    RETURN_IF_ERROR(_init_compaction_column_paths(read_params));
     Status st = _init_collector(read_params);
     return st;
+}
+
+Status TabletReader::_init_compaction_column_paths(const TabletReaderParams& read_params) {
+    if (!config::enable_compaction_flat_json || !is_compaction(read_params.reader_type) ||
+        read_params.column_access_paths == nullptr) {
+        return Status::OK();
+    }
+
+    if (!read_params.column_access_paths->empty()) {
+        VLOG(3) << "Compaction flat json paths exists: " << read_params.column_access_paths->size();
+        return Status::OK();
+    }
+
+    DCHECK(is_compaction(read_params.reader_type) && read_params.column_access_paths != nullptr &&
+           read_params.column_access_paths->empty());
+    int num_readers = 0;
+    for (const auto& rowset : _rowsets) {
+        auto segments = rowset->segments();
+        std::for_each(segments.begin(), segments.end(),
+                      [&](const auto& segment) { num_readers += segment->num_rows() > 0 ? 1 : 0; });
+    }
+
+    std::vector<const ColumnReader*> readers;
+    for (size_t i = 0; i < _tablet_schema->num_columns(); i++) {
+        const auto& col = _tablet_schema->column(i);
+        auto col_name = std::string(col.name());
+        if (_schema.get_field_by_name(col_name) == nullptr || col.type() != LogicalType::TYPE_JSON) {
+            continue;
+        }
+        readers.clear();
+        for (const auto& rowset : _rowsets) {
+            for (const auto& segment : rowset->segments()) {
+                if (segment->num_rows() == 0) {
+                    continue;
+                }
+                auto reader = segment->column_with_uid(col.unique_id());
+                if (reader != nullptr && reader->column_type() == LogicalType::TYPE_JSON &&
+                    nullptr != reader->sub_readers() && !reader->sub_readers()->empty()) {
+                    readers.emplace_back(reader);
+                }
+            }
+        }
+        if (readers.size() == num_readers) {
+            // must all be flat json type
+            JsonPathDeriver deriver;
+            deriver.derived(readers);
+            auto paths = deriver.flat_paths();
+            auto types = deriver.flat_types();
+
+            VLOG(3) << "Compaction flat json column: " << JsonFlatPath::debug_flat_json(paths, types, true);
+            ASSIGN_OR_RETURN(auto res, ColumnAccessPath::create(TAccessPathType::ROOT, col_name, i));
+            for (size_t j = 0; j < paths.size(); j++) {
+                ColumnAccessPath::insert_json_path(res.get(), types[j], paths[j]);
+            }
+            res->set_from_compaction(true);
+            read_params.column_access_paths->emplace_back(std::move(res));
+        }
+    }
+    return Status::OK();
 }
 
 Status TabletReader::_init_collector_for_pk_index_read() {

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -87,6 +87,7 @@ private:
                                  MemPool* mempool);
 
     Status _init_collector_for_pk_index_read();
+    Status _init_compaction_column_paths(const TabletReaderParams& read_params);
 
     TabletSharedPtr _tablet;
     TabletSchemaCSPtr _tablet_schema;

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -131,6 +131,7 @@ Status VerticalCompactionTask::_compact_column_group(bool is_key, int column_gro
     reader_params.reader_type =
             compaction_type() == BASE_COMPACTION ? READER_BASE_COMPACTION : READER_CUMULATIVE_COMPACTION;
     reader_params.profile = _runtime_profile.create_child("merge_rowsets");
+    reader_params.column_access_paths = &_column_access_paths;
 
     StatusOr<int32_t> ret = _calculate_chunk_size_for_column_group(column_group);
     if (!ret.ok()) {

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -44,6 +44,7 @@
 #include "exprs/expr_context.h"
 #include "gutil/casts.h"
 #include "runtime/types.h"
+#include "storage/rowset/column_reader.h"
 #include "types/logical_type.h"
 #include "util/json.h"
 #include "util/json_converter.h"
@@ -330,6 +331,39 @@ void JsonPathDeriver::derived(const std::vector<const Column*>& json_datas) {
     _finalize();
 }
 
+void JsonPathDeriver::derived(const std::vector<const ColumnReader*>& json_readers) {
+    DCHECK(_paths.empty());
+    DCHECK(_types.empty());
+    DCHECK(_derived_maps.empty());
+    DCHECK(_path_root == nullptr);
+
+    if (json_readers.empty()) {
+        return;
+    }
+
+    _path_root = std::make_shared<JsonFlatPath>();
+    _total_rows = 0;
+
+    // extract flat paths
+    for (const auto& reader : json_readers) {
+        DCHECK_EQ(LogicalType::TYPE_JSON, reader->column_type());
+        DCHECK(!reader->sub_readers()->empty());
+        _total_rows += reader->num_rows();
+
+        int start = reader->is_nullable() ? 1 : 0;
+        int end = reader->has_remain_json() ? reader->sub_readers()->size() - 1 : reader->sub_readers()->size();
+        _has_remain |= reader->has_remain_json();
+        for (size_t i = start; i < end; i++) {
+            const auto& sub = (*reader->sub_readers())[i];
+            auto leaf = JsonFlatPath::normalize_from_path(sub->name(), _path_root.get());
+            _derived_maps[leaf].type &= flat_json::LOGICAL_TYPE_TO_JSON_BITS.at(sub->column_type());
+            _derived_maps[leaf].hits += reader->num_rows();
+        }
+    }
+    _json_sparsity_factory = 1; // only extract common schema
+    _finalize();
+}
+
 void JsonPathDeriver::_derived_on_flat_json(const std::vector<const Column*>& json_datas) {
     // extract flat paths
     for (size_t k = 0; k < json_datas.size(); k++) {
@@ -338,7 +372,7 @@ void JsonPathDeriver::_derived_on_flat_json(const std::vector<const Column*>& js
         size_t hits = 0;
         if (col->is_nullable()) {
             auto nullable = down_cast<const NullableColumn*>(col);
-            hits = nullable->null_count();
+            hits = col->size() - nullable->null_count();
             json_col = down_cast<const JsonColumn*>(nullable->data_column().get());
         } else {
             hits = col->size();
@@ -349,8 +383,8 @@ void JsonPathDeriver::_derived_on_flat_json(const std::vector<const Column*>& js
             continue;
         }
 
-        auto paths = json_col->flat_column_paths();
-        auto types = json_col->flat_column_types();
+        const auto& paths = json_col->flat_column_paths();
+        const auto& types = json_col->flat_column_types();
 
         for (size_t i = 0; i < paths.size(); i++) {
             auto leaf = JsonFlatPath::normalize_from_path(paths[i], _path_root.get());
@@ -455,7 +489,7 @@ void JsonPathDeriver::_finalize() {
             // leaf node
             // check sparsity, same key may appear many times in json, so we need avoid duplicate compute hits
             auto desc = _derived_maps[node];
-            if (desc.multi_times <= 0 && desc.hits >= _total_rows * config::json_flat_sparsity_factor) {
+            if (desc.multi_times <= 0 && desc.hits >= _total_rows * _json_sparsity_factory) {
                 hit_leaf.emplace_back(node, path);
                 node->type = flat_json::JSON_BITS_TO_LOGICAL_TYPE.at(desc.type);
                 node->remain = false; // later update
@@ -478,7 +512,7 @@ void JsonPathDeriver::_finalize() {
     for (auto& [node, path] : hit_leaf) {
         if (_paths.size() >= limit) {
             node->remain = true;
-            _has_remain = true;
+            _has_remain |= true;
             continue;
         }
         node->index = _paths.size();
@@ -544,6 +578,7 @@ JsonFlattener::JsonFlattener(const std::vector<std::string>& paths, const std::v
 void JsonFlattener::flatten(const Column* json_column) {
     for (auto& col : _flat_columns) {
         DCHECK_EQ(col->size(), 0);
+        col->reserve(json_column->size());
     }
     // input
     const JsonColumn* json_data = nullptr;
@@ -701,34 +736,22 @@ std::vector<ColumnPtr> JsonFlattener::mutable_result() {
 }
 
 JsonMerger::JsonMerger(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain)
-        : _has_remain(has_remain) {
+        : _src_paths(std::move(paths)), _has_remain(has_remain) {
     _src_root = std::make_shared<JsonFlatPath>();
 
-    for (size_t i = 0; i < paths.size(); i++) {
-        auto* leaf = JsonFlatPath::normalize_from_path(paths[i], _src_root.get());
+    for (size_t i = 0; i < _src_paths.size(); i++) {
+        auto* leaf = JsonFlatPath::normalize_from_path(_src_paths[i], _src_root.get());
         leaf->type = types[i];
         leaf->index = i;
     }
 }
 
-void dfs_exclude(JsonFlatPath* node) {
-    if (node->children.empty()) {
-        return;
-    }
-    bool all_exclude = true;
-    for (auto& [_, child] : node->children) {
-        dfs_exclude(child.get());
-        all_exclude &= (child->op == JsonFlatPath::OP_EXCLUDE);
-    }
-    node->op = all_exclude ? JsonFlatPath::OP_EXCLUDE : JsonFlatPath::OP_INCLUDE;
-}
-
 void JsonMerger::set_exclude_paths(const std::vector<std::string>& exclude_paths) {
-    for (auto& path : exclude_paths) {
+    this->_exclude_paths = exclude_paths;
+    for (auto& path : _exclude_paths) {
         auto* leaf = JsonFlatPath::normalize_from_path(path, _src_root.get());
         leaf->op = JsonFlatPath::OP_EXCLUDE;
     }
-    dfs_exclude(_src_root.get());
 }
 
 void JsonMerger::set_root_path(const std::string& base_path) {
@@ -742,12 +765,13 @@ ColumnPtr JsonMerger::merge(const std::vector<ColumnPtr>& columns) {
     _result = NullableColumn::create(JsonColumn::create(), NullColumn::create());
     _json_result = down_cast<JsonColumn*>(down_cast<NullableColumn*>(_result.get())->data_column().get());
     _null_result = down_cast<NullColumn*>(down_cast<NullableColumn*>(_result.get())->null_column().get());
+    size_t rows = columns[0]->size();
+    _result->reserve(rows);
 
     for (auto& col : columns) {
         _src_columns.emplace_back(col.get());
     }
 
-    size_t rows = columns[0]->size();
     if (_src_root->op == JsonFlatPath::OP_INCLUDE) {
         _merge_impl<true>(rows);
     } else {
@@ -814,24 +838,25 @@ void JsonMerger::_merge_json_with_remain(const JsonFlatPath* root, const vpack::
             }
             continue;
         }
-        if (iter->second->op == JsonFlatPath::OP_EXCLUDE) {
+        auto* child = iter->second.get();
+        if (child->op == JsonFlatPath::OP_EXCLUDE) {
             continue;
         }
         if (v.isObject()) {
-            if (iter->second->op == JsonFlatPath::OP_IGNORE) {
-                _merge_json_with_remain<false>(iter->second.get(), &v, builder, index);
-            } else if (iter->second->op == JsonFlatPath::OP_ROOT) {
-                _merge_json_with_remain<true>(iter->second.get(), &v, builder, index);
+            if (child->op == JsonFlatPath::OP_IGNORE) {
+                _merge_json_with_remain<false>(child, &v, builder, index);
+            } else if (child->op == JsonFlatPath::OP_ROOT) {
+                _merge_json_with_remain<true>(child, &v, builder, index);
             } else {
-                DCHECK(iter->second->op == JsonFlatPath::OP_INCLUDE);
+                DCHECK(child->op == JsonFlatPath::OP_INCLUDE);
                 builder->add(k, vpack::Value(vpack::ValueType::Object));
-                _merge_json_with_remain<true>(iter->second.get(), &v, builder, index);
+                _merge_json_with_remain<true>(child, &v, builder, index);
                 builder->close();
             }
             continue;
         }
         // leaf node
-        DCHECK(iter->second->op == JsonFlatPath::OP_INCLUDE || iter->second->op == JsonFlatPath::OP_ROOT);
+        DCHECK(child->op == JsonFlatPath::OP_INCLUDE || child->op == JsonFlatPath::OP_ROOT);
         builder->add(k, v);
     }
     for (auto& [child_name, child] : root->children) {
@@ -862,7 +887,7 @@ void JsonMerger::_merge_json(const JsonFlatPath* root, vpack::Builder* builder, 
         }
 
         if (child->children.empty()) {
-            DCHECK(child->op == JsonFlatPath::OP_INCLUDE);
+            DCHECK(child->op == JsonFlatPath::OP_INCLUDE || child->op == JsonFlatPath::OP_ROOT);
             auto col = _src_columns[child->index];
             if (!col->is_null(index)) {
                 DCHECK(flat_json::JSON_MERGE_FUNC.contains(child->type));
@@ -885,17 +910,6 @@ void JsonMerger::_merge_json(const JsonFlatPath* root, vpack::Builder* builder, 
     }
 }
 
-HyperJsonTransformer::HyperJsonTransformer(JsonPathDeriver& deriver)
-        : _dst_remain(deriver.has_remain_json()), _dst_paths(deriver.flat_paths()), _dst_types(deriver.flat_types()) {
-    for (size_t i = 0; i < _dst_paths.size(); i++) {
-        _dst_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(_dst_types[i]), true));
-    }
-
-    if (_dst_remain) {
-        _dst_columns.emplace_back(JsonColumn::create());
-    }
-}
-
 HyperJsonTransformer::HyperJsonTransformer(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
                                            bool has_remain)
         : _dst_remain(has_remain), _dst_paths(std::move(paths)), _dst_types(types) {
@@ -910,13 +924,12 @@ HyperJsonTransformer::HyperJsonTransformer(const std::vector<std::string>& paths
 
 void HyperJsonTransformer::init_read_task(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
                                           bool has_remain) {
-    DCHECK(_src_paths.empty());
-    DCHECK(_src_types.empty());
+    _src_paths = paths;
+    _src_types = types;
 
-    _src_paths.assign(paths.begin(), paths.end());
-    _src_types.assign(types.begin(), types.end());
     _merge_tasks.clear();
     _flat_tasks.clear();
+    _pool.clear();
 
     std::vector<int> equals;
     std::vector<int> merges;
@@ -1037,15 +1050,14 @@ void HyperJsonTransformer::init_read_task(const std::vector<std::string>& paths,
     }
 }
 
-void HyperJsonTransformer::init_compaction_task(JsonColumn* column) {
-    DCHECK(column->is_flat_json());
-    _src_paths.clear();
-    _src_types.clear();
+void HyperJsonTransformer::init_compaction_task(const std::vector<std::string>& paths,
+                                                const std::vector<LogicalType>& types, bool has_remain) {
+    _src_paths = paths;
+    _src_types = types;
+
     _merge_tasks.clear();
     _flat_tasks.clear();
-
-    _src_paths.assign(column->flat_column_paths().begin(), column->flat_column_paths().end());
-    _src_types.assign(column->flat_column_types().begin(), column->flat_column_types().end());
+    _pool.clear();
 
     std::unordered_set<std::string> _src_set(_src_paths.begin(), _src_paths.end());
 
@@ -1059,6 +1071,8 @@ void HyperJsonTransformer::init_compaction_task(JsonColumn* column) {
     for (size_t j = 0; j < _src_paths.size(); j++) {
         size_t i = 0;
         for (; i < _dst_paths.size(); i++) {
+            DCHECK(!_src_paths[j].starts_with(_dst_paths[i] + "."));
+            DCHECK(!_dst_paths[i].starts_with(_src_paths[j] + "."));
             if (_dst_paths[i] == _src_paths[j]) {
                 auto& mk = _merge_tasks.emplace_back();
                 mk.is_merge = false;
@@ -1082,7 +1096,7 @@ void HyperJsonTransformer::init_compaction_task(JsonColumn* column) {
     }
 
     std::vector<std::string> all_flat_paths; // for remove from remain
-    if (column->has_remain()) {
+    if (has_remain) {
         for (size_t i = 0; i < _dst_paths.size(); i++) {
             if (_src_set.find(_dst_paths[i]) == _src_set.end()) {
                 // merge to remain
@@ -1117,9 +1131,9 @@ void HyperJsonTransformer::init_compaction_task(JsonColumn* column) {
             p.emplace_back(_src_paths[index]);
             t.emplace_back(_src_types[index]);
         }
-        mk.merger = std::make_unique<JsonMerger>(p, t, column->has_remain());
+        mk.merger = std::make_unique<JsonMerger>(p, t, has_remain);
         mk.merger->set_exclude_paths(all_flat_paths);
-        if (column->has_remain()) {
+        if (has_remain) {
             _merge_tasks[0].src_index.emplace_back(_src_paths.size());
         }
     }
@@ -1205,7 +1219,7 @@ Status HyperJsonTransformer::_merge(const MergeTask& task, std::vector<ColumnPtr
     if (task.dst_index == _dst_paths.size()) {
         DCHECK(_dst_remain);
         // output to remain
-        if (task.src_index.size() == 1 && task.src_index[0] == _src_paths.size()) {
+        if (task.src_index.size() == 1 && task.src_index[0] == _src_paths.size() && !task.merger->has_exclude_paths()) {
             // only use remain
             _dst_columns[task.dst_index] = columns[task.src_index[0]];
             return Status::OK();
@@ -1251,17 +1265,6 @@ void HyperJsonTransformer::_flat(const FlatTask& task, std::vector<ColumnPtr>& c
 
     for (size_t i = 0; i < task.dst_index.size(); i++) {
         _dst_columns[task.dst_index[i]] = result[i];
-    }
-}
-
-void HyperJsonTransformer::reset() {
-    _src_paths.clear();
-    _src_types.clear();
-    _merge_tasks.clear();
-    _flat_tasks.clear();
-    _pool.clear();
-    for (size_t i = 0; i < _dst_columns.size(); i++) {
-        _dst_columns[i] = _dst_columns[i]->clone_empty();
     }
 }
 

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -613,8 +613,8 @@ TEST_F(FlatJsonColumnRWTest, testDeepFlatJson) {
     }
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
@@ -658,11 +658,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperFlatJson) {
     }
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
@@ -825,8 +825,8 @@ TEST_F(FlatJsonColumnRWTest, testDeepJson) {
     }
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
@@ -866,11 +866,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperJson) {
     }
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
@@ -910,11 +910,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeJson) {
     }
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2.b3");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
@@ -950,11 +950,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson) {
     }
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b2");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
@@ -990,11 +990,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson2) {
     }
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
@@ -1252,8 +1252,8 @@ TEST_F(FlatJsonColumnRWTest, testDeepNullFlatJson) {
 
     ColumnPtr write_col = create_json(json, true);
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
@@ -1292,11 +1292,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperNullFlatJson) {
     ColumnPtr write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
@@ -1459,8 +1459,8 @@ TEST_F(FlatJsonColumnRWTest, testDeepNullJson) {
     ColumnPtr write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
@@ -1495,11 +1495,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperNullJson) {
     auto write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
@@ -1534,11 +1534,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperNullJson2) {
     auto write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.b.b2.b3");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
@@ -1572,11 +1572,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeNullJson) {
     ColumnPtr write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2.b3");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
@@ -1605,11 +1605,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeNullJson) {
     ColumnPtr write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.b.b2");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;
@@ -1638,11 +1638,11 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeNullJson2) {
     ColumnPtr write_col = create_json(json, true);
 
     ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "root.b.b4.b5");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.b.b2");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "root.a");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "root.ff.f1");
-    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "root.gg.g1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
 
     ColumnPtr read_col = write_col->clone_empty();
     ColumnWriterOptions writer_opts;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Follow PR #48104

this pr for optimize compaction performance
| SSB | Scalar Data | Json | Flat Json(Before #48104) | FlatJson（PR #48104) | FlatJson (This PR) |
| -- | -- | -- | -- | -- | -- |
| Data Size | 58.828 GB | 152.616GB | 245.947 GB | 58.571 GB | 58.571 GB |
| compaction time | 4min30s | 35min20s | 46min51s | 23 min 30s | 6min12s |

Compaction Before:
Read all json subfield in FlatJson -> Merge to a real json -> Compaction merge rows base on json -> json flatten to flat-subfield -> storage flat json

Compaction Now:
To derive the flat json schema when read -> Read all json subfield by schema -> Compaction merge rows base on same flat json schema  -> to derive new schema base on flat json -> storage flat json

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
