### PR TITLE
[Enhancement] Use protobuf arena to optimize the memory alloc of PersistentIndexMetaPB

### DIFF
--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 syntax = "proto3";
+option cc_enable_arenas = true;
 
 package starrocks;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

IndexWalMetaPB will allocate small memory multiple times, which is not friendly to the memory allocator.

```
               |                     |          |          |          |          |--14.00%--starrocks::PersistentIndexMetaPB::_InternalParse
               |                     |          |          |          |          |          |          
               |                     |          |          |          |          |           --13.82%--starrocks::MutableIndexMetaPB::_InternalParse
               |                     |          |          |          |          |                     |          
               |                     |          |          |          |          |                     |--9.30%--starrocks::IndexWalMetaPB::_InternalParse
               |                     |          |          |          |          |                     |          |          
               |                     |          |          |          |          |                     |          |--4.73%--operator new
               |                     |          |          |          |          |                     |          |          |          
               |                     |          |          |          |          |                     |          |          |--3.09%--my_malloc
               |                     |          |          |          |          |                     |          |          |          |          
               |                     |          |          |          |          |                     |          |          |          |--1.17%--je_malloc_default
               |                     |          |          |          |          |                     |          |          |          |          |          
               |                     |          |          |          |          |                     |          |          |          |           --1.08%--je_tcache_alloc_small_hard
               |                     |          |          |          |          |                     |          |          |          |                     |          
               |                     |          |          |          |          |                     |          |          |          |                      --0.99%--je_arena_cache_bin_fill_small
               |                     |          |          |          |          |                     |          |          |          |          
               |                     |          |          |          |          |                     |          |          |           --0.78%--jenallocx
               |                     |          |          |          |          |                     |          |          |          
               |                     |          |          |          |          |                     |          |           --1.24%--jemalloc
               |                     |          |          |          |          |                     |          |          
               |                     |          |          |          |          |                     |          |--1.57%--google::protobuf::internal::ParseContext::ParseMessage<starrocks::PagePointerPB>
               |                     |          |          |          |          |                     |          |          |          
               |                     |          |          |          |          |                     |          |           --0.91%--starrocks::PagePointerPB::_InternalParse
               |                     |          |          |          |          |                     |          |          
               |                     |          |          |          |          |                     |           --0.87%--google::protobuf::internal::ParseContext::ParseMessage<starrocks::EditVersionPB>
               |                     |          |          |          |          |                     |                     |          
               |                     |          |          |          |          |                     |                      --0.59%--starrocks::EditVersionPB::_InternalParse
               |                     |          |          |          |          |                     |          
               |                     |          |          |          |          |                      --2.10%--operator new
               |                     |          |          |          |          |                                |          
               |                     |          |          |          |          |                                 --1.50%--my_malloc
               |                     |          |          |          |          |                                           |          
               |                     |          |          |          |          |                                            --0.59%--je_malloc_default
```

```
               |                     |          |           --7.01%--starrocks::PersistentIndexMetaPB::~PersistentIndexMetaPB
               |                     |          |                     |          
               |                     |          |                     |--4.93%--google::protobuf::internal::RepeatedPtrFieldBase::Destroy<google::protobuf::RepeatedPtrField<starrocks::IndexWalMetaPB>::TypeHandler>
               |                     |          |                     |          |          
               |                     |          |                     |          |--1.90%--my_free
               |                     |          |                     |          |          |          
               |                     |          |                     |          |           --0.88%--jemalloc_usable_size
               |                     |          |                     |          |          
               |                     |          |                     |          |--1.38%--je_free_default
               |                     |          |                     |          |          |          
               |                     |          |                     |          |           --1.28%--je_tcache_bin_flush_small
               |                     |          |                     |          |          
               |                     |          |                     |          |--0.56%--starrocks::PagePointerPB::~PagePointerPB
               |                     |          |                     |          |          
               |                     |          |                     |           --0.54%--starrocks::EditVersionPB::~EditVersionPB
               |                     |          |                     |          
               |                     |          |                      --1.72%--jefree
```

```
insert into xxx select * from lineorder limit 10;
or
insert into xxx select * from lineorder;
```

Before optimization:

For one tablet, the `PersistentIndexMetaPB` will alloc 10 times and total 412bytes.

After optimization

For one tablet, the `PersistentIndexMetaPB` will alloc 1 times and total 512bytes.

`PersistentIndexMetaPB` is only for temporary use and will not reside in the memory. It will be released immediately after use. Moreover, the memory allocation of fixed size is more friendly to the memory allocator.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
