### PR TITLE
[BugFix] Fix com.google.gson.JsonSyntaxException in TaskRunHistoryTable replay json data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -27,6 +27,7 @@ import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TResultBatch;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 
@@ -118,7 +119,8 @@ public class TaskRunHistoryTable {
                         Strings.quote(DateUtils.formatTimeStampInMill(status.getFinishTime(), ZoneId.systemDefault()));
                 String expireTime =
                         Strings.quote(DateUtils.formatTimeStampInMill(status.getExpireTime(), ZoneId.systemDefault()));
-
+                // Since the content is stored in JSON format and insert into the starrocks olap table, we need to escape the
+                // content to make it safer in deserializing the json.
                 return MessageFormat.format(INSERT_SQL_VALUE,
                         String.valueOf(status.getTaskId()),
                         Strings.quote(status.getQueryId()),
@@ -127,7 +129,7 @@ public class TaskRunHistoryTable {
                         createTime,
                         finishTime,
                         expireTime,
-                        Strings.quote(status.toJSON()));
+                        Strings.quote(StringEscapeUtils.escapeJava(status.toJSON())));
             }).collect(Collectors.joining(", "));
 
             String sql = insert + values;
@@ -175,5 +177,4 @@ public class TaskRunHistoryTable {
         List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
         return TaskRunStatus.fromResultBatch(batch);
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -470,7 +470,7 @@ public class TaskRunStatus implements Writable {
     /**
      * Only used for deserialization of ResultBatch
      */
-    static class TaskRunStatusJSONRecord {
+    public static class TaskRunStatusJSONRecord {
         /**
          * Only one item in the array, like:
          * { data: [ {TaskRunStatus} ] }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -487,9 +487,15 @@ public class TaskRunStatus implements Writable {
         List<TaskRunStatus> res = new ArrayList<>();
         for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
             for (ByteBuffer buffer : batch.getRows()) {
-                ByteBuf copied = Unpooled.copiedBuffer(buffer);
-                String jsonString = copied.toString(Charset.defaultCharset());
-                res.addAll(ListUtils.emptyIfNull(TaskRunStatusJSONRecord.fromJson(jsonString).data));
+                String jsonString = "";
+                try {
+                    ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                    jsonString = copied.toString(Charset.defaultCharset());
+                    res.addAll(ListUtils.emptyIfNull(TaskRunStatusJSONRecord.fromJson(jsonString).data));
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to deserialize TaskRunStatus from json， please delete it from " +
+                            "_statistics_.task_run_history table: " + jsonString, e);
+                }
             }
         }
         return res;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -14,8 +14,10 @@
 
 package com.starrocks.scheduler.history;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.common.Config;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.statistic.StatsConstants;
@@ -26,10 +28,16 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.logging.log4j.util.Strings;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,33 +68,28 @@ public class TaskRunHistoryTest {
 
     @Test
     public void testCRUD(@Mocked RepoExecutor repo) {
+        TaskRunStatus status = new TaskRunStatus();
+        status.setQueryId("aaa");
+        status.setTaskName("t1");
+        status.setState(Constants.TaskRunState.SUCCESS);
         new MockUp<TableKeeper>() {
             @Mock
             public boolean isReady() {
                 return true;
             }
         };
+        String jsonString = StringEscapeUtils.escapeJava(GsonUtils.GSON.toJson(status));
         new Expectations() {
             {
-                repo.executeDML("INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, " +
+                repo.executeDML(String.format("INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, " +
                         "task_state, create_time, finish_time, expire_time, history_content_json) " +
                         "VALUES(0, 'aaa', 't1', 'SUCCESS', '1970-01-01 08:00:00', " +
                         "'1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
-                        "'{\"queryId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
-                        "\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false,\"source\":\"CTAS\"," +
-                        "\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"SUCCESS\"," +
-                        "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
-                        "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{}," +
-                        "\"processStartTime\":0,\"executeOption\":{\"priority\":0,\"isMergeRedundant\":true," +
-                        "\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}')");
+                        "'%s')", jsonString));
             }
         };
 
         TaskRunHistoryTable history = new TaskRunHistoryTable();
-        TaskRunStatus status = new TaskRunStatus();
-        status.setQueryId("aaa");
-        status.setTaskName("t1");
-        status.setState(Constants.TaskRunState.SUCCESS);
         history.addHistory(status);
 
         // lookup by params
@@ -143,7 +146,6 @@ public class TaskRunHistoryTest {
             }
         };
         history.lookupByTaskNames(dbName, taskNames);
-
     }
 
     @Test
@@ -225,14 +227,18 @@ public class TaskRunHistoryTest {
                         "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, task_state, " +
                                 "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'q2', 't2'," +
                                 " 'SUCCESS', '1970-01-01 08:00:00', '1970-01-01 08:00:00', '2024-07-05 15:38:00', " +
-                                "'{\"queryId\":\"q2\",\"taskId\":0,\"taskName\":\"t2\",\"createTime\":0," +
-                                "\"expireTime\":1720165080904,\"priority\":0,\"mergeRedundant\":false," +
-                                "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0," +
-                                "\"state\":\"SUCCESS\",\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false," +
-                                "\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
-                                "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0," +
-                                "\"executeOption\":{\"priority\":0,\"isMergeRedundant\":true,\"isManual\":false," +
-                                "\"isSync\":false,\"isReplay\":false}}}')");
+                                "'{\\\"queryId\\\":\\\"q2\\\",\\\"taskId\\\":0,\\\"taskName\\\":\\\"t2\\\"," +
+                                "\\\"createTime\\\":0," +
+                                "\\\"expireTime\\\":1720165080904,\\\"priority\\\":0,\\\"mergeRedundant\\\":false," +
+                                "\\\"source\\\":\\\"CTAS\\\",\\\"errorCode\\\":0,\\\"finishTime\\\":0,\\\"" +
+                                "processStartTime\\\":0," +
+                                "\\\"state\\\":\\\"SUCCESS\\\",\\\"progress\\\":0,\\\"mvExtraMessage\\\":{\\\"" +
+                                "forceRefresh\\\":false," +
+                                "\\\"mvPartitionsToRefresh\\\":[],\\\"refBasePartitionsToRefreshMap\\\":{}," +
+                                "\\\"basePartitionsToRefreshMap\\\":{},\\\"processStartTime\\\":0," +
+                                "\\\"executeOption\\\":{\\\"priority\\\":0,\\\"isMergeRedundant\\\":true,\\\"" +
+                                "isManual\\\":false," +
+                                "\\\"isSync\\\":false,\\\"isReplay\\\":false}}}')");
 
             }
         };
@@ -282,5 +288,42 @@ public class TaskRunHistoryTest {
         Assert.assertEquals(0, history.getInMemoryHistory().size());
 
         Config.enable_task_history_archive = true;
+    }
+
+    @Test
+    public void testLookBadHistory() {
+        try {
+            String jsonString = "{\"data\":[{\"createTime\": 1723679736257, \"dbName\": " +
+                    "\"default_cluster:test_rename_columnb190692a_5a98_11ef_aa5e_00163e0e489a\", \"errorCode\": 0, \"expireTime\": 1723765136257, \"finishTime\": 1723679737239, \"mergeRedundant\": true, \"mvExtraMessage\": {\"basePartitionsToRefreshMap\": {\"t1\": [\"p3\"]}, \"executeOption\": {\"isManual\": false, \"isMergeRedundant\": true, \"isReplay\": false, \"isSync\": false, \"priority\": 100, \"taskRunProperties\": {\"PARTITION_END\": \"4\", \"PARTITION_START\": \"3\", \"START_TASK_RUN_ID\": \"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"compression\": \"LZ4\", \"datacache\": {\"enable\": \"true\"}, \"enable_async_write_back\": \"false\", \"mvId\": \"490884\", \"replicated_storage\": \"true\", \"replication_num\": \"1\"}}, \"forceRefresh\": false, \"mvPartitionsToRefresh\": [\"p3\"], \"partitionEnd\": \"4\", \"partitionStart\": \"3\", \"processStartTime\": 1723679736946, \"refBasePartitionsToRefreshMap\": {\"t1\": [\"p3\"]}}, \"postRun\": \"ANALYZE SAMPLE TABLE mv1 WITH ASYNC MODE\", \"priority\": 100, \"processStartTime\": 1723679736946, \"progress\": 100, \"properties\": {\"PARTITION_END\": \"4\", \"PARTITION_START\": \"3\", \"START_TASK_RUN_ID\": \"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"compression\": \"LZ4\", \"datacache\": {\"enable\": \"true\"}, \"enable_async_write_back\": \"false\", \"mvId\": \"490884\", \"replicated_storage\": \"true\", \"replication_num\": \"1\"}, \"queryId\": \"b35dc350-5a98-11ef-9acf-00163e08a129\", \"source\": \"MV\", \"startTaskRunId\": \"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"state\": \"SUCCESS\", \"taskId\": 490886, \"taskName\": \"mv-490884\", \"user\": \"root\", \"userIdentity\": {\"host\": \"%\", \"isDomain\": false, \"user\": \"root\"}}]}";
+            List<TaskRunStatus> ans = TaskRunStatus.TaskRunStatusJSONRecord.fromJson(jsonString).data;
+            Preconditions.checkArgument(ans == null);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Expected a string but was BEGIN_OBJECT at line 1 column 568"));
+        }
+    }
+
+    @Test
+    public void testTaskRunStatusSerDer() {
+        TaskRunStatus status = new TaskRunStatus();
+        Map<String, String> properties = new HashMap<>();
+        properties.put("datacache", "{\"enable\": \"true\"}");
+        status.setProperties(properties);
+        String json = GsonUtils.GSON.toJson(status);
+        System.out.println(json);
+        TaskRunStatus dst = GsonUtils.GSON.fromJson(json, TaskRunStatus.class);
+        System.out.println(dst);
+        Assert.assertEquals(json, GsonUtils.GSON.toJson(status));
+    }
+    @Test
+    public void testCase1() {
+        TaskRunStatus status = new TaskRunStatus();
+        Map<String, String> properties = new HashMap<>();
+        properties.put("datacache", "{\"enable\": \"true\"}");
+        status.setProperties(properties);
+        String json = GsonUtils.GSON.toJson(status);
+        System.out.println(json);
+        String res = MessageFormat.format("{0}", Strings.quote(status.toJSON()));
+        System.out.println(res);
+        Assert.assertTrue(res.contains("\"datacache\":\"{\\\"enable\\\": \\\"true\\\"}\""));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -294,7 +294,26 @@ public class TaskRunHistoryTest {
     public void testLookBadHistory() {
         try {
             String jsonString = "{\"data\":[{\"createTime\": 1723679736257, \"dbName\": " +
-                    "\"default_cluster:test_rename_columnb190692a_5a98_11ef_aa5e_00163e0e489a\", \"errorCode\": 0, \"expireTime\": 1723765136257, \"finishTime\": 1723679737239, \"mergeRedundant\": true, \"mvExtraMessage\": {\"basePartitionsToRefreshMap\": {\"t1\": [\"p3\"]}, \"executeOption\": {\"isManual\": false, \"isMergeRedundant\": true, \"isReplay\": false, \"isSync\": false, \"priority\": 100, \"taskRunProperties\": {\"PARTITION_END\": \"4\", \"PARTITION_START\": \"3\", \"START_TASK_RUN_ID\": \"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"compression\": \"LZ4\", \"datacache\": {\"enable\": \"true\"}, \"enable_async_write_back\": \"false\", \"mvId\": \"490884\", \"replicated_storage\": \"true\", \"replication_num\": \"1\"}}, \"forceRefresh\": false, \"mvPartitionsToRefresh\": [\"p3\"], \"partitionEnd\": \"4\", \"partitionStart\": \"3\", \"processStartTime\": 1723679736946, \"refBasePartitionsToRefreshMap\": {\"t1\": [\"p3\"]}}, \"postRun\": \"ANALYZE SAMPLE TABLE mv1 WITH ASYNC MODE\", \"priority\": 100, \"processStartTime\": 1723679736946, \"progress\": 100, \"properties\": {\"PARTITION_END\": \"4\", \"PARTITION_START\": \"3\", \"START_TASK_RUN_ID\": \"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"compression\": \"LZ4\", \"datacache\": {\"enable\": \"true\"}, \"enable_async_write_back\": \"false\", \"mvId\": \"490884\", \"replicated_storage\": \"true\", \"replication_num\": \"1\"}, \"queryId\": \"b35dc350-5a98-11ef-9acf-00163e08a129\", \"source\": \"MV\", \"startTaskRunId\": \"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"state\": \"SUCCESS\", \"taskId\": 490886, \"taskName\": \"mv-490884\", \"user\": \"root\", \"userIdentity\": {\"host\": \"%\", \"isDomain\": false, \"user\": \"root\"}}]}";
+                    "\"default_cluster:test_rename_columnb190692a_5a98_11ef_aa5e_00163e0e489a\", \"errorCode\": 0, " +
+                    "\"expireTime\": 1723765136257, \"finishTime\": 1723679737239, \"mergeRedundant\": true, " +
+                    "\"mvExtraMessage\": {\"basePartitionsToRefreshMap\": {\"t1\": [\"p3\"]}, \"executeOption\": " +
+                    "{\"isManual\": false, \"isMergeRedundant\": true, \"isReplay\": false, \"isSync\": false, " +
+                    "\"priority\": 100, \"taskRunProperties\": {\"PARTITION_END\": \"4\", " +
+                    "\"PARTITION_START\": \"3\", \"START_TASK_RUN_ID\": \"b1f755a8-5a98-11ef-9acf-00163e08a129\", " +
+                    "\"compression\": \"LZ4\", \"datacache\": {\"enable\": \"true\"}, \"enable_async_write_back\": " +
+                    "\"false\", \"mvId\": \"490884\", \"replicated_storage\": \"true\", \"replication_num\": \"1\"}}, " +
+                    "\"forceRefresh\": false, \"mvPartitionsToRefresh\": [\"p3\"], \"partitionEnd\": \"4\", " +
+                    "\"partitionStart\": \"3\", \"processStartTime\": 1723679736946, \"refBasePartitionsToRefreshMap\": " +
+                    "{\"t1\": [\"p3\"]}}, \"postRun\": \"ANALYZE SAMPLE TABLE mv1 WITH ASYNC MODE\", \"priority\": 100, " +
+                    "\"processStartTime\": 1723679736946, \"progress\": 100, \"properties\": " +
+                    "{\"PARTITION_END\": \"4\", \"PARTITION_START\": \"3\", \"START_TASK_RUN_ID\": " +
+                    "\"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"compression\": \"LZ4\", \"datacache\": " +
+                    "{\"enable\": \"true\"}, \"enable_async_write_back\": \"false\", \"mvId\": \"490884\", " +
+                    "\"replicated_storage\": \"true\", \"replication_num\": \"1\"}, \"queryId\": " +
+                    "\"b35dc350-5a98-11ef-9acf-00163e08a129\", \"source\": \"MV\", \"startTaskRunId\": " +
+                    "\"b1f755a8-5a98-11ef-9acf-00163e08a129\", \"state\": \"SUCCESS\", \"taskId\": 490886, " +
+                    "\"taskName\": \"mv-490884\", \"user\": \"root\", \"userIdentity\": {\"host\": \"%\", " +
+                    "\"isDomain\": false, \"user\": \"root\"}}]}";
             List<TaskRunStatus> ans = TaskRunStatus.TaskRunStatusJSONRecord.fromJson(jsonString).data;
             Preconditions.checkArgument(ans == null);
         } catch (Exception e) {


### PR DESCRIPTION

## Why I'm doing:

```
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 1 column 568 path $.data[0].mvExtraMessage.executeOption.taskRunProperties.
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:226) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:705) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:705) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:705) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:705) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:705) ~[starrocks-fe.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:963) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:928) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:877) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:848) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.scheduler.persist.TaskRunStatus$TaskRunStatusJSONRecord.fromJson(TaskRunStatus.java:482) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.persist.TaskRunStatus.fromResultBatch(TaskRunStatus.java:492) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.history.TaskRunHistoryTable.lookup(TaskRunHistoryTable.java:160) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.history.TaskRunHistory.lookupHistory(TaskRunHistory.java:102) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.TaskManager.getMatchedTaskRunStatus(TaskManager.java:625) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.system.information.TaskRunsSystemTable.query(TaskRunsSystemTable.java:189) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.getTaskRuns(FrontendServiceImpl.java:850) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$getTaskRuns.getResult(FrontendService.java:5105) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$getTaskRuns.getResult(FrontendService.java:5082) ~[starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 1 column 568 path $.data[0].mvExtraMessage.executeOption.taskRunProperties.
        at com.google.gson.stream.JsonReader.nextString(JsonReader.java:824) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.TypeAdapters$15.read(TypeAdapters.java:380) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.TypeAdapters$15.read(TypeAdapters.java:368) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:705) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:187) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:145) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:705) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
        ... 33 more
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
