### PR TITLE
[Enhancement] update config rocksdb_opt_delete_range_limit

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1379,7 +1379,7 @@ CONF_mInt32(unused_crm_file_threshold_second, "86400" /** 1day **/);
 
 // When the keys that we want to delete, number of them is larger than this config,
 // we will fallback and using `DeleteRange` in rocksdb.
-CONF_mInt32(rocksdb_opt_delete_range_limit, "10000");
+CONF_mInt32(rocksdb_opt_delete_range_limit, "500");
 
 // python envs config
 // create time worker timeout

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -342,20 +342,18 @@ Status KVStore::OptDeleteRange(ColumnFamilyIndex column_family_index, const std:
                                const std::string& end_key, WriteBatch* batch) {
     rocksdb::ColumnFamilyHandle* handle = _handles[column_family_index];
     int key_cnt = 0;
-    return iterate_range(column_family_index, begin_key, end_key, [&](std::string_view key, std::string_view value) {
-        if (key_cnt >= config::rocksdb_opt_delete_range_limit) {
-            // fallback and use `DeleteRange` instead.
-            batch->Clear();
-            auto st = batch->DeleteRange(handle, begin_key, end_key);
-            if (!st.ok()) {
-                return to_status(st);
-            }
-            return false;
-        }
-        batch->Delete(handle, key);
-        key_cnt++;
-        return true;
-    });
+    return iterate_range(column_family_index, begin_key, end_key,
+                         [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
+                             if (key_cnt >= config::rocksdb_opt_delete_range_limit) {
+                                 // fallback and use `DeleteRange` instead.
+                                 batch->Clear();
+                                 RETURN_ERROR_IF_FALSE(batch->DeleteRange(handle, begin_key, end_key).ok());
+                                 return false;
+                             }
+                             batch->Delete(handle, key);
+                             key_cnt++;
+                             return true;
+                         });
 }
 
 } // namespace starrocks

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -346,7 +346,10 @@ Status KVStore::OptDeleteRange(ColumnFamilyIndex column_family_index, const std:
         if (key_cnt >= config::rocksdb_opt_delete_range_limit) {
             // fallback and use `DeleteRange` instead.
             batch->Clear();
-            batch->DeleteRange(handle, begin_key, end_key);
+            auto st = batch->DeleteRange(handle, begin_key, end_key);
+            if (!st.ok()) {
+                return to_status(st);
+            }
             return false;
         }
         batch->Delete(handle, key);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. After test, we found that when try to batch delete keys which are more than 500, better to use `BatchDelete`.
2. Handle error status return by `DeleteRange`.

## Test
1. Import a range of [0, N), a total of N key value (size 1KB) values.
3. Perform the following steps 100 times and get the total elapsed time:
     a. Delete M keys.
     b. perform `Get` K times from a random location.
  

M/N/K | OptDeleteRanage | DeleteRange
-- | -- | --
100/3000000/10 | 32ms | 41ms
500/3000000/10 | 94ms | 22ms
1000/3000000/10 | 188ms | 19ms
10000/3000000/10 | 1383ms | 16ms
100/3000000/100 | 201ms | 208ms
500/3000000/100 | 136ms | 188ms
1000/3000000/100 | 273ms | 173ms
10000/3000000/100 | 1416ms | 146ms
100/3000000/1000 | 441ms | 1783ms
500/3000000/1000 | 386ms | 1794ms
1000/3000000/1000 | 365ms | 1606ms
10000/3000000/1000 | 1419ms | 1532ms

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
