### PR TITLE
[Enhancement] VIEW in information_schema.tables_config (#49447)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -254,13 +254,16 @@ public class InformationSchemaDataSource {
                         tableConfigInfo.setTable_schema(dbName);
                         tableConfigInfo.setTable_name(table.getName());
 
-                        if (table.isNativeTableOrMaterializedView() || table.getType() == TableType.OLAP_EXTERNAL) {
+                        if (table.isNativeTableOrMaterializedView() || table.isOlapExternalTable()) {
                             // OLAP (done)
                             // OLAP_EXTERNAL (done)
                             // MATERIALIZED_VIEW (done)
                             // LAKE (done)
                             // LAKE_MATERIALIZED_VIEW (done)
                             genNormalTableConfigInfo(table, tableConfigInfo);
+                        } else if (table.isView()) {
+                            // VIEW (done)
+                            tableConfigInfo.setTable_engine(table.getType().toString());
                         }
                         // TODO(cjs): other table type (HIVE, MYSQL, ICEBERG, HUDI, JDBC, ELASTICSEARCH)
                         tList.add(tableConfigInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -107,8 +107,12 @@ public class InformationSchemaDataSourceTest {
                 "REFRESH ASYNC " +
                 "AS SELECT k1, k2 " +
                 "FROM db1.tbl1 ";
-
         starRocksAssert.withMaterializedView(createMvStmtStr);
+
+        String createViewStmtStr = "CREATE VIEW db1.v1 " +
+                "AS SELECT k1, k2 " +
+                "FROM db1.tbl1 ";
+        starRocksAssert.withView(createViewStmtStr);
 
         FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
         TGetTablesConfigRequest req = new TGetTablesConfigRequest();
@@ -139,6 +143,13 @@ public class InformationSchemaDataSourceTest {
         Map<String, String> propsMap = new Gson().fromJson(mvConfig.getProperties(), Map.class);
         Assert.assertEquals("1", propsMap.get("replication_num"));
         Assert.assertEquals("HDD", propsMap.get("storage_medium"));
+
+        TTableConfigInfo viewConfig = response.getTables_config_infos().stream()
+                .filter(t -> t.getTable_engine().equals("VIEW")).findFirst()
+                .orElseGet(null);
+        Assert.assertEquals("VIEW", viewConfig.getTable_engine());
+        Assert.assertEquals("db1", viewConfig.getTable_schema());
+        Assert.assertEquals("v1", viewConfig.getTable_name());
 
     }
 


### PR DESCRIPTION
## Why I'm doing:
In information_schema.tables_config, in TABLE_ENGINE col, if it's a view, the TABLE_ENGINE is empty.
It's better to make this column VIEW when its type is view.
## What I'm doing:
Add extra logic in function `generateTablesConfigResponse`. If the table is OlapView or the table is ConnectorView(HIVE_VIEW or ICEBERG_VIEW), the tableConfigInfo set the table_engine col with corresponding table type.
Fixes #49447. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
