### PR TITLE
[BugFix] Fix pipe insert sql does not have credentials

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -781,7 +781,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * `toSqlWithoutTbl` will return sql without table name for column name, so it can be easier to compare two expr.
      */
     public String toSqlWithoutTbl() {
-        return new AstToSQLBuilder.AST2SQLBuilderVisitor(false, true).visit(this);
+        return new AstToSQLBuilder.AST2SQLBuilderVisitor(false, true, true).visit(this);
     }
 
     public String explain() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/FilePipeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/FilePipeSource.java
@@ -241,7 +241,7 @@ public class FilePipeSource implements GsonPostProcessable {
 
         FileTableFunctionRelation fileRelation = new FileTableFunctionRelation(properties, NodePosition.ZERO);
         select.setRelation(fileRelation);
-        return AstToSQLBuilder.toSQL(sqlStmt);
+        return AstToSQLBuilder.toSQLWithCredential(sqlStmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -62,11 +62,16 @@ public class AstToSQLBuilder {
     public static String buildSimple(StatementBase statement) {
         Map<TableName, Table> tables = AnalyzerUtils.collectAllTableAndViewWithAlias(statement);
         boolean sameCatalogDb = tables.keySet().stream().map(TableName::getCatalogAndDb).distinct().count() == 1;
-        return new AST2SQLBuilderVisitor(sameCatalogDb, false).visit(statement);
+        return new AST2SQLBuilderVisitor(sameCatalogDb, false, true).visit(statement);
     }
 
     public static String toSQL(ParseNode statement) {
-        return new AST2SQLBuilderVisitor(false, false).visit(statement);
+        return new AST2SQLBuilderVisitor(false, false, true).visit(statement);
+    }
+
+    // for executable SQL with credential, such as pipe insert sql
+    public static String toSQLWithCredential(ParseNode statement) {
+        return new AST2SQLBuilderVisitor(false, false, false).visit(statement);
     }
 
     // return sql from ast or default sql if builder throws exception.
@@ -86,7 +91,8 @@ public class AstToSQLBuilder {
         protected final boolean simple;
         protected final boolean withoutTbl;
 
-        public AST2SQLBuilderVisitor(boolean simple, boolean withoutTbl) {
+        public AST2SQLBuilderVisitor(boolean simple, boolean withoutTbl, boolean hideCredential) {
+            super(hideCredential);
             this.simple = simple;
             this.withoutTbl = withoutTbl;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -51,7 +51,7 @@ public class CachingMvPlanContextBuilder {
          * @param parseNode
          */
         public AstKey(ParseNode parseNode) {
-            this.sql = new AstToSQLBuilder.AST2SQLBuilderVisitor(true, false).visit(parseNode);
+            this.sql = new AstToSQLBuilder.AST2SQLBuilderVisitor(true, false, true).visit(parseNode);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
@@ -155,7 +155,7 @@ public class DesensitizedSQLBuilder {
         private final Map<String, String> desensitizedDict;
 
         public DesensitizedSQLVisitor(boolean simple, boolean withoutTbl, Map<String, String> desensitizedDict) {
-            super(simple, withoutTbl);
+            super(simple, withoutTbl, true);
             this.desensitizedDict = desensitizedDict;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/StorageVolumeAnalysisTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/StorageVolumeAnalysisTest.java
@@ -78,7 +78,7 @@ public class StorageVolumeAnalysisTest {
         Assert.assertTrue(stmt instanceof CreateStorageVolumeStmt);
         Assert.assertEquals(true, AuditEncryptionChecker.needEncrypt(stmt));
         Assert.assertEquals("CREATE STORAGE VOLUME storage_volume_1 TYPE = s3 " +
-                "LOCATIONS = ('s3://xxx', 's3://yyy') PROPERTIES (\"aws.s3.access_key\" = \"******\", \"aws.s3.secret_key\" = \"******\")",
+                "LOCATIONS = ('s3://xxx', 's3://yyy') PROPERTIES (\"aws.s3.access_key\" = \"***\", \"aws.s3.secret_key\" = \"***\")",
                 AstToStringBuilder.toString(stmt));
 
         sql = "CREATE STORAGE VOLUME storage_volume_1 type = azblob " +
@@ -87,7 +87,7 @@ public class StorageVolumeAnalysisTest {
         Assert.assertTrue(stmt instanceof CreateStorageVolumeStmt);
         Assert.assertEquals(true, AuditEncryptionChecker.needEncrypt(stmt));
         Assert.assertEquals("CREATE STORAGE VOLUME storage_volume_1 TYPE = azblob " +
-                        "LOCATIONS = ('azblob://xxx', 'azblob://yyy') PROPERTIES (\"azure.blob.shared_key\" = \"******\", \"azure.blob.sas_token\" = \"******\")",
+                        "LOCATIONS = ('azblob://xxx', 'azblob://yyy') PROPERTIES (\"azure.blob.shared_key\" = \"***\", \"azure.blob.sas_token\" = \"***\")",
                 AstToStringBuilder.toString(stmt));
 
         sql = "CREATE STORAGE VOLUME hdfsvolume TYPE = HDFS LOCATIONS = ('hdfs://abc');";
@@ -128,8 +128,8 @@ public class StorageVolumeAnalysisTest {
         stmt = AnalyzeTestUtil.analyzeSuccess(sql);
         Assert.assertTrue(stmt instanceof AlterStorageVolumeStmt);
         Assert.assertEquals(true, AuditEncryptionChecker.needEncrypt(stmt));
-        Assert.assertEquals("ALTER STORAGE VOLUME storage_volume_1 SET (\"aws.s3.access_key\" = \"******\", " +
-                "\"aws.s3.secret_key\" = \"******\", \"azure.blob.shared_key\" = \"******\", \"azure.blob.sas_token\" = \"******\")",
+        Assert.assertEquals("ALTER STORAGE VOLUME storage_volume_1 SET (\"aws.s3.access_key\" = \"***\", " +
+                "\"aws.s3.secret_key\" = \"***\", \"azure.blob.shared_key\" = \"***\", \"azure.blob.sas_token\" = \"***\")",
                 AstToStringBuilder.toString(stmt));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
@@ -234,7 +234,7 @@ public class SelectUsingAliasTest extends PlanTestBase {
     private void testSqlRewrite(String sql, String expected, boolean withoutTbl) {
         StatementBase stmt = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
         Analyzer.analyze(stmt, connectContext);
-        String afterSql = new AstToSQLBuilder.AST2SQLBuilderVisitor(false, withoutTbl).visit(stmt);
+        String afterSql = new AstToSQLBuilder.AST2SQLBuilderVisitor(false, withoutTbl, true).visit(stmt);
         Assert.assertEquals(expected, afterSql.replaceAll("`", ""));
     }
 }

--- a/test/sql/test_pipe/R/basic
+++ b/test/sql/test_pipe/R/basic
@@ -41,7 +41,13 @@ select count(*) from t1;
 -- !result
 create pipe p1 properties('auto_ingest'='false') as 
     insert into t1 
-    select * from files('path' = 'oss://${oss_bucket}/test_pipe/${uuid0}/col_not_null.parquet', 'format'='parquet');
+    select * from files(
+        'path' = 'oss://${oss_bucket}/test_pipe/${uuid0}/col_not_null.parquet',
+        'format' = 'parquet',
+        'aws.s3.access_key' = '${oss_ak}',
+        'aws.s3.secret_key' = '${oss_sk}',
+        'aws.s3.endpoint' = '${oss_endpoint}'
+        );
 -- result:
 -- !result
 alter pipe p1 suspend;

--- a/test/sql/test_pipe/T/basic
+++ b/test/sql/test_pipe/T/basic
@@ -20,7 +20,13 @@ select count(*) from t1;
 
 create pipe p1 properties('auto_ingest'='false') as 
     insert into t1 
-    select * from files('path' = 'oss://${oss_bucket}/test_pipe/${uuid0}/col_not_null.parquet', 'format'='parquet');
+    select * from files(
+        'path' = 'oss://${oss_bucket}/test_pipe/${uuid0}/col_not_null.parquet',
+        'format' = 'parquet',
+        'aws.s3.access_key' = '${oss_ak}',
+        'aws.s3.secret_key' = '${oss_sk}',
+        'aws.s3.endpoint' = '${oss_endpoint}'
+        );
 
 alter pipe p1 suspend;
 select pipe_name, state from information_schema.pipes where database_name = 'db_${uuid0}' and pipe_name = 'p1';


### PR DESCRIPTION
## Why I'm doing:
`Pipe` uses `AstToSQLBuilder.toSQL` to create insert SQL, and the default behavior of `AstToSQLBuilder.toSQL` is to remove the credential, which will cause the pipe task to be abnormal.

## What I'm doing:
add new function `AstToSQLBuilder.toSQLWithCredential` to retain credentials.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
