### PR TITLE
[BugFix] Revert useMetadataCache to true after executing the insert q…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -346,7 +346,6 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         }
         List<PartitionInfo> hivePartitions;
         try {
-            useMetadataCache = true;
             hivePartitions = GlobalStateMgr.getCurrentState().getMetadataMgr()
                     .getPartitions(this.getCatalogName(), this, partitionNames);
         } catch (StarRocksConnectorException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -202,7 +202,7 @@ public class RemoteFileOperations {
             final Object attachment = (attachments != null) ? attachments.get(i) : null;
             pathKey.setScanContext(scanContext);
             tasks.add(() -> {
-                Map<RemotePathKey, List<RemoteFileDesc>> res = remoteFileIO.getRemoteFiles(pathKey);
+                Map<RemotePathKey, List<RemoteFileDesc>> res = remoteFileIO.getRemoteFiles(pathKey, params.isUseCache());
                 List<RemoteFileDesc> files = res.get(pathKey);
                 RemoteFileInfo remoteFileInfo = buildRemoteFileInfo(partition, files);
                 remoteFileInfo.setAttachment(attachment);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -54,7 +54,6 @@ import com.starrocks.analysis.UserVariableHint;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalOlapTable;
-import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.ResourceGroup;
@@ -749,16 +748,6 @@ public class StmtExecutor {
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
             if (context.getState().isError() && coord != null) {
                 coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, context.getState().getErrorMessage());
-            }
-
-            if (parsedStmt instanceof InsertStmt) {
-                // Revert useMetadataCache to true after executing the insert query that
-                // insert into target_table select from hive_table.
-                InsertStmt insertStmt = (InsertStmt) parsedStmt;
-                List<Table> tables = new ArrayList<>();
-                AnalyzerUtils.collectSpecifyExternalTables(insertStmt.getQueryStatement(), tables, Table::isHiveTable);
-                tables.stream().map(table -> (HiveTable) table)
-                         .forEach(table -> table.useMetadataCache(true));
             }
 
             if (parsedStmt != null && parsedStmt.isExistQueryScopeHint()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -54,6 +54,7 @@ import com.starrocks.analysis.UserVariableHint;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalOlapTable;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.ResourceGroup;
@@ -748,6 +749,16 @@ public class StmtExecutor {
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
             if (context.getState().isError() && coord != null) {
                 coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, context.getState().getErrorMessage());
+            }
+
+            if (parsedStmt instanceof InsertStmt) {
+                // Revert useMetadataCache to true after executing the insert query that
+                // insert into target_table select from hive_table.
+                InsertStmt insertStmt = (InsertStmt) parsedStmt;
+                List<Table> tables = new ArrayList<>();
+                AnalyzerUtils.collectSpecifyExternalTables(insertStmt.getQueryStatement(), tables, Table::isHiveTable);
+                tables.stream().map(table -> (HiveTable) table)
+                         .forEach(table -> table.useMetadataCache(true));
             }
 
             if (parsedStmt != null && parsedStmt.isExistQueryScopeHint()) {


### PR DESCRIPTION
## Why I'm doing:
This pr(https://github.com/StarRocks/starrocks/pull/22272) try to disable the Hive metadata cache when the hiveTable is used as a queryRelation in the insert statement. However, this approach did not work as expected.

## What I'm doing:

Revert useMetadataCache to true after executing the insert query that insert into target_table select from hive_table.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
