### PR TITLE
[BugFix] fix missing big_query log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -134,6 +134,8 @@ public class Config extends ConfigBase {
     public static String[] audit_log_modules = {"slow_query", "query"};
     @ConfField(mutable = true)
     public static long qe_slow_log_ms = 5000;
+    @ConfField(mutable = true)
+    public static boolean enable_qe_slow_log = true;
     @ConfField
     public static String audit_log_roll_interval = "DAY";
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -157,6 +157,13 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                         AuditLog.getBigQueryAudit().log(sb.toString());
                     }
                 }
+                if (Config.enable_qe_slow_log && queryTime > Config.qe_slow_log_ms) {
+                    if (Config.audit_log_json_format) {
+                        AuditLog.getSlowAudit().log(objectMapper.writeValueAsString(logMap));
+                    } else {
+                        AuditLog.getSlowAudit().log(sb.toString());
+                    }
+                }
                 if (Config.audit_log_json_format) {
                     AuditLog.getQueryAudit().log(objectMapper.writeValueAsString(logMap));
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -149,10 +149,12 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                         logMap.put("bigQueryLogCPUSecondThreshold", event.bigQueryLogCPUSecondThreshold);
                         logMap.put("bigQueryLogScanBytesThreshold", event.bigQueryLogScanBytesThreshold);
                         logMap.put("bigQueryLogScanRowsThreshold", event.bigQueryLogScanRowsThreshold);
+                        AuditLog.getBigQueryAudit().log(objectMapper.writeValueAsString(logMap));
                     } else {
                         sb.append("|bigQueryLogCPUSecondThreshold=").append(event.bigQueryLogCPUSecondThreshold);
                         sb.append("|bigQueryLogScanBytesThreshold=").append(event.bigQueryLogScanBytesThreshold);
                         sb.append("|bigQueryLogScanRowsThreshold=").append(event.bigQueryLogScanRowsThreshold);
+                        AuditLog.getBigQueryAudit().log(sb.toString());
                     }
                 }
                 if (Config.audit_log_json_format) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

introduced by #45768

In this pr, I add the missing slow/big query log back and provide a switch to turn off slow_query log
﻿
both big and slow query log can be disabled by the following command
```sql
 admin set frontend config("enable_qe_slow_log"="false");
 set global enable_big_query_log = false;
```
﻿


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
