### PR TITLE
[Enhancement] support sql_mode=ANSI_QUOTES

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -7014,6 +7014,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
+    public ParseNode visitAnsiQuotedIdentifier(StarRocksParser.AnsiQuotedIdentifierContext context) {
+        String quotedString = context.DOUBLE_QUOTED_TEXT().getText();
+        quotedString = quotedString.substring(1, quotedString.length() - 1).replace("\"\"", "\"");
+        return new Identifier(quotedString, createPos(context));
+    }
+
+    @Override
     public ParseNode visitDigitIdentifier(StarRocksParser.DigitIdentifierContext context) {
         return new Identifier(context.getText(), createPos(context));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -231,6 +231,7 @@ public class SqlParser {
         int exprLimit = Math.max(Config.expr_children_limit, sessionVariable.getExprChildrenLimit());
         int tokenLimit = Math.max(MIN_TOKEN_LIMIT, sessionVariable.getParseTokensLimit());
         StarRocksParser parser = new StarRocksParser(tokenStream);
+        parser.setSqlMode(sessionVariable.getSqlMode());
         parser.removeErrorListeners();
         parser.addErrorListener(new ErrorHandler());
         parser.removeParseListeners();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2575,7 +2575,7 @@ fileFormat
 
 string
     : SINGLE_QUOTED_TEXT
-    | DOUBLE_QUOTED_TEXT
+    | {(sqlMode & com.starrocks.qe.SqlModeHelper.MODE_ANSI_QUOTES) == 0 }? DOUBLE_QUOTED_TEXT
     ;
 
 binary
@@ -2686,10 +2686,11 @@ writeBranch
     ;
 
 identifier
-    : LETTER_IDENTIFIER      #unquotedIdentifier
-    | nonReserved            #unquotedIdentifier
-    | DIGIT_IDENTIFIER       #digitIdentifier
-    | BACKQUOTED_IDENTIFIER  #backQuotedIdentifier
+    : LETTER_IDENTIFIER                                                                         #unquotedIdentifier
+    | nonReserved                                                                               #unquotedIdentifier
+    | DIGIT_IDENTIFIER                                                                          #digitIdentifier
+    | BACKQUOTED_IDENTIFIER                                                                     #backQuotedIdentifier
+    | {(sqlMode & com.starrocks.qe.SqlModeHelper.MODE_ANSI_QUOTES) != 0 }? DOUBLE_QUOTED_TEXT   #ansiQuotedIdentifier
     ;
 
 identifierList

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -267,6 +267,18 @@ class ParserTest {
     }
 
     @Test
+    void testAnsiQuotes() {
+        String sql = "select \"t\".\"a\" from \"t\" ";
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setSqlMode(SqlModeHelper.MODE_ANSI_QUOTES);
+        try {
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+        } catch (Exception e) {
+            fail("sql should success. errMsg: " +  e.getMessage());
+        }
+    }
+
+    @Test
     void testSettingSqlMode() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         Object lock = new Object();


### PR DESCRIPTION
## Why I'm doing:
for compatibility
MySQL support set sql_mode=ANSI_QUOTES
## What I'm doing:
support sql_mode=ANSI_QUOTES, like:
```
starrocks> set sql_mode='ANSI_QUOTES';
Query OK, 0 rows affected (0.00 sec)

starrocks> select "t"."a" from "t";
+------+
| a    |
+------+
|    1 |
|    0 |
+------+
2 rows in set (0.01 sec)
```

The principle is the same as that of mysql-workbench：
https://github.com/mysql/mysql-workbench/blob/8.0/library/parsers/grammars/MySQLParser.g4

Fixes #49685

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
