### PR TITLE
[BugFix] Fix the bug of  AnalyticSinkOperator::set_finishing (backport #28125)

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -61,6 +61,12 @@ void AnalyticSinkOperator::close(RuntimeState* state) {
 
 Status AnalyticSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
+
+    // skip processing if cancelled
+    if (state->is_cancelled()) {
+        return Status::OK();
+    }
+
     _analytor->input_eos() = true;
     RETURN_IF_ERROR((this->*_process_by_partition_if_necessary)());
     _analytor->sink_complete();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
*** Aborted at 1724033491 (unix time) try "date -d @1724033491" if you are using GNU date ***
PC: @          0x2e22a51 starrocks::Analytor::current_chunk_size()
*** SIGSEGV (@0x0) received by PID 37179 (TID 0x2b2444db8700) from PID 0; stack trace: ***
    @          0x5c30f02 google::(anonymous namespace)::FailureSignalHandler()
    @     0x2b23aa3aa630 (unknown)
    @          0x2e22a51 starrocks::Analytor::current_chunk_size()
    @          0x30e3b0f starrocks::pipeline::AnalyticSinkOperator::_process_by_partition_if_necessary_for_unbounded_preceding_range_frame_streaming()
    @          0x30e3209 starrocks::pipeline::AnalyticSinkOperator::set_finishing()
    @          0x2db6969 starrocks::pipeline::PipelineDriver::_mark_operator_finishing()
    @          0x2db6a19 starrocks::pipeline::PipelineDriver::_mark_operator_finished()
    @          0x2db700b starrocks::pipeline::PipelineDriver::_mark_operator_cancelled()
    @          0x2db75fa starrocks::pipeline::PipelineDriver::cancel_operators()
    @          0x5206ef6 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x4be8fe2 starrocks::ThreadPool::dispatch_thread()
    @          0x4be3a7a starrocks::Thread::supervise_thread()
    @     0x2b23aa3a2ea5 start_thread
    @     0x2b23aadc3b0d __clone
    @                0x0 (unknown)
```

Backport some bugfix of #28125 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

