### PR TITLE
[BugFix] fix common expr reuse issue in nested lambda expr (backport #49755)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -66,7 +66,7 @@ public class ScalarOperatorsReuse {
                                                         ColumnRefFactory factory) {
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>>
                 commonSubOperatorsByDepth = collectCommonSubScalarOperators(null, operators,
-                factory, false);
+                factory);
 
         Map<ScalarOperator, ColumnRefOperator> commonSubOperators =
                 commonSubOperatorsByDepth.values().stream()
@@ -94,9 +94,9 @@ public class ScalarOperatorsReuse {
     public static Map<Integer, Map<ScalarOperator, ColumnRefOperator>> collectCommonSubScalarOperators(
             Projection projection,
             List<ScalarOperator> scalarOperators,
-            ColumnRefFactory columnRefFactory, boolean reuseLambdaDependentExpr) {
+            ColumnRefFactory columnRefFactory) {
         // 1. Recursively collect common sub operators for the input operators
-        CommonSubScalarOperatorCollector operatorCollector = new CommonSubScalarOperatorCollector(reuseLambdaDependentExpr);
+        CommonSubScalarOperatorCollector operatorCollector = new CommonSubScalarOperatorCollector();
         scalarOperators.forEach(operator -> operator.accept(operatorCollector,
                 new CommonSubScalarOperatorCollectorContext(false)));
         if (projection != null) {
@@ -263,6 +263,19 @@ public class ScalarOperatorsReuse {
     }
     private static class CommonSubScalarOperatorCollectorContext {
         public boolean isPartOfLambdaExpr = false;
+        // used to record the lambda arguments during visiting operator.
+
+        // take map_apply((k,v)->(k, array_sum(array_map(arg -> arg * v, array_column), map_column))) as an example,
+        // when visiting `array_sum(array_map(arg -> arg * v, array_column))`,
+        // currentLambdaArguments will contain k and v,
+        // outerLambdaArguments will be empty since there are no higher-order lambda functions nested outside.
+        // when visiting `arg * v`,
+        // currentLambdaArguments will contain arg,
+        // outerLambdaArguments will contain k and v since there is a map_apply's lambda expr outside.
+
+        // this information will help us determine whether an operator can be reused.
+        public Set<ColumnRefOperator> currentLambdaArguments = Sets.newHashSet();
+        public Set<ColumnRefOperator> outerLambdaArguments = Sets.newHashSet();
 
         public CommonSubScalarOperatorCollectorContext(boolean isPartOfLambdaExpr) {
             this.isPartOfLambdaExpr = isPartOfLambdaExpr;
@@ -280,49 +293,62 @@ public class ScalarOperatorsReuse {
         private final Map<Integer, Set<ScalarOperator>> operatorsByDepth = new HashMap<>();
         private final Map<Integer, Set<ScalarOperator>> commonOperatorsByDepth = new HashMap<>();
 
-        // isLambdaDependent means whether an expression is dependent on outer lambda arguments,
-        // it works when not reuse lambda-dependent sub expressions. For example, select array_length(a), array_sum(a)
-        // from (select array_map(x->2*x+1+2*x, array) as a from t)A; when reuseLambdaDependentExpr is
-        // false, the 2*x is lambda dependent, but array_map(x->2*x+1+2*x, array) isn't,
-        // so 2*x can't be reused, array_map(x->2*x+1+2*x, array) can be reused.
-        // 2*x can be reused within the array_map when reuseLambdaDependentExpr is true.
-        private boolean isLambdaDependent;
-
-        private final boolean reuseLambdaDependentExpr;
-
         public boolean hasLambdaFunction() {
             return hasLambdaFunction;
         }
 
         // enable some special logic codes only for lambda functions.
         private boolean hasLambdaFunction;
-        private Set<ColumnRefOperator> lambdaArguments = Sets.newHashSet();
 
-        private CommonSubScalarOperatorCollector(boolean reuseLambdaDependentExpr) {
-            this.reuseLambdaDependentExpr = reuseLambdaDependentExpr;
-            this.isLambdaDependent = false;
-            this.hasLambdaFunction = reuseLambdaDependentExpr;
+        private CommonSubScalarOperatorCollector() {
         }
 
 
-        private int collectCommonOperatorsByDepth(int depth, ScalarOperator operator, boolean isPartOfLambdaExpr) {
+        private int collectCommonOperatorsByDepth(int depth, ScalarOperator operator,
+                                                  CommonSubScalarOperatorCollectorContext context) {
             Set<ScalarOperator> operators = getOperatorsByDepth(depth, operatorsByDepth);
-            isLambdaDependent = false;
-            lambdaArguments.clear();
-            if (!isLambdaDependent(operator)) {
-                // If this operator has appeared before,
-                // or if it is within a lambda function but does not depend on lambda function's arguments,
+
+            boolean isDependentOnOuterLambda = isDependentOnOuterLambdaArguments(operator, context);
+            if (!isDependentOnOuterLambda) {
+                boolean isDependentOnCurrentLambdaArguments = isDependentOnCurrentLambdaArguments(operator, context);
+                // if this operator has appeared before,
+                // ot it is within a lambda function but does not depend on current lambda function's arguments,
                 // we treat it as a common operator.
-                if (isPartOfLambdaExpr || operators.contains(operator)) {
+                if (operators.contains(operator) || (context.isPartOfLambdaExpr && !isDependentOnCurrentLambdaArguments)) {
                     Set<ScalarOperator> commonOperators = getOperatorsByDepth(depth, commonOperatorsByDepth);
                     commonOperators.add(operator);
                 }
-            }
-            // lambda-dependent expressions should not be put into operators.
-            if (!isLambdaDependent) {
-                operators.add(operator);
+                if (!isDependentOnCurrentLambdaArguments) {
+                    operators.add(operator);
+                }
             }
             return depth;
+        }
+
+        private boolean isDependentOnCurrentLambdaArguments(ScalarOperator operator,
+                                                            CommonSubScalarOperatorCollectorContext context) {
+            if (operator.getOpType().equals(OperatorType.LAMBDA_ARGUMENT)) {
+                return context.currentLambdaArguments.contains(operator);
+            }
+            for (ScalarOperator child : operator.getChildren()) {
+                if (isDependentOnCurrentLambdaArguments(child, context)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean isDependentOnOuterLambdaArguments(ScalarOperator operator,
+                                                          CommonSubScalarOperatorCollectorContext context) {
+            if (operator.getOpType().equals(OperatorType.LAMBDA_ARGUMENT)) {
+                return context.outerLambdaArguments.contains(operator);
+            }
+            for (ScalarOperator child : operator.getChildren()) {
+                if (isDependentOnOuterLambdaArguments(child, context)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private static Set<ScalarOperator> getOperatorsByDepth(int depth,
@@ -337,9 +363,14 @@ public class ScalarOperatorsReuse {
                 return 0;
             }
 
+
+            if (scalarOperator instanceof LambdaFunctionOperator) {
+                context.currentLambdaArguments.addAll(((LambdaFunctionOperator) scalarOperator).getRefColumns());
+            }
+
             return collectCommonOperatorsByDepth(scalarOperator.getChildren().stream().map(argument ->
                             argument.accept(this, context)).reduce(Math::max).map(m -> m + 1).orElse(1),
-                    scalarOperator, context.isPartOfLambdaExpr);
+                    scalarOperator, context);
         }
 
         @Override
@@ -347,7 +378,11 @@ public class ScalarOperatorsReuse {
                                                    CommonSubScalarOperatorCollectorContext context) {
             // a lambda function like  x->x+1 can't be reused anymore, so directly visit its lambda expression.
             hasLambdaFunction = true;
-            return visit(scalarOperator.getLambdaExpr(), new CommonSubScalarOperatorCollectorContext(true));
+            CommonSubScalarOperatorCollectorContext newContext = new CommonSubScalarOperatorCollectorContext(true);
+            newContext.outerLambdaArguments.addAll(context.outerLambdaArguments);
+            newContext.outerLambdaArguments.addAll(context.currentLambdaArguments);
+            newContext.currentLambdaArguments.addAll(scalarOperator.getRefColumns());
+            return visit(scalarOperator.getLambdaExpr(), newContext);
         }
 
         @Override
@@ -357,58 +392,31 @@ public class ScalarOperatorsReuse {
                 // try to reuse non deterministic function
                 // for example:
                 // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
-                return collectCommonOperatorsByDepth(1, scalarOperator, context.isPartOfLambdaExpr);
+                return collectCommonOperatorsByDepth(1, scalarOperator, context);
             } else if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 // to keep the same logic as origin
                 return 0;
             } else {
                 return collectCommonOperatorsByDepth(scalarOperator.getChildren().stream().map(argument ->
                         argument.accept(this, context)).reduce(Math::max).map(m -> m + 1).orElse(1),
-                        scalarOperator, context.isPartOfLambdaExpr);
+                        scalarOperator, context);
             }
         }
 
         @Override
         public Integer visitDictMappingOperator(DictMappingOperator scalarOperator,
                                                 CommonSubScalarOperatorCollectorContext context) {
-            return collectCommonOperatorsByDepth(1, scalarOperator, context.isPartOfLambdaExpr);
-        }
-
-
-        // a lambda-dependent expressions also can't be reused if reuseLambdaDependentExpr is false.
-        // For example, array_map(x->2x+1+2x,array),2x is lambda-dependent, so it can't be reused if
-        // reuseLambdaDependentExpr is false, but array_map(x->2x+1+2x,array) can be reused if needed.
-        private boolean isLambdaDependent(ScalarOperator scalarOperator) {
-
-            if (hasLambdaFunction && !reuseLambdaDependentExpr) {
-                if (scalarOperator instanceof LambdaFunctionOperator) {
-                    LambdaFunctionOperator lambdaOp = (LambdaFunctionOperator) scalarOperator;
-                    lambdaArguments.addAll(lambdaOp.getRefColumns());
-                }
-
-                if (scalarOperator.getOpType().equals(OperatorType.LAMBDA_ARGUMENT)) {
-                    isLambdaDependent = !lambdaArguments.contains(scalarOperator);
-                    return isLambdaDependent;
-                }
-            }
-
-            for (ScalarOperator child : scalarOperator.getChildren()) {
-                if (isLambdaDependent(child)) {
-                    return true;
-                }
-            }
-            return false;
+            return collectCommonOperatorsByDepth(1, scalarOperator, context);
         }
     }
 
 
-    public static Projection rewriteProjectionOrLambdaExpr(Projection projection, ColumnRefFactory columnRefFactory,
-                                                           boolean reuseLambdaDependentExpr) {
+    public static Projection rewriteProjectionOrLambdaExpr(Projection projection, ColumnRefFactory columnRefFactory) {
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = projection.getColumnRefMap();
         List<ScalarOperator> scalarOperators = Lists.newArrayList(columnRefMap.values());
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubOperatorsByDepth = ScalarOperatorsReuse
                 .collectCommonSubScalarOperators(projection, scalarOperators,
-                        columnRefFactory, reuseLambdaDependentExpr);
+                        columnRefFactory);
 
         Map<ScalarOperator, ColumnRefOperator> commonSubOperators =
                 commonSubOperatorsByDepth.values().stream()
@@ -494,7 +502,7 @@ public class ScalarOperatorsReuse {
                     operator.isNullable(), false);
             columnRefMap.put(keyCol, operator.getLambdaExpr());
             Projection fakeProjection =
-                    rewriteProjectionOrLambdaExpr(new Projection(columnRefMap), columnRefFactory, true);
+                    rewriteProjectionOrLambdaExpr(new Projection(columnRefMap), columnRefFactory);
             columnRefMap = fakeProjection.getCommonSubOperatorMap();
             if (!columnRefMap.isEmpty()) {
                 operator.addColumnToExpr(columnRefMap);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
@@ -59,7 +59,7 @@ public class ScalarOperatorsReuseRule implements TreeRewriteRule {
             Projection projection = input.getOp().getProjection();
 
             projection = ScalarOperatorsReuse.rewriteProjectionOrLambdaExpr(projection,
-                    context.getOptimizerContext().getColumnRefFactory(), false);
+                    context.getOptimizerContext().getColumnRefFactory());
 
             if (projection.needReuseLambdaDependentExpr()) {
                 // rewrite lambda functions with lambda arguments

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
@@ -118,7 +118,7 @@ public class ScalarOperatorsReuseTest {
         List<ScalarOperator> oldOperators = Lists.newArrayList(add1, add3, multi);
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
 
         // FixMe(kks): This case could improve
         assertEquals(commonSubScalarOperators.size(), 3);
@@ -146,7 +146,7 @@ public class ScalarOperatorsReuseTest {
         List<ScalarOperator> oldOperators = Lists.newArrayList(addABC, addBCD);
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
 
         // FixMe(kks): could we improve this case?
         assertTrue(commonSubScalarOperators.isEmpty());
@@ -172,7 +172,7 @@ public class ScalarOperatorsReuseTest {
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
-                        columnRefFactory, false);
+                        columnRefFactory);
         Assert.assertFalse(commonSubScalarOperators.isEmpty());
     }
 
@@ -196,7 +196,7 @@ public class ScalarOperatorsReuseTest {
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
-                        columnRefFactory, false);
+                        columnRefFactory);
         assertEquals(3, commonSubScalarOperators.size());
     }
 
@@ -222,7 +222,7 @@ public class ScalarOperatorsReuseTest {
 
         // reuse lambda argument non-related sub expressions : t1*2
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
         assertEquals(commonSubScalarOperators.size(), 1);
     }
 
@@ -248,7 +248,7 @@ public class ScalarOperatorsReuseTest {
 
         // reuse lambda argument related sub expressions : x*2
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, true);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
         assertEquals(commonSubScalarOperators.size(), 1);
 
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -752,12 +752,6 @@ public class ExpressionTest extends PlanTestBase {
                 "  |  <slot 8> : map_size(3: m)\n" +
                 "  |  <slot 9> : CAST(8: map_size AS BIGINT)");
 
-        sql = "select array_generate(0, `k`, 1) as a," +
-                " map_apply((k, v) -> (k, array_sum(array_map(arg -> arg * v, `a`))), `m` ) from test_reuse_lambda_expr;";
-        plan = getFragmentPlan(sql);
-        assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 9> : array_generate(0, 1: k, 1)");
-
         sql = "select array_map(x -> array_map(x->x+100, x),[[1,23],[4,3,2]]);";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  1:Project\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -751,6 +751,27 @@ public class ExpressionTest extends PlanTestBase {
                 "  |  <slot 7> : 1: k * 10\n" +
                 "  |  <slot 8> : map_size(3: m)\n" +
                 "  |  <slot 9> : CAST(8: map_size AS BIGINT)");
+
+        sql = "select array_generate(0, `k`, 1) as a," +
+                " map_apply((k, v) -> (k, array_sum(array_map(arg -> arg * v, `a`))), `m` ) from test_reuse_lambda_expr;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  common expressions:\n" +
+                "  |  <slot 9> : array_generate(0, 1: k, 1)");
+
+        sql = "select array_map(x -> array_map(x->x+100, x),[[1,23],[4,3,2]]);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 4> : " +
+                "array_map(<slot 2> -> array_map(<slot 3> -> CAST(<slot 3> AS SMALLINT) + 100, <slot 2>), [[1,23],[4,3,2]])");
+
+        sql = "select array_map(x->array_map(y->array_filter(z-> z > array_length(x),y),x), [[[1,23],[4,3,2]],[[3]]]);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 5> : array_map(<slot 2> -> " +
+                "array_map(<slot 3> -> " +
+                "array_filter(<slot 3>, array_map(<slot 4> -> CAST(<slot 4> AS INT) > <slot 8>, <slot 3>))\n" +
+                "        lambda common expressions:{<slot 8> <-> array_length(<slot 2>)}\n" +
+                "        , <slot 2>), [[[1,23],[4,3,2]],[[3]]])");
     }
 
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

backport #49755

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
