### PR TITLE
[BugFix] Fix prune json error when pushdown on join

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1156,4 +1156,18 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "ColumnAccessPath: [/ar1/INDEX/a/b/c(bigint(20)), /mp1/INDEX/a/b/c(bigint(20))]");
     }
 
+    @Test
+    public void testCantPruneComplexJsonOnJoin() throws Exception {
+        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(20);
+        String sql = "select x.v4 -> 'platform_id', x.v3 -> 'p2' " +
+                "from (select JSON_OBJECT('p1', t0.v1, 'p2', js0.v1, 'p3', 3) as v3, js0.j1 as v4 " +
+                "      from t0 left join js0 on js0.v1 = t0.v2 where cast(js0.j1 -> 'v4' as int) + t0.v2 > 1) x";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  equal join conjunct: [3: v1, BIGINT, true] = [2: v2, BIGINT, true]\n" +
+                "  |  other join predicates: " +
+                "cast(cast([13: json_query, JSON, true] as INT) as BIGINT) + [2: v2, BIGINT, true] > 1");
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:
```
2024-08-14 11:32:06 2024-08-14 16:32:06.274Z WARN (starrocks-mysql-nio-pool-7|5333) [StmtExecutor.execute():737] execute Exception, sql select * from developer.test_table WHERE properties -> 'platform_id' is not null
2024-08-14 11:32:06  java.lang.IllegalStateException
2024-08-14 11:32:06     at com.google.common.base.Preconditions.checkState(Preconditions.java:496)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.OptExpression.getOutputColumns(OptExpression.java:140)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.generatePushDownProject(PushDownSubfieldRule.java:157)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visitLogicalJoin(PushDownSubfieldRule.java:295)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visitLogicalJoin(PushDownSubfieldRule.java:86)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator.accept(LogicalJoinOperator.java:214)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visitChildren(PushDownSubfieldRule.java:132)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visitLogicalProject(PushDownSubfieldRule.java:226)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visitLogicalProject(PushDownSubfieldRule.java:86)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator.accept(LogicalProjectOperator.java:103)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visitChildren(PushDownSubfieldRule.java:132)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visit(PushDownSubfieldRule.java:146)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule$PushDowner.visit(PushDownSubfieldRule.java:86)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.OptExpressionVisitor.visitLogicalTreeAnchor(OptExpressionVisitor.java:99)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator.accept(LogicalTreeAnchorOperator.java:52)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule.rewrite(PushDownSubfieldRule.java:59)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.Optimizer.pruneSubfield(Optimizer.java:736)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.Optimizer.logicalRuleRewrite(Optimizer.java:507)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.Optimizer.rewriteAndValidatePlan(Optimizer.java:676)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:238)
2024-08-14 11:32:06     at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:186)
2024-08-14 11:32:06     at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:319)
2024-08-14 11:32:06     at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:134)
2024-08-14 11:32:06     at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:93)
2024-08-14 11:32:06     at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:534)
2024-08-14 11:32:06     at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:355)
2024-08-14 11:32:06     at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:550)
2024-08-14 11:32:06     at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:884)
2024-08-14 11:32:06     at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
2024-08-14 11:32:06     at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2024-08-14 11:32:06     at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2024-08-14 11:32:06     at java.base/java.lang.Thread.run(Thread.java:829)
```

## What I'm doing:
when some complex expression can't pushdown to join node, will generate new project on join, but join node expression may was been re-construct, lose output property, then throw the exception.
should generate project first, then re-construct the rewrite node

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
