### PR TITLE
[BugFix] Fix spill preagg miss rows when has streaming chunks

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -60,7 +60,7 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
         _aggregator->spiller()->cancel();
     }
 
-    if (!_aggregator->spiller()->spilled()) {
+    if (!_aggregator->spiller()->spilled() && _streaming_chunks.empty()) {
         RETURN_IF_ERROR(AggregateBlockingSinkOperator::set_finishing(state));
         return Status::OK();
     }
@@ -242,8 +242,8 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
         _aggregator->update_num_input_rows(hit_count);
         RETURN_IF_ERROR(_aggregator->check_has_error());
     }
-    // finally, check memory usage of streaming_chunks and hash table, decide wether to spill
 
+    // finally, check memory usage of streaming_chunks and hash table, decide whether to spill
     size_t revocable_mem_bytes = _streaming_bytes + _aggregator->hash_map_memory_usage();
     set_revocable_mem_bytes(revocable_mem_bytes);
     if (revocable_mem_bytes > max_mem_usage) {

--- a/test/sql/test_spill/R/test_spill_agg_streaming_strategy
+++ b/test/sql/test_spill/R/test_spill_agg_streaming_strategy
@@ -8,6 +8,9 @@ set spill_mode="force";
 set streaming_preaggregation_mode="force_streaming";
 -- result:
 -- !result
+set pipeline_dop=1;
+-- result:
+-- !result
 CREATE TABLE t1 (
     k1 INT,
     k2 VARCHAR(20))
@@ -16,6 +19,9 @@ PROPERTIES('replication_num'='1');
 -- result:
 -- !result
 insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+set enable_agg_spill_preaggregation=true;
 -- result:
 -- !result
 admin enable failpoint 'spill_always_streaming';
@@ -37,7 +43,7 @@ select avg(k1) x from (select * from t1 union all select * from t1)t group by k2
 admin disable failpoint 'spill_always_streaming';
 -- result:
 -- !result
-admin disable failpoint 'spill_always_selection_streaming';
+admin enable failpoint 'spill_always_selection_streaming';
 -- result:
 -- !result
 select avg(k1) x from (select * from t1 union all select * from t1)t group by k2 order by x limit 10;
@@ -52,6 +58,10 @@ select avg(k1) x from (select * from t1 union all select * from t1)t group by k2
 8.0
 9.0
 10.0
+-- !result
+select count(*), sum(x) from (select sum(k1) x from (select * from t1 union all SELECT generate_series + 40960, generate_series + 40960 FROM TABLE(generate_series(1,  40960)))t group by k2 ) t;
+-- result:
+81920	3355484160
 -- !result
 admin disable failpoint 'spill_always_selection_streaming';
 -- result:

--- a/test/sql/test_spill/T/test_spill_agg_streaming_strategy
+++ b/test/sql/test_spill/T/test_spill_agg_streaming_strategy
@@ -3,6 +3,7 @@
 set enable_spill=true;
 set spill_mode="force";
 set streaming_preaggregation_mode="force_streaming";
+set pipeline_dop=1;
 
 CREATE TABLE t1 (
     k1 INT,
@@ -13,13 +14,14 @@ PROPERTIES('replication_num'='1');
 -- always streaming
 insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 
--- set enable_agg_spill_preaggregation=false;
+set enable_agg_spill_preaggregation=true;
 
 admin enable failpoint 'spill_always_streaming';
 select avg(k1) x from (select * from t1 union all select * from t1)t group by k2 order by x limit 10;
 admin disable failpoint 'spill_always_streaming';
 
-admin disable failpoint 'spill_always_selection_streaming';
+admin enable failpoint 'spill_always_selection_streaming';
 select avg(k1) x from (select * from t1 union all select * from t1)t group by k2 order by x limit 10;
+select count(*), sum(x) from (select sum(k1) x from (select * from t1 union all SELECT generate_series + 40960, generate_series + 40960 FROM TABLE(generate_series(1,  40960)))t group by k2 ) t;
 admin disable failpoint 'spill_always_selection_streaming';
 


### PR DESCRIPTION
## Why I'm doing:

The spill pre agg does not flush any hash tables if there are streaming chunks at this time. this part of the data will be lost.

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
