### PR TITLE
[Enhancement] precheck capacity limit in ArrayColumn/MapColumn::replicate

### DIFF
--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -107,6 +107,8 @@ public:
 
     void append_default(size_t count) override;
 
+    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+
     void fill_default(const Filter& filter) override;
 
     void update_rows(const Column& src, const uint32_t* indexes) override;

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -165,6 +165,29 @@ void MapColumn::append_default(size_t count) {
     _offsets->append_value_multiple_times(&offset, count);
 }
 
+ColumnPtr MapColumn::replicate(const std::vector<uint32_t>& offsets) {
+    auto dest = this->clone_empty();
+    auto dest_size = offsets.size() - 1;
+    DCHECK(this->size() >= dest_size) << "Ths size of the source column is less when duplicating it.";
+    dest->reserve(offsets.back());
+
+    size_t dest_map_size = 0;
+    for (int i = 0; i < dest_size; i++) {
+        dest_map_size += get_map_size(i) * (offsets[i + 1] - offsets[i]);
+    }
+    if (dest_map_size >= MAX_CAPACITY_LIMIT) {
+        throw std::runtime_error("Size of MapColumn exceed the limit");
+    }
+    std::string err_msg;
+    for (int i = 0; i < dest_size; ++i) {
+        dest->append_value_multiple_times(*this, i, offsets[i + 1] - offsets[i]);
+        if (UNLIKELY(capacity_limit_reached(&err_msg))) {
+            throw std::runtime_error("Size of MapColumn exceed the limit");
+        }
+    }
+    return dest;
+}
+
 void MapColumn::fill_default(const Filter& filter) {
     std::vector<uint32_t> indexes;
     for (size_t i = 0; i < filter.size(); i++) {

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -96,6 +96,8 @@ public:
 
     void append_default(size_t count) override;
 
+    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+
     void fill_default(const Filter& filter) override;
 
     void update_rows(const Column& src, const uint32_t* indexes) override;

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -120,6 +120,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
                 return Status::InternalError(fmt::format(
                         "The size of the captured column {} is less than array's size.", captured->get_name()));
             }
+
             cur_chunk->append_column(captured->replicate(input_array->offsets_column()->get_data()), id);
         }
         if (cur_chunk->num_rows() <= chunk->num_rows() * 8) {

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1225,4 +1225,21 @@ PARALLEL_TEST(ArrayColumnTest, test_reference_memory_usage) {
     }
 }
 
+PARALLEL_TEST(ArrayColumnTest, test_replicate) {
+    auto offsets = UInt32Column::create();
+    auto elements = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    auto array_column = ArrayColumn::create(elements, offsets);
+
+    const size_t array_size = 100000;
+    for (size_t i = 0; i < array_size; i++) {
+        elements->append_datum(i);
+    }
+    offsets->append(array_size);
+
+    auto column = array_column->replicate({0, 1});
+    ASSERT_EQ(column->size(), 1);
+
+    ASSERT_THROW((array_column->replicate({0, 100000})), std::runtime_error);
+}
+
 } // namespace starrocks

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1467,4 +1467,26 @@ TEST(MapColumnTest, test_hash) {
     ASSERT_EQ(hash, hash1);
 }
 
+TEST(MapColumnTest, test_replicate) {
+    auto offsets = UInt32Column::create();
+    auto keys_data = Int32Column::create();
+    auto keys_null = NullColumn::create();
+    auto keys = NullableColumn::create(keys_data, keys_null);
+    auto values_data = Int32Column::create();
+    auto values_null = NullColumn::create();
+    auto values = NullableColumn::create(values_data, values_null);
+    auto map_column = MapColumn::create(keys, values, offsets);
+
+    const int32_t map_size = 100000;
+    DatumMap map;
+    for (int32_t i = 0; i < map_size; i++) {
+        map[i] = i;
+    }
+    map_column->append_datum(map);
+
+    auto new_column = map_column->replicate({0, 1});
+    ASSERT_EQ(new_column->size(), 1);
+
+    ASSERT_THROW((map_column->replicate({0, 100000})), std::runtime_error);
+}
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

When applying `replicate` to nested Column such as array and map, columns may become very large. Adding a pre check mechanism to avoid allocating too much memory.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
