### PR TITLE
[BugFix] Fix incorrect generated column serialized data for dictionary_get expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1362,7 +1362,7 @@ public class AstToStringBuilder {
 
         @Override
         public String visitDictionaryGetExpr(DictionaryGetExpr node, Void context) {
-            return "DICTIONARY_GET";
+            return node.toSql();
         }
 
         private String visitAstList(List<? extends ParseNode> contexts) {

--- a/test/sql/test_dictionary/R/test_dictionary
+++ b/test/sql/test_dictionary/R/test_dictionary
@@ -1244,3 +1244,78 @@ DROP DICTIONARY test_dictionary_multiple_row_multi_value;
 DROP DICTIONARY test_dictionary_multiple_row_single_value;
 -- result:
 -- !result
+-- name: test_dictionary_show_create_table_gen_col
+CREATE TABLE `t_dictionary_show_create_table_gen_col_1` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_dictionary_show_create_table_gen_col_1 VALUES (1,1);
+-- result:
+-- !result
+[UC]DROP DICTIONARY test_dictionary_show_create_table_gen_col;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: dictionary: test_dictionary_show_create_table_gen_col does not exist.')
+-- !result
+CREATE DICTIONARY test_dictionary_show_create_table_gen_col USING t_dictionary_show_create_table_gen_col_1 (k KEY, v VALUE);
+-- result:
+-- !result
+function: wait_refresh_dictionary_finish("test_dictionary_show_create_table_gen_col", "FINISHED")
+-- result:
+None
+-- !result
+CREATE TABLE `t_dictionary_show_create_table_gen_col_2` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AS dictionary_get("test_dictionary_show_create_table_gen_col", k)[1] COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_dictionary_show_create_table_gen_col_2 VALUES (1);
+-- result:
+-- !result
+SELECT * FROM t_dictionary_show_create_table_gen_col_2;
+-- result:
+1	1
+-- !result
+SHOW CREATE TABLE t_dictionary_show_create_table_gen_col_2;
+-- result:
+t_dictionary_show_create_table_gen_col_2	CREATE TABLE `t_dictionary_show_create_table_gen_col_2` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v` bigint(20) NULL AS DICTIONARY_GET('test_dictionary_show_create_table_gen_col', k)[1] COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "false",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+DROP TABLE t_dictionary_show_create_table_gen_col_1;
+-- result:
+-- !result
+DROP TABLE t_dictionary_show_create_table_gen_col_2;
+-- result:
+-- !result
+DROP DICTIONARY test_dictionary_show_create_table_gen_col;
+-- result:
+-- !result

--- a/test/sql/test_dictionary/T/test_dictionary
+++ b/test/sql/test_dictionary/T/test_dictionary
@@ -588,3 +588,45 @@ DROP TABLE t_dictionary_multiple_row;
 DROP TABLE t_dictionary_multiple_row_fact;
 DROP DICTIONARY test_dictionary_multiple_row_multi_value;
 DROP DICTIONARY test_dictionary_multiple_row_single_value;
+
+-- name: test_dictionary_show_create_table_gen_col
+CREATE TABLE `t_dictionary_show_create_table_gen_col_1` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_dictionary_show_create_table_gen_col_1 VALUES (1,1);
+
+[UC]DROP DICTIONARY test_dictionary_show_create_table_gen_col;
+CREATE DICTIONARY test_dictionary_show_create_table_gen_col USING t_dictionary_show_create_table_gen_col_1 (k KEY, v VALUE);
+function: wait_refresh_dictionary_finish("test_dictionary_show_create_table_gen_col", "FINISHED")
+
+CREATE TABLE `t_dictionary_show_create_table_gen_col_2` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AS dictionary_get("test_dictionary_show_create_table_gen_col", k)[1] COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_dictionary_show_create_table_gen_col_2 VALUES (1);
+SELECT * FROM t_dictionary_show_create_table_gen_col_2;
+
+SHOW CREATE TABLE t_dictionary_show_create_table_gen_col_2;
+
+DROP TABLE t_dictionary_show_create_table_gen_col_1;
+DROP TABLE t_dictionary_show_create_table_gen_col_2;
+DROP DICTIONARY test_dictionary_show_create_table_gen_col;


### PR DESCRIPTION
## Why I'm doing:
After SR support rename column, column need to deserialize/serialize the generated expression using AstToStringBuilder but not DictionaryGetExpr::toSql(). But AstToStringBuilder for dictionary_get expression has wrong return value and cause the incorrect deserialize/serialize value for it.

## What I'm doing:
Call DictionaryGetExpr::toSql() in AstToStringBuilder for dictionary_get which make the string corrent.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
