### PR TITLE
[Enhancement] support invalidate lake compaction with in queue time considered

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -70,6 +70,16 @@ public:
 
     bool allow_partial_success() const;
 
+    void set_last_check_time(int64_t now) {
+        std::lock_guard l(_mtx);
+        _last_check_time = now;
+    }
+
+    int64_t last_check_time() const {
+        std::lock_guard l(_mtx);
+        return _last_check_time;
+    }
+
 private:
     const static int64_t kDefaultTimeoutMs = 24L * 60 * 60 * 1000; // 1 day
 
@@ -80,6 +90,9 @@ private:
     ::google::protobuf::Closure* _done;
     Status _status;
     int64_t _timeout_deadline_ms;
+    // compaction's last check time in second, initialized when first put into task queue,
+    // used to help check whether it's valid periodically, task's in queue time is considered
+    int64_t _last_check_time;
     std::vector<std::unique_ptr<CompactionTaskContext>> _contexts;
 };
 

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -80,7 +80,6 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     std::atomic<int> runs{0};
     // the first tablet of a compaction request, will ask FE periodically to see if compaction is valid
     bool is_checker;
-    int64_t last_check_time = INT64_MAX;
     Status status;
     Progress progress;
     std::shared_ptr<CompactionTaskCallback> callback;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -483,8 +483,8 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
                     not_used_segments->second.begin(),
                     segments->begin() + metadata().next_compaction_offset() + _compaction_segment_limit,
                     segments->end());
-            LOG(INFO) << "tablet: " << tablet_id() << ", version: " << version() << ", rowset: " << metadata().id()
-                      << ", total segments: " << metadata().segments_size()
+            LOG(INFO) << "tablet: " << tablet_id() << ", version: " << _tablet_metadata->version()
+                      << ", rowset: " << metadata().id() << ", total segments: " << metadata().segments_size()
                       << ", compacted segments: " << not_used_segments->first.size()
                       << ", uncompacted segments: " << not_used_segments->second.size();
         }

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -120,7 +120,7 @@ TEST_F(LakeCompactionSchedulerTest, test_compaction_cancel) {
     {
         auto cb = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, nullptr);
         CompactionTaskContext ctx(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */, true /* is_checker */, cb);
-        ctx.last_check_time = 0;
+        cb->set_last_check_time(0);
         EXPECT_TRUE(compaction_should_cancel(&ctx).ok());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

if a compaction stays in queue for a long time, support aborting it immediately when it starts to execute in case this compaction is invalid in FE.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
