### PR TITLE
[Enhancement] optimize kWayMergeSort in percentile_cont

### DIFF
--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -69,12 +69,13 @@ struct PercentileState {
 
 template <LogicalType LT, typename CppType, bool reverse>
 void kWayMergeSort(const typename PercentileStateTypes<LT>::GridType& grid, std::vector<CppType>& b,
-                   std::vector<int>& ls, std::map<int, int>& mp, size_t goal, int k, CppType& junior_elm,
+                   std::vector<int>& ls, std::vector<int>& mp, size_t goal, int k, CppType& junior_elm,
                    CppType& senior_elm) {
     CppType minV = RunTimeTypeLimits<LT>::min_value();
     CppType maxV = RunTimeTypeLimits<LT>::max_value();
     b.resize(k + 1);
     ls.resize(k);
+    mp.resize(k);
     for (int i = 0; i < k; ++i) {
         if constexpr (reverse) {
             mp[i] = grid[i].size() - 2;
@@ -426,7 +427,7 @@ class PercentileContAggregateFunction final : public PercentileContDiscAggregate
 
         std::vector<InputCppType> b;
         std::vector<int> ls;
-        std::map<int, int> mp;
+        std::vector<int> mp;
 
         size_t k = grid.size();
         size_t rowsNum = 0;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

replace unnecessary map in percentile_cont's  kWayMergeSort with vector to optimize performance.

I built a simple query based on ssb_100g for testing.

```sql
set pipeline_dop=1;
set streaming_preaggregation_mode='force_streaming';
select year(lo_orderdate), percentile_cont(lo_orderkey, 0.5)  from lineorder group by year(lo_orderdate);
```

before optimization
query time: 11 min 47.25 sec
GetResultsTime of second agg phase: 10m45s

after optimization
query time: 2m20s
GetResultsTime of second agg phase: 1m2s

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
