### PR TITLE
[BugFix] fix common expr reuse issue in nested lambda expr (backport #49755)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
@@ -59,7 +59,7 @@ public class ScalarOperatorsReuseRule implements TreeRewriteRule {
             Projection projection = input.getOp().getProjection();
 
             projection = ScalarOperatorsReuse.rewriteProjectionOrLambdaExpr(projection,
-                    context.getOptimizerContext().getColumnRefFactory(), false);
+                    context.getOptimizerContext().getColumnRefFactory());
 
             if (projection.needReuseLambdaDependentExpr()) {
                 // rewrite lambda functions with lambda arguments

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
@@ -118,7 +118,7 @@ public class ScalarOperatorsReuseTest {
         List<ScalarOperator> oldOperators = Lists.newArrayList(add1, add3, multi);
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
 
         // FixMe(kks): This case could improve
         assertEquals(commonSubScalarOperators.size(), 3);
@@ -146,7 +146,7 @@ public class ScalarOperatorsReuseTest {
         List<ScalarOperator> oldOperators = Lists.newArrayList(addABC, addBCD);
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
 
         // FixMe(kks): could we improve this case?
         assertTrue(commonSubScalarOperators.isEmpty());
@@ -172,7 +172,7 @@ public class ScalarOperatorsReuseTest {
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
-                        columnRefFactory, false);
+                        columnRefFactory);
         Assert.assertFalse(commonSubScalarOperators.isEmpty());
     }
 
@@ -196,7 +196,7 @@ public class ScalarOperatorsReuseTest {
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
-                        columnRefFactory, false);
+                        columnRefFactory);
         assertEquals(3, commonSubScalarOperators.size());
     }
 
@@ -222,7 +222,7 @@ public class ScalarOperatorsReuseTest {
 
         // reuse lambda argument non-related sub expressions : t1*2
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
         assertEquals(commonSubScalarOperators.size(), 1);
     }
 
@@ -248,7 +248,7 @@ public class ScalarOperatorsReuseTest {
 
         // reuse lambda argument related sub expressions : x*2
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, true);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
         assertEquals(commonSubScalarOperators.size(), 1);
 
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -780,6 +780,27 @@ public class ExpressionTest extends PlanTestBase {
                 "  |  <slot 7> : 1: k * 10\n" +
                 "  |  <slot 8> : map_size(3: m)\n" +
                 "  |  <slot 9> : CAST(8: map_size AS BIGINT)");
+
+        sql = "select array_generate(0, `k`, 1) as a," +
+                " map_apply((k, v) -> (k, array_sum(array_map(arg -> arg * v, `a`))), `m` ) from test_reuse_lambda_expr;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  common expressions:\n" +
+                "  |  <slot 9> : array_generate(0, 1: k, 1)");
+
+        sql = "select array_map(x -> array_map(x->x+100, x),[[1,23],[4,3,2]]);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 4> : " +
+                "array_map(<slot 2> -> array_map(<slot 3> -> CAST(<slot 3> AS SMALLINT) + 100, <slot 2>), [[1,23],[4,3,2]])");
+
+        sql = "select array_map(x->array_map(y->array_filter(z-> z > array_length(x),y),x), [[[1,23],[4,3,2]],[[3]]]);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 5> : array_map(<slot 2> -> " +
+                "array_map(<slot 3> -> " +
+                "array_filter(<slot 3>, array_map(<slot 4> -> CAST(<slot 4> AS INT) > <slot 8>, <slot 3>))\n" +
+                "        lambda common expressions:{<slot 8> <-> array_length(<slot 2>)}\n" +
+                "        , <slot 2>), [[[1,23],[4,3,2]],[[3]]])");
     }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -781,12 +781,6 @@ public class ExpressionTest extends PlanTestBase {
                 "  |  <slot 8> : map_size(3: m)\n" +
                 "  |  <slot 9> : CAST(8: map_size AS BIGINT)");
 
-        sql = "select array_generate(0, `k`, 1) as a," +
-                " map_apply((k, v) -> (k, array_sum(array_map(arg -> arg * v, `a`))), `m` ) from test_reuse_lambda_expr;";
-        plan = getFragmentPlan(sql);
-        assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 9> : array_generate(0, 1: k, 1)");
-
         sql = "select array_map(x -> array_map(x->x+100, x),[[1,23],[4,3,2]]);";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  1:Project\n" +


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
backport #49755

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate

