### PR TITLE
[Enhancement] Add memory alloc profile log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1334,6 +1334,42 @@ public class Config extends ConfigBase {
     public static long memory_tracker_interval_seconds = 60;
 
     /**
+     * true to enable collect proc memory alloc profile
+     */
+    @ConfField(mutable = true)
+    public static boolean proc_profile_mem_enable = true;
+
+    /**
+     * true to enable collect proc cpu profile
+     */
+    @ConfField(mutable = true)
+    public static boolean proc_profile_cpu_enable = true;
+
+    /**
+     * The number of seconds between proc profile collections
+     */
+    @ConfField(mutable = true)
+    public static long proc_profile_collect_interval_s = 600;
+
+    /**
+     * The number of seconds it takes to collect single proc profile
+     */
+    @ConfField(mutable = true)
+    public static long proc_profile_collect_time_s = 300;
+
+    /**
+     * The number of days to retain profile files
+     */
+    @ConfField(mutable = true)
+    public static int proc_profile_file_retained_days = 2;
+
+    /**
+     * The number of size to retain profile files
+     */
+    @ConfField(mutable = true)
+    public static long proc_profile_file_retained_size_bytes = Long.MAX_VALUE;
+
+    /**
      * If batch creation of partitions is allowed to create half of the partitions, it is easy to generate holes.
      * By default, this is not enabled. If it is turned on, the partitions built by batch creation syntax will
      * not allow partial creation.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1336,38 +1336,38 @@ public class Config extends ConfigBase {
     /**
      * true to enable collect proc memory alloc profile
      */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "true to enable collect proc memory alloc profile")
     public static boolean proc_profile_mem_enable = true;
 
     /**
      * true to enable collect proc cpu profile
      */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "true to enable collect proc cpu profile")
     public static boolean proc_profile_cpu_enable = true;
 
     /**
      * The number of seconds between proc profile collections
      */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "The number of seconds between proc profile collections")
     public static long proc_profile_collect_interval_s = 600;
 
     /**
      * The number of seconds it takes to collect single proc profile
      */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "The number of seconds it takes to collect single proc profile")
     public static long proc_profile_collect_time_s = 300;
 
     /**
      * The number of days to retain profile files
      */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "The number of days to retain profile files")
     public static int proc_profile_file_retained_days = 2;
 
     /**
-     * The number of size to retain profile files
+     * The number of bytes to retain profile files
      */
-    @ConfField(mutable = true)
-    public static long proc_profile_file_retained_size_bytes = Long.MAX_VALUE;
+    @ConfField(mutable = true, comment = "The number of bytes to retain profile files")
+    public static long proc_profile_file_retained_size_bytes = 2L * 1024 * 1024 * 1024;
 
     /**
      * If batch creation of partitions is allowed to create half of the partitions, it is easy to generate holes.

--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -1,0 +1,201 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory;
+
+import com.starrocks.StarRocksFE;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.FrontendDaemon;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+public class ProcProfileCollector extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(ProcProfileCollector.class);
+    private static final String CPU_FILE_NAME_PREFIX = "cpu-profile-";
+    private static final String MEM_FILE_NAME_PREFIX = "mem-profile-";
+
+    private final SimpleDateFormat profileTimeFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
+    private final String profileLogDir;
+
+    private long lastCollectTime = -1;
+
+    private boolean initialized = false;
+
+    public ProcProfileCollector() {
+        super("ProcProfileCollector");
+        profileLogDir = Config.sys_log_dir + "/proc_profile";
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (!initialized) {
+            File file = new File(profileLogDir);
+            file.mkdirs();
+            initialized = true;
+        }
+
+        if (lastCollectTime == -1L
+                || (System.currentTimeMillis() - lastCollectTime > Config.proc_profile_collect_interval_s * 1000)) {
+
+            lastCollectTime = System.currentTimeMillis();
+
+            if (Config.proc_profile_cpu_enable) {
+                collectCPUProfile();
+            }
+
+            if (Config.proc_profile_mem_enable) {
+                collectMemProfile();
+            }
+        }
+
+        deleteExpiredFiles();
+    }
+
+    private void collectMemProfile() {
+        String fileName = MEM_FILE_NAME_PREFIX + currentTimeString() + ".html";
+        collectProfile(StarRocksFE.STARROCKS_HOME_DIR + "/bin/profiler.sh",
+                "-e", "alloc",
+                "-d", String.valueOf(Config.proc_profile_collect_time_s),
+                "-f", profileLogDir + "/" +  fileName,
+                getPid());
+
+        try {
+            compressFile(fileName);
+        } catch (IOException e) {
+            LOG.warn("compress file {} failed", fileName, e);
+        }
+    }
+
+    private void collectCPUProfile() {
+        String fileName = CPU_FILE_NAME_PREFIX + currentTimeString() + ".html";
+        collectProfile(StarRocksFE.STARROCKS_HOME_DIR + "/bin/profiler.sh",
+                "-e", "cpu",
+                "-d", String.valueOf(Config.proc_profile_collect_time_s),
+                "-f", profileLogDir + "/" +  fileName,
+                getPid());
+
+        try {
+            compressFile(fileName);
+        } catch (IOException e) {
+            LOG.warn("compress file {} failed", fileName, e);
+        }
+    }
+
+    private void collectProfile(String... command) {
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder(command);
+            Process process = processBuilder.start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    sb.append(line).append("\n");
+                }
+                if (sb.length() > 0) {
+                    LOG.info("collect profile output: {}", sb.toString());
+                }
+            }
+            process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            LOG.warn("collect profile failed", e);
+        }
+    }
+
+    private void compressFile(String fileName) throws IOException {
+        File sourceFile = new File(profileLogDir + "/" + fileName);
+        try (FileOutputStream fileOutputStream = new FileOutputStream(profileLogDir + "/" + fileName + ".tar.gz");
+                GzipCompressorOutputStream gzipOutputStream = new GzipCompressorOutputStream(fileOutputStream);
+                TarArchiveOutputStream tarArchive = new TarArchiveOutputStream(gzipOutputStream);
+                FileInputStream fileInputStream = new FileInputStream(sourceFile)) {
+            TarArchiveEntry tarEntry = new TarArchiveEntry(sourceFile, sourceFile.getName());
+            tarArchive.putArchiveEntry(tarEntry);
+
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = fileInputStream.read(buffer)) > 0) {
+                tarArchive.write(buffer, 0, len);
+            }
+            tarArchive.closeArchiveEntry();
+            tarArchive.finish();
+        }
+
+        sourceFile.delete();
+    }
+
+    private void deleteExpiredFiles() {
+        File dir = new File(profileLogDir);
+        List<File> validFiles = new ArrayList<>();
+        long totalSize = 0;
+        for (File file : dir.listFiles()) {
+            if (file.getName().startsWith(CPU_FILE_NAME_PREFIX)
+                    || file.getName().startsWith(MEM_FILE_NAME_PREFIX)) {
+                validFiles.add(file);
+                totalSize += file.length();
+            }
+        }
+
+        //sort file by time desc
+        validFiles.sort((f1, f2) -> {
+            String comparableName1 = getTimePart(f1.getName());
+            String comparableName2 = getTimePart(f2.getName());
+            return -(comparableName1.compareTo(comparableName2));
+        });
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.DAY_OF_MONTH, -Config.proc_profile_file_retained_days);
+        String timeToDelete = profileTimeFormat.format(calendar.getTime());
+        long sizeReserved = totalSize;
+        for (File file : validFiles) {
+            String timePart = getTimePart(file.getName());
+            if (timePart.compareTo(timeToDelete) < 0
+                    || sizeReserved > Config.proc_profile_file_retained_size_bytes) {
+                sizeReserved -= file.length();
+                file.delete();
+            }
+        }
+    }
+
+    private String currentTimeString() {
+        return profileTimeFormat.format(new Date(System.currentTimeMillis()));
+    }
+
+    private String getTimePart(String fileName) {
+        return fileName.startsWith(CPU_FILE_NAME_PREFIX) ?
+                fileName.substring(CPU_FILE_NAME_PREFIX.length(), fileName.indexOf("."))
+                : fileName.substring(MEM_FILE_NAME_PREFIX.length(), fileName.indexOf("."));
+    }
+
+    private String getPid() {
+        return ManagementFactory
+                .getRuntimeMXBean()
+                .getName()
+                .split("@")[0];
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -161,11 +161,11 @@ public class ProcProfileCollector extends FrontendDaemon {
             }
         }
 
-        //sort file by time desc
+        //sort file by time asc
         validFiles.sort((f1, f2) -> {
             String comparableName1 = getTimePart(f1.getName());
             String comparableName2 = getTimePart(f2.getName());
-            return -(comparableName1.compareTo(comparableName2));
+            return comparableName1.compareTo(comparableName2);
         });
 
         Calendar calendar = Calendar.getInstance();
@@ -178,6 +178,8 @@ public class ProcProfileCollector extends FrontendDaemon {
                     || sizeReserved > Config.proc_profile_file_retained_size_bytes) {
                 sizeReserved -= file.length();
                 file.delete();
+            } else {
+                break;
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -154,6 +154,7 @@ import com.starrocks.load.routineload.RoutineLoadScheduler;
 import com.starrocks.load.routineload.RoutineLoadTaskScheduler;
 import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.memory.MemoryUsageTracker;
+import com.starrocks.memory.ProcProfileCollector;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
@@ -478,6 +479,8 @@ public class GlobalStateMgr {
 
     private MemoryUsageTracker memoryUsageTracker;
 
+    private ProcProfileCollector procProfileCollector;
+
     private final MetaRecoveryDaemon metaRecoveryDaemon = new MetaRecoveryDaemon();
 
     private TemporaryTableMgr temporaryTableMgr;
@@ -764,6 +767,7 @@ public class GlobalStateMgr {
         nodeMgr.registerLeaderChangeListener(globalSlotProvider::leaderChangeListener);
 
         this.memoryUsageTracker = new MemoryUsageTracker();
+        this.procProfileCollector = new ProcProfileCollector();
 
         this.sqlParser = new SqlParser(AstBuilder.getInstance());
         this.analyzer = new Analyzer(Analyzer.AnalyzerVisitor.getInstance());
@@ -1405,6 +1409,8 @@ public class GlobalStateMgr {
         lockChecker.start();
 
         refreshDictionaryCacheTaskDaemon.start();
+
+        procProfileCollector.start();
 
         // The memory tracker should be placed at the end
         memoryUsageTracker.start();


### PR DESCRIPTION
## Why I'm doing:
Add memory profile files into log/proc_profile to help position memory problems.

## What I'm doing:
There are two params to collect profiles: `proc_profile_collect_interval_s` and `proc_profile_collect_time_s`. 
`proc_profile_collect_interval_s` is the number of seconds between proc profile collections,
`proc_profile_collect_time_s` The number of seconds it takes to collect single proc profile.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
