### PR TITLE
[BugFix] fix BE graceful exit and cache limit overflow issue caused by MetadataCache

### DIFF
--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -19,6 +19,14 @@
 
 namespace starrocks {
 
+MetadataCache* MetadataCache::_s_instance = nullptr;
+
+void MetadataCache::create_cache(size_t capacity) {
+    if (_s_instance == nullptr) {
+        _s_instance = new MetadataCache(capacity);
+    }
+}
+
 MetadataCache::MetadataCache(size_t capacity) {
     _cache.reset(new_lru_cache(capacity));
 }

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -34,6 +34,11 @@ public:
 
     DISALLOW_COPY_AND_MOVE(MetadataCache);
 
+    // Create global instance of this class
+    static void create_cache(size_t capacity);
+
+    static MetadataCache* instance() { return _s_instance; }
+
     // will be called after rowset load metadata.
     void cache_rowset(Rowset* ptr);
 
@@ -47,6 +52,8 @@ private:
     void _insert(const std::string& key, Rowset* ptr, size_t size);
     void _erase(const std::string& key);
     static void _cache_value_deleter(const CacheKey& /*key*/, void* value);
+
+    static MetadataCache* _s_instance;
 
     // LRU cache for metadata
     std::unique_ptr<Cache> _cache;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -81,10 +81,7 @@ Rowset::~Rowset() {
     if (_keys_type != PRIMARY_KEYS) {
         // ONLY support non-pk table now.
         // evict rowset before destroy, in case this rowset no close yet.
-        auto metadata_cache = StorageEngine::instance()->tablet_manager()->metadata_cache();
-        if (metadata_cache != nullptr) {
-            metadata_cache->evict_rowset(this);
-        }
+        MetadataCache::instance()->evict_rowset(this);
     }
 #endif
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
@@ -191,7 +188,7 @@ Status Rowset::do_load() {
     if (config::metadata_cache_memory_limit_percent > 0 && _keys_type != PRIMARY_KEYS) {
         // Add rowset to lru metadata cache for memory control.
         // ONLY support non-pk table now.
-        StorageEngine::instance()->tablet_manager()->metadata_cache()->cache_rowset(this);
+        MetadataCache::instance()->cache_rowset(this);
     }
 #endif
     return Status::OK();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -136,6 +136,13 @@ StorageEngine::StorageEngine(const EngineOptions& options)
 #ifdef USE_STAROS
     _local_pk_index_manager = std::make_unique<lake::LocalPkIndexManager>();
 #endif
+#ifndef BE_TEST
+    const int64_t process_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
+    const int64_t lru_cache_limit = process_limit * (int64_t)config::metadata_cache_memory_limit_percent / (int64_t)100;
+    MetadataCache::create_cache(lru_cache_limit);
+    REGISTER_GAUGE_STARROCKS_METRIC(metadata_cache_bytes_total,
+                                    [&]() { return MetadataCache::instance()->get_memory_usage(); });
+#endif
 }
 
 StorageEngine::~StorageEngine() {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -50,7 +50,6 @@
 #include "storage/compaction_manager.h"
 #include "storage/data_dir.h"
 #include "storage/olap_common.h"
-#include "storage/rowset/metadata_cache.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
@@ -89,13 +88,6 @@ TabletManager::TabletManager(int64_t tablet_map_lock_shard_size)
           _last_update_stat_ms(0) {
     CHECK_GT(_tablets_shards.size(), 0) << "tablets shard count greater than 0";
     CHECK_EQ(_tablets_shards.size() & _tablets_shards_mask, 0) << "tablets shard count must be power of two";
-#ifndef BE_TEST
-    const int64_t process_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
-    const int32_t lru_cache_limit = process_limit * config::metadata_cache_memory_limit_percent / 100;
-    _metadata_cache = std::make_unique<MetadataCache>(lru_cache_limit);
-    REGISTER_GAUGE_STARROCKS_METRIC(metadata_cache_bytes_total,
-                                    [this]() { return _metadata_cache->get_memory_usage(); });
-#endif
 }
 
 Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bool update_meta, bool force) {

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -199,8 +199,6 @@ public:
 
     Status generate_pk_dump();
 
-    MetadataCache* metadata_cache() const { return _metadata_cache.get(); }
-
 private:
     using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;
     using TabletSet = std::unordered_set<int64_t>;
@@ -277,9 +275,6 @@ private:
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
     static Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);
-
-    // LRU cache for metadata
-    std::unique_ptr<MetadataCache> _metadata_cache;
 
     std::vector<TabletsShard> _tablets_shards;
     const int64_t _tablets_shards_mask;


### PR DESCRIPTION
## Why I'm doing:
1. Fix BE graceful exit issue.
2. `lru_cache_limit` can be overflow because of using `int32_t` by mistake:
```
const int32_t lru_cache_limit = process_limit * config::metadata_cache_memory_limit_percent / 100;
```

## What I'm doing:
1. Move `MetadataCache` from tablet manager to a global static var, so it can be destroy at last and BE can exit graceful.
2. Fix `lru_cache_limit` overflow issue.

fix 
https://github.com/StarRocks/StarRocksTest/issues/8423
https://github.com/StarRocks/StarRocksTest/issues/8396


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
