### PR TITLE
[BugFix] add thrift max_message_size configuration

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1408,10 +1408,21 @@ CONF_mInt32(config_vector_index_build_concurrency, "8");
 // default not to build the empty index
 CONF_mInt32(config_vector_index_default_build_threshold, "0");
 
-CONF_mInt32(thrift_max_message_size, "1073741824"); // 1 GB
+// When upgrade thrift to 0.20.0, the MaxMessageSize member defines the maximum size of a (received) message, in bytes.
+// The default value is represented by a constant named DEFAULT_MAX_MESSAGE_SIZE, whose value is 100 * 1024 * 1024 bytes.
+// This will cause FE to fail during deserialization when the returned result set is larger than 100M. Therefore,
+// we set a default value of 1G and the maximum configurable value is 2G.
+CONF_mInt32(thrift_max_message_size, "1073741824");
 
+// MaxFrameSize limits the size of one frame of data for the TFramedTransport. Since all implementations currently send
+// messages in one frame only if TFramedTransport is used, this value may interfere with MaxMessageSize.
+// In the case of an conflict, the smaller value of the two is used (see remark below). The default value is called
+// DEFAULT_MAX_FRAME_SIZE and has a value of 16384000 bytes. This value is used consistently across all Thrift libraries,
+// so we use the same value with the old version.
 CONF_mInt32(thrift_max_frame_size, "16384000");
 
+// The RecursionLimit defines, how deep structures may be nested into each other. The default named DEFAULT_RECURSION_DEPTH
+// allows for structures nested up to 64 levels deep.
 CONF_mInt32(thrift_max_recursion_depth, "64");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -946,9 +946,6 @@ CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
 // this is a default value, maybe changed by global_runtime_filter_rpc_http_min_size in session variable.
 CONF_Int64(send_runtime_filter_via_http_rpc_min_size, "67108864");
 
-// -1: ulimited, 0: limit by memory use, >0: limit by queue_size
-CONF_mInt64(runtime_filter_queue_limit, "-1");
-
 CONF_Int64(rpc_connect_timeout_ms, "30000");
 
 CONF_Int32(max_batch_publish_latency_ms, "100");
@@ -1410,5 +1407,11 @@ CONF_mInt32(config_vector_index_build_concurrency, "8");
 
 // default not to build the empty index
 CONF_mInt32(config_vector_index_default_build_threshold, "0");
+
+CONF_mInt32(thrift_max_message_size, "1073741824"); // 1 GB
+
+CONF_mInt32(thrift_max_frame_size, "16384000");
+
+CONF_mInt32(thrift_max_recursion_depth, "64");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -946,6 +946,9 @@ CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
 // this is a default value, maybe changed by global_runtime_filter_rpc_http_min_size in session variable.
 CONF_Int64(send_runtime_filter_via_http_rpc_min_size, "67108864");
 
+// -1: ulimited, 0: limit by memory use, >0: limit by queue_size
+CONF_mInt64(runtime_filter_queue_limit, "-1");
+
 CONF_Int64(rpc_connect_timeout_ms, "30000");
 
 CONF_Int32(max_batch_publish_latency_ms, "100");

--- a/be/src/util/thrift_util.cpp
+++ b/be/src/util/thrift_util.cpp
@@ -58,7 +58,10 @@
 namespace starrocks {
 
 ThriftSerializer::ThriftSerializer(bool compact, int initial_buffer_size)
-        : _mem_buffer(new apache::thrift::transport::TMemoryBuffer(initial_buffer_size)) {
+        : _mem_buffer(new apache::thrift::transport::TMemoryBuffer(
+                  initial_buffer_size, std::make_shared<apache::thrift::TConfiguration>(
+                                               config::thrift_max_message_size, config::thrift_max_frame_size,
+                                               config::thrift_max_recursion_depth))) {
     if (compact) {
         apache::thrift::protocol::TCompactProtocolFactoryT<apache::thrift::transport::TMemoryBuffer> factory;
         _protocol = factory.getProtocol(_mem_buffer);

--- a/be/src/util/thrift_util.h
+++ b/be/src/util/thrift_util.h
@@ -151,10 +151,11 @@ Status deserialize_thrift_msg(const uint8_t* buf, uint32_t* len, TProtocolType t
     // transport. TMemoryBuffer is not const-safe, although we use it in
     // a const-safe way, so we have to explicitly cast away the const.
     std::shared_ptr<apache::thrift::transport::TMemoryBuffer> tmem_transport(
-            new apache::thrift::transport::TMemoryBuffer(const_cast<uint8_t*>(buf), *len),
-            std::make_shared<apache::thrift::TConfiguration>(config::thrift_max_message_size,
-                                                             config::thrift_max_frame_size,
-                                                             config::thrift_max_recursion_depth));
+            new apache::thrift::transport::TMemoryBuffer(
+                    const_cast<uint8_t*>(buf), *len, apache::thrift::transport::TMemoryBuffer::MemoryPolicy::OBSERVE,
+                    std::make_shared<apache::thrift::TConfiguration>(config::thrift_max_message_size,
+                                                                     config::thrift_max_frame_size,
+                                                                     config::thrift_max_recursion_depth)));
     std::shared_ptr<apache::thrift::protocol::TProtocol> tproto = create_deserialize_protocol(tmem_transport, type);
 
     try {

--- a/be/src/util/thrift_util.h
+++ b/be/src/util/thrift_util.h
@@ -45,6 +45,7 @@
 #include <sstream>
 #include <vector>
 
+#include "common/config.h"
 #include "common/status.h"
 
 namespace starrocks {
@@ -150,7 +151,10 @@ Status deserialize_thrift_msg(const uint8_t* buf, uint32_t* len, TProtocolType t
     // transport. TMemoryBuffer is not const-safe, although we use it in
     // a const-safe way, so we have to explicitly cast away the const.
     std::shared_ptr<apache::thrift::transport::TMemoryBuffer> tmem_transport(
-            new apache::thrift::transport::TMemoryBuffer(const_cast<uint8_t*>(buf), *len));
+            new apache::thrift::transport::TMemoryBuffer(const_cast<uint8_t*>(buf), *len),
+            std::make_shared<apache::thrift::TConfiguration>(config::thrift_max_message_size,
+                                                             config::thrift_max_frame_size,
+                                                             config::thrift_max_recursion_depth));
     std::shared_ptr<apache::thrift::protocol::TProtocol> tproto = create_deserialize_protocol(tmem_transport, type);
 
     try {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -29,6 +29,7 @@ import com.starrocks.common.util.Util;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TColumn;
@@ -47,7 +48,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
-import org.apache.thrift.protocol.TBinaryProtocol;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -337,7 +337,7 @@ public class IcebergTable extends Table {
             // partition info may be very big, and it is the same in plan fragment send to every be.
             // extract and serialize it as a string, will get better performance(about 3x in test).
             try {
-                TSerializer serializer = new TSerializer(TBinaryProtocol::new);
+                TSerializer serializer = ConfigurableSerDesFactory.getTSerializer();
                 byte[] bytes = serializer.serialize(tPartitionMap);
                 byte[] compressedBytes = Util.compress(bytes);
                 TCompressedPartitionMap tCompressedPartitionMap = new TCompressedPartitionMap();

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3095,4 +3095,15 @@ public class Config extends ConfigBase {
     
     @ConfField
     public static boolean enable_alter_struct_column = true;
+
+    // since thrift@0.16.0, it adds a default setting max_message_size = 100M which may prevent
+    // large bytes to being deserialized successfully. So we give a 1G default value here.
+    @ConfField(mutable = true)
+    public static int thrift_max_message_size = 1024 * 1024 * 1024;
+
+    @ConfField(mutable = true)
+    public static int thrift_max_frame_size = 16384000;
+
+    @ConfField(mutable = true)
+    public static int thrift_max_recursion_depth = 64;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -55,6 +55,7 @@ import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -319,7 +320,7 @@ public class TableQueryPlanAction extends RestBaseAction {
         // serialize TQueryPlanInfo and encode plan with Base64 to string in order to translate by json format
         String opaquedQueryPlan;
         try {
-            TSerializer serializer = new TSerializer();
+            TSerializer serializer = ConfigurableSerDesFactory.getTSerializer();
             byte[] queryPlanStream = serializer.serialize(tQueryPlanInfo);
             opaquedQueryPlan = Base64.getEncoder().encodeToString(queryPlanStream);
         } catch (TException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -65,6 +65,8 @@ import java.util.Stack;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.starrocks.rpc.ConfigurableSerDesFactory.Protocol.SIMPLE_JSON;
+
 // FragmentNormalizer is used to normalize a cacheable Fragment. After a cacheable Fragment
 // is normalized, FragmentNormalizer draws out required information as follows from the fragment.
 // 1. MD5 digest: semantically-equivalent Fragments always produce the same MD5 digest.
@@ -231,7 +233,7 @@ public class FragmentNormalizer {
         uncacheable = uncacheable || hasNonDeterministicFunctions(expr);
         TExpr texpr = expr.normalize(this);
         try {
-            TSerializer ser = ConfigurableSerDesFactory.getTSerializer("simple_json");
+            TSerializer ser = ConfigurableSerDesFactory.getTSerializer(SIMPLE_JSON.name());
             return ByteBuffer.wrap(ser.serialize(texpr));
         } catch (Exception ignored) {
             Preconditions.checkArgument(false);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -35,11 +35,11 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.PartitionKey;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.UnionFind;
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TCacheParam;
@@ -49,7 +49,6 @@ import com.starrocks.thrift.TNormalPlanNode;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
-import org.apache.thrift.protocol.TSimpleJSONProtocol;
 
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -232,7 +231,7 @@ public class FragmentNormalizer {
         uncacheable = uncacheable || hasNonDeterministicFunctions(expr);
         TExpr texpr = expr.normalize(this);
         try {
-            TSerializer ser = new TSerializer(new TSimpleJSONProtocol.Factory());
+            TSerializer ser = ConfigurableSerDesFactory.getTSerializer("simple_json");
             return ByteBuffer.wrap(ser.serialize(texpr));
         } catch (Exception ignored) {
             Preconditions.checkArgument(false);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -40,6 +40,7 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.PFetchDataResult;
 import com.starrocks.proto.PUniqueId;
 import com.starrocks.rpc.BackendServiceClient;
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.rpc.PFetchDataRequest;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.thrift.TNetworkAddress;
@@ -123,7 +124,7 @@ public class ResultReceiver {
                 byte[] serialResult = request.getSerializedResult();
                 if (serialResult != null && serialResult.length > 0) {
                     TResultBatch resultBatch = new TResultBatch();
-                    TDeserializer deserializer = new TDeserializer();
+                    TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();
                     deserializer.deserialize(resultBatch, serialResult);
                     rowBatch.setBatch(resultBatch);
                     rowBatch.setEos(pResult.eos);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -35,6 +35,7 @@ import com.starrocks.proto.PExecShortCircuitResult;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.rpc.PBackendService;
 import com.starrocks.rpc.PExecShortCircuitRequest;
 import com.starrocks.server.GlobalStateMgr;
@@ -135,7 +136,7 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
                 RowBatch rowBatch = new RowBatch();
                 rowBatch.setEos(i.incrementAndGet() == be2ShortCircuitRequests.keys().size());
                 if (serialResult != null && serialResult.length > 0) {
-                    TDeserializer deserializer = new TDeserializer();
+                    TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();
                     TResultBatch resultBatch = new TResultBatch();
                     deserializer.deserialize(resultBatch, serialResult);
                     rowBatch.setBatch(resultBatch);
@@ -143,7 +144,7 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
                 rowBatchQueue.offer(rowBatch);
 
                 if (shortCircuitResult.profile != null) {
-                    TDeserializer deserializer = new TDeserializer();
+                    TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();
                     TRuntimeProfileTree runtimeProfileTree = new TRuntimeProfileTree();
                     deserializer.deserialize(runtimeProfileTree, shortCircuitResult.profile);
                     RuntimeProfile beProfile = new RuntimeProfile(beAddress.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
@@ -20,15 +20,11 @@ package com.starrocks.rpc;
 import com.baidu.bjf.remoting.protobuf.annotation.Ignore;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.TSerializer;
-import org.apache.thrift.protocol.TBinaryProtocol;
-import org.apache.thrift.protocol.TCompactProtocol;
-import org.apache.thrift.protocol.TJSONProtocol;
 import org.apache.thrift.transport.TTransportException;
 
 // used to compatible with our older thrift protocol
@@ -39,16 +35,7 @@ public class AttachmentRequest {
     protected byte[] serializedResult;
 
     public static TSerializer getSerializer(String protocol) throws TTransportException {
-        TSerializer serializer;
-        if (StringUtils.equalsIgnoreCase(protocol, "compact")) {
-            serializer = new TSerializer(TCompactProtocol::new);
-        } else if (StringUtils.equalsIgnoreCase(protocol, "json")) {
-            serializer = new TSerializer(TJSONProtocol::new);
-        } else {
-            // default bianry
-            serializer = new TSerializer(TBinaryProtocol::new);
-        }
-        return serializer;
+        return ConfigurableSerDesFactory.getTSerializer(protocol);
     }
 
     public <T extends TBase<T, F>, F extends TFieldIdEnum> void setRequest(TBase<T, F> request, String protocol)
@@ -61,7 +48,7 @@ public class AttachmentRequest {
 
     public <T extends TBase<T, F>, F extends TFieldIdEnum> void setRequest(TBase<T, F> request)
             throws TException {
-        TSerializer serializer = new TSerializer(TBinaryProtocol::new);
+        TSerializer serializer = ConfigurableSerDesFactory.getTSerializer();
 
         serializedRequest = serializer.serialize(request);
     }
@@ -83,12 +70,12 @@ public class AttachmentRequest {
     }
 
     public <T extends TBase<T, F>, F extends TFieldIdEnum> void getResult(TBase<T, F> result) throws TException {
-        TDeserializer deserializer = new TDeserializer();
+        TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();
         deserializer.deserialize(result, serializedResult);
     }
 
     public <T extends TBase<T, F>, F extends TFieldIdEnum> void getRequest(TBase<T, F> request) throws TException {
-        TDeserializer deserializer = new TDeserializer();
+        TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();
         deserializer.deserialize(request, serializedRequest);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableSerDesFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableSerDesFactory.java
@@ -22,19 +22,37 @@ import org.apache.thrift.transport.TTransportException;
 public class ConfigurableSerDesFactory {
 
     public static TSerializer getTSerializer() throws TTransportException {
-        return getTSerializer("binary");
+        return getTSerializer(Protocol.BINARY.name());
     }
 
     public static TSerializer getTSerializer(String protocol) throws TTransportException {
-        TProtocolFactory factory = ConfigurableTProtocolFactory.getTProtocolFactory(protocol);
+        Protocol p = Protocol.getProtocol(protocol);
+        TProtocolFactory factory = ConfigurableTProtocolFactory.getTProtocolFactory(p);
         return new TSerializer(factory);
     }
     public static TDeserializer getTDeserializer() throws TTransportException {
-        return getTDeserializer("binary");
+        return getTDeserializer(Protocol.BINARY.name());
     }
 
     public static TDeserializer getTDeserializer(String protocol) throws TTransportException {
-        TProtocolFactory factory = ConfigurableTProtocolFactory.getTProtocolFactory(protocol);
+        Protocol p = Protocol.getProtocol(protocol);
+        TProtocolFactory factory = ConfigurableTProtocolFactory.getTProtocolFactory(p);
         return new TDeserializer(factory);
+    }
+
+    public enum Protocol {
+        BINARY,
+        COMPACT,
+        JSON,
+        SIMPLE_JSON;
+
+        public static Protocol getProtocol(String name) {
+            for (Protocol protocol : Protocol.values()) {
+                if (protocol.name().equalsIgnoreCase(name)) {
+                    return protocol;
+                }
+            }
+            return BINARY;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableSerDesFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableSerDesFactory.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.rpc;
+
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.transport.TTransportException;
+
+public class ConfigurableSerDesFactory {
+
+    public static TSerializer getTSerializer() throws TTransportException {
+        return getTSerializer("binary");
+    }
+
+    public static TSerializer getTSerializer(String protocol) throws TTransportException {
+        TProtocolFactory factory = ConfigurableTProtocolFactory.getTProtocolFactory(protocol);
+        return new TSerializer(factory);
+    }
+    public static TDeserializer getTDeserializer() throws TTransportException {
+        return getTDeserializer("binary");
+    }
+
+    public static TDeserializer getTDeserializer(String protocol) throws TTransportException {
+        TProtocolFactory factory = ConfigurableTProtocolFactory.getTProtocolFactory(protocol);
+        return new TDeserializer(factory);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableTProtocolFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableTProtocolFactory.java
@@ -52,14 +52,14 @@ public class ConfigurableTProtocolFactory {
     public static class ConfigurableTCompactFactory implements TProtocolFactory {
 
         private static final long NO_LENGTH_LIMIT = -1;
-        private final long stringLengthLimit_;
-        private final long containerLengthLimit_;
+        private final long stringLengthLimit;
+        private final long containerLengthLimit;
 
         private final TConfiguration configuration;
 
         public ConfigurableTCompactFactory(TConfiguration configuration) {
-            this.stringLengthLimit_ = NO_LENGTH_LIMIT;
-            this.containerLengthLimit_ = NO_LENGTH_LIMIT;
+            this.stringLengthLimit = NO_LENGTH_LIMIT;
+            this.containerLengthLimit = NO_LENGTH_LIMIT;
             this.configuration = configuration;
         }
 
@@ -68,7 +68,7 @@ public class ConfigurableTProtocolFactory {
             trans.getConfiguration().setMaxFrameSize(configuration.getMaxFrameSize());
             trans.getConfiguration().setMaxMessageSize(configuration.getMaxMessageSize());
             trans.getConfiguration().setRecursionLimit(configuration.getRecursionLimit());
-            return new TCompactProtocol(trans, stringLengthLimit_, containerLengthLimit_);
+            return new TCompactProtocol(trans, stringLengthLimit, containerLengthLimit);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableTProtocolFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableTProtocolFactory.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.rpc;
+
+import com.starrocks.common.Config;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.thrift.TConfiguration;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TJSONProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.protocol.TSimpleJSONProtocol;
+import org.apache.thrift.transport.TTransport;
+
+public class ConfigurableTProtocolFactory {
+
+    public static TProtocolFactory getTProtocolFactory(String protocol) {
+        TProtocolFactory factory;
+        TConfiguration configuration = buildTConfiguration();
+        if (StringUtils.equalsIgnoreCase(protocol, "compact")) {
+            factory = new ConfigurableTCompactFactory(configuration);
+        } else if (StringUtils.equalsIgnoreCase(protocol, "json")) {
+            factory = new ConfigurableTJsonFactory(configuration);
+        } else if (StringUtils.equalsIgnoreCase(protocol, "simple_json")) {
+            factory = new ConfigurableTSimpleJSONFactory(configuration);
+        } else {
+            // default binary
+            factory = new ConfigurableTBinaryFactory(configuration);
+        }
+        return factory;
+    }
+
+    public static TConfiguration buildTConfiguration() {
+        return new TConfiguration(Config.thrift_max_message_size, Config.thrift_max_frame_size,
+                Config.thrift_max_recursion_depth);
+    }
+
+
+    public static class ConfigurableTCompactFactory implements TProtocolFactory {
+
+        private static final long NO_LENGTH_LIMIT = -1;
+        private final long stringLengthLimit_;
+        private final long containerLengthLimit_;
+
+        private final TConfiguration configuration;
+
+        public ConfigurableTCompactFactory(TConfiguration configuration) {
+            this.stringLengthLimit_ = NO_LENGTH_LIMIT;
+            this.containerLengthLimit_ = NO_LENGTH_LIMIT;
+            this.configuration = configuration;
+        }
+
+        @Override
+        public TProtocol getProtocol(TTransport trans) {
+            trans.getConfiguration().setMaxFrameSize(configuration.getMaxFrameSize());
+            trans.getConfiguration().setMaxMessageSize(configuration.getMaxMessageSize());
+            trans.getConfiguration().setRecursionLimit(configuration.getRecursionLimit());
+            return new TCompactProtocol(trans, stringLengthLimit_, containerLengthLimit_);
+        }
+    }
+
+    public static class ConfigurableTBinaryFactory extends TBinaryProtocol.Factory {
+        private final TConfiguration configuration;
+
+        public ConfigurableTBinaryFactory(TConfiguration configuration) {
+            super();
+            this.configuration = configuration;
+        }
+
+        @Override
+        public TProtocol getProtocol(TTransport trans) {
+            trans.getConfiguration().setMaxFrameSize(configuration.getMaxFrameSize());
+            trans.getConfiguration().setMaxMessageSize(configuration.getMaxMessageSize());
+            trans.getConfiguration().setRecursionLimit(configuration.getRecursionLimit());
+            return new TBinaryProtocol(
+                    trans, stringLengthLimit_, containerLengthLimit_, strictRead_, strictWrite_);
+        }
+    }
+
+    public static class ConfigurableTJsonFactory extends TJSONProtocol.Factory {
+        private final TConfiguration configuration;
+
+        public ConfigurableTJsonFactory(TConfiguration configuration) {
+            super();
+            this.configuration = configuration;
+        }
+
+        @Override
+        public TProtocol getProtocol(TTransport trans) {
+            trans.getConfiguration().setMaxFrameSize(configuration.getMaxFrameSize());
+            trans.getConfiguration().setMaxMessageSize(configuration.getMaxMessageSize());
+            trans.getConfiguration().setRecursionLimit(configuration.getRecursionLimit());
+            return new TJSONProtocol(trans, fieldNamesAsString_);
+        }
+    }
+
+    public static class ConfigurableTSimpleJSONFactory extends TSimpleJSONProtocol.Factory {
+
+        private final TConfiguration configuration;
+
+        public ConfigurableTSimpleJSONFactory(TConfiguration configuration) {
+            super();
+            this.configuration = configuration;
+        }
+
+        @Override
+        public TProtocol getProtocol(TTransport trans) {
+            trans.getConfiguration().setMaxFrameSize(configuration.getMaxFrameSize());
+            trans.getConfiguration().setMaxMessageSize(configuration.getMaxMessageSize());
+            trans.getConfiguration().setRecursionLimit(configuration.getRecursionLimit());
+            return new TSimpleJSONProtocol(trans);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableTProtocolFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/ConfigurableTProtocolFactory.java
@@ -15,7 +15,6 @@
 package com.starrocks.rpc;
 
 import com.starrocks.common.Config;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -27,18 +26,22 @@ import org.apache.thrift.transport.TTransport;
 
 public class ConfigurableTProtocolFactory {
 
-    public static TProtocolFactory getTProtocolFactory(String protocol) {
+    public static TProtocolFactory getTProtocolFactory(ConfigurableSerDesFactory.Protocol protocol) {
         TProtocolFactory factory;
         TConfiguration configuration = buildTConfiguration();
-        if (StringUtils.equalsIgnoreCase(protocol, "compact")) {
-            factory = new ConfigurableTCompactFactory(configuration);
-        } else if (StringUtils.equalsIgnoreCase(protocol, "json")) {
-            factory = new ConfigurableTJsonFactory(configuration);
-        } else if (StringUtils.equalsIgnoreCase(protocol, "simple_json")) {
-            factory = new ConfigurableTSimpleJSONFactory(configuration);
-        } else {
-            // default binary
-            factory = new ConfigurableTBinaryFactory(configuration);
+        switch (protocol) {
+            case JSON:
+                factory = new ConfigurableTJsonFactory(configuration);
+                break;
+            case SIMPLE_JSON:
+                factory = new ConfigurableTSimpleJSONFactory(configuration);
+                break;
+            case COMPACT:
+                factory = new ConfigurableTCompactFactory(configuration);
+                break;
+            default:
+                factory = new ConfigurableTBinaryFactory(configuration);
+                break;
         }
         return factory;
     }

--- a/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
@@ -22,6 +22,7 @@ import com.starrocks.connector.share.iceberg.CommonMetadataBean;
 import com.starrocks.connector.share.iceberg.IcebergMetricsBean;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.thrift.TIcebergMetadata;
 import com.starrocks.thrift.TMetadataEntry;
 import com.starrocks.thrift.TResultBatch;
@@ -176,7 +177,7 @@ public class MetadataParser {
 
     private List<DataFile> buildIcebergDataFile(TResultBatch resultBatch) throws TTransportException {
         List<DataFile> dataFiles = new ArrayList<>();
-        TDeserializer deserializer = new TDeserializer();
+        TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();;
         for (ByteBuffer bb : resultBatch.rows) {
             TMetadataEntry metadataEntry = deserializeToMetadataThrift(deserializer, bb);
             DataFile baseFile = (DataFile) parseThriftToIcebergDataFile(metadataEntry);

--- a/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
@@ -177,7 +177,7 @@ public class MetadataParser {
 
     private List<DataFile> buildIcebergDataFile(TResultBatch resultBatch) throws TTransportException {
         List<DataFile> dataFiles = new ArrayList<>();
-        TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();;
+        TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();
         for (ByteBuffer bb : resultBatch.rows) {
             TMetadataEntry metadataEntry = deserializeToMetadataThrift(deserializer, bb);
             DataFile baseFile = (DataFile) parseThriftToIcebergDataFile(metadataEntry);

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http;
 
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.thrift.TQueryPlanInfo;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -86,7 +87,7 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
             String queryPlan = jsonObject.getString("opaqued_query_plan");
             Assert.assertNotNull(queryPlan);
             byte[] binaryPlanInfo = Base64.getDecoder().decode(queryPlan);
-            TDeserializer deserializer = new TDeserializer();
+            TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();;
             TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
             deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo);
             Assert.assertEquals("alias_1", tQueryPlanInfo.output_names.get(0));

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -87,7 +87,7 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
             String queryPlan = jsonObject.getString("opaqued_query_plan");
             Assert.assertNotNull(queryPlan);
             byte[] binaryPlanInfo = Base64.getDecoder().decode(queryPlan);
-            TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();;
+            TDeserializer deserializer = ConfigurableSerDesFactory.getTDeserializer();
             TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
             deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo);
             Assert.assertEquals("alias_1", tQueryPlanInfo.output_names.get(0));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
@@ -24,6 +24,7 @@ import com.starrocks.proto.StatusPB;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.RowBatch;
 import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.rpc.PFetchDataRequest;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.thrift.FrontendServiceVersion;
@@ -292,7 +293,7 @@ public class GetNextTest extends SchedulerTestBase {
         }
         TResultBatch resultBatch = new TResultBatch(rows, false, 0);
 
-        TSerializer serializer = new TSerializer();
+        TSerializer serializer = ConfigurableSerDesFactory.getTSerializer();
         return serializer.serialize(resultBatch);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/AttachmentRequestTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/AttachmentRequestTest.java
@@ -1,0 +1,38 @@
+package com.starrocks.rpc;
+
+import com.starrocks.common.Config;
+import com.starrocks.thrift.TBinaryLiteral;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+class AttachmentRequestTest {
+
+    @Test
+    void readBinaryTest() throws TException {
+        Config.thrift_max_message_size = 1000000;
+        AttachmentRequest attachmentRequest = new AttachmentRequest();
+        byte[] bytes = new byte[2000000];
+        for (int i = 0; i < 2000000; i++) {
+            bytes[i] = (byte) (i % 128);
+        }
+        TBinaryLiteral binaryLiteral = new TBinaryLiteral(ByteBuffer.wrap(bytes));
+        attachmentRequest.setRequest(binaryLiteral);
+        TBinaryLiteral res1 = new TBinaryLiteral();
+        Assert.assertThrows("MaxMessageSize reached", TTransportException.class, () -> attachmentRequest.getRequest(res1));
+
+        Config.thrift_max_message_size = 5000000;
+        TBinaryLiteral res2 = new TBinaryLiteral();
+        attachmentRequest.getRequest(res2);
+        Assert.assertEquals(2000000, res2.value.remaining());
+    }
+
+    @After
+    public void after() {
+        Config.thrift_max_message_size = 1024 * 1024 * 1024;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/AttachmentRequestTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/AttachmentRequestTest.java
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.starrocks.rpc;
 
 import com.starrocks.common.Config;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
+import com.starrocks.rpc.AttachmentRequest;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.RuleSet;
@@ -25,11 +26,18 @@ import com.starrocks.sql.optimizer.rule.transformation.JoinAssociativityRule;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class JoinTest extends PlanTestBase {
+
+    @Test
+    public void test() throws TTransportException {
+        AttachmentRequest.getSerializer("binary");
+        System.out.println();
+    }
     @Test
     public void testIsNullPredicatePushdownClear() throws Exception {
         {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -18,7 +18,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
-import com.starrocks.rpc.AttachmentRequest;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.RuleSet;
@@ -26,18 +25,12 @@ import com.starrocks.sql.optimizer.rule.transformation.JoinAssociativityRule;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.thrift.transport.TTransportException;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class JoinTest extends PlanTestBase {
 
-    @Test
-    public void test() throws TTransportException {
-        AttachmentRequest.getSerializer("binary");
-        System.out.println();
-    }
     @Test
     public void testIsNullPredicatePushdownClear() throws Exception {
         {

--- a/test/sql/test_conf/R/test_configure
+++ b/test/sql/test_conf/R/test_configure
@@ -1,4 +1,4 @@
--- name: test_configure
+-- name: test_configure @sequential
 admin set frontend config ("thrift_max_message_size"="10485760");
 -- result:
 []

--- a/test/sql/test_conf/R/test_configure
+++ b/test/sql/test_conf/R/test_configure
@@ -1,0 +1,62 @@
+-- name: test_configure
+admin set frontend config ("thrift_max_message_size"="10485760");
+-- result:
+[]
+-- !result
+set group_concat_max_len = 1073741824;
+-- result:
+[]
+-- !result
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(65535)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+[]
+-- !result
+insert into tab1 values (1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(2, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(3, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(4, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(5, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+-- result:
+[]
+-- !result
+select group_concat(k2) from (select t1.k2 from tab1 t1 join tab1 t2 join tab1 t3 join tab1 t4 join tab1 t5 join tab1 t6 join tab1 t7) t;
+-- result:
+E: (1064, 'MaxMessageSize reached')
+-- !result
+admin set frontend config ("thrift_max_message_size"="1073741824");
+-- result:
+[]
+-- !result
+select length(group_concat(k2)) from (select t1.k2 from tab1 t1 join tab1 t2 join tab1 t3 join tab1 t4 join tab1 t5 join tab1 t6 join tab1 t7) t;
+-- result:
+15703124
+-- !result
+set @str = (select /*+ set_var(group_concat_max_len = 1073741824)*/ group_concat(k2) from (select t1.k2 from tab1 t1 join tab1 t2 join tab1 t3 join tab1 t4 join tab1 t5 join tab1 t6 join tab1 t7) t);
+-- result:
+[]
+-- !result
+update information_schema.be_configs set value = '10485760' where name ='thrift_max_message_size';
+-- result:
+[]
+-- !result
+select length(@str);
+-- result:
+[REGEX] .*MaxMessageSize reached.*
+-- !result
+update information_schema.be_configs set value = '1073741824' where name ='thrift_max_message_size';
+-- result:
+[]
+-- !result
+select length(@str);
+-- result:
+15703124
+-- !result

--- a/test/sql/test_conf/T/test_configure
+++ b/test/sql/test_conf/T/test_configure
@@ -1,0 +1,32 @@
+-- name: test_configure
+admin set frontend config ("thrift_max_message_size"="10485760");
+set group_concat_max_len = 1073741824;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(65535)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into tab1 values (1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(2, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(3, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(4, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+(5, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+select group_concat(k2) from (select t1.k2 from tab1 t1 join tab1 t2 join tab1 t3 join tab1 t4 join tab1 t5 join tab1 t6 join tab1 t7) t;
+admin set frontend config ("thrift_max_message_size"="1073741824");
+select length(group_concat(k2)) from (select t1.k2 from tab1 t1 join tab1 t2 join tab1 t3 join tab1 t4 join tab1 t5 join tab1 t6 join tab1 t7) t;
+
+set @str = (select /*+ set_var(group_concat_max_len = 1073741824)*/ group_concat(k2) from (select t1.k2 from tab1 t1 join tab1 t2 join tab1 t3 join tab1 t4 join tab1 t5 join tab1 t6 join tab1 t7) t);
+
+update information_schema.be_configs set value = '10485760' where name ='thrift_max_message_size';
+select length(@str);
+update information_schema.be_configs set value = '1073741824' where name ='thrift_max_message_size';
+select length(@str);
+
+

--- a/test/sql/test_conf/T/test_configure
+++ b/test/sql/test_conf/T/test_configure
@@ -1,4 +1,4 @@
--- name: test_configure
+-- name: test_configure @sequential
 admin set frontend config ("thrift_max_message_size"="10485760");
 set group_concat_max_len = 1073741824;
 CREATE table tab1 (


### PR DESCRIPTION
## Why I'm doing:
When upgrade thrift to 0.20.0, the MaxMessageSize member defines the maximum size of a (received) message, in bytes.
The default value is represented by a constant named DEFAULT_MAX_MESSAGE_SIZE, whose value is 100 * 1024 * 1024 bytes.
This will cause FE to fail during deserialization when the returned result set is larger than 100M. Therefore, we add thrift max_message_size configuration and set a default value of 1G and the maximum configurable value is 2G.

## What I'm doing:
Add FE/BE configuration to increase MaxMessageSize when necessary.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
