### PR TITLE
[BugFix] Fix synchronized mv crash if defined query's columns are unordered

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -84,13 +84,10 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.Field;
-import com.starrocks.sql.analyzer.RelationFields;
-import com.starrocks.sql.analyzer.RelationId;
-import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -119,7 +116,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 /**
  * Version 2 of RollupJob.
@@ -426,8 +422,9 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         tbl.rebuildFullSchema();
     }
 
-    private Expr analyzeExpr(Type type, String name, Expr defineExpr, Map<String, SlotDescriptor> slotDescByName,
-                             List<Expr> outputExprs, OlapTable tbl, TableName tableName) throws AlterCancelException {
+    private Expr analyzeExpr(SelectAnalyzer.RewriteAliasVisitor visitor,
+                             Type type, String name, Expr defineExpr,
+                             Map<String, SlotDescriptor> slotDescByName) throws AlterCancelException {
         List<SlotRef> slots = new ArrayList<>();
         defineExpr.collect(SlotRef.class, slots);
         for (SlotRef slot : slots) {
@@ -452,20 +449,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             smap.getRhs().add(slotRef);
         }
         Expr newExpr = defineExpr.clone(smap);
-        // sourceScope must be set null tableName for its Field in RelationFields
-        // because we hope slotRef can not be resolved in sourceScope but can be
-        // resolved in outputScope to force to replace the node using outputExprs.
-        Scope sourceScope = new Scope(RelationId.anonymous(),
-                new RelationFields(tbl.getBaseSchema().stream().map(col ->
-                                new Field(col.getName(), col.getType(), null, null))
-                        .collect(Collectors.toList())));
-        Scope outputScope = new Scope(RelationId.anonymous(),
-                new RelationFields(tbl.getBaseSchema().stream().map(col ->
-                                new Field(col.getName(), col.getType(), tableName, null))
-                        .collect(Collectors.toList())));
-        SelectAnalyzer.RewriteAliasVisitor visitor =
-                new SelectAnalyzer.RewriteAliasVisitor(sourceScope, outputScope,
-                        outputExprs, new ConnectContext());
         newExpr = newExpr.accept(visitor, null);
         newExpr = Expr.analyzeAndCastFold(newExpr);
         if (!newExpr.getType().equals(type)) {
@@ -573,13 +556,19 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
                     TableName tableName = new TableName(db.getFullName(), tbl.getName());
                     Map<String, Expr> defineExprs = Maps.newHashMap();
+
+                    // sourceScope must be set null tableName for its Field in RelationFields
+                    // because we hope slotRef can not be resolved in sourceScope but can be
+                    // resolved in outputScope to force to replace the node using outputExprs.
+                    SelectAnalyzer.RewriteAliasVisitor visitor = MVUtils.buildRewriteAliasVisitor(new ConnectContext(),
+                            tbl, tableName, outputExprs);
                     for (Column column : rollupColumns) {
                         if (column.getDefineExpr() == null) {
                             continue;
                         }
 
-                        Expr definedExpr = analyzeExpr(column.getType(), column.getName(), column.getDefineExpr(),
-                                slotDescByName, outputExprs, tbl, tableName);
+                        Expr definedExpr = analyzeExpr(visitor, column.getType(), column.getName(),
+                                column.getDefineExpr(), slotDescByName);
 
                         defineExprs.put(column.getName(), definedExpr);
 
@@ -591,8 +580,8 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                     Expr whereExpr = null;
                     if (whereClause != null) {
                         Type type = ScalarType.createType(PrimitiveType.BOOLEAN);
-                        whereExpr = analyzeExpr(type, CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME, whereClause,
-                                slotDescByName, outputExprs, tbl, tableName);
+                        whereExpr = analyzeExpr(visitor, type, CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME,
+                                whereClause, slotDescByName);
                         List<SlotRef> slots = Lists.newArrayList();
                         whereExpr.collect(SlotRef.class, slots);
                         slots.stream().map(slot -> slot.getColumnName()).forEach(usedBaseTableColNames::add);
@@ -605,11 +594,18 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                     "found in the base table.");
                         }
                     }
-
-                    List<ColumnId> usedColIds = new ArrayList<>(usedBaseTableColNames.size());
+                    // make sure the key columns are in the front of the list which is the limitation of the be `ChunkAggregator`
+                    List<ColumnId> usedColIds = Lists.newArrayList();
+                    List<ColumnId> nonKeyColIds = Lists.newArrayList();
                     for (String name : usedBaseTableColNames) {
-                        usedColIds.add(tbl.getColumn(name).getColumnId());
+                        Column col = tbl.getColumn(name);
+                        if (col.isKey()) {
+                            usedColIds.add(col.getColumnId());
+                        } else {
+                            nonKeyColIds.add(col.getColumnId());
+                        }
                     }
+                    usedColIds.addAll(nonKeyColIds);
                     AlterReplicaTask.RollupJobV2Params rollupJobV2Params =
                             new AlterReplicaTask.RollupJobV2Params(defineExprs, whereExpr, descTable, usedColIds);
                     for (Replica rollupReplica : rollupReplicas) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -54,12 +54,12 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
 import com.starrocks.backup.Status;
 import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.backup.mv.MvBackupInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.binlog.BinlogConfig;
-import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.catalog.LocalTablet.TabletHealthStatus;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -88,18 +88,27 @@ import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.persist.ColocatePersistInfo;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.TemporaryTableMgr;
+import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentBatchTask;
@@ -2921,6 +2930,7 @@ public class OlapTable extends Table {
     @Override
     public void onReload() {
         analyzePartitionInfo();
+        analyzeRollupIndexMeta();
         tryToAssignIndexId();
     }
 
@@ -2979,6 +2989,51 @@ public class OlapTable extends Table {
                 SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(i), column.getName(),
                         column.getType(), column.isAllowNull());
                 slotRefs.get(0).setDesc(slotDescriptor);
+            }
+        }
+    }
+
+    /**
+     * Analyze defined expr of columns in rollup index meta.
+     */
+    private void analyzeRollupIndexMeta() {
+        if (indexIdToMeta.size() <= 1) {
+            return;
+        }
+        TableName tableName = new TableName(null, getName());
+        ConnectContext session = new ConnectContext();
+        Optional<SelectAnalyzer.SlotRefTableNameCleaner> visitorOpt = Optional.empty();
+        for (MaterializedIndexMeta indexMeta : indexIdToMeta.values()) {
+            if (indexMeta.getIndexId() == baseIndexId) {
+                continue;
+            }
+            List<Column> columns = indexMeta.getSchema();
+            // Note: Add this try-catch block to avoid the failure of analyzing rollup index meta since this
+            // method will be called in replay method.
+            // And the failure of analyzing rollup index meta will only affect the associated synchronized mvs and
+            // will not affect the whole system.
+            try {
+                for (Column column : columns) {
+                    Expr definedExpr = column.getDefineExpr();
+                    if (definedExpr == null) {
+                        continue;
+                    }
+                    if (visitorOpt.isEmpty()) {
+                        SelectAnalyzer.SlotRefTableNameCleaner visitor = MVUtils.buildSlotRefTableNameCleaner(
+                                session, this, tableName);
+                        visitorOpt = Optional.of(visitor);
+                    }
+                    Preconditions.checkArgument(visitorOpt.isPresent(), "visitor should not be null");
+                    definedExpr.accept(visitorOpt.get(), null);
+                    ExpressionAnalyzer.analyzeExpression(definedExpr, new AnalyzeState(),
+                            new Scope(RelationId.anonymous(),
+                                    new RelationFields(this.getBaseSchema().stream()
+                                            .map(col -> new Field(col.getName(), col.getType(),
+                                                    tableName, null))
+                                            .collect(Collectors.toList()))), session);
+                }
+            } catch (Exception e) {
+                LOG.warn("Analyze rollup index meta failed, index id: {}, table:{}", indexMeta.getIndexId(), getName(), e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -700,7 +700,6 @@ public class InsertPlanner {
                                              ConnectContext session) {
         Set<Column> baseSchema = Sets.newHashSet(outputBaseSchema);
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
-
         for (int columnIdx = 0; columnIdx < outputFullSchema.size(); ++columnIdx) {
             Column targetColumn = outputFullSchema.get(columnIdx);
 
@@ -751,14 +750,6 @@ public class InsertPlanner {
                                     "please check the associated materialized view " + targetIndexMetaName
                                     + " of target table:" + insertStatement.getTargetTable().getName());
                 }
-
-                ExpressionAnalyzer.analyzeExpression(targetColumn.getDefineExpr(), new AnalyzeState(),
-                        new Scope(RelationId.anonymous(),
-                                new RelationFields(insertStatement.getTargetTable().getBaseSchema().stream()
-                                        .map(col -> new Field(col.getName(), col.getType(),
-                                                insertStatement.getTableName(), null))
-                                        .collect(Collectors.toList()))), session);
-
                 ExpressionMapping expressionMapping =
                         new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()),
                                 Lists.newArrayList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -615,6 +615,45 @@ public class SelectAnalyzer {
         }
     }
 
+    /**
+     * SlotRefTableNameCleaner is used to clean the table name of SlotRef which may be introduced by relation
+     * alias.In some scenes(eg: synchronized materialized view), the source scope is always defined(the single table),
+     * it's safe to remove the alias table name to avoid ambiguous semantics in the analyzer stage.
+     * Note: This cleaner will change the input expr directly instead of cloning a new expr.
+     */
+    public static class SlotRefTableNameCleaner implements AstVisitor<Expr, Void> {
+        private final Scope sourceScope;
+        private final ConnectContext session;
+
+        public SlotRefTableNameCleaner(Scope sourceScope, ConnectContext session) {
+            this.sourceScope = sourceScope;
+            this.session = session;
+        }
+
+        @Override
+        public Expr visit(ParseNode expr) {
+            return visit(expr, null);
+        }
+
+        @Override
+        public Expr visitExpression(Expr expr, Void context) {
+            for (int i = 0; i < expr.getChildren().size(); ++i) {
+                expr.setChild(i, visit(expr.getChild(i)));
+            }
+            return expr;
+        }
+
+        @Override
+        public Expr visitSlot(SlotRef slotRef, Void context) {
+            if (sourceScope.tryResolveField(slotRef).isPresent() &&
+                    !session.getSessionVariable().getEnableGroupbyUseOutputAlias()) {
+                return slotRef;
+            }
+            slotRef.setTblName(null);
+            return slotRef;
+        }
+    }
+
     private static class NotFullGroupByRewriter implements AstVisitor<Expr, Void> {
         private final Map<Expr, Expr> columnsNotInGroupBy;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -58,14 +58,20 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.View;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.UnsupportedMVException;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnBitmapAggPattern;
@@ -211,7 +217,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
 
     // NOTE: This method is used to replay persistent MaterializedViewMeta,
     // so need keep the same with `genColumnAndSetIntoStmt` and keep compatible with old version policy.
-    public Map<String, Expr> parseDefineExprWithoutAnalyze(String originalSql) throws AnalysisException {
+    public Map<String, Expr> parseDefineExprWithoutAnalyze(String originalSql) {
         Map<String, Expr> result = Maps.newHashMap();
         SelectList selectList = null;
         QueryRelation queryRelation = queryStatement.getQueryRelation();
@@ -250,9 +256,6 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                         break;
                     }
                     default: {
-                        if (functionCallExpr.isAggregateFunction()) {
-                            throw new AnalysisException("Unsupported function:" + functionName);
-                        }
                         MVColumnItem item = buildNonAggColumnItem(selectListItem, slots);
                         expr = item.getDefineExpr();
                         name = item.getName();
@@ -363,6 +366,47 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                         "Aggregate type table do not support count function in materialized view");
             }
         }
+        // analyze table if it has alias
+        analyzeExprWithTableAlias(context, this.dbName, table, getMVColumnItemList());
+    }
+
+    private void analyzeExprWithTableAlias(ConnectContext context,
+                                           String dbName,
+                                           Table table,
+                                           List<MVColumnItem> mvColumnItems) {
+        // sourceScope must be set null tableName for its Field in RelationFields
+        // because we hope slotRef can not be resolved in sourceScope but can be
+        // resolved in outputScope to force to replace the node using outputExprs.
+        TableName tableName = new TableName(dbName, table.getName());
+        SelectAnalyzer.SlotRefTableNameCleaner visitor = MVUtils.buildSlotRefTableNameCleaner(context,
+                table, tableName);
+        for (MVColumnItem mvColumnItem : mvColumnItems) {
+            Expr expr = mvColumnItem.getDefineExpr();
+            if (expr == null) {
+                continue;
+            }
+            // to not disturb queryStatement, clone the expr
+            Expr cloned = expr.clone();
+            analyzeExprWithTableAlias(context, visitor, table, tableName, cloned);
+            mvColumnItem.setDefineExpr(cloned);
+        }
+    }
+
+    private void analyzeExprWithTableAlias(ConnectContext context,
+                                           SelectAnalyzer.SlotRefTableNameCleaner visitor,
+                                           Table table,
+                                           TableName tableName,
+                                           Expr expr) {
+        if (expr == null) {
+            return;
+        }
+        expr.accept(visitor, null);
+        ExpressionAnalyzer.analyzeExpression(expr, new AnalyzeState(),
+                new Scope(RelationId.anonymous(),
+                        new RelationFields(table.getBaseSchema().stream()
+                                .map(col -> new Field(col.getName(), col.getType(),
+                                        tableName, null))
+                                .collect(Collectors.toList()))), context);
     }
 
     private int genColumnAndSetIntoStmt(Table table, SelectRelation selectRelation) {

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_unorder
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_unorder
@@ -1,0 +1,157 @@
+-- name: test_sync_materialized_view_unorder
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 string NOT NULL,
+    k2 string,
+    k3 DECIMAL(34,0),
+    k4 DATE NOT NULL,
+    v1 BIGINT sum DEFAULT "0"
+)
+AGGREGATE KEY(k1,  k2, k3,  k4)
+DISTRIBUTED BY HASH(k4);
+-- result:
+-- !result
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 as 
+SELECT a.k3, DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(a.v1) AS cnt FROM t1 a WHERE a.k2 = 'a' GROUP BY a.k3, DATE_FORMAT(a.k4, '%Y-%m');
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: print_hit_materialized_view('SELECT k3, DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY k3, DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+-- result:
+True
+-- !result
+select count(1) from test_mv1 [_SYNC_MV_];
+-- result:
+1
+-- !result
+SELECT k3, DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY k3, DATE_FORMAT(k4, '%Y-%m');
+-- result:
+11	2024-08	2
+-- !result
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+-- result:
+-- !result
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+-- result:
+-- !result
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+-- result:
+-- !result
+ALTER TABLE t1 COMPACT;
+-- result:
+-- !result
+select sleep(10);
+-- result:
+1
+-- !result
+function: print_hit_materialized_view('SELECT k3, DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY k3, DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+-- result:
+True
+-- !result
+function: print_hit_materialized_view('SELECT a.k3, DATE_FORMAT(a.k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = "a" GROUP BY a.k3, DATE_FORMAT(a.k4, "%Y-%m");', 'test_mv1')
+-- result:
+True
+-- !result
+select count(1) from test_mv1 [_SYNC_MV_];
+-- result:
+1
+-- !result
+SELECT k3, DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY k3, DATE_FORMAT(k4, '%Y-%m');
+-- result:
+11	2024-08	8
+-- !result
+SELECT a.k3, DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = 'a' GROUP BY a.k3, DATE_FORMAT(a.k4, '%Y-%m');
+-- result:
+11	2024-08	8
+-- !result
+set enable_sync_materialized_view_rewrite=false;
+-- result:
+-- !result
+SELECT k3, DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY k3, DATE_FORMAT(k4, '%Y-%m');
+-- result:
+11	2024-08	8
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+set enable_sync_materialized_view_rewrite=true;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 as 
+SELECT DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(a.v1) AS cnt FROM t1 a WHERE a.k2 = 'a' GROUP BY DATE_FORMAT(a.k4, '%Y-%m');
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: print_hit_materialized_view('SELECT DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+-- result:
+True
+-- !result
+function: print_hit_materialized_view('SELECT DATE_FORMAT(a.k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = "a" GROUP BY DATE_FORMAT(a.k4, "%Y-%m");', 'test_mv1')
+-- result:
+True
+-- !result
+select count(1) from test_mv1 [_SYNC_MV_];
+-- result:
+1
+-- !result
+SELECT DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY DATE_FORMAT(k4, '%Y-%m');
+-- result:
+2024-08	8
+-- !result
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+-- result:
+-- !result
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+-- result:
+-- !result
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+-- result:
+-- !result
+ALTER TABLE t1 COMPACT;
+-- result:
+-- !result
+select sleep(10);
+-- result:
+1
+-- !result
+function: print_hit_materialized_view('SELECT DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+-- result:
+True
+-- !result
+function: print_hit_materialized_view('SELECT DATE_FORMAT(a.k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = "a" GROUP BY DATE_FORMAT(a.k4, "%Y-%m");', 'test_mv1')
+-- result:
+True
+-- !result
+select count(1) from test_mv1 [_SYNC_MV_];
+-- result:
+1
+-- !result
+SELECT DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY DATE_FORMAT(k4, '%Y-%m');
+-- result:
+2024-08	14
+-- !result
+SELECT DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = 'a' GROUP BY DATE_FORMAT(a.k4, '%Y-%m');
+-- result:
+2024-08	14
+-- !result
+set enable_sync_materialized_view_rewrite=false;
+-- result:
+-- !result
+SELECT DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY DATE_FORMAT(k4, '%Y-%m');
+-- result:
+2024-08	14
+-- !result
+set enable_sync_materialized_view_rewrite=true;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_unorder
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_unorder
@@ -1,0 +1,65 @@
+-- name: test_sync_materialized_view_unorder
+
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
+CREATE TABLE t1 (
+    k1 string NOT NULL,
+    k2 string,
+    k3 DECIMAL(34,0),
+    k4 DATE NOT NULL,
+    v1 BIGINT sum DEFAULT "0"
+)
+AGGREGATE KEY(k1,  k2, k3,  k4)
+DISTRIBUTED BY HASH(k4);
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+
+-- case1: with unordered columns
+CREATE MATERIALIZED VIEW test_mv1 as 
+SELECT a.k3, DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(a.v1) AS cnt FROM t1 a WHERE a.k2 = 'a' GROUP BY a.k3, DATE_FORMAT(a.k4, '%Y-%m');
+
+function: wait_materialized_view_finish()
+
+function: print_hit_materialized_view('SELECT k3, DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY k3, DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+select count(1) from test_mv1 [_SYNC_MV_];
+SELECT k3, DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY k3, DATE_FORMAT(k4, '%Y-%m');
+
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+ALTER TABLE t1 COMPACT;
+select sleep(10);
+
+function: print_hit_materialized_view('SELECT k3, DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY k3, DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+function: print_hit_materialized_view('SELECT a.k3, DATE_FORMAT(a.k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = "a" GROUP BY a.k3, DATE_FORMAT(a.k4, "%Y-%m");', 'test_mv1')
+select count(1) from test_mv1 [_SYNC_MV_];
+SELECT k3, DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY k3, DATE_FORMAT(k4, '%Y-%m');
+SELECT a.k3, DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = 'a' GROUP BY a.k3, DATE_FORMAT(a.k4, '%Y-%m');
+set enable_sync_materialized_view_rewrite=false;
+SELECT k3, DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY k3, DATE_FORMAT(k4, '%Y-%m');
+drop materialized view test_mv1;
+set enable_sync_materialized_view_rewrite=true;
+
+-- case2: with unordered columns
+CREATE MATERIALIZED VIEW test_mv1 as 
+SELECT DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(a.v1) AS cnt FROM t1 a WHERE a.k2 = 'a' GROUP BY DATE_FORMAT(a.k4, '%Y-%m');
+
+function: wait_materialized_view_finish()
+function: print_hit_materialized_view('SELECT DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+function: print_hit_materialized_view('SELECT DATE_FORMAT(a.k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = "a" GROUP BY DATE_FORMAT(a.k4, "%Y-%m");', 'test_mv1')
+select count(1) from test_mv1 [_SYNC_MV_];
+SELECT DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY DATE_FORMAT(k4, '%Y-%m');
+
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1), ('100', NULL, NULL, '2024-08-08', 2), ('200', 'a', 11.00, '2024-08-06', 1);
+ALTER TABLE t1 COMPACT;
+select sleep(10);
+
+function: print_hit_materialized_view('SELECT DATE_FORMAT(k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1  WHERE k2 = "a" GROUP BY DATE_FORMAT(k4, "%Y-%m");', 'test_mv1')
+function: print_hit_materialized_view('SELECT DATE_FORMAT(a.k4, "%Y-%m") AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = "a" GROUP BY DATE_FORMAT(a.k4, "%Y-%m");', 'test_mv1')
+select count(1) from test_mv1 [_SYNC_MV_];
+SELECT DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY DATE_FORMAT(k4, '%Y-%m');
+SELECT DATE_FORMAT(a.k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1 a WHERE k2 = 'a' GROUP BY DATE_FORMAT(a.k4, '%Y-%m');
+set enable_sync_materialized_view_rewrite=false;
+SELECT DATE_FORMAT(k4, '%Y-%m') AS month, sum(v1) AS cnt FROM t1  WHERE k2 = 'a' GROUP BY DATE_FORMAT(k4, '%Y-%m');
+set enable_sync_materialized_view_rewrite=true;

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_event_trigger
+-- name: test_mv_refresh_with_event_trigger @slow
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union3
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union3
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_multi_union3
+-- name: test_mv_refresh_with_multi_union3 @slow
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_event_trigger
+-- name: test_mv_refresh_with_event_trigger @slow
 
 create database db_${uuid0};
 use db_${uuid0};

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union3
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union3
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_multi_union3
+-- name: test_mv_refresh_with_multi_union3 @slow
 
 create database db_${uuid0};
 use db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
- BE will crash if creating synchronized mv below:
```
CREATE TABLE t1 (
    k1 string NOT NULL,
    k2 string,
    k3 DECIMAL(34,0),
    k4 DATE NOT NULL,
    v1 BIGINT sum DEFAULT "0"
)
AGGREGATE KEY(k1,  k2, k3,  k4)
DISTRIBUTED BY HASH(k4);

insert into t1 values ('200', 'a', 11.00, '2024-08-06', 1);

CREATE MATERIALIZED VIEW test_mv1 as 
SELECT
	  a.k1 ,
    DATE_FORMAT(a.k4, '%Y-%m') AS month, 
    sum(k3) AS cnt
FROM     
	t1 a 
WHERE
    k2 = '200'
GROUP BY
    a.k1, DATE_FORMAT(a.k4, '%Y-%m')
```


exception:
```
*** Aborted at 1722929720 (unix time) try "date -d @1722929720" if you are using GNU date ***
PC: @     0x2aeb1af3d207 __GI_raise
*** SIGABRT (@0xa132) received by PID 41266 (TID 0x2afe8f136700) from PID 41266; stack trace: ***
    @          0x6538582 google::(anonymous namespace)::FailureSignalHandler()
    @     0x2aeb1a3d35d0 (unknown)
    @     0x2aeb1af3d207 __GI_raise
    @     0x2aeb1af3e8f8 __GI_abort
    @          0x2a6413e starrocks::failure_function()
    @          0x652bf5d google::LogMessage::Fail()
    @          0x652e3cf google::LogMessage::SendToLog()
    @          0x652baae google::LogMessage::Flush()
    @          0x652e9d9 google::LogMessageFatal::~LogMessageFatal()
    @          0x55edab2 starrocks::ColumnAggregatorFactory::create_key_column_aggregator()
    @          0x501a5a9 starrocks::ChunkAggregator::ChunkAggregator()
    @          0x5482b6f starrocks::AggregateIterator::init_encoded_schema()
    @          0x5005c71 starrocks::TabletReader::_init_collector()
    @          0x5006fc9 starrocks::TabletReader::open()
    @          0x4fea4a7 starrocks::SchemaChangeHandler::_do_process_alter_tablet_normal()
    @          0x4fec53b starrocks::SchemaChangeHandler::_do_process_alter_tablet()
    @          0x4fed22a starrocks::SchemaChangeHandler::process_alter_tablet()
    @          0x4f7eafa starrocks::EngineAlterTabletTask::execute()
    @          0x4e2d0ae starrocks::StorageEngine::execute_task()
    @          0x3280b30 starrocks::run_alter_tablet_task()
    @          0x2d0b99c starrocks::ThreadPool::dispatch_thread()
    @          0x2d0564a starrocks::Thread::supervise_thread()
    @     0x2aeb1a3cbdd5 start_thread
```
## What I'm doing:
- `ChunkAggregator` supports unordered keys/agg columns;
- `CreateMaterializedViewStmt` supports table with alias;

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
