### PR TITLE
[BugFix] fix redundant partition info in CompactionManager meta

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
@@ -21,12 +21,21 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.persist.metablock.SRMetaBlockEOFException;
+import com.starrocks.persist.metablock.SRMetaBlockException;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.MetaUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -143,5 +152,47 @@ public class CompactionMgrTest {
             }
         };
         Assert.assertEquals(true, compactionManager.existCompaction(txnId));
+    }
+
+    @Test
+    public void testSaveAndLoad() throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
+        CompactionMgr compactionMgr = new CompactionMgr();
+        PartitionIdentifier partition1 = new PartitionIdentifier(1, 2, 3);
+        PartitionIdentifier partition2 = new PartitionIdentifier(1, 2, 4);
+        PartitionIdentifier partition3 = new PartitionIdentifier(1, 2, 5);
+
+        compactionMgr.handleLoadingFinished(partition1, 2, System.currentTimeMillis(),
+                Quantiles.compute(Lists.newArrayList(1d)));
+        compactionMgr.handleLoadingFinished(partition2, 3, System.currentTimeMillis(),
+                Quantiles.compute(Lists.newArrayList(2d)));
+        compactionMgr.handleLoadingFinished(partition3, 4, System.currentTimeMillis(),
+                Quantiles.compute(Lists.newArrayList(3d)));
+
+        Assert.assertEquals(3, compactionMgr.getPartitionStatsCount());
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public boolean isPartitionExist(GlobalStateMgr stateMgr, long dbId, long tableId, long partitionId) {
+                if (partitionId == 3) {
+                    return true;
+                }
+                if (partitionId == 4) {
+                    return false;
+                }
+                if (partitionId == 5) {
+                    return false;
+                }
+                return true;
+            }
+        };
+
+        ByteArrayOutputStream bstream = new ByteArrayOutputStream();
+        DataOutputStream ostream = new DataOutputStream(bstream);
+        compactionMgr.save(ostream);
+        CompactionMgr compactionMgr2 = new CompactionMgr();
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bstream.toByteArray()));
+        SRMetaBlockReader reader = new SRMetaBlockReader(dis);
+        compactionMgr2.load(reader);
+        Assert.assertEquals(1, compactionMgr2.getPartitionStatsCount());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

compaction manager's partition info is never removed in Checkpoint thread, need to remove non-existed partitions info, otherwise FE image will grow.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
