### PR TITLE
[BugFix] Add column comment info for jdbc catalog table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -90,7 +90,8 @@ public abstract class JDBCSchemaResolver {
                     columnSet.getInt("COLUMN_SIZE"),
                     columnSet.getInt("DECIMAL_DIGITS"));
             fullSchema.add(new Column(columnSet.getString("COLUMN_NAME"), type,
-                    columnSet.getString("IS_NULLABLE").equals("YES")));
+                    columnSet.getString("IS_NULLABLE").equals("YES"),
+                    columnSet.getString("REMARKS")));
         }
         return fullSchema;
     }


### PR DESCRIPTION
## Why I'm doing:
When execute "show create table  xxx " in a jdbc catalog table, the result data don't contain column comment.
<img width="709" alt="企业微信截图_7a51f1f9-7b3b-433b-87dd-165f2c6c0eb4" src="https://github.com/user-attachments/assets/e1084ea4-1d64-42f9-a4b2-8e2d6be825d4">

## What I'm doing:
Add comment info at JDBCSchemaResolver.convertToSRTable()
The result data after fixed:
<img width="986" alt="企业微信截图_d9dcbbdc-5ce6-41ee-927f-02dc5bde026a" src="https://github.com/user-attachments/assets/4ee74205-52cc-4a69-8557-53ae3d8b398c">


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
