### PR TITLE
[Enhancement] No need to build slice to get value from ConstColumn

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -268,7 +268,7 @@ public:
         }
     }
 
-    ValueType get_data(uint32_t index) const { _immuable_container[index]; }
+    ValueType get_data(uint32_t index) const { return _immuable_container[index]; }
 
     Container& get_data() {
         if (!_slices_cache) {

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -268,6 +268,8 @@ public:
         }
     }
 
+    ValueType get_data(uint32_t index) const { _immuable_container[index]; }
+
     Container& get_data() {
         if (!_slices_cache) {
             _build_slices();

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -312,13 +312,13 @@ public:
     template <LogicalType Type>
     static inline RunTimeCppType<Type> get_const_value(const Column* col) {
         const ColumnPtr& c = as_raw_column<ConstColumn>(col)->data_column();
-        return cast_to_raw<Type>(c)->get_data()[0];
+        return cast_to_raw<Type>(c)->get_data(0);
     }
 
     template <LogicalType Type>
     static inline RunTimeCppType<Type> get_const_value(const ColumnPtr& col) {
         const ColumnPtr& c = as_raw_column<ConstColumn>(col)->data_column();
-        return cast_to_raw<Type>(c)->get_data()[0];
+        return cast_to_raw<Type>(c)->get_data(0);
     }
 
     static Column* get_data_column(Column* column) {

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -214,6 +214,8 @@ public:
 
     const Container& get_data() const { return _data; }
 
+    ValueType get_data(uint32_t index) const { return _data[index]; }
+
     Datum get(size_t n) const override { return Datum(_data[n]); }
 
     std::string debug_item(size_t idx) const override;

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -38,6 +38,17 @@ protected:
     }
 };
 
+TEST_F(ColumnHelperTest, get_const_value) {
+    Slice slice("12345");
+    auto column = ColumnHelper::create_const_column<TYPE_VARCHAR>(slice, 10);
+
+    auto result = ColumnHelper::get_const_value<TYPE_VARCHAR>(column.get());
+    ASSERT_EQ(result, slice);
+
+    result = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
+    ASSERT_EQ(result, slice);
+}
+
 TEST_F(ColumnHelperTest, cast_to_nullable_column) {
     auto col = ColumnHelper::cast_to_nullable_column(create_column());
     ASSERT_TRUE(col->is_nullable());

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -47,6 +47,9 @@ TEST_F(ColumnHelperTest, get_const_value) {
 
     result = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     ASSERT_EQ(result, slice);
+
+    column = ColumnHelper::create_const_column<TYPE_INT>(1, 10);
+    ASSERT_EQ(ColumnHelper::get_const_value<TYPE_INT>(column), 1);
 }
 
 TEST_F(ColumnHelperTest, cast_to_nullable_column) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
*** Aborted at 1721023771 (unix time) try "date -d @1721023771" if you are using GNU date ***
PC: @          0x2d8c0e8 std::vector<>::reserve()
*** SIGSEGV (@0x0) received by PID 65447 (TID 0x7fc2670e0700) from PID 0; stack trace: ***
    @          0x5c211e2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fc5cb1a87fb os::Linux::chained_handler()
    @     0x7fc5cb1ad35c JVM_handle_linux_signal
    @     0x7fc5cb19fe78 signalHandler()
    @     0x7fc5ca630630 (unknown)
    @          0x2d8c0e8 std::vector<>::reserve()
    @          0x2d8c193 starrocks::vectorized::BinaryColumnBase<>::_build_slices()
    @          0x5282028 starrocks::vectorized::EncryptionFunctions::fpe_decrypt()
    @          0x40a079a starrocks::vectorized::VectorizedFunctionCallExpr::evaluate_checked()
    @          0x39439d3 starrocks::ExprContext::evaluate()
    @          0x3943d1f starrocks::ExprContext::evaluate()
    @          0x30567fc starrocks::pipeline::ProjectOperator::push_chunk()
    @          0x2db392e starrocks::pipeline::PipelineDriver::process()
    @          0x51f460a starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x4bdc592 starrocks::ThreadPool::dispatch_thread()
    @          0x4bd702a starrocks::Thread::supervise_thread()
    @     0x7fc5ca628ea5 start_thread
    @     0x7fc5c9c43b0d __clone
```

BinaryColumn::get_data() is not thread safe, If misused, it can easily cause some problems.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
