### PR TITLE
[BugFix] fix type mismatch error in meta scan count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggToMetaScanRule.java
@@ -131,9 +131,14 @@ public class PushDownAggToMetaScanRule extends TransformationRule {
 
             aggColumnIdToNames.put(metaColumn.getId(), metaColumnName);
             Column c = metaScan.getColRefToColumnMetaMap().get(usedColumn);
-            if (hasCountAgg) {
+            if (aggCall.getFnName().equals(FunctionSet.COUNT) || hasCountAgg) {
                 Column copiedColumn = new Column(c);
-                copiedColumn.setIsAllowNull(true);
+                if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+                    copiedColumn.setType(Type.BIGINT);
+                }
+                if (hasCountAgg) {
+                    copiedColumn.setIsAllowNull(true);
+                }
                 newScanColumnRefs.put(metaColumn, copiedColumn);
             } else {
                 newScanColumnRefs.put(metaColumn, c);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -96,14 +96,19 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
 
             aggColumnIdToNames.put(metaColumn.getId(), metaColumnName);
             Column c = scanOperator.getColRefToColumnMetaMap().get(usedColumn);
-            if (hasCountAgg) {
+
+            if (aggCall.getFnName().equals(FunctionSet.COUNT) || hasCountAgg) {
                 Column copiedColumn = new Column(c);
-                copiedColumn.setIsAllowNull(true);
+                if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+                    copiedColumn.setType(Type.BIGINT);
+                }
+                if (hasCountAgg) {
+                    copiedColumn.setIsAllowNull(true);
+                }
                 newScanColumnRefs.put(metaColumn, copiedColumn);
             } else {
                 newScanColumnRefs.put(metaColumn, c);
             }
-
 
             Function aggFunction = aggCall.getFunction();
             String newAggFnName = aggCall.getFnName();

--- a/test/sql/test_agg/R/test_meta_scan_agg
+++ b/test/sql/test_agg/R/test_meta_scan_agg
@@ -1,0 +1,53 @@
+-- name: test_meta_scan_agg
+create table t0 (
+    c0 DATE,
+    c1 INT,
+    c2 BIGINT
+) DUPLICATE key (c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 values ('2024-01-01', 1, 1), ('2024-01-02', 2, 2), ('2024-01-03', 3, 3), ('2024-01-04', 4, 4), ('2024-01-05', 5, 5);
+-- result:
+-- !result
+set enable_rewrite_simple_agg_to_meta_scan=true;
+-- result:
+-- !result
+set enable_exchange_pass_through=false;
+-- result:
+-- !result
+select count() from t0;
+-- result:
+5
+-- !result
+select count(c0) from t0;
+-- result:
+5
+-- !result
+select count(c1) from t0;
+-- result:
+5
+-- !result
+select count(c2) from t0;
+-- result:
+5
+-- !result
+select min(c0),max(c0),min(c1),max(c1),min(c2),max(c2) from t0;
+-- result:
+2024-01-01	2024-01-05	1	5	1	5
+-- !result
+select count(c0) from t0[_META_];
+-- result:
+5
+-- !result
+select count(c1) from t0[_META_];
+-- result:
+5
+-- !result
+select count(c2) from t0[_META_];
+-- result:
+5
+-- !result
+select min(c0),max(c0),min(c1),max(c1),min(c2),max(c2) from t0[_META_];
+-- result:
+2024-01-01	2024-01-05	1	5	1	5
+-- !result

--- a/test/sql/test_agg/T/test_meta_scan_agg
+++ b/test/sql/test_agg/T/test_meta_scan_agg
@@ -1,0 +1,22 @@
+-- name: test_meta_scan_agg
+
+create table t0 (
+    c0 DATE,
+    c1 INT,
+    c2 BIGINT
+) DUPLICATE key (c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+
+insert into t0 values ('2024-01-01', 1, 1), ('2024-01-02', 2, 2), ('2024-01-03', 3, 3), ('2024-01-04', 4, 4), ('2024-01-05', 5, 5);
+
+set enable_rewrite_simple_agg_to_meta_scan=true;
+set enable_exchange_pass_through=false;
+select count() from t0;
+select count(c0) from t0;
+select count(c1) from t0;
+select count(c2) from t0;
+select min(c0),max(c0),min(c1),max(c1),min(c2),max(c2) from t0;
+
+select count(c0) from t0[_META_];
+select count(c1) from t0[_META_];
+select count(c2) from t0[_META_];
+select min(c0),max(c0),min(c1),max(c1),min(c2),max(c2) from t0[_META_];


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #49691

for `count` function in meta scan, we should make sure the type of used column in meta scan node is BIGINT  instead of its original type. otherwise, exchange node cannot deserialize data due to type mismatch.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
