### PR TITLE
[BugFix] Remove json value from error message

### DIFF
--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -579,8 +579,7 @@ PARALLEL_TEST(JsonParserTest, test_document_stream_parser_invalid_type_array) {
     st = parser->get_current(&row);
     ASSERT_TRUE(st.is_data_quality_error());
     ASSERT_TRUE(st.message().find("The value is array type in json document stream, you can set strip_outer_array=true "
-                                  "to parse each element of the array as individual rows, "
-                                  "value: [{\"key\":1},{\"key\":2}]") != std::string::npos);
+                                  "to parse each element of the array as individual rows") != std::string::npos);
 }
 
 PARALLEL_TEST(JsonParserTest, test_document_stream_parser_invalid_type_not_object) {
@@ -598,8 +597,7 @@ PARALLEL_TEST(JsonParserTest, test_document_stream_parser_invalid_type_not_objec
     simdjson::ondemand::object row;
     st = parser->get_current(&row);
     ASSERT_TRUE(st.is_data_quality_error());
-    ASSERT_TRUE(st.message().find("The value should be object type in json document stream, value: 1") !=
-                std::string::npos);
+    ASSERT_TRUE(st.message().find("The value should be object type in json document stream") != std::string::npos);
 }
 
 PARALLEL_TEST(JsonParserTest, test_document_stream_parser_with_jsonroot_invalid_type_array) {


### PR DESCRIPTION
## Why I'm doing:
JsonFunctions::to_json_string may crash when json is invalid.

## What I'm doing:
remove json value from error message, and improve it later.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8327

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
