### PR TITLE
[Refactor] Unify sched_entity_type logic for scan task

### DIFF
--- a/be/src/exec/pipeline/pipeline.cpp
+++ b/be/src/exec/pipeline/pipeline.cpp
@@ -103,8 +103,7 @@ void Pipeline::instantiate_drivers(RuntimeState* state) {
         if (auto* scan_operator = driver->source_scan_operator()) {
             scan_operator->set_workgroup(workgroup);
             scan_operator->set_query_ctx(query_ctx->get_shared_ptr());
-            if (dynamic_cast<ConnectorScanOperator*>(scan_operator) != nullptr ||
-                dynamic_cast<SchemaScanOperator*>(scan_operator) != nullptr) {
+            if (scan_operator->sched_entity_type() == workgroup::ScanSchedEntityType::CONNECTOR) {
                 scan_operator->set_scan_executor(state->exec_env()->connector_scan_executor());
             } else {
                 scan_operator->set_scan_executor(state->exec_env()->scan_executor());

--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -99,4 +99,13 @@ Status ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_
     return _status;
 }
 
+const workgroup::WorkGroupScanSchedEntity* ChunkSource::_scan_sched_entity(const workgroup::WorkGroup* wg) const {
+    DCHECK(wg != nullptr);
+    if (_scan_op->sched_entity_type() == workgroup::ScanSchedEntityType::CONNECTOR) {
+        return wg->connector_scan_sched_entity();
+    } else {
+        return wg->scan_sched_entity();
+    }
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -85,7 +85,7 @@ protected:
     // MUST be implemented by different ChunkSource
     virtual Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) = 0;
     // The schedule entity of this workgroup for resource group.
-    virtual const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const = 0;
+    const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const;
 
     ScanOperator* _scan_op;
     const int32_t _scan_operator_seq;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -876,12 +876,6 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     return Status::EndOfFile("");
 }
 
-const workgroup::WorkGroupScanSchedEntity* ConnectorChunkSource::_scan_sched_entity(
-        const workgroup::WorkGroup* wg) const {
-    DCHECK(wg != nullptr);
-    return wg->connector_scan_sched_entity();
-}
-
 uint64_t ConnectorChunkSource::avg_row_mem_bytes() const {
     if (_chunk_rows_read == 0) return 0;
     return _chunk_mem_bytes / _chunk_rows_read;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -117,6 +117,10 @@ public:
     ConnectorScanOperatorAdaptiveProcessor* adaptive_processor() const { return _adaptive_processor; }
     bool enable_adaptive_io_tasks() const { return _enable_adaptive_io_tasks; }
 
+    workgroup::ScanSchedEntityType sched_entity_type() const override {
+        return workgroup::ScanSchedEntityType::CONNECTOR;
+    }
+
 private:
     int64_t _adjust_scan_mem_limit(int64_t old_chunk_source_mem_bytes, int64_t new_chunk_source_mem_bytes);
     mutable ConnectorScanOperatorAdaptiveProcessor* _adaptive_processor;
@@ -148,8 +152,6 @@ protected:
 
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
-
-    const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const override;
 
     ConnectorScanOperatorIOTasksMemLimiter* _get_io_tasks_mem_limiter() const;
 

--- a/be/src/exec/pipeline/scan/meta_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/meta_chunk_source.cpp
@@ -47,9 +47,4 @@ Status MetaChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     return _scanner->get_chunk(state, chunk);
 }
 
-const workgroup::WorkGroupScanSchedEntity* MetaChunkSource::_scan_sched_entity(const workgroup::WorkGroup* wg) const {
-    DCHECK(wg != nullptr);
-    return wg->scan_sched_entity();
-}
-
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/meta_chunk_source.h
+++ b/be/src/exec/pipeline/scan/meta_chunk_source.h
@@ -36,8 +36,6 @@ public:
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
 
-    const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const override;
-
     MetaScanContextPtr _scan_ctx;
 
     std::shared_ptr<MetaScanner> _scanner;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -486,11 +486,6 @@ Status OlapChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     return _read_chunk_from_storage(_runtime_state, (*chunk).get());
 }
 
-const workgroup::WorkGroupScanSchedEntity* OlapChunkSource::_scan_sched_entity(const workgroup::WorkGroup* wg) const {
-    DCHECK(wg != nullptr);
-    return wg->scan_sched_entity();
-}
-
 // mapping a slot-column-id to schema-columnid
 Status OlapChunkSource::_init_global_dicts(TabletReaderParams* params) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -53,8 +53,6 @@ public:
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
 
-    const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const override;
-
     Status _get_tablet(const TInternalScanRange* scan_range);
     Status _init_reader_params(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges,
                                const std::vector<uint32_t>& scanner_columns, std::vector<uint32_t>& reader_columns);

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -59,6 +59,8 @@ public:
 
     void update_metrics(RuntimeState* state) override { _merge_chunk_source_profiles(state); }
 
+    virtual workgroup::ScanSchedEntityType sched_entity_type() const { return workgroup::ScanSchedEntityType::OLAP; }
+
     void set_scan_executor(workgroup::ScanExecutor* scan_executor) { _scan_executor = scan_executor; }
 
     void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }

--- a/be/src/exec/pipeline/scan/schema_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.cpp
@@ -169,8 +169,4 @@ Status SchemaChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     return Status::OK();
 }
 
-const workgroup::WorkGroupScanSchedEntity* SchemaChunkSource::_scan_sched_entity(const workgroup::WorkGroup* wg) const {
-    DCHECK(wg != nullptr);
-    return wg->connector_scan_sched_entity();
-}
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/schema_chunk_source.h
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.h
@@ -46,8 +46,6 @@ public:
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
 
-    const workgroup::WorkGroupScanSchedEntity* _scan_sched_entity(const workgroup::WorkGroup* wg) const override;
-
     const TupleDescriptor* _dest_tuple_desc;
     std::unique_ptr<SchemaScanner> _schema_scanner;
 

--- a/be/src/exec/pipeline/scan/schema_scan_operator.h
+++ b/be/src/exec/pipeline/scan/schema_scan_operator.h
@@ -69,6 +69,10 @@ private:
     bool is_buffer_full() const override;
     void set_buffer_finished() override;
 
+    workgroup::ScanSchedEntityType sched_entity_type() const override {
+        return workgroup::ScanSchedEntityType::CONNECTOR;
+    }
+
     SchemaScanContextPtr _ctx;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -367,7 +367,7 @@ int64_t WorkGroupScanTaskQueue::_bandwidth_quota_ns() const {
 }
 
 workgroup::WorkGroupScanSchedEntity* WorkGroupScanTaskQueue::_sched_entity(workgroup::WorkGroup* wg) {
-    if (_sched_entity_type == SchedEntityType::CONNECTOR) {
+    if (_sched_entity_type == ScanSchedEntityType::CONNECTOR) {
         return wg->connector_scan_sched_entity();
     } else {
         return wg->scan_sched_entity();
@@ -375,7 +375,7 @@ workgroup::WorkGroupScanSchedEntity* WorkGroupScanTaskQueue::_sched_entity(workg
 }
 
 const workgroup::WorkGroupScanSchedEntity* WorkGroupScanTaskQueue::_sched_entity(const workgroup::WorkGroup* wg) const {
-    if (_sched_entity_type == SchedEntityType::CONNECTOR) {
+    if (_sched_entity_type == ScanSchedEntityType::CONNECTOR) {
         return wg->connector_scan_sched_entity();
     } else {
         return wg->scan_sched_entity();

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -206,9 +206,7 @@ private:
 
 class WorkGroupScanTaskQueue final : public ScanTaskQueue {
 public:
-    enum SchedEntityType { OLAP, CONNECTOR };
-
-    WorkGroupScanTaskQueue(SchedEntityType sched_entity_type) : _sched_entity_type(sched_entity_type) {}
+    WorkGroupScanTaskQueue(ScanSchedEntityType sched_entity_type) : _sched_entity_type(sched_entity_type) {}
     ~WorkGroupScanTaskQueue() override = default;
 
     void close() override;
@@ -252,7 +250,7 @@ private:
     };
     using WorkgroupSet = std::set<workgroup::WorkGroupScanSchedEntity*, WorkGroupScanSchedEntityComparator>;
 
-    const SchedEntityType _sched_entity_type;
+    const ScanSchedEntityType _sched_entity_type;
 
     mutable std::mutex _global_mutex;
     std::condition_variable _cv;

--- a/be/src/exec/workgroup/work_group_fwd.h
+++ b/be/src/exec/workgroup/work_group_fwd.h
@@ -27,6 +27,8 @@ using WorkGroupPtr = std::shared_ptr<WorkGroup>;
 
 class ScanTaskQueue;
 
+enum class ScanSchedEntityType : uint8_t { OLAP, CONNECTOR };
+
 template <typename Q>
 class WorkGroupSchedEntity;
 using WorkGroupDriverSchedEntity = WorkGroupSchedEntity<pipeline::DriverQueue>;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -439,10 +439,9 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&connector_scan_worker_thread_pool_with_workgroup));
-    _connector_scan_executor =
-            new workgroup::ScanExecutor(std::move(connector_scan_worker_thread_pool_with_workgroup),
-                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>(
-                                                workgroup::WorkGroupScanTaskQueue::SchedEntityType::CONNECTOR));
+    _connector_scan_executor = new workgroup::ScanExecutor(
+            std::move(connector_scan_worker_thread_pool_with_workgroup),
+            std::make_unique<workgroup::WorkGroupScanTaskQueue>(workgroup::ScanSchedEntityType::CONNECTOR));
     _connector_scan_executor->initialize(connector_num_io_threads);
 
     workgroup::DefaultWorkGroupInitialization default_workgroup_init;
@@ -514,9 +513,9 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&scan_worker_thread_pool_with_workgroup));
-    _scan_executor = new workgroup::ScanExecutor(std::move(scan_worker_thread_pool_with_workgroup),
-                                                 std::make_unique<workgroup::WorkGroupScanTaskQueue>(
-                                                         workgroup::WorkGroupScanTaskQueue::SchedEntityType::OLAP));
+    _scan_executor = new workgroup::ScanExecutor(
+            std::move(scan_worker_thread_pool_with_workgroup),
+            std::make_unique<workgroup::WorkGroupScanTaskQueue>(workgroup::ScanSchedEntityType::OLAP));
     _scan_executor->initialize(num_io_threads);
     // it means acting as compute node while store_path is empty. some threads are not needed for that case.
     Status status = _load_path_mgr->init();


### PR DESCRIPTION
## Why I'm doing:

The are two places to decide which scan sched entity to use (`OLAP` or `CONNECTOR`) for resource group.
- When deciding to use which scan executor, we use `dynamic_cast<ConnectorScanOperator*>(scan_operator) != nullptr || dynamic_cast<SchemaScanOperator*>(scan_operator) != nullptr`.
- When ChunkSource decides the `scan_sched_entity`, we use the virtual method `ChunkSource::scan_sched_entity()`.

It’s easy to introduce bugs, like #49842, when we modify the related code.

## What I'm doing:

Unify this two logics to a virtual method `ScanOperator::sched_entity_type`.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
