### PR TITLE
[Enhancement] Make `warehouse` variable session accessable only

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1961,7 +1961,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_COUNT_STAR_OPTIMIZATION, flag = VariableMgr.INVISIBLE)
     private boolean enableCountStarOptimization = true;
 
-    @VariableMgr.VarAttr(name = WAREHOUSE_NAME)
+    @VariableMgr.VarAttr(name = WAREHOUSE_NAME, flag = VariableMgr.SESSION_ONLY)
     private String warehouseName = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
 
     @VarAttr(name = ENABLE_PARTITION_COLUMN_VALUE_ONLY_OPTIMIZATION, flag = VariableMgr.INVISIBLE)

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
@@ -127,21 +127,6 @@ public class SetStmtTest {
     }
 
     @Test
-    public void setWarehouse() {
-        SystemVariable setEmpty = new SystemVariable(SetType.SESSION, SessionVariable.WAREHOUSE_NAME, new StringLiteral(""));
-        SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setEmpty)), ctx);
-
-        SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.WAREHOUSE_NAME, new StringLiteral("not_exists"));
-        try {
-            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
-            Assert.fail("should fail");
-        } catch (SemanticException e) {
-            Assert.assertEquals("Getting analyzing error. Detail message: warehouse not exists: not_exists.",
-                    e.getMessage());
-        }
-    }
-
-    @Test
     public void testSetNonNegativeLongVariable() throws UserException {
         List<String> fields = Lists.newArrayList(
                 SessionVariable.LOAD_MEM_LIMIT,

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
@@ -127,6 +127,21 @@ public class SetStmtTest {
     }
 
     @Test
+    public void setWarehouse() {
+        SystemVariable setEmpty = new SystemVariable(SetType.SESSION, SessionVariable.WAREHOUSE_NAME, new StringLiteral(""));
+        SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setEmpty)), ctx);
+
+        SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.WAREHOUSE_NAME, new StringLiteral("not_exists"));
+        try {
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assert.fail("should fail");
+        } catch (SemanticException e) {
+            Assert.assertEquals("Getting analyzing error. Detail message: warehouse not exists: not_exists.",
+                    e.getMessage());
+        }
+    }
+
+    @Test
     public void testSetNonNegativeLongVariable() throws UserException {
         List<String> fields = Lists.newArrayList(
                 SessionVariable.LOAD_MEM_LIMIT,

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -275,5 +275,17 @@ public class VariableMgrTest {
         List<List<String>> vars2 = VariableMgr.dump(SetType.SESSION, null, null);
         Assert.assertTrue(vars.size() == vars2.size());
     }
+
+    @Test
+    public void testWarehouseVar() {
+        SystemVariable systemVariable =
+                new SystemVariable(SetType.GLOBAL, SessionVariable.WAREHOUSE_NAME, new StringLiteral("warehouse_1"));
+        try {
+            VariableMgr.setSystemVariable(null, systemVariable, false);
+        } catch (DdlException e) {
+            Assert.assertEquals("Variable 'warehouse' is a SESSION variable and can't be used with SET GLOBAL",
+                    e.getMessage());
+        }
+    }
 }
 


### PR DESCRIPTION
## Why I'm doing:

The `warehouse` variable should not be set as a global variable.

## What I'm doing:

Not allow setting `warehouse` variable as global.
```
(1228, "Variable 'warehouse' is a SESSION variable and can't be used with SET GLOBAL") [SQL: set global warehouse = "test_wh_2";]
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
