### PR TITLE
[BugFix] Fix the mem statistics bug of SegmentReplicateExecutor

### DIFF
--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -78,7 +78,8 @@ Status ReplicateChannel::_init() {
         LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }
-    _mem_tracker = GlobalEnv::GetInstance()->load_mem_tracker();
+    _mem_tracker = std::make_unique<MemTracker>(-1, "replicate: " + UniqueId(_opt->load_id).to_string(),
+                                                GlobalEnv::GetInstance()->load_mem_tracker());
     if (!_mem_tracker) {
         auto msg = fmt::format("Failed to get load mem tracker for {} failed.", debug_string().c_str());
         LOG(WARNING) << msg;
@@ -161,8 +162,9 @@ void ReplicateChannel::_send_request(SegmentPB* segment, butil::IOBuf& data, boo
         _closure->cntl.request_attachment().append(data);
     }
     _closure->request_size = _closure->cntl.request_attachment().size();
+
     // brpc send buffer is also considered as part of the memory used by load
-    _mem_tracker->consume(_closure->request_size);
+    _mem_tracker->consume_without_root(_closure->request_size);
 
     _stub->tablet_writer_add_segment(&_closure->cntl, &request, &_closure->result, _closure);
 
@@ -175,7 +177,7 @@ void ReplicateChannel::_send_request(SegmentPB* segment, butil::IOBuf& data, boo
 Status ReplicateChannel::_wait_response(std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                                         std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos) {
     if (_closure->join()) {
-        _mem_tracker->release(_closure->request_size);
+        _mem_tracker->release_without_root(_closure->request_size);
         if (_closure->cntl.Failed()) {
             _st = Status::InternalError(_closure->cntl.ErrorText());
             LOG(WARNING) << "Failed to send rpc to " << debug_string() << " err=" << _st;

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -88,27 +88,6 @@ Status ReplicateChannel::_init() {
     return Status::OK();
 }
 
-Status ReplicateChannel::sync_segment(SegmentPB* segment, butil::IOBuf& data, bool eos,
-                                      std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
-                                      std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos) {
-    RETURN_IF_ERROR(_st);
-
-    // 1. init sync channel
-    _st = _init();
-    RETURN_IF_ERROR(_st);
-
-    // 2. send segment sync request
-    _send_request(segment, data, eos);
-
-    // 3. wait result
-    RETURN_IF_ERROR(_wait_response(replicate_tablet_infos, failed_tablet_infos));
-
-    VLOG(1) << "Sync tablet " << _opt->tablet_id << " segment id " << (segment == nullptr ? -1 : segment->segment_id())
-            << " eos " << eos << " to [" << _host << ":" << _port << "] res " << _closure->result.DebugString();
-
-    return _st;
-}
-
 Status ReplicateChannel::async_segment(SegmentPB* segment, butil::IOBuf& data, bool eos,
                                        std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                                        std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos) {

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -62,6 +62,8 @@ private:
     Status _wait_response(std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                           std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);
 
+    std::unique_ptr<MemTracker> _mem_tracker;
+
     const DeltaWriterOptions* _opt;
     const std::string _host;
     const int32_t _port;
@@ -69,7 +71,6 @@ private:
 
     ReusableClosure<PTabletWriterAddSegmentResult>* _closure = nullptr;
     std::shared_ptr<PInternalService_RecoverableStub> _stub;
-    MemTracker* _mem_tracker = nullptr;
 
     bool _inited = false;
     Status _st = Status::OK();

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -42,10 +42,6 @@ public:
     ReplicateChannel(const DeltaWriterOptions* opt, std::string host, int32_t port, int64_t node_id);
     ~ReplicateChannel();
 
-    Status sync_segment(SegmentPB* segment, butil::IOBuf& data, bool eos,
-                        std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
-                        std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);
-
     Status async_segment(SegmentPB* segment, butil::IOBuf& data, bool eos,
                          std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                          std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`SegmentReplicateExecutor` have 3 problems:

1. The memory was already recorded once through mem_hook and again through MemTracker::consume, resulting in double recording of the same memory to `ProcessMemTracker`
2. When the cancel occurs, `MemTracker::release` will not be called, resulting in infinite accumulation of load memory statistics.
3. Resident MemTracker should not use to record mem usage directly

How to reproduce:

```
insert into t1 select * from xxx;

After running for a period of time, execute Ctrl+C

select * from information_schema.be_metrics where name like "%load_mem_bytes%"
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
