### PR TITLE
[BugFix] Fix use after free in partition_meta table

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -176,7 +176,8 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
         }
         case 11: {
             // VERSION_TXN_TYPE
-            Slice version_txn_type = Slice(to_string(info.version_txn_type));
+            std::string version_txn_type_str = to_string(info.version_txn_type);
+            Slice version_txn_type = Slice(version_txn_type_str);
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&version_txn_type);
             break;
         }


### PR DESCRIPTION
## Why I'm doing:
There is use after free in partition_meta table.

## What I'm doing:
Fix use after free in partition_meta table

Fixes https://github.com/StarRocks/StarRocksTest/issues/8324

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
