### PR TITLE
[BugFix] Fix check of overflow for converting floating to intergal (backport #49707)

### DIFF
--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -30,6 +30,7 @@
 #include "types/hll.h"
 #include "util/date_func.h"
 #include "util/json.h"
+#include "util/numeric_types.h"
 #include "velocypack/Iterator.h"
 
 namespace starrocks::vectorized {
@@ -389,12 +390,7 @@ DEFINE_UNARY_FN_WITH_IMPL(ImplicitToNumber, value) {
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(NumberCheck, value) {
-    // std::numeric_limits<T>::lowest() is a finite value x such that there is no other
-    // finite value y where y < x.
-    // This is different from std::numeric_limits<T>::min() for floating-point types.
-    // So we use lowest instead of min for lower bound of all types.
-    return (value < (Type)std::numeric_limits<ResultType>::lowest()) |
-           (value > (Type)std::numeric_limits<ResultType>::max());
+    return check_number_overflow<Type, ResultType>(value);
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(NumberCheckWithThrowException, value) {
@@ -402,8 +398,7 @@ DEFINE_UNARY_FN_WITH_IMPL(NumberCheckWithThrowException, value) {
     // finite value y where y < x.
     // This is different from std::numeric_limits<T>::min() for floating-point types.
     // So we use lowest instead of min for lower bound of all types.
-    auto result = (value < (Type)std::numeric_limits<ResultType>::lowest()) |
-                  (value > (Type)std::numeric_limits<ResultType>::max());
+    const auto result = NumberCheck::apply<Type, ResultType>(value);
     if (result) {
         std::stringstream ss;
         if constexpr (std::is_same_v<Type, __int128_t>) {

--- a/be/src/formats/json/numeric_column.cpp
+++ b/be/src/formats/json/numeric_column.cpp
@@ -4,6 +4,7 @@
 
 #include "column/fixed_length_column.h"
 #include "gutil/strings/substitute.h"
+#include "util/numeric_types.h"
 #include "util/string_parser.hpp"
 
 namespace starrocks::vectorized {
@@ -18,7 +19,7 @@ static inline bool checked_cast(const FromType& from, ToType* to) {
 #if defined(__clang__)
     DIAGNOSTIC_IGNORE("-Wimplicit-const-int-float-conversion")
 #endif
-    return (from < std::numeric_limits<ToType>::lowest() || from > std::numeric_limits<ToType>::max());
+    return check_number_overflow<FromType, ToType>(from);
     DIAGNOSTIC_POP
 }
 

--- a/be/src/util/numeric_types.h
+++ b/be/src/util/numeric_types.h
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <type_traits>
+
+namespace starrocks {
+
+template <typename FromType, typename ToType>
+static constexpr FromType floating_to_intergral_lower_bound =
+        static_cast<FromType>(std::numeric_limits<ToType>::lowest());
+
+template <typename FromType, typename ToType>
+static constexpr FromType floating_to_intergral_upper_bound = static_cast<FromType>(2) *
+                                                              (std::numeric_limits<ToType>::max() / 2 + 1);
+
+/// Check whether the value of type `FromType` overflows when converted to type `ToType`.
+/// If overflow, return true; otherwise, return false.
+template <typename FromType, typename ToType>
+bool check_number_overflow(FromType value) {
+    if constexpr (std::is_floating_point_v<FromType> && std::is_integral_v<ToType>) {
+        // For floating-point numbers, we cannot use `value > (Type)std::numeric_limits<ResultType>::max()` to
+        // determine whether `value` exceeds the maximum value of ResultType. The reason is as follows:
+        //
+        // `std::numeric_limits<ResultType>::max()` is `2^n-1`, where n is 63, 31, 15 or 7, this number cannot be
+        // exactly represented by floating-point numbers, so when converted to Type, it will be rounded up to `2^n`.
+        // Therefore, when `value` is `2^n`, `value > (Type)std::numeric_limits<ResultType>::max()` will return false.
+        // However, in actual conversion, overflow will occur, resulting in the maximum or minimum value of ResultType,
+        // depending on the architecture, compiler, and compilation parameters.
+        //
+        // Because `2^n` can be exactly represented by floating-point numbers, we use `value >= (Type)2^n` to determine
+        // whether it is overflow, rather than `value > (Type)2^n-1`.
+        return !(value >= floating_to_intergral_lower_bound<FromType, ToType> &&
+                 value < floating_to_intergral_upper_bound<FromType, ToType>);
+    } else {
+        // std::numeric_limits<T>::lowest() is a finite value x such that there is no other
+        // finite value y where y < x.
+        // This is different from std::numeric_limits<T>::min() for floating-point types.
+        // So we use lowest instead of min for lower bound of all types.
+        return (value < (FromType)std::numeric_limits<ToType>::lowest()) |
+               (value > (FromType)std::numeric_limits<ToType>::max());
+    }
+}
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -329,6 +329,7 @@ set(EXEC_FILES
         ./util/ratelimit_test.cpp
         ./util/cpu_usage_info_test.cpp
         ./util/concurrent_limiter_test.cpp
+        ./util/numeric_types_test.cpp
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
         )

--- a/be/test/util/numeric_types_test.cpp
+++ b/be/test/util/numeric_types_test.cpp
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/numeric_types.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(TestNumericTypes, test_check_number_overflow) {
+    EXPECT_FALSE((check_number_overflow<double, int64_t>(9223372036854775000.0)));
+    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775807.0)));
+    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775807.3)));
+    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775808.0)));
+    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775809.0)));
+
+    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854675807.0)));
+    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854775807.0)));
+    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854775808.0)));
+    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854775809.0)));
+    EXPECT_TRUE((check_number_overflow<double, int64_t>(-9223372036854778808.0)));
+
+    EXPECT_FALSE((check_number_overflow<float, int32_t>(2147483000.0)));
+    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483647.0)));
+    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483647.3)));
+    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483648.0)));
+    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483649.0)));
+
+    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147473647.0)));
+    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147483647.0)));
+    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147483648.0)));
+    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147483649.0)));
+    EXPECT_TRUE((check_number_overflow<float, int32_t>(-2147494649.0)));
+
+    EXPECT_FALSE((check_number_overflow<float, int16_t>(32767)));
+    EXPECT_TRUE((check_number_overflow<float, int16_t>(32768)));
+    EXPECT_TRUE((check_number_overflow<float, int16_t>(32769)));
+    EXPECT_FALSE((check_number_overflow<float, int16_t>(-32765)));
+    EXPECT_FALSE((check_number_overflow<float, int16_t>(-32767)));
+    EXPECT_FALSE((check_number_overflow<float, int16_t>(-32768)));
+    EXPECT_TRUE((check_number_overflow<float, int16_t>(-32770)));
+
+    EXPECT_FALSE((check_number_overflow<float, int8_t>(127)));
+    EXPECT_TRUE((check_number_overflow<float, int8_t>(128)));
+    EXPECT_TRUE((check_number_overflow<float, int8_t>(129)));
+
+    EXPECT_FALSE((check_number_overflow<float, int8_t>(-127)));
+    EXPECT_FALSE((check_number_overflow<float, int8_t>(-128)));
+    EXPECT_TRUE((check_number_overflow<float, int8_t>(-129)));
+
+    {
+        double d_value = 9223372036854775000.0;
+        for (int i = 0; i < 10000; i++) {
+            d_value -= 10000.0;
+            EXPECT_FALSE((check_number_overflow<double, int64_t>(d_value)));
+        }
+    }
+
+    {
+        double d_value = 9223372036854775808.0;
+        for (int i = 0; i < 10000; i++) {
+            d_value += 10000.0;
+            EXPECT_TRUE((check_number_overflow<double, int64_t>(d_value)));
+        }
+    }
+
+    {
+        float d_value = 2147483000.0;
+        for (int i = 0; i < 10000; i++) {
+            d_value -= 1000.0;
+            EXPECT_FALSE((check_number_overflow<float, int32_t>(d_value)));
+        }
+    }
+
+    {
+        float d_value = 2147483649.0;
+        for (int i = 0; i < 10000; i++) {
+            d_value += 1000.0;
+            EXPECT_TRUE((check_number_overflow<float, int32_t>(d_value)));
+        }
+    }
+}
+
+} // namespace starrocks


### PR DESCRIPTION
CP from #49707.

## Why I'm doing:
For floating-point numbers, we cannot use `value > (Type)std::numeric_limits<ResultType>::max()` to determine whether `value` exceeds the maximum value of ResultType. The reason is as follows:

`std::numeric_limits<ResultType>::max()` is `2^n-1`, where n is 63, 31, 15 or 7, this number cannot be exactly represented by floating-point numbers, so when converted to Type, it will be rounded up to `2^n`. Therefore, when `value` is `2^n`, `value > (Type)std::numeric_limits<ResultType>::max()` will return false. However, in actual conversion, overflow will occur, resulting in the maximum or minimum value of ResultType, depending on the architecture, compiler, and compilation parameters.

## What I'm doing:




Because `2^n` can be exactly represented by floating-point numbers, we use `value >= (Type)2^n` to determine whether it is overflow, rather than `value > (Type)2^n-1`.

Fixes #49591

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
