### PR TITLE
[Enhancement] fix common expression reuse issue in MapOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -39,6 +39,7 @@ import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.MapOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
@@ -177,6 +178,14 @@ public class ScalarOperatorsReuse {
             ScalarOperator newOperator = new LambdaFunctionOperator(operator.getRefColumns(),
                     operator.getLambdaExpr().accept(this, null), operator.getType()
             );
+            return tryRewrite(newOperator);
+        }
+
+        @Override
+        public ScalarOperator visitMap(MapOperator operator, Void context) {
+            ScalarOperator newOperator = new MapOperator(operator.getType(),
+                    operator.getChildren().stream().map(argument -> argument.accept(this, null)).
+                            collect(Collectors.toList()));
             return tryRewrite(newOperator);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -482,8 +482,10 @@ public class TrinoQueryTest extends TrinoTestBase {
                 "map_from_arrays([1,2,3], ['a','b','c']))");
 
         sql = "select transform_values(map(array [1, 2, 3], array ['a', 'b', 'c']), (k, v) -> k * k);";
-        assertPlanContains(sql, "map_apply((<slot 2>, <slot 3>) -> map{<slot 2>:CAST(<slot 2> AS SMALLINT) * " +
-                "CAST(<slot 2> AS SMALLINT)}, map_from_arrays([1,2,3], ['a','b','c']))");
+        assertPlanContains(sql, "  1:Project\n" +
+                "  |  <slot 4> : map_apply((<slot 2>, <slot 3>) -> map{<slot 2>:<slot 6> * <slot 6>}\n" +
+                "        lambda common expressions:{<slot 6> <-> CAST(<slot 2> AS SMALLINT)}\n" +
+                "        , map_from_arrays([1,2,3], ['a','b','c']))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -748,31 +748,40 @@ public class ExpressionTest extends PlanTestBase {
 
     @Test
     public void testReuseIndependentExprInLambdaFunction() throws Exception {
-        starRocksAssert.withTable("create table if not exists test_reuse_lambda_expr (k bigint, v array<bigint>) " +
+        starRocksAssert.withTable("create table if not exists test_reuse_lambda_expr " +
+                "(k bigint, v array<bigint>, m map<bigint, bigint>) " +
                 "duplicate key(k) distributed by hash(k) buckets 1 properties('replication_num'='1');");
         String sql = "select array_map((arg0, arg1) -> arg0 + arg1 + array_length(`v`), `v`, `v`) from test_reuse_lambda_expr";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 6> : array_length(2: v)\n" +
-                "  |  <slot 7> : CAST(6: array_length AS BIGINT)");
+                "  |  <slot 7> : array_length(2: v)\n" +
+                "  |  <slot 8> : CAST(7: array_length AS BIGINT)");
 
         sql = "select array_length(array_map((arg0, arg1) -> " +
                 "arg0 + arg1 + array_length(`v`) + array_length(array_filter((arg0) -> length(arg0) > 4, `v`)),`v`,`v`)) " +
                 "from test_reuse_lambda_expr";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 7> : array_length(2: v)\n" +
-                "  |  <slot 8> : CAST(7: array_length AS BIGINT)\n" +
-                "  |  <slot 9> : array_map(<slot 5> -> length(CAST(<slot 5> AS VARCHAR)) > 4, 2: v)\n" +
-                "  |  <slot 10> : array_filter(2: v, 9: array_map)\n" +
-                "  |  <slot 11> : array_length(10: array_filter)\n" +
-                "  |  <slot 12> : CAST(11: array_length AS BIGINT)");
+                "  |  <slot 8> : array_length(2: v)\n" +
+                "  |  <slot 9> : CAST(8: array_length AS BIGINT)\n" +
+                "  |  <slot 10> : array_map(<slot 6> -> length(CAST(<slot 6> AS VARCHAR)) > 4, 2: v)\n" +
+                "  |  <slot 11> : array_filter(2: v, 10: array_map)\n" +
+                "  |  <slot 12> : array_length(11: array_filter)\n" +
+                "  |  <slot 13> : CAST(12: array_length AS BIGINT)");
 
         sql = "select k, array_filter(x -> x > k + 10, `v`) from test_reuse_lambda_expr";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 5> : 1: k + 10");
+                "  |  <slot 6> : 1: k + 10");
+
+        sql = "select map_apply((arg0, arg1) -> (arg0 + k * 10, arg1 + map_size(`m`)), `m`) from test_reuse_lambda_expr";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  common expressions:\n" +
+                "  |  <slot 7> : 1: k * 10\n" +
+                "  |  <slot 8> : map_size(3: m)\n" +
+                "  |  <slot 9> : CAST(8: map_size AS BIGINT)");
     }
+
 
     @Test
     public void testInPredicateNormalize() throws Exception {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
