### PR TITLE
[Enhancement] Add tracer for delta log reader

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
@@ -78,8 +78,8 @@ public class TimeWatcher {
 
         public void close() {
             reentrantCount--;
+            levels--;
             if (reentrantCount == 0) {
-                levels--;
                 stopWatch.stop();
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
@@ -19,8 +19,6 @@ import com.google.common.cache.LoadingCache;
 import com.starrocks.common.Pair;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultEngine;
-import io.delta.kernel.defaults.engine.DefaultJsonHandler;
-import io.delta.kernel.defaults.engine.DefaultParquetHandler;
 import io.delta.kernel.engine.JsonHandler;
 import io.delta.kernel.engine.ParquetHandler;
 import io.delta.kernel.types.StructType;
@@ -49,13 +47,13 @@ public class DeltaLakeEngine extends DefaultEngine {
     @Override
     public JsonHandler getJsonHandler() {
         return properties.isEnableDeltaLakeJsonMetaCache() ? new DeltaLakeJsonHandler(hadoopConf, jsonCache) :
-                new DefaultJsonHandler(hadoopConf);
+                new TraceDefaultJsonHandler(hadoopConf);
     }
 
     @Override
     public ParquetHandler getParquetHandler() {
         return properties.isEnableDeltaLakeCheckpointMetaCache() ? new DeltaLakeParquetHandler(hadoopConf, checkpointCache) :
-                new DefaultParquetHandler(hadoopConf);
+                new TraceDefaultParquetHandler(hadoopConf);
     }
 
     public static DeltaLakeEngine create(Configuration hadoopConf, DeltaLakeCatalogProperties properties,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
@@ -17,6 +17,8 @@ package com.starrocks.connector.delta;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultParquetHandler;
 import io.delta.kernel.exceptions.KernelEngineException;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static java.lang.String.format;
 
 public class DeltaLakeParquetHandler extends DefaultParquetHandler {
@@ -46,16 +49,19 @@ public class DeltaLakeParquetHandler extends DefaultParquetHandler {
     }
 
     public static List<ColumnarBatch> readParquetFile(String filePath, StructType physicalSchema, Configuration hadoopConf) {
-        io.delta.kernel.defaults.internal.parquet.ParquetFileReader batchReader =
-                new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(hadoopConf);
-        CloseableIterator<ColumnarBatch> currentFileReader = batchReader.read(filePath, physicalSchema, Optional.empty());
+        try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL,
+                "DeltaLakeParquetHandler.readParquetFileAndGetColumnarBatch")) {
+            io.delta.kernel.defaults.internal.parquet.ParquetFileReader batchReader =
+                    new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(hadoopConf);
+            CloseableIterator<ColumnarBatch> currentFileReader = batchReader.read(filePath, physicalSchema, Optional.empty());
 
-        List<ColumnarBatch> result = Lists.newArrayList();
-        while (currentFileReader != null && currentFileReader.hasNext()) {
-            result.add(currentFileReader.next());
+            List<ColumnarBatch> result = Lists.newArrayList();
+            while (currentFileReader != null && currentFileReader.hasNext()) {
+                result.add(currentFileReader.next());
+            }
+            Utils.closeCloseables(currentFileReader);
+            return result;
         }
-        Utils.closeCloseables(currentFileReader);
-        return result;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultJsonHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultJsonHandler.java
@@ -1,0 +1,162 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.defaults.engine.DefaultJsonHandler;
+import io.delta.kernel.exceptions.KernelEngineException;
+import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
+import static java.lang.String.format;
+
+public class TraceDefaultJsonHandler extends DefaultJsonHandler {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    // by default BigDecimals are truncated and read as floats
+    private static final ObjectReader OBJECT_READER_READ_BIG_DECIMALS = MAPPER
+            .reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+
+    private final Configuration hadoopConf;
+    private final int maxBatchSize;
+    public TraceDefaultJsonHandler(Configuration hadoopConf) {
+        super(hadoopConf);
+        this.hadoopConf = hadoopConf;
+        this.maxBatchSize =
+                hadoopConf.getInt("delta.kernel.default.json.reader.batch-size", 1024);
+    }
+
+    // This method copies the implementation from DefaultJsonHandler.java
+    @Override
+    public CloseableIterator<ColumnarBatch> readJsonFiles(
+            CloseableIterator<FileStatus> scanFileIter,
+            StructType physicalSchema,
+            Optional<Predicate> predicate) throws IOException {
+        return new CloseableIterator<ColumnarBatch>() {
+            private FileStatus currentFile;
+            private BufferedReader currentFileReader;
+            private String nextLine;
+
+            @Override
+            public void close() throws IOException {
+                Utils.closeCloseables(currentFileReader, scanFileIter);
+            }
+
+            @Override
+            public boolean hasNext() {
+                if (nextLine != null) {
+                    return true; // we have un-consumed last read line
+                }
+
+                // There is no file in reading or the current file being read has no more data
+                // initialize the next file reader or return false if there are no more files to
+                // read.
+                try {
+                    if (currentFileReader == null ||
+                            (nextLine = currentFileReader.readLine()) == null) {
+
+                        tryOpenNextFile();
+                        if (currentFileReader != null) {
+                            nextLine = currentFileReader.readLine();
+                        }
+                    }
+                } catch (IOException ex) {
+                    throw new KernelEngineException(
+                            format("Error reading JSON file: %s", currentFile.getPath()), ex);
+                }
+
+                return nextLine != null;
+            }
+
+            @Override
+            public ColumnarBatch next() {
+                if (nextLine == null) {
+                    throw new NoSuchElementException();
+                }
+
+                List<Row> rows = new ArrayList<>();
+                int currentBatchSize = 0;
+                try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "TraceDefaultJsonHandler.JsonToColumnarBatch")) {
+                    do {
+                        // hasNext already reads the next one and keeps it in member variable `nextLine`
+                        rows.add(parseJson(nextLine, physicalSchema));
+                        nextLine = null;
+                        currentBatchSize++;
+                    } while (currentBatchSize < maxBatchSize && hasNext());
+
+                    return new io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch(
+                            physicalSchema, rows);
+                }
+            }
+
+            private void tryOpenNextFile() throws IOException {
+                Utils.closeCloseables(currentFileReader); // close the current opened file
+                currentFileReader = null;
+
+                if (scanFileIter.hasNext()) {
+                    try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "TraceDefaultJsonHandler.ReadJsonFile")) {
+                        currentFile = scanFileIter.next();
+                        Path filePath = new Path(currentFile.getPath());
+                        FileSystem fs = filePath.getFileSystem(hadoopConf);
+                        FSDataInputStream stream = null;
+                        try {
+                            stream = fs.open(filePath);
+                            currentFileReader = new BufferedReader(
+                                    new InputStreamReader(stream, StandardCharsets.UTF_8));
+                        } catch (Exception e) {
+                            Utils.closeCloseablesSilently(stream); // close it avoid leaking resources
+                            throw e;
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private Row parseJson(String json, StructType readSchema) {
+        try {
+            final JsonNode jsonNode = OBJECT_READER_READ_BIG_DECIMALS.readTree(json);
+            return new io.delta.kernel.defaults.internal.data.DefaultJsonRow(
+                    (ObjectNode) jsonNode, readSchema);
+        } catch (JsonProcessingException ex) {
+            throw new KernelEngineException(format("Could not parse JSON: %s", json), ex);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultParquetHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/TraceDefaultParquetHandler.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.defaults.engine.DefaultParquetHandler;
+import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
+
+public class TraceDefaultParquetHandler extends DefaultParquetHandler {
+    private final Configuration hadoopConf;
+    public TraceDefaultParquetHandler(Configuration hadoopConf) {
+        super(hadoopConf);
+        this.hadoopConf = hadoopConf;
+    }
+
+    // This method copies the implementation from DefaultParquetHandler.java
+    @Override
+    public CloseableIterator<ColumnarBatch> readParquetFiles(
+            CloseableIterator<FileStatus> fileIter,
+            StructType physicalSchema,
+            Optional<Predicate> predicate) throws IOException {
+        return new CloseableIterator<ColumnarBatch>() {
+            private final io.delta.kernel.defaults.internal.parquet.ParquetFileReader batchReader =
+                    new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(hadoopConf);
+            private CloseableIterator<ColumnarBatch> currentFileReader;
+
+            @Override
+            public void close() throws IOException {
+                Utils.closeCloseables(currentFileReader, fileIter);
+            }
+
+            @Override
+            public boolean hasNext() {
+                if (currentFileReader != null && currentFileReader.hasNext()) {
+                    return true;
+                } else {
+                    // There is no file in reading or the current file being read has no more data.
+                    // Initialize the next file reader or return false if there are no more files to
+                    // read.
+                    Utils.closeCloseables(currentFileReader);
+                    currentFileReader = null;
+                    if (fileIter.hasNext()) {
+                        try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL,
+                                "TraceDefaultParquetHandler.readParquetFile")) {
+                            String nextFile = fileIter.next().getPath();
+                            currentFileReader = batchReader.read(nextFile, physicalSchema, predicate);
+                            return hasNext(); // recurse since it's possible the loaded file is empty
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+            }
+
+            @Override
+            public ColumnarBatch next() {
+                try (Timer ignored = Tracers.watchScope(Tracers.get(), EXTERNAL, "TraceDefaultParquetHandler.GetColumnarBatch")) {
+                    return currentFileReader.next();
+                }
+            }
+        };
+    }
+}

--- a/test/sql/test_deltalake/R/test_deltalake_trace
+++ b/test/sql/test_deltalake/R/test_deltalake_trace
@@ -10,6 +10,9 @@ create external catalog delta_test_${uuid0} PROPERTIES (
 );
 -- result:
 -- !result
+set enable_profile=true;
+-- result:
+-- !result
 function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp;", "TraceDefaultJsonHandler.ReadJsonFile")
 -- result:
 None

--- a/test/sql/test_deltalake/R/test_deltalake_trace
+++ b/test/sql/test_deltalake/R/test_deltalake_trace
@@ -1,0 +1,45 @@
+-- name: test_deltalake_trace
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "enable_deltalake_json_meta_cache" = "false",
+    "enable_deltalake_checkpoint_meta_cache" = "false",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp;", "TraceDefaultJsonHandler.ReadJsonFile")
+-- result:
+None
+-- !result
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_legacy_checkpoint limit 10;", "TraceDefaultParquetHandler.readParquetFile")
+-- result:
+None
+-- !result
+drop catalog delta_test_${uuid0};
+-- result:
+-- !result
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "enable_deltalake_json_meta_cache" = "true",
+    "enable_deltalake_checkpoint_meta_cache" = "true",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp;", "DeltaLakeJsonHandler.readParseJsonFile")
+-- result:
+None
+-- !result
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_legacy_checkpoint limit 10;", "DeltaLakeParquetHandler.readParquetFileAndGetColumnarBatch")
+-- result:
+None
+-- !result
+drop catalog delta_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_deltalake/T/test_deltalake_trace
+++ b/test/sql/test_deltalake/T/test_deltalake_trace
@@ -10,6 +10,8 @@ create external catalog delta_test_${uuid0} PROPERTIES (
     "aws.s3.endpoint"="${oss_endpoint}"
 );
 
+set enable_profile=true;
+
 function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp;", "TraceDefaultJsonHandler.ReadJsonFile")
 function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_legacy_checkpoint limit 10;", "TraceDefaultParquetHandler.readParquetFile")
 

--- a/test/sql/test_deltalake/T/test_deltalake_trace
+++ b/test/sql/test_deltalake/T/test_deltalake_trace
@@ -1,0 +1,31 @@
+-- name: test_deltalake_trace
+
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "enable_deltalake_json_meta_cache" = "false",
+    "enable_deltalake_checkpoint_meta_cache" = "false",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp;", "TraceDefaultJsonHandler.ReadJsonFile")
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_legacy_checkpoint limit 10;", "TraceDefaultParquetHandler.readParquetFile")
+
+drop catalog delta_test_${uuid0};
+
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "enable_deltalake_json_meta_cache" = "true",
+    "enable_deltalake_checkpoint_meta_cache" = "true",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp;", "DeltaLakeJsonHandler.readParseJsonFile")
+function: assert_trace_times_contains("select * from delta_test_${uuid0}.delta_oss_db.delta_legacy_checkpoint limit 10;", "DeltaLakeParquetHandler.readParquetFileAndGetColumnarBatch")
+
+drop catalog delta_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
add more time tacer for delta lake query when read delta log
## What I'm doing:
first query：
![image](https://github.com/user-attachments/assets/b09d1e22-b5d7-4551-9fed-e4369c59ca69)
second query：
![image](https://github.com/user-attachments/assets/3b9f7842-7285-47f7-b926-a42be459178b)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
