### PR TITLE
[BugFix] make sure metadata cache quit safety

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -81,7 +81,10 @@ Rowset::~Rowset() {
     if (_keys_type != PRIMARY_KEYS) {
         // ONLY support non-pk table now.
         // evict rowset before destroy, in case this rowset no close yet.
-        StorageEngine::instance()->tablet_manager()->metadata_cache()->evict_rowset(this);
+        auto metadata_cache = StorageEngine::instance()->tablet_manager()->metadata_cache();
+        if (metadata_cache != nullptr) {
+            metadata_cache->evict_rowset(this);
+        }
     }
 #endif
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -278,6 +278,9 @@ private:
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
     static Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);
 
+    // LRU cache for metadata
+    std::unique_ptr<MetadataCache> _metadata_cache;
+
     std::vector<TabletsShard> _tablets_shards;
     const int64_t _tablets_shards_mask;
     LockTable _schema_change_lock_tbl;
@@ -300,9 +303,6 @@ private:
     // context for compaction checker
     size_t _cur_shard = 0;
     std::unordered_set<int64_t> _shard_visited_tablet_ids;
-
-    // LRU cache for metadata
-    std::unique_ptr<MetadataCache> _metadata_cache;
 };
 
 inline bool TabletManager::LockTable::is_locked(int64_t tablet_id) {


### PR DESCRIPTION
## Why I'm doing:
When BE quit, Rowset will call `metadata_cache->evict_rowset` on deconstruct function, but `metadata_cache` may release already. And then it will lead to crash like:
![img_v3_02dj_ab539e2c-7375-4f6c-889d-3e7b011c476g](https://github.com/user-attachments/assets/061d1372-74dd-417c-92d3-206b574e707e)


## What I'm doing:
Fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
