### PR TITLE
[Enhancement] add maxStringLength for JsonTemplateLayout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -258,7 +258,7 @@ public class Log4jConfig extends XmlConfiguration {
         if (jsonLoggingConfValue.equalsIgnoreCase(Config.sys_log_format)) {
             // json logging
             String jsonLayout =
-                    "<JsonTemplateLayout locationInfoEnabled=\"true\">\n" +
+                    "<JsonTemplateLayout maxStringLength=\"104857600\" locationInfoEnabled=\"true\">\n" +
                             "        <EventTemplate><![CDATA[\n{\n" +
                             "   \"@timestamp\": {\n" +
                             "       \"$resolver\": \"timestamp\",\n" +


### PR DESCRIPTION
## Why I'm doing:
Profile logs are often large, and the default JsonTemplateLayout will truncate 16386 strings, so set it to a very large value here, such as 100MB, so that it will basically never be truncated.

## What I'm doing:
set maxStringLength = 100MB

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
