### PR TITLE
[BugFix] Add column comment for jdbc catalog table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -91,8 +91,12 @@ public abstract class JDBCSchemaResolver {
                     columnSet.getInt("DECIMAL_DIGITS"));
 
             String comment = "";
-            if (columnSet.getString("REMARKS") != null) {
-                comment = columnSet.getString("REMARKS");
+            // Add try-cache to prevent exceptions when the metadata of some databases does not contain REMARKS
+            try{
+                if (columnSet.getString("REMARKS") != null) {
+                    comment = columnSet.getString("REMARKS");
+                }
+            } catch (SQLException ignored) {
             }
 
             fullSchema.add(new Column(columnSet.getString("COLUMN_NAME"), type,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -90,7 +90,8 @@ public abstract class JDBCSchemaResolver {
                     columnSet.getInt("COLUMN_SIZE"),
                     columnSet.getInt("DECIMAL_DIGITS"));
             fullSchema.add(new Column(columnSet.getString("COLUMN_NAME"), type,
-                    columnSet.getString("IS_NULLABLE").equals("YES")));
+                    columnSet.getString("IS_NULLABLE").equals("YES"),
+                    columnSet.getString("REMARKS")));
         }
         return fullSchema;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -92,12 +92,11 @@ public abstract class JDBCSchemaResolver {
 
             String comment = "";
             // Add try-cache to prevent exceptions when the metadata of some databases does not contain REMARKS
-            try{
+            try {
                 if (columnSet.getString("REMARKS") != null) {
                     comment = columnSet.getString("REMARKS");
                 }
-            } catch (SQLException ignored) {
-            }
+            } catch (SQLException ignored) { }
 
             fullSchema.add(new Column(columnSet.getString("COLUMN_NAME"), type,
                     columnSet.getString("IS_NULLABLE").equals("YES"), comment));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -89,9 +89,14 @@ public abstract class JDBCSchemaResolver {
                     columnSet.getString("TYPE_NAME"),
                     columnSet.getInt("COLUMN_SIZE"),
                     columnSet.getInt("DECIMAL_DIGITS"));
+
+            String comment = "";
+            if (columnSet.getString("REMARKS") != null) {
+                comment = columnSet.getString("REMARKS");
+            }
+
             fullSchema.add(new Column(columnSet.getString("COLUMN_NAME"), type,
-                    columnSet.getString("IS_NULLABLE").equals("YES"),
-                    columnSet.getString("REMARKS")));
+                    columnSet.getString("IS_NULLABLE").equals("YES"), comment));
         }
         return fullSchema;
     }


### PR DESCRIPTION
## Why I'm doing:
When execute "show create table xxx " statement in a jdbc catalog table, the result data don't contain column comment info:
![image](https://github.com/user-attachments/assets/8e6edaf5-3812-43d9-9ff6-17673b678e08)

## What I'm doing:
Add comment info at JDBCSchemaResolver.convertToSRTable()
The result data after fixed:
![image](https://github.com/user-attachments/assets/03fa08c5-1334-43ee-b561-c862dd4f33f5)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
