### PR TITLE
[BugFix] fix wrong sched_entity for schema_chunk_source

### DIFF
--- a/be/src/exec/pipeline/scan/schema_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.cpp
@@ -171,6 +171,6 @@ Status SchemaChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
 
 const workgroup::WorkGroupScanSchedEntity* SchemaChunkSource::_scan_sched_entity(const workgroup::WorkGroup* wg) const {
     DCHECK(wg != nullptr);
-    return wg->scan_sched_entity();
+    return wg->connector_scan_sched_entity();
 }
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
#49318 move the SchemaScan from `ScanExecutor` to `ConnectorScanExecutor`, but didn't change sched_entity. It may lead to crash or deadlock at be.

Trigger case: the `SchemaScan::read_chunk` takes more than 5ms, will run into this case.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
