### PR TITLE
[BugFix] take the dblock when reading tables in sys.object_dependencies

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
@@ -22,6 +22,8 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -76,46 +78,52 @@ public class SysObjectDependencies {
         }
 
         // list dependencies of mv
+        Locker locker = new Locker();
         Collection<Database> dbs = GlobalStateMgr.getCurrentState().getLocalMetastore().getFullNameToDb().values();
         for (Database db : CollectionUtils.emptyIfNull(dbs)) {
             String catalog = Optional.ofNullable(db.getCatalogName())
                     .orElse(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
-            for (Table table : db.getTables()) {
-                // If it is not a materialized view, we do not need to verify permissions
-                if (!table.isMaterializedView()) {
-                    continue;
-                }
-                // Only show tables with privilege
-                try {
-                    Authorizer.checkAnyActionOnTableLikeObject(currentUser, null, db.getFullName(), table);
-                } catch (AccessDeniedException e) {
-                    continue;
-                }
-
-                MaterializedView mv = (MaterializedView) table;
-                for (BaseTableInfo refObj : CollectionUtils.emptyIfNull(mv.getBaseTableInfos())) {
-                    TObjectDependencyItem item = new TObjectDependencyItem();
-                    item.setObject_id(mv.getId());
-                    item.setObject_name(mv.getName());
-                    item.setDatabase(db.getFullName());
-                    item.setCatalog(catalog);
-                    item.setObject_type(mv.getType().toString());
-
-                    item.setRef_object_id(refObj.getTableId());
-                    item.setRef_database(refObj.getDbName());
-                    item.setRef_catalog(refObj.getCatalogName());
-                    Optional<Table> refTable = MvUtils.getTableWithIdentifier(refObj);
-                    item.setRef_object_type(getRefObjectType(refTable, mv.getName()));
-                    // If the ref table is dropped/swapped/renamed, the actual info would be inconsistent with
-                    // BaseTableInfo, so we use the source-of-truth information
-                    if (refTable.isEmpty()) {
-                        item.setRef_object_name(refObj.getTableName());
-                    } else {
-                        item.setRef_object_name(refTable.get().getName());
+            locker.lockDatabase(db, LockType.READ);
+            try {
+                for (Table table : db.getTables()) {
+                    // If it is not a materialized view, we do not need to verify permissions
+                    if (!table.isMaterializedView()) {
+                        continue;
+                    }
+                    // Only show tables with privilege
+                    try {
+                        Authorizer.checkAnyActionOnTableLikeObject(currentUser, null, db.getFullName(), table);
+                    } catch (AccessDeniedException e) {
+                        continue;
                     }
 
-                    response.addToItems(item);
+                    MaterializedView mv = (MaterializedView) table;
+                    for (BaseTableInfo refObj : CollectionUtils.emptyIfNull(mv.getBaseTableInfos())) {
+                        TObjectDependencyItem item = new TObjectDependencyItem();
+                        item.setObject_id(mv.getId());
+                        item.setObject_name(mv.getName());
+                        item.setDatabase(db.getFullName());
+                        item.setCatalog(catalog);
+                        item.setObject_type(mv.getType().toString());
+
+                        item.setRef_object_id(refObj.getTableId());
+                        item.setRef_database(refObj.getDbName());
+                        item.setRef_catalog(refObj.getCatalogName());
+                        Optional<Table> refTable = MvUtils.getTableWithIdentifier(refObj);
+                        item.setRef_object_type(getRefObjectType(refTable, mv.getName()));
+                        // If the ref table is dropped/swapped/renamed, the actual info would be inconsistent with
+                        // BaseTableInfo, so we use the source-of-truth information
+                        if (refTable.isEmpty()) {
+                            item.setRef_object_name(refObj.getTableName());
+                        } else {
+                            item.setRef_object_name(refTable.get().getName());
+                        }
+
+                        response.addToItems(item);
+                    }
                 }
+            } finally {
+                locker.unLockDatabase(db, LockType.READ);
             }
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
