### PR TITLE
[BugFix] check submit finish publish task success or not (backport #31463)

### DIFF
--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -155,7 +155,11 @@ Status PublishVersionManager::finish_publish_version_task() {
 #endif
                         remove_task_info(finish_request.task_type, finish_request.signature);
                     });
-            erase_finish_task_signature.emplace_back(signature);
+            if (st.ok()) {
+                erase_finish_task_signature.emplace_back(signature);
+            } else {
+                LOG(WARNING << "submit finish publish task failed: " << signature;
+            }
         }
 
         std::vector<int64_t> clear_txn;
@@ -169,7 +173,11 @@ Status PublishVersionManager::finish_publish_version_task() {
 #endif
                             remove_task_info(finish_request.task_type, finish_request.signature);
                         });
-                erase_waitting_finish_task_signature.emplace_back(signature);
+                if (st.ok()) {
+                    erase_waitting_finish_task_signature.emplace_back(signature);
+                } else {
+                    LOG(WARNING << "submit finish publish task failed: " << signature;
+                }
             }
         }
         for (auto& signature : erase_finish_task_signature) {

--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -158,7 +158,7 @@ Status PublishVersionManager::finish_publish_version_task() {
             if (st.ok()) {
                 erase_finish_task_signature.emplace_back(signature);
             } else {
-                LOG(WARNING << "submit finish publish task failed: " << signature;
+                LOG(WARNING) << "submit finish publish task failed: " << signature;
             }
         }
 
@@ -176,7 +176,7 @@ Status PublishVersionManager::finish_publish_version_task() {
                 if (st.ok()) {
                     erase_waitting_finish_task_signature.emplace_back(signature);
                 } else {
-                    LOG(WARNING << "submit finish publish task failed: " << signature;
+                    LOG(WARNING) << "submit finish publish task failed: " << signature;
                 }
             }
         }


### PR DESCRIPTION
## Why I'm doing:
We need to check submit finish publish task status. If status is not ok, we should not remove the task right now.

## What I'm doing:
Check the submit task status.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate

