### PR TITLE
[BugFix] fix iceberg partition prune on v2 table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -202,9 +202,12 @@ public class IcebergTable extends Table {
         return indexes;
     }
 
+    // TODO(stephen): we should refactor this part to be compatible with cases of different transform result types
+    //  in the same partition column.
     // day(dt) -> identity dt
     public boolean hasPartitionTransformedEvolution() {
-        return getNativeTable().spec().fields().stream().anyMatch(field -> field.transform().isVoid());
+        return (!isV2Format() && getNativeTable().spec().fields().stream().anyMatch(field -> field.transform().isVoid())) ||
+                (isV2Format() && getNativeTable().spec().specId() > 0);
     }
 
     public boolean isV2Format() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -751,13 +751,14 @@ public class PartitionUtil {
         return ICEBERG_DEFAULT_PARTITION;
     }
 
-    public static List<String> getIcebergPartitionValues(PartitionSpec spec, StructLike partition) {
+    public static List<String> getIcebergPartitionValues(PartitionSpec spec,
+                                                         StructLike partition,
+                                                         boolean existPartitionTransformedEvolution) {
         PartitionData partitionData = (PartitionData) partition;
         List<String> partitionValues = new ArrayList<>();
-        boolean existPartitionEvolution = spec.fields().stream().anyMatch(field -> field.transform().isVoid());
         for (int i = 0; i < spec.fields().size(); i++) {
             PartitionField partitionField = spec.fields().get(i);
-            if ((!partitionField.transform().isIdentity() && existPartitionEvolution) ||
+            if ((!partitionField.transform().isIdentity() && existPartitionTransformedEvolution) ||
                     (partitionField.transform().isVoid() && partitionData.get(i) == null)) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -717,9 +717,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         Set<List<String>> scannedPartitions = new HashSet<>();
         PartitionSpec spec = icebergTable.getNativeTable().spec();
         List<Column> partitionColumns = icebergTable.getPartitionColumnsIncludeTransformed();
+        boolean existPartitionTransformedEvolution = ((IcebergTable) table).hasPartitionTransformedEvolution();
         for (FileScanTask fileScanTask : icebergSplitTasks) {
             org.apache.iceberg.PartitionData partitionData = (org.apache.iceberg.PartitionData) fileScanTask.file().partition();
-            List<String> values = PartitionUtil.getIcebergPartitionValues(spec, partitionData);
+            List<String> values = PartitionUtil.getIcebergPartitionValues(
+                    spec, partitionData, existPartitionTransformedEvolution);
 
             if (values.size() != partitionColumns.size()) {
                 // ban partition evolution and non-identify column.
@@ -753,7 +755,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                             partitionField)).getType());
                 }
 
-                if (icebergTable.hasPartitionTransformedEvolution()) {
+                if (existPartitionTransformedEvolution) {
                     srTypes = partitionColumns.stream()
                             .map(Column::getType)
                             .collect(Collectors.toList());

--- a/test/sql/test_iceberg/R/test_iceberg_transformed_partition
+++ b/test/sql/test_iceberg/R/test_iceberg_transformed_partition
@@ -1,0 +1,15 @@
+-- name: test_iceberg_transformed_partition
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;","cardinality=1")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;","cardinality=1")
+-- result:
+None
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_transformed_partition
+++ b/test/sql/test_iceberg/T/test_iceberg_transformed_partition
@@ -1,0 +1,8 @@
+-- name: test_iceberg_transformed_partition
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_identity_to_bucket_partition;","cardinality=1")
+function: assert_explain_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;","cardinality=1")
+
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
https://iceberg.apache.org/spec/#partition-transforms
The void transform may be used to replace the transform in an existing partition field so that the field is effectively dropped in v1 tables. See partition evolution below.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
