### PR TITLE
[BugFix] Fix get error tablet schema during query(backport #49977)

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -305,8 +305,9 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
 
     auto scope = IOProfiler::scope(IOProfiler::TAG_QUERY, _scan_range->tablet_id);
 
-    if (_scan_node->thrift_olap_scan_node().__isset.schema_id) {
-        _tablet_schema = GlobalTabletSchemaMap::Instance()->get(_scan_node->thrift_olap_scan_node().schema_id);
+    if (_scan_node->thrift_olap_scan_node().__isset.schema_id && _scan_node->thrift_olap_scan_node().schema_id > 0 &&
+        _scan_node->thrift_olap_scan_node().schema_id == _tablet->tablet_schema()->id()) {
+        _tablet_schema = _tablet->tablet_schema();
     }
 
     if (_tablet_schema == nullptr) {


### PR DESCRIPTION
## Why I'm doing:
This pr(https://github.com/StarRocks/starrocks/pull/48485) try to get a tablet schema from `GlobalTableSchemaMap` according to a unique `schema_id` to avoid coping tablet schema during query. However, there are some scenarios where the same schema ID maps to different tablet schemas.
e.g.
1. create table in old version sr which has three columns, with the column names and unique IDs being:  {c1:1, c2:3, c3:2} and tablet schema id is 'x'
2. do some replace partition operations such as optimize table. Because the table is created in old version, the unique is is assigned by BE. So the new created tablet schema is {c1:1, c2:2, c3:3} and schema id is  'x'
3. when we try to insert a new tablet schema with id is 'x' into `GlobalTableSchemaMap`, we will check the the column unique id. If check failed, we do not update the `GlobalTableSchemaMap` but create a new tablet schema to the new tablet.
4. when we init olap_reader, the `schema_id` assigned by FE is 'x', we try to get the tablet schema from 'GlobalSchemaMap` which maybe not correct.


## What I'm doing:
Do not get tablet schema from `GlobalSchemaMap` and get tablet schema from `tablet` directly when we found the `schema_id` is equal.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8385

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

