### PR TITLE
[Enhancement] Optimize performance of roaring2range

### DIFF
--- a/be/src/storage/roaring2range.h
+++ b/be/src/storage/roaring2range.h
@@ -24,7 +24,7 @@ static inline SparseRange<> roaring2range(const Roaring& roaring) {
     BitmapRangeIterator iter(roaring);
     uint32_t from;
     uint32_t to;
-    while (iter.next_range(1024, &from, &to)) {
+    while (iter.next_range(&from, &to)) {
         range.add(Range<>(from, to));
     }
     return range;

--- a/be/src/storage/rowset/bitmap_range_iterator.h
+++ b/be/src/storage/rowset/bitmap_range_iterator.h
@@ -38,11 +38,12 @@
 
 namespace starrocks {
 
+using Roaring = roaring::Roaring;
+
 // A fast range iterator for roaring bitmap. Output ranges use closed-open form, like [from, to).
 // Example:
 //   input bitmap:  [0 1 4 5 6 7 10 15 16 17 18 19]
-//   output ranges: [0,2), [4,8), [10,11), [15,20) (when max_range_size=10)
-//   output ranges: [0,2), [4,8), [10,11), [15,18), [18,20) (when max_range_size=3)
+//   output ranges: [0,2), [4,8), [10,11), [15,20)
 class BitmapRangeIterator {
 public:
     explicit BitmapRangeIterator(const Roaring& bitmap) {
@@ -52,25 +53,23 @@ public:
 
     ~BitmapRangeIterator() = default;
 
-    bool has_more_range() const { return !_eof; }
-
-    // read next range into [*from, *to) whose size <= max_range_size.
+    // read next range into [*from, *to)
     // return false when there is no more range.
-    bool next_range(uint32_t max_range_size, uint32_t* from, uint32_t* to) {
+    bool next_range(uint32_t* from, uint32_t* to) {
         if (_eof) {
             return false;
         }
         *from = _buf[_buf_pos];
-        uint32_t range_size = 0;
+        auto last_val = *from;
+
         do {
-            _last_val = _buf[_buf_pos];
             _buf_pos++;
-            range_size++;
-            if (_buf_pos == _buf_size) { // read next batch
+            last_val++;
+            if (_buf_pos == _buf_size) {
                 _read_next_batch();
             }
-        } while (range_size < max_range_size && !_eof && _buf[_buf_pos] == _last_val + 1);
-        *to = *from + range_size;
+        } while (!_eof && _buf[_buf_pos] == last_val);
+        *to = last_val;
         return true;
     }
 
@@ -85,7 +84,6 @@ private:
     static const uint32_t kBatchSize = 256;
 
     roaring::api::roaring_uint32_iterator_t _iter{};
-    uint32_t _last_val{0};
     uint32_t _buf_pos{0};
     uint32_t _buf_size{0};
     bool _eof{false};

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -234,6 +234,7 @@ set(EXEC_FILES
         ./storage/persistent_index_test.cpp
         ./storage/primary_index_test.cpp
         ./storage/primary_key_encoder_test.cpp
+        ./storage/roaring2range_test.cpp
         ./storage/tablet_mgr_test.cpp
         ./storage/tablet_schema_helper.cpp
         ./storage/version_graph_test.cpp

--- a/be/test/storage/roaring2range_test.cpp
+++ b/be/test/storage/roaring2range_test.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/roaring2range.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+class Roaring2rangeTest : public testing::Test {};
+
+TEST_F(Roaring2rangeTest, test_roaring2range) {
+    Roaring roaring_1;
+    auto ret_1 = roaring2range(roaring_1);
+    ASSERT_EQ(ret_1.to_string(), "()");
+
+    Roaring roaring_2;
+    roaring_2.addRange(1, 10);
+    auto ret_2 = roaring2range(roaring_2);
+    ASSERT_EQ(ret_2.to_string(), "([1,10))");
+
+    Roaring roaring_3;
+    roaring_3.addRange(1, 10);
+    roaring_3.addRange(15, 20);
+    auto ret_3 = roaring2range(roaring_3);
+    ASSERT_EQ(ret_3.to_string(), "([1,10), [15,20))");
+
+    Roaring roaring_4;
+    roaring_4.addRange(1, 300);
+    roaring_4.addRange(400, 500);
+    roaring_4.addRange(600, 1000);
+    auto ret_4 = roaring2range(roaring_4);
+    ASSERT_EQ(ret_4.to_string(), "([1,300), [400,500), [600,1000))");
+
+    Roaring roaring_5;
+    roaring_5.addRange(1, 257);
+    auto ret_5 = roaring2range(roaring_5);
+    ASSERT_EQ(ret_5.to_string(), "([1,257))");
+}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. The interface `SparseRange<T>::add` is not friendly for add continous range, will result in high frequency memory  allocation and cpu usage.
2. When there are many values ​​in bitmap, `next_range` is called more often.
3. Remove `_last_value` from `BitmapRangeIterator`
4. Remove `max_range_size` from interface `next_range`.

Performance test

select count(*) from xxx; // 30,000,000 line

```
mysqlslap -uroot -hxxx -Pxxx --create-schema=ssb_20 --concurrency=20 --number-of-queries=1000 --query='select count(*) from xxx where lo_partkey=300000;'
```

![image](https://github.com/user-attachments/assets/8046e7ec-4708-4ca2-aa12-bf6e02e26a36)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
