### PR TITLE
[Enhancement] Simplify boolean cast operator

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -983,7 +983,7 @@ public class SubqueryTest extends PlanTestBase {
             assertContains(plan, "  8:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (PARTITIONED)\n" +
                     "  |  colocate: false, reason: \n" +
-                    "  |  equal join conjunct: 1: v1 = 13: cast");
+                    "  |  equal join conjunct: 1: v1 = 13: if");
         }
         {
             // Uncorrelated 2
@@ -997,7 +997,7 @@ public class SubqueryTest extends PlanTestBase {
             assertContains(plan, "HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
-                    "  |  equal join conjunct: 1: v1 = 13: cast");
+                    "  |  equal join conjunct: 1: v1 = 13: if");
         }
         {
             // Uncorrelated 3, multi subqueries
@@ -1012,11 +1012,11 @@ public class SubqueryTest extends PlanTestBase {
             assertContains(plan, "HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
-                    "  |  equal join conjunct: 1: v1 = 20: cast");
+                    "  |  equal join conjunct: 1: v1 = 20: if");
             assertContains(plan, "HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
-                    "  |  equal join conjunct: 4: v4 = 19: cast");
+                    "  |  equal join conjunct: 4: v4 = 19: if");
         }
         {
             // correlated 1
@@ -1033,7 +1033,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
-                    "  |  other predicates: CAST(11: countRows IS NOT NULL AS BIGINT) IS NOT NULL");
+                    "  |  other predicates: if(11: countRows IS NOT NULL, 1, 0) IS NOT NULL");
         }
         {
             // correlated 2
@@ -1049,7 +1049,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
-                    "  |  other predicates: CAST(11: countRows IS NOT NULL AS BIGINT) IS NOT NULL");
+                    "  |  other predicates: if(11: countRows IS NOT NULL, 1, 0) IS NOT NULL");
         }
         {
             // correlated 3, multi subqueries
@@ -1067,12 +1067,12 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
-                    "  |  other predicates: CAST(15: countRows IS NOT NULL AS BIGINT) IS NOT NULL");
+                    "  |  other predicates: if(15: countRows IS NOT NULL, 1, 0) IS NOT NULL");
             assertContains(plan, "HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 11: v10\n" +
-                    "  |  other predicates: 2: v2 = CAST(16: countRows IS NULL AS BIGINT)");
+                    "  |  other predicates: 2: v2 = if(16: countRows IS NULL, 1, 0)");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UDFTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UDFTest.java
@@ -86,12 +86,14 @@ public class UDFTest extends PlanTestBase {
         explain = getVerboseExplain(sql);
         Assert.assertTrue(explain.contains("  1:Project"));
         Assert.assertTrue(explain.contains("  |  output columns:\n" +
-                "  |  17 <-> cast([4: c_0_3, BOOLEAN, false] as VARCHAR)"));
+                "  |  17 <-> if[([4: c_0_3, BOOLEAN, false], '1', '0'); " +
+                "args: BOOLEAN,VARCHAR,VARCHAR; result: VARCHAR; args nullable: false; result nullable: true]"));
 
         sql = "select table_function from tab0, table_function(c_0_3 + 3)";
         explain = getVerboseExplain(sql);
         Assert.assertTrue(
-                explain.contains("  |  17 <-> cast(cast([4: c_0_3, BOOLEAN, false] as SMALLINT) + 3 as VARCHAR)"));
+                explain.contains("  |  17 <-> cast(if[([4: c_0_3, BOOLEAN, false], 1, 0); args: BOOLEAN,SMALLINT,SMALLINT; " +
+                        "result: SMALLINT; args nullable: false; result nullable: true] + 3 as VARCHAR)"));
 
         sql = "select v1,v2,v3,t.unnest,o.unnest from t0,unnest([1,2,3]) t, unnest([4,5,6]) o ";
         explain = getFragmentPlan(sql);


### PR DESCRIPTION
## Why I'm doing:
`where cast(bool_expr as int) = 1`

in this case `bool_expr` can't push down, but it is equals to `where bool_expr`.

## What I'm doing:
convert `cast(bool_expr as type)` to `if(bool_expr, cast(true as type), cast(false as type))`

and `SimplifiedCaseWhenRule` will do the other works.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
