### PR TITLE
[BugFix] fix del encryption upgrade issue

### DIFF
--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -62,7 +62,7 @@ Status HorizontalPkTabletWriter::flush_del_file(const Column& deletes) {
         wopts.encryption_info = pair.info;
         encryption_meta.swap(pair.encryption_meta);
     }
-    ASSIGN_OR_RETURN(auto of, fs::new_writable_file(_tablet_mgr->del_location(_tablet_id, name)));
+    ASSIGN_OR_RETURN(auto of, fs::new_writable_file(wopts, _tablet_mgr->del_location(_tablet_id, name)));
     size_t sz = serde::ColumnArraySerde::max_serialized_size(deletes);
     std::vector<uint8_t> content(sz);
     if (serde::ColumnArraySerde::serialize(deletes, content.data()) == nullptr) {

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -112,6 +112,7 @@ struct PrimaryKeyParam {
     bool enable_persistent_index = false;
     PersistentIndexTypePB persistent_index_type = PersistentIndexTypePB::LOCAL;
     PartialUpdateMode partial_update_mode = PartialUpdateMode::ROW_MODE;
+    bool enable_transparent_data_encryption = false;
 };
 
 inline StatusOr<TabletMetadataPtr> TEST_publish_single_version(TabletManager* tablet_mgr, int64_t tablet_id,


### PR DESCRIPTION
## Why I'm doing:
When upgrade from old version, `del_encryption_metas` in op_write could be empty, and visit i-th by default will cause crash like:
```
*** SIGABRT (@0x8a5c) received by PID 35420 (TID 0x7f93fa5f7700) from PID 35420; stack trace: ***
    @          0x77e7a52 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f96429345f0 (unknown)
    @     0x7f964258d337 __GI_raise
    @     0x7f964258ea28 __GI_abort
    @          0x34ed0ee starrocks::failure_function()
    @          0x77db42d google::LogMessage::Fail()
    @          0x77dd89f google::LogMessage::SendToLog()
    @          0x77daf7e google::LogMessage::Flush()
    @          0x77ddea9 google::LogMessageFatal::~LogMessageFatal()
    @          0x79ba804 brpc::BaiduStreamingLogHandler()
    @          0x7b4068a google::protobuf::internal::LogMessage::Finish()
    @          0x7b7eaf0 google::protobuf::RepeatedPtrField<>::Get()
    @          0x61349f6 starrocks::lake::RowsetUpdateState::load_delete()
    @          0x6124377 starrocks::lake::UpdateManager::publish_primary_key_tablet()
    @          0x6163c61 starrocks::lake::PrimaryKeyTxnLogApplier::apply_write_log()
```

## What I'm doing:
Check `del_encryption_metas` length before visit `i-th` item.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
