### PR TITLE
[Enhancement]use poco to replace curl in aws sdk as http client

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -245,6 +245,10 @@ endforeach()
 find_package(AWSSDK REQUIRED COMPONENTS core s3 s3-crt transfer identity-management sts)
 include_directories(${AWSSDK_INCLUDE_DIRS})
 
+set(Poco_ROOT_DIR ${THIRDPARTY_DIR})
+find_package(Poco REQUIRED COMPONENTS Net NetSSL)
+include_directories(&{Poco_INCLUDE_DIRS})
+
 add_library(libevent STATIC IMPORTED)
 set_target_properties(libevent PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libevent.a)
 
@@ -858,6 +862,7 @@ set(STARROCKS_DEPENDENCIES
     lz4
     libevent
     curl
+    ${Poco_LIBRARIES}
     libz
     libbz2
     gflags

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -922,6 +922,9 @@ CONF_String(aws_sdk_logging_trace_level, "trace");
 // Enabling RFC-3986 encoding will make sure these characters are properly encoded.
 CONF_Bool(aws_sdk_enable_compliant_rfc3986_encoding, "false");
 
+// use poco client to replace default curl client
+CONF_Bool(enable_poco_client_for_aws_sdk, "true");
+
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");
 // default: 16MB

--- a/be/src/fs/CMakeLists.txt
+++ b/be/src/fs/CMakeLists.txt
@@ -28,6 +28,9 @@ set(EXEC_FILES
     fs_s3.cpp
     hdfs/fs_hdfs.cpp
     hdfs/hdfs_fs_cache.cpp
+    s3/poco_http_client_factory.cpp
+    s3/poco_http_client.cpp
+    s3/poco_common.cpp
     fs_util.cpp
     fs_starlet.cpp
     )

--- a/be/src/fs/s3/poco_common.cpp
+++ b/be/src/fs/s3/poco_common.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/s3/poco_common.h"
+
+#include <Poco/Exception.h>
+#include <fmt/format.h>
+
+#include <memory>
+#include <sstream>
+
+namespace starrocks::poco {
+
+bool isHTTPS(const Poco::URI& uri) {
+    if (uri.getScheme() == "https")
+        return true;
+    else if (uri.getScheme() == "http")
+        return false;
+    else
+        throw std::runtime_error(fmt::format("Unsupported scheme in URI '{}'", uri.toString()));
+}
+
+HTTPSessionPtr makeHTTPSessionImpl(const std::string& host, Poco::UInt16 port, bool https, bool keep_alive,
+                                   bool resolve_host) {
+    HTTPSessionPtr session;
+
+    if (https) {
+        session = std::make_shared<Poco::Net::HTTPSClientSession>(host, port);
+    } else {
+        session = std::make_shared<Poco::Net::HTTPClientSession>(host, port);
+    }
+
+    // doesn't work properly without patch
+    session->setKeepAlive(keep_alive);
+    return session;
+}
+
+void setTimeouts(Poco::Net::HTTPClientSession& session, const ConnectionTimeouts& timeouts) {
+    session.setTimeout(timeouts.connection_timeout, timeouts.send_timeout, timeouts.receive_timeout);
+    session.setKeepAliveTimeout(timeouts.http_keep_alive_timeout);
+}
+
+HTTPSessionPtr makeHTTPSession(const Poco::URI& uri, const ConnectionTimeouts& timeouts, bool resolve_host) {
+    const std::string& host = uri.getHost();
+    Poco::UInt16 port = uri.getPort();
+    bool https = isHTTPS(uri);
+
+    auto session = makeHTTPSessionImpl(host, port, https, false, resolve_host);
+    setTimeouts(*session, timeouts);
+    return session;
+}
+
+std::string getCurrentExceptionMessage() {
+    std::stringstream ss;
+
+    try {
+        throw;
+    } catch (const Poco::Exception& e) {
+        ss << fmt::format("Poco::Exception. e.code() = {}, e.displayText() = {}, e.what() = {}", e.code(),
+                          e.displayText(), e.what());
+    } catch (const std::exception& e) {
+        ss << fmt::format("std::exception. type: {}, e.what() = {}", typeid(e).name(), e.what());
+    } catch (...) {
+        ss << fmt::format("Unknown exception from poco client");
+    }
+
+    return ss.str();
+}
+
+// 1) https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-200-internalerror/
+// 2) https://github.com/aws/aws-sdk-cpp/issues/658
+bool checkRequestCanReturn2xxAndErrorInBody(Aws::Http::HttpRequest& request) {
+    auto query_params = request.GetQueryStringParameters();
+    if (request.HasHeader("x-amz-copy-source")) {
+        // CopyObject https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+        if (query_params.empty()) return true;
+
+        // UploadPartCopy https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html
+        if (query_params.contains("partNumber") && query_params.contains("uploadId")) return true;
+
+    } else {
+        // CompleteMultipartUpload https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+        if (query_params.size() == 1 && query_params.contains("uploadId")) return true;
+    }
+
+    return false;
+}
+
+} // namespace starrocks::poco

--- a/be/src/fs/s3/poco_common.h
+++ b/be/src/fs/s3/poco_common.h
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Poco/Net/HTTPClientSession.h>
+#include <Poco/Net/HTTPSClientSession.h>
+#include <Poco/Timespan.h>
+#include <Poco/Types.h>
+#include <Poco/URI.h>
+#include <aws/core/http/HttpRequest.h>
+
+#include <memory>
+
+namespace starrocks::poco {
+
+struct ConnectionTimeouts {
+    Poco::Timespan connection_timeout;
+    Poco::Timespan send_timeout;
+    Poco::Timespan receive_timeout;
+    Poco::Timespan http_keep_alive_timeout{0};
+
+    ConnectionTimeouts() = default;
+
+    ConnectionTimeouts(const Poco::Timespan& connection_timeout_, const Poco::Timespan& send_timeout_,
+                       const Poco::Timespan& receive_timeout_)
+            : connection_timeout(connection_timeout_), send_timeout(send_timeout_), receive_timeout(receive_timeout_) {}
+};
+
+using HTTPSessionPtr = std::shared_ptr<Poco::Net::HTTPClientSession>;
+
+bool isHTTPS(const Poco::URI& uri);
+
+HTTPSessionPtr makeHTTPSessionImpl(const std::string& host, Poco::UInt16 port, bool https, bool keep_alive,
+                                   bool resolve_host = true);
+
+void setTimeouts(Poco::Net::HTTPClientSession& session, const ConnectionTimeouts& timeouts);
+
+HTTPSessionPtr makeHTTPSession(const Poco::URI& uri, const ConnectionTimeouts& timeouts, bool resolve_host);
+
+std::string getCurrentExceptionMessage();
+
+bool checkRequestCanReturn2xxAndErrorInBody(Aws::Http::HttpRequest& request);
+
+enum ResponseCode {
+    SUCCESS_RESPONSE_MIN = 200,
+    SUCCESS_RESPONSE_MAX = 299,
+    TOO_MANY_REQUEST = 429,
+    SERVICE_UNAVALIABLE = 503
+};
+
+} // namespace starrocks::poco

--- a/be/src/fs/s3/poco_http_client.cpp
+++ b/be/src/fs/s3/poco_http_client.cpp
@@ -1,0 +1,207 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/s3/poco_http_client.h"
+
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/StreamCopier.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+#include <aws/core/monitoring/HttpClientMetrics.h>
+#include <aws/core/utils/ratelimiter/RateLimiterInterface.h>
+#include <fmt/format.h>
+
+#include <istream>
+#include <utility>
+
+#include "common/logging.h"
+#include "fs/s3/poco_common.h"
+#include "io/s3_zero_copy_iostream.h"
+
+namespace starrocks::poco {
+
+PocoHttpClient::PocoHttpClient(const Aws::Client::ClientConfiguration& clientConfiguration)
+        : timeouts(ConnectionTimeouts(
+                  Poco::Timespan(clientConfiguration.connectTimeoutMs * 1000),     // connection timeout.
+                  Poco::Timespan(clientConfiguration.httpRequestTimeoutMs * 1000), // send timeout.
+                  Poco::Timespan(clientConfiguration.httpRequestTimeoutMs * 1000)  // receive timeout.
+                  )) {}
+
+std::shared_ptr<Aws::Http::HttpResponse> PocoHttpClient::MakeRequest(
+        const std::shared_ptr<Aws::Http::HttpRequest>& request,
+        Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
+        Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {
+    auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("PocoHttpClient", request);
+    MakeRequestInternal(*request, response, readLimiter, writeLimiter);
+    return response;
+}
+
+void PocoHttpClient::MakeRequestInternal(Aws::Http::HttpRequest& request,
+                                         std::shared_ptr<Aws::Http::Standard::StandardHttpResponse>& response,
+                                         Aws::Utils::RateLimits::RateLimiterInterface*,
+                                         Aws::Utils::RateLimits::RateLimiterInterface*) const {
+    auto uri = request.GetUri().GetURIString();
+
+    const int MAX_REDIRECT_ATTEMPTS = 10;
+    try {
+        for (int attempt = 0; attempt < MAX_REDIRECT_ATTEMPTS; ++attempt) {
+            Poco::URI poco_uri(uri);
+
+            // URI may changed, because of redirection
+            auto session = makeHTTPSession(poco_uri, timeouts, false);
+
+            Poco::Net::HTTPRequest poco_request(Poco::Net::HTTPRequest::HTTP_1_1);
+
+            /** According to RFC-2616, Request-URI is allowed to be encoded.
+            * However, there is no clear agreement on which exact symbols must be encoded.
+            * Effectively, `Poco::URI` chooses smaller subset of characters to encode,
+            * whereas Amazon S3 and Google Cloud Storage expects another one.
+            * In order to successfully execute a request, a path must be exact representation
+            * of decoded path used by `AWSAuthSigner`.
+            * Therefore we shall encode some symbols "manually" to fit the signatures.
+            */
+
+            std::string path_and_query;
+            const std::string& query = poco_uri.getRawQuery();
+            const std::string reserved = "?#:;+@&=%"; // Poco::URI::RESERVED_QUERY_PARAM without '/' plus percent sign.
+            Poco::URI::encode(poco_uri.getPath(), reserved, path_and_query);
+
+            // `target_uri.getPath()` could return an empty string, but a proper HTTP request must
+            // always contain a non-empty URI in its first line (e.g. "POST / HTTP/1.1" or "POST /?list-type=2 HTTP/1.1").
+            if (path_and_query.empty()) path_and_query = "/";
+
+            // Append the query param to URI
+            if (!query.empty()) {
+                path_and_query += '?';
+                path_and_query += query;
+            }
+
+            poco_request.setURI(path_and_query);
+
+            switch (request.GetMethod()) {
+            case Aws::Http::HttpMethod::HTTP_GET:
+                poco_request.setMethod(Poco::Net::HTTPRequest::HTTP_GET);
+                break;
+            case Aws::Http::HttpMethod::HTTP_POST:
+                poco_request.setMethod(Poco::Net::HTTPRequest::HTTP_POST);
+                break;
+            case Aws::Http::HttpMethod::HTTP_DELETE:
+                poco_request.setMethod(Poco::Net::HTTPRequest::HTTP_DELETE);
+                break;
+            case Aws::Http::HttpMethod::HTTP_PUT:
+                poco_request.setMethod(Poco::Net::HTTPRequest::HTTP_PUT);
+                break;
+            case Aws::Http::HttpMethod::HTTP_HEAD:
+                poco_request.setMethod(Poco::Net::HTTPRequest::HTTP_HEAD);
+                break;
+            case Aws::Http::HttpMethod::HTTP_PATCH:
+                poco_request.setMethod(Poco::Net::HTTPRequest::HTTP_PATCH);
+                break;
+            }
+
+            for (const auto& [header_name, header_value] : request.GetHeaders()) {
+                poco_request.set(header_name, header_value);
+            }
+
+            auto& request_body_stream = session->sendRequest(poco_request);
+
+            if (request.GetContentBody()) {
+                // Rewind content body buffer.
+                // NOTE: we should do that always (even if `attempt == 0`) because the same request can be retried also by AWS,
+                // see retryStrategy in Aws::Client::ClientConfiguration.
+                request.GetContentBody()->clear();
+                request.GetContentBody()->seekg(0);
+
+                // Todo, check this stream copy
+                [[maybe_unused]] auto size =
+                        Poco::StreamCopier::copyStream(*request.GetContentBody(), request_body_stream);
+            }
+
+            Poco::Net::HTTPResponse poco_response;
+
+            if (dynamic_cast<starrocks::io::S3ZeroCopyIOStream *>(&(response->GetResponseBody()))) {
+                poco_response.setResponseIOStream(&(response->GetResponseBody()),
+                                                  (static_cast<Aws::Utils::Stream::PreallocatedStreamBuf*>(response->GetResponseBody().rdbuf()))->GetBuffer(),
+                                                  (static_cast<starrocks::io::S3ZeroCopyIOStream&>(response->GetResponseBody())).getSize());
+            }
+
+            auto& response_body_stream = session->receiveResponse(poco_response);
+
+            int status_code = static_cast<int>(poco_response.getStatus());
+
+            if (poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT) {
+                auto location = poco_response.get("location");
+                uri = location;
+                continue;
+            }
+
+            response->SetResponseCode(static_cast<Aws::Http::HttpResponseCode>(status_code));
+            response->SetContentType(poco_response.getContentType());
+
+            for (const auto& [header_name, header_value] : poco_response) {
+                response->AddHeader(header_name, header_value);
+            }
+
+            // Request is successful but for some special requests we can have actual error message in body
+            // TODO, there is one more copy, but in these cases that RequestCanReturn2xxAndErrorInBody, it's trivial.
+            if (status_code >= ResponseCode::SUCCESS_RESPONSE_MIN &&
+                status_code <= ResponseCode::SUCCESS_RESPONSE_MAX && checkRequestCanReturn2xxAndErrorInBody(request)) {
+                // reading the full response
+                std::string response_string((std::istreambuf_iterator<char>(response_body_stream)),
+                                            std::istreambuf_iterator<char>());
+
+                const static std::string_view needle = "<Error>";
+                if (auto it = std::search(response_string.begin(), response_string.end(),
+                                          std::default_searcher(needle.begin(), needle.end()));
+                    it != response_string.end()) {
+                    LOG(WARNING) << "Response for request contain <Error> tag in body, settings internal server error "
+                                    "(500 code)";
+                    response->SetResponseCode(Aws::Http::HttpResponseCode::INTERNAL_SERVER_ERROR);
+                }
+
+                if (!poco_response.isBodyFilled()) {
+                    response->GetResponseBody().write(response_string.data(), response_string.size());
+                }
+            } else {
+                if (status_code == ResponseCode::TOO_MANY_REQUEST || status_code == ResponseCode::SERVICE_UNAVALIABLE) {
+                    // pass
+                    // TODO, throttling
+                }
+                if (status_code >= ResponseCode::SUCCESS_RESPONSE_MIN &&
+                    status_code <= ResponseCode::SUCCESS_RESPONSE_MAX) {
+                    if (!poco_response.isBodyFilled()) {
+                        Poco::StreamCopier::copyStream(response_body_stream, response->GetResponseBody());
+                    }
+                } else {
+                    std::string error_message;
+                    Poco::StreamCopier::copyToString(response_body_stream, error_message);
+
+                    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+                    response->SetClientErrorMessage(error_message);
+                }
+            }
+
+            return;
+        }
+        throw std::runtime_error(
+                fmt::format("Too many redirects while trying to access {}", request.GetUri().GetURIString()));
+    } catch (...) {
+        response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+        response->SetClientErrorMessage(getCurrentExceptionMessage());
+    }
+}
+
+} // namespace starrocks::poco

--- a/be/src/fs/s3/poco_http_client.h
+++ b/be/src/fs/s3/poco_http_client.h
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Poco/Net/HTTPClientSession.h>
+#include <Poco/URI.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/http/Scheme.h>
+
+#include <string>
+
+#include "fs/s3/poco_common.h"
+
+namespace Aws::Http::Standard {
+class StandardHttpResponse;
+}
+
+namespace starrocks::poco {
+
+class PocoHttpClient : public Aws::Http::HttpClient {
+public:
+    explicit PocoHttpClient(const Aws::Client::ClientConfiguration& clientConfiguration);
+    ~PocoHttpClient() override = default;
+
+    std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+            const std::shared_ptr<Aws::Http::HttpRequest>& request,
+            Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
+            Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const override;
+
+private:
+    void MakeRequestInternal(Aws::Http::HttpRequest& request,
+                             std::shared_ptr<Aws::Http::Standard::StandardHttpResponse>& response,
+                             Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
+                             Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const;
+
+    ConnectionTimeouts timeouts;
+};
+
+} // namespace starrocks::poco

--- a/be/src/fs/s3/poco_http_client_factory.cpp
+++ b/be/src/fs/s3/poco_http_client_factory.cpp
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/s3/poco_http_client_factory.h"
+
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+
+#include "fs/s3/poco_http_client.h"
+
+namespace starrocks::poco {
+
+std::shared_ptr<Aws::Http::HttpClient> PocoHttpClientFactory::CreateHttpClient(
+        const Aws::Client::ClientConfiguration& clientConfiguration) const {
+    return std::make_shared<PocoHttpClient>(clientConfiguration);
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> PocoHttpClientFactory::CreateHttpRequest(
+        const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const {
+    return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> PocoHttpClientFactory::CreateHttpRequest(
+        const Aws::Http::URI& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const {
+    auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("PocoHttpClientFactory", uri, method);
+    request->SetResponseStreamFactory(streamFactory);
+
+    return request;
+}
+
+} // namespace starrocks::poco

--- a/be/src/fs/s3/poco_http_client_factory.h
+++ b/be/src/fs/s3/poco_http_client_factory.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Poco/Net/NetSSL.h>
+#include <aws/core/http/HttpClientFactory.h>
+
+namespace Aws::Http {
+class HttpClient;
+class HttpRequest;
+} // namespace Aws::Http
+
+namespace starrocks::poco {
+
+class PocoHttpClientFactory : public Aws::Http::HttpClientFactory {
+public:
+    PocoHttpClientFactory() : Aws::Http::HttpClientFactory() { Poco::Net::initializeSSL(); }
+    ~PocoHttpClientFactory() override { Poco::Net::uninitializeSSL(); }
+    [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+            const Aws::Client::ClientConfiguration& clientConfiguration) const override;
+    [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+            const Aws::String& uri, Aws::Http::HttpMethod method,
+            const Aws::IOStreamFactory& streamFactory) const override;
+    [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+            const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
+            const Aws::IOStreamFactory& streamFactory) const override;
+};
+
+} // namespace starrocks::poco

--- a/be/src/io/s3_zero_copy_iostream.h
+++ b/be/src/io/s3_zero_copy_iostream.h
@@ -26,11 +26,14 @@ class S3ZeroCopyIOStream : public Aws::IOStream {
 public:
     S3ZeroCopyIOStream(char* buf, size_t size)
             : Aws::IOStream(
-                      new Aws::Utils::Stream::PreallocatedStreamBuf(reinterpret_cast<unsigned char*>(buf), size)) {
+                      new Aws::Utils::Stream::PreallocatedStreamBuf(reinterpret_cast<unsigned char*>(buf), size)),
+              _buf_size(size) {
         DCHECK(rdbuf());
     }
 
     S3ZeroCopyIOStream(const char* buf, size_t size) : S3ZeroCopyIOStream(const_cast<char*>(buf), size) {}
+
+    size_t getSize() { return _buf_size; }
 
     S3ZeroCopyIOStream(const S3ZeroCopyIOStream&) = delete;
     void operator=(const S3ZeroCopyIOStream&) = delete;
@@ -41,6 +44,9 @@ public:
         // corresponding new in constructor
         delete rdbuf();
     }
+
+private:
+    size_t _buf_size = 0;
 };
 
 } // namespace starrocks::io

--- a/be/src/io/s3_zero_copy_iostream.h
+++ b/be/src/io/s3_zero_copy_iostream.h
@@ -25,8 +25,7 @@ namespace starrocks::io {
 class S3ZeroCopyIOStream : public Aws::IOStream {
 public:
     S3ZeroCopyIOStream(char* buf, size_t size)
-            : Aws::IOStream(
-                      new Aws::Utils::Stream::PreallocatedStreamBuf(reinterpret_cast<unsigned char*>(buf), size)),
+            : Aws::IOStream(new Aws::Utils::Stream::PreallocatedStreamBuf(reinterpret_cast<unsigned char*>(buf), size)),
               _buf_size(size) {
         DCHECK(rdbuf());
     }

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -54,6 +54,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "exec/pipeline/query_context.h"
+#include "fs/s3/poco_http_client_factory.h"
 #include "runtime/exec_env.h"
 #include "runtime/heartbeat_flags.h"
 #include "runtime/jdbc_driver_manager.h"
@@ -212,6 +213,9 @@ int main(int argc, char** argv) {
         aws_sdk_options.httpOptions.compliantRfc3986Encoding = true;
     }
     Aws::InitAPI(aws_sdk_options);
+    if (starrocks::config::enable_poco_client_for_aws_sdk) {
+        Aws::Http::SetHttpClientFactory(std::make_shared<starrocks::poco::PocoHttpClientFactory>());
+    }
 
     std::vector<starrocks::StorePath> paths;
     auto olap_res = starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(EXEC_FILES
         ./fs/encrypt_file_test.cpp
         ./fs/key_cache_test.cpp
         ./fs/output_stream_wrapper_test.cpp
+        ./fs/poco_http_client_test.cpp
         ./exec/column_value_range_test.cpp
         ./exec/es/es_query_builder_test.cpp
         ./exec/es/es_scan_reader_test.cpp

--- a/be/test/fs/poco_http_client_test.cpp
+++ b/be/test/fs/poco_http_client_test.cpp
@@ -1,0 +1,173 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/s3/poco_http_client.h"
+
+#include <aws/core/Aws.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "fs/s3/poco_http_client_factory.h"
+#include "io/s3_input_stream.h"
+#include "testutil/assert.h"
+
+namespace starrocks::poco {
+
+static const char* kObjectName = "starrocks_ut_poco_test.txt";
+static const char* kObjectContent = "0123456789";
+
+class PocoHttpClientTest : public testing::Test {
+public:
+    PocoHttpClientTest() = default;
+    ~PocoHttpClientTest() override = default;
+
+    static void SetUpTestCase();
+    static void TearDownTestCase();
+
+    static void put_object(const std::string& object_content);
+
+protected:
+    inline static const char* s_bucket_name = nullptr;
+    inline static const char* ak = nullptr;
+    inline static const char* sk = nullptr;
+};
+
+void PocoHttpClientTest::SetUpTestCase() {
+    Aws::InitAPI(Aws::SDKOptions());
+    Aws::Http::SetHttpClientFactory(std::make_shared<starrocks::poco::PocoHttpClientFactory>());
+
+    s_bucket_name = config::object_storage_bucket.empty() ? getenv("STARROCKS_UT_S3_BUCKET")
+                                                          : config::object_storage_bucket.c_str();
+    if (s_bucket_name == nullptr) {
+        FAIL() << "s3 bucket name not set";
+    }
+
+    ak = config::object_storage_access_key_id.empty() ? getenv("STARROCKS_UT_S3_AK")
+                                                      : config::object_storage_access_key_id.c_str();
+    sk = config::object_storage_secret_access_key.empty() ? getenv("STARROCKS_UT_S3_SK")
+                                                          : config::object_storage_secret_access_key.c_str();
+    if (ak == nullptr) {
+        FAIL() << "s3 access key id not set";
+    }
+    if (sk == nullptr) {
+        FAIL() << "s3 secret access key not set";
+    }
+    put_object(kObjectContent);
+}
+
+void PocoHttpClientTest::TearDownTestCase() {
+    Aws::ShutdownAPI(Aws::SDKOptions());
+}
+
+void PocoHttpClientTest::put_object(const std::string& object_content) {
+    Aws::Client::ClientConfiguration config;
+    config.endpointOverride = config::object_storage_endpoint.empty() ? getenv("STARROCKS_UT_S3_ENDPOINT")
+                                                                      : config::object_storage_endpoint;
+
+    auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
+    auto client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
+                                                      Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, true);
+
+    std::shared_ptr<Aws::IOStream> stream = Aws::MakeShared<Aws::StringStream>("", object_content);
+
+    Aws::S3::Model::PutObjectRequest request;
+    request.SetBucket(s_bucket_name);
+    request.SetKey(kObjectName);
+    request.SetBody(stream);
+
+    Aws::S3::Model::PutObjectOutcome outcome = client->PutObject(request);
+    CHECK(outcome.IsSuccess()) << outcome.GetError().GetMessage();
+}
+
+TEST_F(PocoHttpClientTest, TestNormalAccess) {
+    Aws::Client::ClientConfiguration config;
+    config.endpointOverride = config::object_storage_endpoint.empty() ? getenv("STARROCKS_UT_S3_ENDPOINT")
+                                                                      : config::object_storage_endpoint;
+    // Create a custom retry strategy
+    int maxRetries = 2;
+    long scaleFactor = 25;
+    std::shared_ptr<Aws::Client::RetryStrategy> retryStrategy =
+            std::make_shared<Aws::Client::DefaultRetryStrategy>(maxRetries, scaleFactor);
+
+    // Create a client configuration object and set the custom retry strategy
+    config.retryStrategy = retryStrategy;
+
+    auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
+
+    auto client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
+                                                      Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, true);
+
+    auto stream = std::make_unique<starrocks::io::S3InputStream>(client, s_bucket_name, kObjectName);
+    char buf[6];
+    ASSIGN_OR_ABORT(auto r, stream->read(buf, sizeof(buf)));
+    ASSERT_EQ("012345", std::string_view(buf, r));
+}
+
+TEST_F(PocoHttpClientTest, TestErrorEndpoint) {
+    Aws::Client::ClientConfiguration config;
+    config.endpointOverride = "http://127.0.0.1";
+
+    // Create a custom retry strategy
+    int maxRetries = 2;
+    long scaleFactor = 25;
+    std::shared_ptr<Aws::Client::RetryStrategy> retryStrategy =
+            std::make_shared<Aws::Client::DefaultRetryStrategy>(maxRetries, scaleFactor);
+
+    // Create a client configuration object and set the custom retry strategy
+    config.retryStrategy = retryStrategy;
+
+    auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
+    auto client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
+                                                      Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, true);
+
+    auto stream = std::make_unique<starrocks::io::S3InputStream>(client, s_bucket_name, kObjectName);
+    char buf[6];
+    auto r = stream->read(buf, sizeof(buf));
+    EXPECT_TRUE(r.status().message().find("Poco::Exception") != std::string::npos);
+}
+
+TEST_F(PocoHttpClientTest, TestErrorAkSk) {
+    Aws::Client::ClientConfiguration config;
+    config.endpointOverride = config::object_storage_endpoint.empty() ? getenv("STARROCKS_UT_S3_ENDPOINT")
+                                                                      : config::object_storage_endpoint;
+
+    // Create a custom retry strategy
+    int maxRetries = 2;
+    long scaleFactor = 25;
+    std::shared_ptr<Aws::Client::RetryStrategy> retryStrategy =
+            std::make_shared<Aws::Client::DefaultRetryStrategy>(maxRetries, scaleFactor);
+
+    // Create a client configuration object and set the custom retry strategy
+    config.retryStrategy = retryStrategy;
+
+    std::string error_sk = "12345";
+    auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, error_sk.data());
+    auto client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
+                                                      Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, true);
+
+    auto stream = std::make_unique<starrocks::io::S3InputStream>(client, s_bucket_name, kObjectName);
+    char buf[6];
+    auto r = stream->read(buf, sizeof(buf));
+    EXPECT_TRUE(r.status().message().find("SdkResponseCode=403") != std::string::npos);
+}
+
+} // namespace starrocks::poco


### PR DESCRIPTION
## Why I'm doing:
we know performance of curl is awful from many places.

## What I'm doing:
use poco replace curl in aws sdk as http client.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
