### PR TITLE
[BugFix] Fix the profile will not record if it is run on FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1154,7 +1154,7 @@ public class StmtExecutor {
         List<Expr> outputExprs = execPlan.getOutputExprs();
 
         if (executeInFe) {
-            coord = new FeExecuteCoordinator(context, execPlan);
+            coord = new FeExecuteCoordinator(context, execPlan, fragments, scanNodes, descTable);
         } else {
             coord = getCoordinatorFactory().createQueryScheduler(context, fragments, scanNodes, descTable);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -16,6 +16,8 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.qe.RowBatch;
 import com.starrocks.qe.scheduler.FeExecuteCoordinator;
+import com.starrocks.thrift.TDescriptorTable;
+import org.apache.commons.compress.utils.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -216,7 +218,8 @@ public class SelectConstTest extends PlanTestBase {
 
     private void assertFeExecuteResult(String sql, String expected) throws Exception {
         ExecPlan execPlan = getExecPlan(sql);
-        FeExecuteCoordinator coordinator = new FeExecuteCoordinator(connectContext, execPlan);
+        FeExecuteCoordinator coordinator = new FeExecuteCoordinator(connectContext, execPlan,
+                Lists.newArrayList(), Lists.newArrayList(), new TDescriptorTable());
         RowBatch rowBatch = coordinator.getNext();
         byte[] bytes = rowBatch.getBatch().getRows().get(0).array();
         int lengthOffset = getOffset(bytes);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix the issue https://github.com/StarRocks/starrocks/issues/49817

There are the sql which to be executed on FE node.
![image](https://github.com/user-attachments/assets/1e0288a5-b0cb-4c57-a8c7-717a4da41d16)

The content is like
![image](https://github.com/user-attachments/assets/36dbf5de-a42c-4d49-b78b-84970c3e2f65)
```bash
Query:
  Summary:
     - Query ID: 3d2153fc-5ec4-11ef-b6c5-5254008c25fa
     - Start Time: 2024-08-20 15:17:20
     - End Time: 2024-08-20 15:17:20
     - Total: 8ms
     - Query Type: Query
     - Query State: Finished
     - StarRocks Version: 3.3.2-vigo-a7406ce
     - User: root
     - Default Db: default
     - Sql Statement: select * from test where sale_year=779999
     - Variables: parallel_fragment_exec_instance_num=1,max_parallel_scan_instance_num=-1,pipeline_dop=0,enable_adaptive_sink_dop=true,enable_runtime_adaptive_dop=false,runtime_profile_report_interval=10
     - NonDefaultSessionVariables: {"catalog":{"defaultValue":"default_catalog","actualValue":"hive_catalog_test"},"cboPushDownAggregateMode_v1":{"defaultValue":-1,"actualValue":0},"enable_adaptive_sink_dop":{"defaultValue":false,"actualValue":true},"enable_profile":{"defaultValue":false,"actualValue":true}}
     - Collect Profile Time: 1ms
     - IsProfileAsync: false
  Planner:
     - -- Parser[1] 0
     - -- Total[1] 5ms
     -     -- Analyzer[1] 0
     -         -- Lock[1] 0
     -         -- AnalyzeDatabase[1] 0
     -         -- AnalyzeTemporaryTable[1] 0
     -         -- AnalyzeTable[1] 0
     -     -- Transformer[1] 0
     -     -- Optimizer[1] 3ms
     -         -- MVPreprocess[1] 0
     -             -- MVChooseCandidates[1] 0
     -             -- MVGenerateMvPlan[1] 0
     -             -- MVValidateMv[1] 0
     -             -- MVProcessWithView[1] 0
     -         -- RuleBaseOptimize[1] 1ms
     -         -- CostBaseOptimize[1] 0
     -         -- PhysicalRewrite[1] 0
     -         -- PlanValidate[1] 0
     -             -- InputDependenciesChecker[1] 0
     -             -- TypeChecker[1] 0
     -             -- CTEUniqueChecker[1] 0
     -             -- ColumnReuseChecker[1] 0
     -     -- ExecPlanBuild[1] 0
    Reason:
  Execution:
     - FrontendProfileMergeTime: 35.086us
     - QueryAllocatedMemoryUsage: 0.000 B
     - QueryCumulativeCpuTime: 0ns
     - QueryCumulativeNetworkTime: 0ns
     - QueryCumulativeOperatorTime: 0ns
     - QueryCumulativeScanTime: 0ns
     - QueryDeallocatedMemoryUsage: 0.000 B
     - QueryExecutionWallTime: 0ns
     - QueryPeakMemoryUsagePerNode: 0.000 B
     - QueryPeakScheduleTime: 0ns
     - QuerySpillBytes: 0.000 B
     - QuerySumMemoryUsage: 0.000 B
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5