### PR TITLE
[BugFix] Fix partition live number not update

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -435,20 +435,16 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public TableProperty buildPartitionTTL() {
-        if (partitionTTLNumber != INVALID) {
-            return this;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)) {
+            partitionTTLNumber = Integer.parseInt(properties.get(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER));
         }
-        partitionTTLNumber = Integer.parseInt(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER,
-                String.valueOf(INVALID)));
         return this;
     }
 
     public TableProperty buildPartitionLiveNumber() {
-        if (partitionTTLNumber != INVALID) {
-            return this;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)) {
+            partitionTTLNumber = Integer.parseInt(properties.get(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER));
         }
-        partitionTTLNumber = Integer.parseInt(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER,
-                String.valueOf(INVALID)));
         return this;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyTest.java
@@ -115,8 +115,15 @@ public class TablePropertyTest {
 
         // 2. Read objects from file
         DataInputStream in = new DataInputStream(new FileInputStream(file));
-        TableProperty readTableProperty = TableProperty.read(in);
-        Assert.assertEquals(2, readTableProperty.getPartitionTTLNumber());
+        TableProperty newTableProperty = TableProperty.read(in);
+        Assert.assertEquals(2, newTableProperty.getPartitionTTLNumber());
         in.close();
+
+        // 3. Update again
+        properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER, "3");
+        newTableProperty.modifyTableProperties(properties);
+        newTableProperty.buildPartitionLiveNumber();
+        newTableProperty.buildPartitionTTL();
+        Assert.assertEquals(3, newTableProperty.getPartitionTTLNumber());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
`alter table tbl set ("partition_live_number" = "2")` can modify table partition live number,
but when FE restarts, `partition_live_number` will be recovered to old value.

`buildPartitionLiveNumber` checks the current value of `partitionTTLNumber` and does not update if it is not `-1`.

## What I'm doing:
fix the update check. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
