### PR TITLE
[Enhancement] Support replication from non-TDE cluster to TDE cluster

### DIFF
--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "common/status.h"
+#include "fs/encryption.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gutil/macros.h"
 #include "storage/lake/tablet_metadata.h"
@@ -48,9 +49,9 @@ private:
     Status replicate_remote_snapshot(const TReplicateSnapshotRequest& request, const TSnapshotInfo& src_snapshot_info,
                                      const TabletMetadataPtr& tablet_metadata);
 
-    static Status convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,
-                                      TxnLogPB::OpWrite* op_write,
-                                      std::unordered_map<std::string, std::string>* segment_filename_map);
+    static Status convert_rowset_meta(
+            const RowsetMeta& rowset_meta, TTransactionId transaction_id, TxnLogPB::OpWrite* op_write,
+            std::unordered_map<std::string, std::pair<std::string, FileEncryptionInfo>>* segment_filename_map);
 
     static Status convert_delete_predicate_pb(DeletePredicatePB* delete_predicate);
 

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -23,6 +23,7 @@
 #include "common/config.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
+#include "fs/key_cache.h"
 #include "runtime/exec_env.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -53,6 +54,7 @@ public:
     ~LakeReplicationTxnManagerTest() override = default;
 
     void SetUp() override {
+        config::enable_transparent_data_encryption = false;
         std::vector<starrocks::StorePath> paths;
         CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
         _test_dir = paths[0].path + "/lake";
@@ -73,8 +75,11 @@ public:
             auto src_tablet = create_tablet(_src_tablet_id, 1, _schema_hash);
 
             std::vector<int64_t> keys{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+            Int64Column deletes;
+            int64_t deletes_array[2] = {10, 11};
+            deletes.append_numbers(deletes_array, sizeof(int64_t) * 2);
             for (int i = 2; i <= _src_version; i++) {
-                ASSERT_TRUE(src_tablet->rowset_commit(i, create_rowset(src_tablet, keys)).ok());
+                ASSERT_TRUE(src_tablet->rowset_commit(i, create_rowset(src_tablet, keys, &deletes)).ok());
             }
         }
     }
@@ -86,6 +91,7 @@ public:
         EXPECT_TRUE(status.ok()) << status;
         status = fs::remove_all(config::storage_root_path);
         EXPECT_TRUE(status.ok() || status.is_not_found()) << status;
+        config::enable_transparent_data_encryption = false;
     }
 
     TCreateTabletReq get_create_tablet_req(int64_t tablet_id, int64_t version, int32_t schema_hash,
@@ -341,6 +347,72 @@ TEST_P(LakeReplicationTxnManagerTest, test_publish_failed) {
 }
 
 TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
+    EXPECT_TRUE(status.ok()) << status;
+
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok()) << status;
+
+    status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok()) << status;
+
+    auto txn_info = TxnInfoPB();
+    txn_info.set_txn_id(_transaction_id);
+    txn_info.set_combined_txn_log(false);
+    txn_info.set_commit_time(0);
+    auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
+    auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_info_span);
+    EXPECT_TRUE(status_or.ok()) << status_or.status();
+
+    EXPECT_EQ(_src_version, status_or.value()->version());
+}
+
+TEST_P(LakeReplicationTxnManagerTest, test_run_normal_encrypted) {
+    EncryptionKeyPB pb;
+    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    pb.set_plain_key("0000000000000000");
+    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+    auto val_st = root_encryption_key->generate_key();
+    EXPECT_TRUE(val_st.ok());
+    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+    encryption_key->set_id(2);
+    KeyCache::instance().add_key(root_encryption_key);
+    KeyCache::instance().add_key(encryption_key);
+    config::enable_transparent_data_encryption = true;
+
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -866,8 +866,9 @@ public class ReplicationJob implements GsonPostProcessable {
         sendRunningTasks();
     }
 
-    private void sendReplicateSnapshotTasks() {
+    private void sendReplicateSnapshotTasks() throws Exception {
         runningTasks.clear();
+        byte[] encryptionMeta = GlobalStateMgr.getCurrentState().getKeyMgr().getCurrentKEKAsEncryptionMeta();
         for (PartitionInfo partitionInfo : partitionInfos.values()) {
             for (IndexInfo indexInfo : partitionInfo.getIndexInfos().values()) {
                 for (TabletInfo tabletInfo : indexInfo.getTabletInfos().values()) {
@@ -893,7 +894,7 @@ public class ReplicationJob implements GsonPostProcessable {
                                 indexInfo.getSchemaHash(), partitionInfo.getVersion(),
                                 srcToken, tabletInfo.getSrcTabletId(), getTabletType(srcTableType),
                                 indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(),
-                                flippedSrcSnapshotInfos);
+                                flippedSrcSnapshotInfos, encryptionMeta);
                         runningTasks.put(task, task);
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.task;
 
-import com.starrocks.task.AgentTask;
 import com.starrocks.thrift.TReplicateSnapshotRequest;
 import com.starrocks.thrift.TSnapshotInfo;
 import com.starrocks.thrift.TTabletType;
@@ -35,11 +34,12 @@ public class ReplicateSnapshotTask extends AgentTask {
     private final int srcSchemaHash;
     private final long srcVisibleVersion;
     private final List<TSnapshotInfo> srcSnapshotInfos;
+    private final byte[] encryptionMeta;
 
     public ReplicateSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-            TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion,
-            String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
-            long srcVisibleVersion, List<TSnapshotInfo> srcSnapshotInfos) {
+                                 TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion, String srcToken,
+                                 long srcTabletId, TTabletType srcTabletType, int srcSchemaHash, long srcVisibleVersion,
+                                 List<TSnapshotInfo> srcSnapshotInfos, byte[] encryptionMeta) {
         super(null, backendId, TTaskType.REPLICATE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId,
                 System.currentTimeMillis());
         this.transactionId = transactionId;
@@ -52,6 +52,7 @@ public class ReplicateSnapshotTask extends AgentTask {
         this.srcSchemaHash = srcSchemaHash;
         this.srcVisibleVersion = srcVisibleVersion;
         this.srcSnapshotInfos = srcSnapshotInfos;
+        this.encryptionMeta = encryptionMeta;
     }
 
     public TReplicateSnapshotRequest toThrift() {
@@ -71,6 +72,7 @@ public class ReplicateSnapshotTask extends AgentTask {
         request.setSrc_schema_hash(srcSchemaHash);
         request.setSrc_visible_version(srcVisibleVersion);
         request.setSrc_snapshot_infos(srcSnapshotInfos);
+        request.setEncryption_meta(encryptionMeta);
 
         return request;
     }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -400,6 +400,7 @@ struct TRemoteSnapshotRequest {
      11: optional Types.TSchemaHash src_schema_hash
      12: optional Types.TVersion src_visible_version
      13: optional list<Types.TSnapshotInfo> src_snapshot_infos
+     14: optional binary encryption_meta
  }
 
 enum TTabletMetaType {


### PR DESCRIPTION
## Why I'm doing:

Currently, directly downloaded file(like in replication and clone) are not encrypted, so  eplication from non-TDE cluster to TDE cluster is not supported.

## What I'm doing:

Support replication from non-TDE cluster to TDE cluster

Fixes #49384

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
