### PR TITLE
[Enhancement] Add interface roaring2range with start

### DIFF
--- a/be/src/storage/roaring2range.h
+++ b/be/src/storage/roaring2range.h
@@ -30,6 +30,18 @@ static inline SparseRange<> roaring2range(const Roaring& roaring) {
     return range;
 }
 
+static inline SparseRange<> roaring2range(const Roaring& roaring, uint32_t start, uint32_t size) {
+    SparseRange<> range;
+    BitmapRangeIterator iter(roaring, start);
+    uint32_t from;
+    uint32_t to;
+    while (size > 0 && iter.next_range(size, &from, &to)) {
+        range.add(Range<>(from, to));
+        size -= (to - from);
+    }
+    return range;
+}
+
 static inline Roaring range2roaring(const SparseRange<>& range) {
     Roaring roaring;
     for (SparseRangeIterator<> iter = range.new_iterator(); iter.has_more(); /**/) {

--- a/be/test/storage/roaring2range_test.cpp
+++ b/be/test/storage/roaring2range_test.cpp
@@ -48,4 +48,46 @@ TEST_F(Roaring2rangeTest, test_roaring2range) {
     auto ret_5 = roaring2range(roaring_5);
     ASSERT_EQ(ret_5.to_string(), "([1,257))");
 }
+
+TEST_F(Roaring2rangeTest, test_roaring2range_with_start) {
+    Roaring roaring_1;
+    auto ret_1 = roaring2range(roaring_1, 1, 10);
+    ASSERT_EQ(ret_1.to_string(), "()");
+
+    Roaring roaring_2;
+    roaring_2.addRange(1, 10);
+    auto ret_2_1 = roaring2range(roaring_2, 1, 20);
+    ASSERT_EQ(ret_2_1.to_string(), "([1,10))");
+    auto ret_2_2 = roaring2range(roaring_2, 1, 5);
+    ASSERT_EQ(ret_2_2.to_string(), "([1,6))");
+    auto ret_2_3 = roaring2range(roaring_2, 3, 5);
+    ASSERT_EQ(ret_2_3.to_string(), "([3,8))");
+
+    Roaring roaring_3;
+    roaring_3.addRange(1, 10);
+    roaring_3.addRange(15, 20);
+    auto ret_3_1 = roaring2range(roaring_3, 1, 80);
+    ASSERT_EQ(ret_3_1.to_string(), "([1,10), [15,20))");
+    auto ret_3_2 = roaring2range(roaring_3, 1, 12);
+    ASSERT_EQ(ret_3_2.to_string(), "([1,10), [15,18))");
+    auto ret_3_3 = roaring2range(roaring_3, 16, 2);
+    ASSERT_EQ(ret_3_3.to_string(), "([16,18))");
+
+    Roaring roaring_4;
+    roaring_4.addRange(1, 300);
+    roaring_4.addRange(400, 500);
+    roaring_4.addRange(600, 1000);
+    auto ret_4_1 = roaring2range(roaring_4, 1, 2000);
+    ASSERT_EQ(ret_4_1.to_string(), "([1,300), [400,500), [600,1000))");
+    auto ret_4_2 = roaring2range(roaring_4, 450, 30);
+    ASSERT_EQ(ret_4_2.to_string(), "([450,480))");
+    auto ret_4_3 = roaring2range(roaring_4, 450, 200);
+    ASSERT_EQ(ret_4_3.to_string(), "([450,500), [600,750))");
+
+    Roaring roaring_5;
+    roaring_5.addRange(1, 257);
+    auto ret_5 = roaring2range(roaring_5, 1, 300);
+    ASSERT_EQ(ret_5.to_string(), "([1,257))");
+}
+
 } // namespace starrocks

--- a/be/test/storage/roaring2range_test.cpp
+++ b/be/test/storage/roaring2range_test.cpp
@@ -83,6 +83,8 @@ TEST_F(Roaring2rangeTest, test_roaring2range_with_start) {
     ASSERT_EQ(ret_4_2.to_string(), "([450,480))");
     auto ret_4_3 = roaring2range(roaring_4, 450, 200);
     ASSERT_EQ(ret_4_3.to_string(), "([450,500), [600,750))");
+    auto ret_4_4 = roaring2range(roaring_4, 2000, 200);
+    ASSERT_EQ(ret_4_4.to_string(), "()");
 
     Roaring roaring_5;
     roaring_5.addRange(1, 257);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add an interface to convert a certain range of roaring bitmap values ​​into `SparseRange`, which will be used in the later `apply_del_vector` optimization. This interface improves performance by skipping previous ranges and interrupting early.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
