### PR TITLE
[BugFix] should respect the session variables that have been set previously

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -84,7 +84,7 @@ public class UserProperty {
             return;
         }
 
-        String newDatabase = "";
+        String newDatabase = getDatabase();
         for (Pair<String, String> entry : properties) {
             String key = entry.first;
             String value = entry.second;
@@ -112,7 +112,7 @@ public class UserProperty {
                 throw new DdlException("Unknown user property(" + key + ")");
             }
         }
-        if (!newDatabase.isEmpty()) {
+        if (!newDatabase.equalsIgnoreCase(getDatabase())) {
             checkDatabase(newDatabase);
             setDatabase(newDatabase);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.VariableExpr;
 import com.starrocks.authentication.UserProperty;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
@@ -1109,6 +1110,11 @@ public class ConnectContext {
             // set session variables
             Map<String, String> sessionVariables = userProperty.getSessionVariables();
             for (Map.Entry<String, String> entry : sessionVariables.entrySet()) {
+                String currentValue = VariableMgr.getValue(sessionVariable, new VariableExpr(entry.getKey()));
+                if (!currentValue.equalsIgnoreCase(VariableMgr.getDefaultValue(entry.getKey()))) {
+                    // If the current session variable is not default value, we should respect it.
+                    continue;
+                }
                 SystemVariable variable = new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue()));
                 modifySystemVariable(variable, true);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
@@ -248,6 +248,7 @@ public class UserPropertyTest {
     @Test
     public void testUpdate_WithDatabase() throws Exception {
         try {
+            // database does not exist
             UserProperty userProperty = new UserProperty();
             List<Pair<String, String>> properties = new ArrayList<>();
             properties.add(new Pair<>(UserProperty.PROP_DATABASE, "xxx"));
@@ -266,7 +267,6 @@ public class UserPropertyTest {
             Assert.assertEquals(databaseName, userProperty.getDatabase());
 
             // reset database for root user
-            userProperty = new UserProperty();
             properties = new ArrayList<>();
             properties.add(new Pair<>(UserProperty.PROP_DATABASE, UserProperty.DATABASE_DEFAULT_VALUE));
             userProperty.update("root", properties);
@@ -436,6 +436,19 @@ public class UserPropertyTest {
             throw e;
         }
         Assert.assertEquals(2, context.getSessionVariable().getStatisticCollectParallelism());
+
+        try {
+            // the session variable statistic_collect_parallel has been set to 2, and it is not equal to its default value 1
+            // updateByUserProperty will ignore setting the session variable statistic_collect_parallel.
+            userProperty = new UserProperty();
+            Map<String, String> sessionVariables = userProperty.getSessionVariables();
+            sessionVariables.put("statistic_collect_parallel", "100");
+            userProperty.setSessionVariables(sessionVariables);
+            context.updateByUserProperty(userProperty);
+        } catch (Exception e) {
+            throw e;
+        }
+        Assert.assertEquals(2, context.getSessionVariable().getStatisticCollectParallelism()); // not 100
 
         try {
             // catalog is valid


### PR DESCRIPTION
## Why I'm doing:

1. When a user runs 'execute as', we should respect the session variables that have been set previously and not overwrite them with the user's properties.
2. can not reset user's database property.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
