### PR TITLE
[UT] Make test_resource_group_big_query stable

### DIFF
--- a/test/sql/test_resource_group/R/test_resource_group_big_query
+++ b/test/sql/test_resource_group/R/test_resource_group_big_query
@@ -45,6 +45,16 @@ create resource group rg_${uuid0}
 with w1 as (select * from t1 union all select * from t1 
     union all select * from t1 union all select * from t1 
     union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
     union all select * from t1 union all select * from t1)
 select /*+SET_VAR(resource_group='rg_${uuid0}')*/ count(1) from w1;
 -- result:

--- a/test/sql/test_resource_group/T/test_resource_group_big_query
+++ b/test/sql/test_resource_group/T/test_resource_group_big_query
@@ -25,6 +25,16 @@ create resource group rg_${uuid0}
 with w1 as (select * from t1 union all select * from t1 
     union all select * from t1 union all select * from t1 
     union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1 
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
+    union all select * from t1 union all select * from t1
     union all select * from t1 union all select * from t1)
 select /*+SET_VAR(resource_group='rg_${uuid0}')*/ count(1) from w1;
 


### PR DESCRIPTION
## Why I'm doing:

The SQL test case `test_resource_group_big_query` expects the query consumes more than one second CPU on one BE and returns a fail status.

However, this query has a small chance of consuming less than 1 second of CPU and not failing.

## What I'm doing:

Make this query more complex to make it always consume more than 1 second.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
