### PR TITLE
[Enhancement] Make broker load pending task executor control by max_broker_load_job_concurrency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -751,6 +751,9 @@ public class GlobalStateMgr {
                 if (Config.max_broker_load_job_concurrency != loadingLoadTaskScheduler.getCorePoolSize()) {
                     loadingLoadTaskScheduler.setPoolSize(Config.max_broker_load_job_concurrency);
                 }
+                if (Config.max_broker_load_job_concurrency != pendingLoadTaskScheduler.getCorePoolSize()) {
+                    pendingLoadTaskScheduler.setPoolSize(Config.max_broker_load_job_concurrency);
+                }
             } catch (Exception e) {
                 LOG.warn("check config failed", e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
@@ -114,6 +114,25 @@ public class LeaderTaskExecutor {
         }
     }
 
+    public int getCorePoolSize() {
+        return executor.getCorePoolSize();
+    }
+
+    public void setPoolSize(int poolSize) {
+        // corePoolSize and maximumPoolSize are same.
+        // When the previous poolSize is larger than the poolSize to be set,
+        // you need to setCorePoolSize first and then setMaximumPoolSize, and vice versa.
+        // Otherwise, it will throw IllegalArgumentException
+        int prePoolSize = executor.getCorePoolSize();
+        if (poolSize < prePoolSize) {
+            executor.setCorePoolSize(poolSize);
+            executor.setMaximumPoolSize(poolSize);
+        } else {
+            executor.setMaximumPoolSize(poolSize);
+            executor.setCorePoolSize(poolSize);
+        }
+    }
+
     private class TaskChecker implements Runnable {
         @Override
         public void run() {

--- a/fe/fe-core/src/test/java/com/starrocks/task/LeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/LeaderTaskExecutorTest.java
@@ -70,6 +70,15 @@ public class LeaderTaskExecutorTest {
         }
     }
 
+    @Test
+    public void testPoolSize() {
+        int size = executor.getCorePoolSize();
+        executor.setPoolSize(size + 1);
+        Assert.assertEquals(size + 1, executor.getCorePoolSize());
+        executor.setPoolSize(size);
+        Assert.assertEquals(size, executor.getCorePoolSize());
+    }
+
     private class TestLeaderTask extends LeaderTask {
 
         public TestLeaderTask(long signature) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #49997

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

## Documentation PRs only:

If you are submitting a PR that adds or changes English documentation and have not
included Chinese documentation, then you can check the box to request GPT to translate the
English doc to Chinese. Please ensure to uncheck the **Do not translate** box if translation is needed.
The workflow will generate a new PR with the Chinese translation after this PR is merged.

- [ ] Yes, translate English markdown files with GPT
- [x] Do not translate
