### PR TITLE
[BugFix] Fix get error tablet schema during query.

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -400,61 +400,6 @@ Status OlapChunkSource::_prune_schema_by_access_paths(Schema* schema) {
     return Status::OK();
 }
 
-// Temporary fix solution, add some check
-// In the vast majority of cases, a schema id can identify an unique tablet schema.
-// However, there are still scenarios where the same schema ID maps to different tablet schemas.
-// e.g.
-// 1. create table in old version sr which has three columns, with the column names and unique IDs being:
-//    {c1:1, c2:3, c3:2} and tablet schema id is 'x'
-// 2. do some replace partition operations such as optimize table. Because the table is created in old version,
-//    the unique is is assigned by BE. So the new created tablet schema is {c1:1, c2:2, c3:3} and schema id is
-//    'x'
-// 3. when we try to insert a new tablet schema with id is 'x' into `GlobalTableSchemaMap', we will check the
-//    the column unique id. If check failed, we do not update the `GlobalTableSchemaMap' but new a new tablet
-//    schema to the new tablet.
-// 4. when we init olap_reader, the `schema_id` assigned by FE is 'x', we try to get the tablet schema from
-//    'GlobalSchemaMap' which maybe not correct.
-void OlapChunkSource::_check_tablet_schema() {
-    if (_tablet_schema == nullptr) {
-        return;
-    }
-
-    bool schema_mismatch = false;
-    if (_scan_node->thrift_olap_scan_node().__isset.columns_desc &&
-        !_scan_node->thrift_olap_scan_node().columns_desc.empty() &&
-        _scan_node->thrift_olap_scan_node().columns_desc[0].col_unique_id >= 0) {
-
-        if (_tablet_schema->num_columns() != _scan_node->thrift_olap_scan_node().columns_desc.size()) {
-            schema_mismatch = true;
-        } else {
-            for (int32_t i = 0; i < _tablet_schema->num_columns(); i++) {
-                if (_scan_node->thrift_olap_scan_node().columns_desc[i].col_unique_id !=
-                    _tablet_schema->column(i).unique_id()) {
-                    schema_mismatch = true;
-                    break;
-                }
-            }
-        }
-        
-    } else {
-        auto tmp_schema = _tablet->tablet_schema();
-        if (_tablet_schema->num_columns() != tmp_schema->num_columns()) {
-            schema_mismatch = true;
-        } else {
-            for (int32_t i = 0; i < _tablet_schema->num_columns(); i++) {
-                if (tmp_schema->column(i).unique_id() != _tablet_schema->column(i).unique_id()) {
-                    schema_mismatch = true;
-                    break;
-                }
-            }
-        }
-    }
-
-    if (schema_mismatch) {
-        _tablet_schema.reset();
-    }
-}
-
 Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();
     // output columns of `this` OlapScanner, i.e, the final output columns of `get_chunk`.
@@ -467,10 +412,10 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_QUERY, _scan_range->tablet_id);
 
     // schema_id that not greater than 0 is invalid
-    if (_scan_node->thrift_olap_scan_node().__isset.schema_id && _scan_node->thrift_olap_scan_node().schema_id > 0) {
-        _tablet_schema = GlobalTabletSchemaMap::Instance()->get(_scan_node->thrift_olap_scan_node().schema_id);
+    if (_scan_node->thrift_olap_scan_node().__isset.schema_id && _scan_node->thrift_olap_scan_node().schema_id > 0 &&
+        _scan_node->thrift_olap_scan_node().schema_id == _tablet->tablet_schema()->id()) {
+        _tablet_schema = _tablet->tablet_schema();
     }
-    _check_tablet_schema();
 
     if (_tablet_schema == nullptr) {
         // if column_desc come from fe, reset tablet schema

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -68,6 +68,7 @@ private:
     void _decide_chunk_size(bool has_predicate);
     Status _init_column_access_paths(Schema* schema);
     Status _prune_schema_by_access_paths(Schema* schema);
+    void _check_tablet_schema();
 
 private:
     TabletReaderParams _params{};

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -68,7 +68,6 @@ private:
     void _decide_chunk_size(bool has_predicate);
     Status _init_column_access_paths(Schema* schema);
     Status _prune_schema_by_access_paths(Schema* schema);
-    void _check_tablet_schema();
 
 private:
     TabletReaderParams _params{};


### PR DESCRIPTION
## Why I'm doing:
This pr(https://github.com/StarRocks/starrocks/pull/48485) try to get a tablet schema from `GlobalTableSchemaMap` according to a unique `schema_id` to avoid coping tablet schema during query. However, there are some scenarios where the same schema ID maps to different tablet schemas.
e.g.
1. create table in old version sr which has three columns, with the column names and unique IDs being:  {c1:1, c2:3, c3:2} and tablet schema id is 'x'
2. do some replace partition operations such as optimize table. Because the table is created in old version, the unique is is assigned by BE. So the new created tablet schema is {c1:1, c2:2, c3:3} and schema id is  'x'
3. when we try to insert a new tablet schema with id is 'x' into `GlobalTableSchemaMap`, we will check the the column unique id. If check failed, we do not update the `GlobalTableSchemaMap` but create a new tablet schema to the new tablet.
4. when we init olap_reader, the `schema_id` assigned by FE is 'x', we try to get the tablet schema from 'GlobalSchemaMap` which maybe not correct.


## What I'm doing:
Do not get tablet schema from `GlobalSchemaMap` and get tablet schema from `tablet` directly when we found the `schema_id` is equal.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8385

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
