### PR TITLE
[BugFix] Fix aliyun.oss.access_key unusable

### DIFF
--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -420,21 +420,12 @@ static std::string build_fs_options_properties(const FSOptions& options) {
     static constexpr char PROP_SEPARATOR = 0x2;
     std::string data;
 
-    if (cloud_configuration != nullptr) {
-        if (cloud_configuration->__isset.cloud_properties) {
-            for (const auto& cloud_property : cloud_configuration->cloud_properties) {
-                data += cloud_property.key;
-                data += KV_SEPARATOR;
-                data += cloud_property.value;
-                data += PROP_SEPARATOR;
-            }
-        } else {
-            for (const auto& [key, value] : cloud_configuration->cloud_properties_v2) {
-                data += key;
-                data += KV_SEPARATOR;
-                data += value;
-                data += PROP_SEPARATOR;
-            }
+    if (cloud_configuration != nullptr && cloud_configuration->__isset.cloud_properties) {
+        for (const auto& [key, value] : cloud_configuration->cloud_properties) {
+            data += key;
+            data += KV_SEPARATOR;
+            data += value;
+            data += PROP_SEPARATOR;
         }
     }
 

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -61,7 +61,7 @@ public:
     static const AWSCloudConfiguration create_aws(const TCloudConfiguration& t_cloud_configuration) {
         DCHECK(t_cloud_configuration.__isset.cloud_type);
         DCHECK(t_cloud_configuration.cloud_type == TCloudType::AWS);
-        std::map<std::string, std::string> properties;
+        std::map<std::string, std::string> properties{};
         if (t_cloud_configuration.__isset.cloud_properties) {
             properties = t_cloud_configuration.cloud_properties;
         }
@@ -96,7 +96,7 @@ public:
     static const AliyunCloudConfiguration create_aliyun(const TCloudConfiguration& t_cloud_configuration) {
         DCHECK(t_cloud_configuration.__isset.cloud_type);
         DCHECK(t_cloud_configuration.cloud_type == TCloudType::ALIYUN);
-        std::map<std::string, std::string> properties;
+        std::map<std::string, std::string> properties{};
         if (t_cloud_configuration.__isset.cloud_properties) {
             properties = t_cloud_configuration.cloud_properties;
         }

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -61,8 +61,10 @@ public:
     static const AWSCloudConfiguration create_aws(const TCloudConfiguration& t_cloud_configuration) {
         DCHECK(t_cloud_configuration.__isset.cloud_type);
         DCHECK(t_cloud_configuration.cloud_type == TCloudType::AWS);
-        std::unordered_map<std::string, std::string> properties;
-        _insert_properties(properties, t_cloud_configuration);
+        std::map<std::string, std::string> properties;
+        if (t_cloud_configuration.__isset.cloud_properties) {
+            properties = t_cloud_configuration.cloud_properties;
+        }
 
         AWSCloudConfiguration aws_cloud_configuration{};
         AWSCloudCredential aws_cloud_credential{};
@@ -94,8 +96,10 @@ public:
     static const AliyunCloudConfiguration create_aliyun(const TCloudConfiguration& t_cloud_configuration) {
         DCHECK(t_cloud_configuration.__isset.cloud_type);
         DCHECK(t_cloud_configuration.cloud_type == TCloudType::ALIYUN);
-        std::unordered_map<std::string, std::string> properties;
-        _insert_properties(properties, t_cloud_configuration);
+        std::map<std::string, std::string> properties;
+        if (t_cloud_configuration.__isset.cloud_properties) {
+            properties = t_cloud_configuration.cloud_properties;
+        }
 
         AliyunCloudConfiguration aliyun_cloud_configuration{};
         AliyunCloudCredential aliyun_cloud_credential{};
@@ -109,22 +113,9 @@ public:
     }
 
 private:
-    static void _insert_properties(std::unordered_map<std::string, std::string>& properties,
-                                   const TCloudConfiguration& t_cloud_configuration) {
-        if (t_cloud_configuration.__isset.deprecated_cloud_properties) {
-            for (const auto& property : t_cloud_configuration.deprecated_cloud_properties) {
-                properties.insert({property.key, property.value});
-            }
-        } else {
-            DCHECK(t_cloud_configuration.__isset.cloud_properties);
-            properties.insert(t_cloud_configuration.cloud_properties.begin(),
-                              t_cloud_configuration.cloud_properties.end());
-        }
-    }
-
     template <typename ReturnType>
-    static ReturnType get_or_default(const std::unordered_map<std::string, std::string>& properties,
-                                     const std::string& key, ReturnType default_value) {
+    static ReturnType get_or_default(const std::map<std::string, std::string>& properties, const std::string& key,
+                                     ReturnType default_value) {
         auto it = properties.find(key);
         if (it != properties.end()) {
             std::string value = it->second;

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -111,14 +111,14 @@ public:
 private:
     static void _insert_properties(std::unordered_map<std::string, std::string>& properties,
                                    const TCloudConfiguration& t_cloud_configuration) {
-        if (t_cloud_configuration.__isset.cloud_properties) {
-            for (const auto& property : t_cloud_configuration.cloud_properties) {
+        if (t_cloud_configuration.__isset.deprecated_cloud_properties) {
+            for (const auto& property : t_cloud_configuration.deprecated_cloud_properties) {
                 properties.insert({property.key, property.value});
             }
         } else {
-            DCHECK(t_cloud_configuration.__isset.cloud_properties_v2);
-            properties.insert(t_cloud_configuration.cloud_properties_v2.begin(),
-                              t_cloud_configuration.cloud_properties_v2.end());
+            DCHECK(t_cloud_configuration.__isset.cloud_properties);
+            properties.insert(t_cloud_configuration.cloud_properties.begin(),
+                              t_cloud_configuration.cloud_properties.end());
         }
     }
 

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -27,7 +27,6 @@ namespace starrocks {
 // TODO(SmithCruise): Should remove when using cpp sdk
 static const std::map<std::string, std::string> get_cloud_properties(const FSOptions& options) {
     const TCloudConfiguration* cloud_configuration = nullptr;
-    std::map<std::string, std::string> properties;
     if (options.cloud_configuration != nullptr) {
         // This branch is used by data lake
         cloud_configuration = options.cloud_configuration;
@@ -35,17 +34,10 @@ static const std::map<std::string, std::string> get_cloud_properties(const FSOpt
         // This branch is used by broker load
         cloud_configuration = &options.hdfs_properties()->cloud_configuration;
     }
-    if (cloud_configuration != nullptr) {
-        if (cloud_configuration->__isset.cloud_properties) {
-            for (const auto& cloud_property : cloud_configuration->cloud_properties) {
-                properties.insert({cloud_property.key, cloud_property.value});
-            }
-            return properties;
-        } else {
-            return cloud_configuration->cloud_properties_v2;
-        }
+    if (cloud_configuration != nullptr && cloud_configuration->__isset.cloud_properties) {
+        return cloud_configuration->cloud_properties;
     }
-    return properties;
+    return {};
 }
 
 static Status create_hdfs_fs_handle(const std::string& namenode, const std::shared_ptr<HdfsFsClient>& hdfs_client,

--- a/be/test/exec/jni_scanner_test.cpp
+++ b/be/test/exec/jni_scanner_test.cpp
@@ -45,7 +45,7 @@ public:
         thrift_from_json_string(base, data);
     }
 
-    void init_fs_options(FSOptions* options, bool v2 = false) {
+    void init_fs_options(FSOptions* options) {
         TCloudConfiguration* cloud_configuration = _pool.add(new TCloudConfiguration());
         options->cloud_configuration = cloud_configuration;
         std::map<std::string, std::string> kvs = {
@@ -53,18 +53,7 @@ public:
                 {"yyy", "yyy0"},
                 {"zzz", "zzz0"},
         };
-        if (v2) {
-            cloud_configuration->__set_cloud_properties(kvs);
-        } else {
-            std::vector<TCloudProperty> props;
-            for (const auto& kv : kvs) {
-                TCloudProperty prop;
-                prop.key = kv.first;
-                prop.value = kv.second;
-                props.push_back(prop);
-            }
-            cloud_configuration->__set_deprecated_cloud_properties(props);
-        }
+        cloud_configuration->__set_cloud_properties(kvs);
     }
 
     void init_hdfs_scanner_context(HdfsScannerContext* ctx, TupleDescriptor* tuple_desc) {
@@ -292,7 +281,7 @@ TEST_F(JniScannerTest, test_create_hive_jni_scanner) {
 
     {
         FSOptions fs_options;
-        init_fs_options(&fs_options, true);
+        init_fs_options(&fs_options);
         options.fs_options = &fs_options;
 
         auto scanner = create_hive_jni_scanner(options);

--- a/be/test/exec/jni_scanner_test.cpp
+++ b/be/test/exec/jni_scanner_test.cpp
@@ -54,7 +54,7 @@ public:
                 {"zzz", "zzz0"},
         };
         if (v2) {
-            cloud_configuration->__set_cloud_properties_v2(kvs);
+            cloud_configuration->__set_cloud_properties(kvs);
         } else {
             std::vector<TCloudProperty> props;
             for (const auto& kv : kvs) {
@@ -63,7 +63,7 @@ public:
                 prop.value = kv.second;
                 props.push_back(prop);
             }
-            cloud_configuration->__set_cloud_properties(props);
+            cloud_configuration->__set_deprecated_cloud_properties(props);
         }
     }
 

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -561,7 +561,7 @@ TEST_F(S3FileSystemTest, test_new_S3_client_with_rename_operation) {
     test_properties[AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR] = "true";
     TCloudConfiguration tCloudConfiguration;
     tCloudConfiguration.__set_cloud_type(TCloudType::AWS);
-    tCloudConfiguration.__set_cloud_properties_v2(test_properties);
+    tCloudConfiguration.__set_cloud_properties(test_properties);
     auto cloud_config = CloudConfigurationFactory::create_aws(tCloudConfiguration);
 
     config.requestTimeoutMs = config::object_storage_rename_file_request_timeout_ms;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -27,6 +27,7 @@ import com.starrocks.credential.aliyun.AliyunCloudConfiguration;
 import com.starrocks.credential.aliyun.AliyunCloudCredential;
 import com.starrocks.credential.aws.AWSCloudConfiguration;
 import com.starrocks.credential.aws.AWSCloudCredential;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
@@ -129,7 +130,9 @@ public class PaimonConnector implements Connector {
 
     public Catalog getPaimonNativeCatalog() {
         if (paimonNativeCatalog == null) {
-            this.paimonNativeCatalog = CatalogFactory.createCatalog(CatalogContext.create(getPaimonOptions()));
+            Configuration configuration = new Configuration();
+            hdfsEnvironment.getCloudConfiguration().applyToConfiguration(configuration);
+            this.paimonNativeCatalog = CatalogFactory.createCatalog(CatalogContext.create(getPaimonOptions(), configuration));
         }
         return paimonNativeCatalog;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
@@ -39,7 +39,7 @@ public class CloudConfiguration {
         properties.put(HadoopExt.HADOOP_RUNTIME_JARS, runtimeJars);
         properties.put(HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING, toConfString());
         properties.put(HadoopExt.HADOOP_USERNAME, hadoopUsername);
-        tCloudConfiguration.setCloud_properties_v2(properties);
+        tCloudConfiguration.setCloud_properties(properties);
     }
 
     public void applyToConfiguration(Configuration configuration) {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
@@ -38,12 +38,12 @@ public class AliyunCloudConfiguration extends CloudConfiguration {
         return aliyunCloudCredential;
     }
 
-    // reuse aws client logic of BE
     @Override
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
         super.toThrift(tCloudConfiguration);
+        // reuse aws client logic of BE
         tCloudConfiguration.setCloud_type(TCloudType.AWS);
-        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties();
         properties.put(CloudConfigurationConstants.AWS_S3_ENABLE_SSL, String.valueOf(true));
         aliyunCloudCredential.toThrift(properties);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudCredential.java
@@ -19,6 +19,8 @@ import com.staros.proto.FileStoreInfo;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.CloudCredential;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
 
 import java.util.Map;
 
@@ -51,11 +53,10 @@ public class AliyunCloudCredential implements CloudCredential {
 
     @Override
     public void applyToConfiguration(Configuration configuration) {
-        configuration.set("fs.oss.impl", "com.aliyun.jindodata.oss.JindoOssFileSystem");
-        configuration.set("fs.AbstractFileSystem.oss.impl", "com.aliyun.jindodata.oss.OSS");
-        configuration.set("fs.oss.accessKeyId", accessKey);
-        configuration.set("fs.oss.accessKeySecret", secretKey);
-        configuration.set("fs.oss.endpoint", endpoint);
+        configuration.set("fs.oss.impl", S3AFileSystem.class.getName());
+        configuration.set(Constants.ACCESS_KEY, accessKey);
+        configuration.set(Constants.SECRET_KEY, secretKey);
+        configuration.set(Constants.ENDPOINT, endpoint);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
@@ -21,6 +21,8 @@ import com.starrocks.credential.CloudType;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
 
 import java.util.Map;
 
@@ -65,25 +67,26 @@ public class AWSCloudConfiguration extends CloudConfiguration {
     @Override
     public void applyToConfiguration(Configuration configuration) {
         super.applyToConfiguration(configuration);
-        configuration.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        configuration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        configuration.set("fs.s3n.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        final String S3AFileSystem = S3AFileSystem.class.getName();
+        configuration.set("fs.s3.impl", S3AFileSystem);
+        configuration.set("fs.s3a.impl", S3AFileSystem);
+        configuration.set("fs.s3n.impl", S3AFileSystem);
         // Below storage using s3 compatible storage api
-        configuration.set("fs.oss.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        configuration.set("fs.ks3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        configuration.set("fs.obs.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        configuration.set("fs.tos.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        configuration.set("fs.cosn.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        configuration.set("fs.oss.impl", S3AFileSystem);
+        configuration.set("fs.ks3.impl", S3AFileSystem);
+        configuration.set("fs.obs.impl", S3AFileSystem);
+        configuration.set("fs.tos.impl", S3AFileSystem);
+        configuration.set("fs.cosn.impl", S3AFileSystem);
 
         // By default, S3AFileSystem will need 4 minutes to timeout when endpoint is unreachable,
         // after change, it will need 30 seconds.
         // Default value is 7.
-        configuration.set("fs.s3a.retry.limit", "3");
+        configuration.set(Constants.RETRY_LIMIT, "3");
         // Default value is 20
-        configuration.set("fs.s3a.attempts.maximum", "5");
+        configuration.set(Constants.MAX_ERROR_RETRIES, "5");
 
-        configuration.set("fs.s3a.path.style.access", String.valueOf(enablePathStyleAccess));
-        configuration.set("fs.s3a.connection.ssl.enabled", String.valueOf(enableSSL));
+        configuration.set(Constants.PATH_STYLE_ACCESS, String.valueOf(enablePathStyleAccess));
+        configuration.set(Constants.SECURE_CONNECTIONS, String.valueOf(enableSSL));
         awsCloudCredential.applyToConfiguration(configuration);
     }
 
@@ -120,7 +123,7 @@ public class AWSCloudConfiguration extends CloudConfiguration {
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
         super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AWS);
-        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties();
         properties.put(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS,
                 String.valueOf(enablePathStyleAccess));
         properties.put(CloudConfigurationConstants.AWS_S3_ENABLE_SSL, String.valueOf(enableSSL));

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
@@ -35,9 +35,9 @@ public class AzureCloudConfiguration extends CloudConfiguration {
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
         super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AZURE);
-        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties();
         azureStorageCloudCredential.toThrift(properties);
-        tCloudConfiguration.setCloud_properties_v2(properties);
+        tCloudConfiguration.setCloud_properties(properties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -21,6 +21,10 @@ import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.starrocks.credential.CloudCredential;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.adl.AdlConfKeys;
+import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
+import org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider;
+import org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -152,13 +156,13 @@ class AzureADLS1CloudCredential extends AzureStorageCloudCredential {
     @Override
     void tryGenerateConfigurationMap() {
         if (useManagedServiceIdentity) {
-            generatedConfigurationMap.put("fs.adl.oauth2.access.token.provider.type", "Msi");
+            generatedConfigurationMap.put(AdlConfKeys.AZURE_AD_TOKEN_PROVIDER_TYPE_KEY, "Msi");
         } else if (!oauth2ClientId.isEmpty() && !oauth2Credential.isEmpty() &&
                 !oauth2Endpoint.isEmpty()) {
-            generatedConfigurationMap.put("fs.adl.oauth2.access.token.provider.type", "ClientCredential");
-            generatedConfigurationMap.put("fs.adl.oauth2.client.id", oauth2ClientId);
-            generatedConfigurationMap.put("fs.adl.oauth2.credential", oauth2Credential);
-            generatedConfigurationMap.put("fs.adl.oauth2.refresh.url", oauth2Endpoint);
+            generatedConfigurationMap.put(AdlConfKeys.AZURE_AD_TOKEN_PROVIDER_TYPE_KEY, "ClientCredential");
+            generatedConfigurationMap.put(AdlConfKeys.AZURE_AD_CLIENT_ID_KEY, oauth2ClientId);
+            generatedConfigurationMap.put(AdlConfKeys.AZURE_AD_CLIENT_SECRET_KEY, oauth2Credential);
+            generatedConfigurationMap.put(AdlConfKeys.AZURE_AD_REFRESH_URL_KEY, oauth2Endpoint);
         }
     }
 
@@ -211,11 +215,15 @@ class AzureADLS2CloudCredential extends AzureStorageCloudCredential {
     @Override
     void tryGenerateConfigurationMap() {
         if (oauth2ManagedIdentity && !oauth2TenantId.isEmpty() && !oauth2ClientId.isEmpty()) {
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.auth.type"), "OAuth");
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.oauth.provider.type"),
-                    "org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider");
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.oauth2.msi.tenant"), oauth2TenantId);
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.oauth2.client.id"), oauth2ClientId);
+            generatedConfigurationMap.put(createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME),
+                    "OAuth");
+            generatedConfigurationMap.put(
+                    createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME),
+                    MsiTokenProvider.class.getName());
+            generatedConfigurationMap.put(createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT),
+                    oauth2TenantId);
+            generatedConfigurationMap.put(createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID),
+                    oauth2ClientId);
         } else if (!storageAccount.isEmpty() && !sharedKey.isEmpty()) {
             // Shared Key is always used by specific storage account, so we don't need to invoke createConfigKey()
             generatedConfigurationMap.put(
@@ -226,12 +234,17 @@ class AzureADLS2CloudCredential extends AzureStorageCloudCredential {
                     sharedKey);
         } else if (!oauth2ClientId.isEmpty() && !oauth2ClientSecret.isEmpty() &&
                 !oauth2ClientEndpoint.isEmpty()) {
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.auth.type"), "OAuth");
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.oauth.provider.type"),
-                    "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider");
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.oauth2.client.id"), oauth2ClientId);
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.oauth2.client.secret"), oauth2ClientSecret);
-            generatedConfigurationMap.put(createConfigKey("fs.azure.account.oauth2.client.endpoint"), oauth2ClientEndpoint);
+            generatedConfigurationMap.put(createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME),
+                    "OAuth");
+            generatedConfigurationMap.put(
+                    createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME),
+                    ClientCredsTokenProvider.class.getName());
+            generatedConfigurationMap.put(createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID),
+                    oauth2ClientId);
+            generatedConfigurationMap.put(createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_CLIENT_SECRET),
+                    oauth2ClientSecret);
+            generatedConfigurationMap.put(createConfigKey(ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_CLIENT_ENDPOINT),
+                    oauth2ClientEndpoint);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
@@ -37,9 +37,9 @@ public class GCPCloudConfiguration extends CloudConfiguration {
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
         super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AZURE);
-        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties();
         gcpCloudCredential.toThrift(properties);
-        tCloudConfiguration.setCloud_properties_v2(properties);
+        tCloudConfiguration.setCloud_properties(properties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
@@ -41,7 +41,7 @@ public class HDFSCloudConfiguration extends CloudConfiguration {
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
         super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.HDFS);
-        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties();
         hdfsCloudCredential.toThrift(properties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/tencent/TencentCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/tencent/TencentCloudConfiguration.java
@@ -38,7 +38,7 @@ public class TencentCloudConfiguration extends CloudConfiguration {
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
         super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AWS);
-        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties();
         properties.put(CloudConfigurationConstants.AWS_S3_ENABLE_SSL, String.valueOf(true));
         tencentCloudCredential.toThrift(properties);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -171,6 +171,49 @@ public class CloudConfigurationFactoryTest {
     }
 
     @Test
+    public void testAzureADLS2ManagedIdentity() {
+        Map<String, String> map = new HashMap<>() {
+            {
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT, "endpoint");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET, "client-secret");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID, "client-id");
+            }
+        };
+
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.AZURE);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        Assert.assertEquals("OAuth", conf.get("fs.azure.account.auth.type"));
+        Assert.assertEquals("org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
+                conf.get("fs.azure.account.oauth.provider.type"));
+        Assert.assertEquals("client-secret", conf.get("fs.azure.account.oauth2.client.secret"));
+        Assert.assertEquals("client-id", conf.get("fs.azure.account.oauth2.client.id"));
+        Assert.assertEquals("endpoint", conf.get("fs.azure.account.oauth2.client.endpoint"));
+    }
+
+    @Test
+    public void testAzureADLS2Oauth2() {
+        Map<String, String> map = new HashMap<>() {
+            {
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY, "true");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID, "client-id");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID, "tenant-id");
+            }
+        };
+
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.AZURE);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        Assert.assertEquals("OAuth", conf.get("fs.azure.account.auth.type"));
+        Assert.assertEquals("org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider",
+                conf.get("fs.azure.account.oauth.provider.type"));
+        Assert.assertEquals("tenant-id", conf.get("fs.azure.account.oauth2.msi.tenant"));
+        Assert.assertEquals("client-id", conf.get("fs.azure.account.oauth2.client.id"));
+    }
+
+    @Test
     public void testGCPCloudConfiguration() {
         Map<String, String> map = new HashMap<String, String>() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -61,8 +61,8 @@ public class CloudConfigurationFactoryTest {
         Assert.assertEquals(cc.getCloudType(), CloudType.AWS);
         TCloudConfiguration tc = new TCloudConfiguration();
         cc.toThrift(tc);
-        Assert.assertEquals(tc.getCloud_properties_v2().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
-        Assert.assertEquals(tc.getCloud_properties_v2().get(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS),
+        Assert.assertEquals(tc.getCloud_properties().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
+        Assert.assertEquals(tc.getCloud_properties().get(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS),
                 "false");
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
@@ -88,7 +88,7 @@ public class CloudConfigurationFactoryTest {
         Assert.assertEquals(cc.getCloudType(), CloudType.ALIYUN);
         TCloudConfiguration tc = new TCloudConfiguration();
         cc.toThrift(tc);
-        Assert.assertEquals(tc.getCloud_properties_v2().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
+        Assert.assertEquals(tc.getCloud_properties().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
@@ -237,7 +237,7 @@ public class CloudConfigurationFactoryTest {
         Assert.assertEquals(cc.getCloudType(), CloudType.TENCENT);
         TCloudConfiguration tc = new TCloudConfiguration();
         cc.toThrift(tc);
-        Assert.assertEquals(tc.getCloud_properties_v2().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
+        Assert.assertEquals(tc.getCloud_properties().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();

--- a/gensrc/thrift/CloudConfiguration.thrift
+++ b/gensrc/thrift/CloudConfiguration.thrift
@@ -32,6 +32,6 @@ struct TCloudProperty {
 
 struct TCloudConfiguration {
     1: optional TCloudType cloud_type;
-    2: optional list<TCloudProperty> cloud_properties; // Deprecated
-    3: optional map<string, string> cloud_properties_v2;
+    2: optional list<TCloudProperty> deprecated_cloud_properties; // Deprecated
+    3: optional map<string, string> cloud_properties;
 }


### PR DESCRIPTION
## Why I'm doing:
Fix aliyun.oss.access_key unusable

## What I'm doing:
Because of aliyun jindo jar is removed, `aliyun.oss.access_key` is unusable.
Remove deprecated_cloud_configuration

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
