### PR TITLE
[BugFix] Allow big integer in json column when stream load with json format

### DIFF
--- a/be/src/util/json_converter.cpp
+++ b/be/src/util/json_converter.cpp
@@ -77,7 +77,7 @@ private:
             break;
         }
         case so::json_type::number: {
-            RETURN_IF_ERROR(convert(value.get_number().value(), field_name, is_object, builder));
+            RETURN_IF_ERROR(convert_number(value, field_name, is_object, builder));
             break;
         }
         case so::json_type::string: {
@@ -124,10 +124,12 @@ private:
         return Status::OK();
     }
 
-    static inline Status convert(SimdJsonNumber num, std::string_view field_name, bool is_object,
-                                 vpack::Builder* builder) {
-        switch (num.get_number_type()) {
+    static inline Status convert_number(SimdJsonValue value, std::string_view field_name, bool is_object,
+                                        vpack::Builder* builder) {
+        DCHECK(value.type() == so::json_type::number);
+        switch (value.get_number_type()) {
         case SimdJsonNumberType::floating_point_number: {
+            SimdJsonNumber num = value.get_number().value();
             if (is_object) {
                 builder->add(toStringRef(field_name), vpack::Value((num.get_double())));
             } else {
@@ -136,6 +138,7 @@ private:
             break;
         }
         case SimdJsonNumberType::signed_integer: {
+            SimdJsonNumber num = value.get_number().value();
             if (is_object) {
                 builder->add(toStringRef(field_name), vpack::Value((num.get_int64())));
             } else {
@@ -144,6 +147,7 @@ private:
             break;
         }
         case SimdJsonNumberType::unsigned_integer: {
+            SimdJsonNumber num = value.get_number().value();
             if (is_object) {
                 builder->add(toStringRef(field_name), vpack::Value((num.get_uint64())));
             } else {
@@ -151,9 +155,28 @@ private:
             }
             break;
         }
+        case SimdJsonNumberType::big_integer: {
+            // try to convert big integer to double which is same as that of velocypack,
+            // see https://github.com/arangodb/velocypack/blob/XYZ1.0/include/velocypack/Parser.h#L43
+            auto s = value.raw_json_token();
+            StringParser::ParseResult r;
+            auto val = StringParser::string_to_float<double>(s.data(), s.size(), &r);
+            if (r != StringParser::PARSE_SUCCESS) {
+                auto err_msg = strings::Substitute("Fail to convert big integer to double. field_name=$0, value=$1",
+                                                   field_name, s);
+                return Status::InvalidArgument(err_msg);
+            }
+            if (is_object) {
+                builder->add(toStringRef(field_name), vpack::Value(val));
+            } else {
+                builder->add(vpack::Value(val));
+            }
+            break;
+        }
         default:
-            return Status::InternalError(
-                    fmt::format("unsupported json number: {}", static_cast<int>(num.get_number_type())));
+            std::stringstream ss;
+            ss << "Unsupported json number type. field=" << field_name << ", type=" << value.get_number_type();
+            return Status::InternalError(ss.str());
         }
         return Status::OK();
     }

--- a/be/src/util/json_converter.cpp
+++ b/be/src/util/json_converter.cpp
@@ -127,6 +127,7 @@ private:
     static inline Status convert_number(SimdJsonValue value, std::string_view field_name, bool is_object,
                                         vpack::Builder* builder) {
         DCHECK(value.type() == so::json_type::number);
+        // can't use value.get_number().get_number_type() because it will throw exception if it's a big integer
         switch (value.get_number_type()) {
         case SimdJsonNumberType::floating_point_number: {
             SimdJsonNumber num = value.get_number().value();
@@ -174,9 +175,8 @@ private:
             break;
         }
         default:
-            std::stringstream ss;
-            ss << "Unsupported json number type. field=" << field_name << ", type=" << value.get_number_type();
-            return Status::InternalError(ss.str());
+            return Status::InternalError(
+                    fmt::format("unsupported json number: {}", static_cast<int>(value.get_number_type().value())));
         }
         return Status::OK();
     }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -12,7 +12,7 @@ set(EXEC_FILES
         ./column/decimalv3_column_test.cpp
         ./column/field_test.cpp
         ./column/fixed_length_column_test.cpp
-        #./column/json_column_test.cpp
+        ./column/json_column_test.cpp
         ./column/map_column_test.cpp
         ./column/struct_column_test.cpp
         ./column/nullable_column_test.cpp
@@ -444,7 +444,7 @@ set(EXEC_FILES
         ./util/uid_util_test.cpp
         ./util/utf8_check_test.cpp
         ./util/int96_test.cpp
-	./util/internal_service_recoverable_stub_test.cpp
+        ./util/internal_service_recoverable_stub_test.cpp
         ./util/bit_packing_test.cpp
         ./util/gc_helper_test.cpp
         ./util/lru_cache_test.cpp

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -423,6 +423,8 @@ INSTANTIATE_TEST_SUITE_P(JsonConvertTest, JsonConvertTestFixture,
                                     std::make_tuple(R"({"a": ""})"),
                                     std::make_tuple(R"({"a": [1, 2, 3]})"),
                                     std::make_tuple(R"({"a": {"b": 1}})"),
+                                    // unsigned integer
+                                    std::make_tuple(R"({"a": 18446744073709551615})"),
 
                                     // empty key
                                     std::make_tuple(R"({"a": {"": ""}})"),
@@ -451,6 +453,13 @@ PARALLEL_TEST(JsonConvertTest, convert_from_simdjson_big_integer) {
     ASSERT_TRUE(double_json.ok());
 
     ASSERT_EQ(double_json.value().to_string_uncheck(), big_integer_json.value().to_string_uncheck());
+
+    // a is simdjson::ondemand::number_type::big_integer, but is overflow for double
+    padded_string double_overflow_str = std::string(400, '1');
+    ondemand::document double_overflow_doc = parser.iterate(double_overflow_str);
+    ondemand::object double_overflow_obj = double_overflow_doc.get_object();
+    auto double_overflow_json = JsonValue::from_simdjson(&double_overflow_obj);
+    ASSERT_FALSE(double_overflow_json.ok());
 }
 
 } // namespace starrocks

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -432,4 +432,25 @@ INSTANTIATE_TEST_SUITE_P(JsonConvertTest, JsonConvertTestFixture,
                                  // clang-format on
                                  ));
 
+PARALLEL_TEST(JsonConvertTest, convert_from_simdjson_big_integer) {
+    using namespace simdjson;
+    ondemand::parser parser;
+
+    // a is simdjson::ondemand::number_type::big_integer, and should be converted to double
+    auto big_integer_str = R"({"a": 10000000000000000000000000000000000000000})"_padded;
+    ondemand::document big_integer_doc = parser.iterate(big_integer_str);
+    ondemand::object big_integer_obj = big_integer_doc.get_object();
+    auto big_integer_json = JsonValue::from_simdjson(&big_integer_obj);
+    ASSERT_TRUE(big_integer_json.ok());
+
+    // a is simdjson::ondemand::number_type::floating_point_number
+    auto double_str = R"({"a": 10000000000000000000000000000000000000000.0})"_padded;
+    ondemand::document double_doc = parser.iterate(double_str);
+    ondemand::object double_obj = double_doc.get_object();
+    auto double_json = JsonValue::from_simdjson(&double_obj);
+    ASSERT_TRUE(double_json.ok());
+
+    ASSERT_EQ(double_json.value().to_string_uncheck(), big_integer_json.value().to_string_uncheck());
+}
+
 } // namespace starrocks

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -455,7 +455,7 @@ PARALLEL_TEST(JsonConvertTest, convert_from_simdjson_big_integer) {
     ASSERT_EQ(double_json.value().to_string_uncheck(), big_integer_json.value().to_string_uncheck());
 
     // a is simdjson::ondemand::number_type::big_integer, but is overflow for double
-    padded_string double_overflow_str = std::string(400, '1');
+    padded_string double_overflow_str = strings::Substitute("{\"a\":$0}", std::string(400, '1'));
     ondemand::document double_overflow_doc = parser.iterate(double_overflow_str);
     ondemand::object double_overflow_obj = double_overflow_doc.get_object();
     auto double_overflow_json = JsonValue::from_simdjson(&double_overflow_obj);


### PR DESCRIPTION
## Why I'm doing:
When loading a json which has big integer field to a json column, both insert into and stream load with csv format can be successful, but stream load with json format will fail
For example

```
CREATE TABLE test.t (
  c0 INT,
  c1 JSON
) PROPERTIES (
  "replication_num"="1"  
);
```

* insert into successes
```
insert into test.t values (1, parse_json('{"a":11111111111111111111111111111111111111111111111111111111}'));
```

* stream load with csv format successes
```
curl --location-trusted  -u root:  -H "Expect:100-continue" -H "label:label5" \
    -H "strict_mode:true" -H "format: csv" -H "column_separator:|" \
    -d "1|{\"a\":11111111111111111111111111111111111111111111111111111111}" \
    -XPUT http://127.0.0.1:8030/api/test/t/_stream_load
```

*  stream load with json format fails
```
curl --location-trusted  -u root:  -H "Expect:100-continue" -H "label:label4" \
    -H "strict_mode:true" -H "format: json" \
    -d "{\"c0\":1,\"c1\":{\"a\":11111111111111111111111111111111111111111111111111111111}}" \
    -XPUT http://127.0.0.1:8030/api/test/t/_stream_load

Error: Data quality error: Failed to parse value as json type, column=c1, error=The JSON element does not have the requested type.
be/src/exec/json_scanner.cpp:586 _construct_column(val, column.get(), _prev_parsed_position[key_index].type, _prev_parsed_position[key_index].key). Row: {"c0":1,"c1":{"a":11111111111111111111111111111111111111111111111111111111}}
```

stream load with json format  should also be successful

## What I'm doing:
The reason is that insert into and stream load with csv format uses velocypack to parse json, and it will convert big integer to double automatically. But stream load with json format uses simdjson to parse json, and it throws exception instead of converting big integer to double. To fix the problem, need to convert the big integer to double manually for simdjson

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
