### PR TITLE
[BugFix] Fix the bug of nest-loop-join set_finishing without check cancel state

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_build_operator.cpp
@@ -44,9 +44,12 @@ StatusOr<ChunkPtr> NLJoinBuildOperator::pull_chunk(RuntimeState* state) {
 
 Status NLJoinBuildOperator::set_finishing(RuntimeState* state) {
     DeferOp op([this]() { _is_finished = true; });
+    if (state->is_cancelled()) {
+        return Status::OK();
+    }
+
     // Used to notify cross_join_left_operator.
-    RETURN_IF_ERROR(_cross_join_context->finish_one_right_sinker(_driver_sequence, state));
-    return Status::OK();
+    return _cross_join_context->finish_one_right_sinker(_driver_sequence, state);
 }
 
 Status NLJoinBuildOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Query is canceled when memory is overcommited, `NLJoinBuildOperator::set_finishing` continue build right table without check status.

```
*** Aborted at 1724088138 (unix time) try "date -d @1724088138" if you are using GNU date ***
PC: @     0x7f059e043895 __memmove_avx_unaligned_erms
*** SIGSEGV (@0x0) received by PID 1351 (TID 0x7f0472519700) from PID 0; stack trace: ***
    @          0x67ec202 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f059ec5fc20 (unknown)
    @     0x7f059e043895 __memmove_avx_unaligned_erms
    @          0x2c3f594 std::vector<>::_M_range_insert<>()
    @          0x2c43014 starrocks::BinaryColumnBase<>::append()
    @          0x347fe0e starrocks::NullableColumn::append()
    @          0x3464ba2 starrocks::Chunk::append()
    @          0x51e4000 starrocks::ChunkAccumulator::push()
    @          0x38331f1 starrocks::pipeline::NLJoinBuildChunkStreamBuilder::init()
    @          0x38334a7 starrocks::pipeline::NLJoinContext::finish_one_right_sinker()
    @          0x383bc1a starrocks::pipeline::NLJoinBuildOperator::set_finishing()
    @          0x3889f8b starrocks::pipeline::PipelineDriver::_mark_operator_finishing()
    @          0x388a099 starrocks::pipeline::PipelineDriver::_mark_operator_finished()
    @          0x388a69b starrocks::pipeline::PipelineDriver::_mark_operator_cancelled()
    @          0x388acba starrocks::pipeline::PipelineDriver::cancel_operators()
    @          0x387dc3b starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x2e896ac starrocks::ThreadPool::dispatch_thread()
    @          0x2e8332a starrocks::Thread::supervise_thread()
    @     0x7f059ec5517a start_thread
    @     0x7f059dfdfdc3 __GI___clone
    @                0x0 (unknown)
```

```
@          0x29e0016  _Znwm.cold
@          0x2c4317a  starrocks::BinaryColumnBase<>::append()
@          0x347fe0e  starrocks::NullableColumn::append()
@          0x34a19d2  starrocks::ArrayColumn::append()
@          0x347fe0e  starrocks::NullableColumn::append()
@          0x3464ba2  starrocks::Chunk::append()
@          0x51e4204  starrocks::ChunkAccumulator::push()
@          0x3831106  starrocks::pipeline::NJJoinBuildInputChannel::add_chunk()
@          0x3831674  starrocks::pipeline::NLJoinContext::append_build_chunk()
@          0x383b593  starrocks::pipeline::NLJoinBuildOperator::push_chunk()
@          0x388bd63  starrocks::pipeline::PipelineDriver::process()
@          0x387d91e  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
@          0x2e896ac  starrocks::ThreadPool::dispatch_thread()
@          0x2e8332a  starrocks::Thread::supervise_thread()
@     0x7f059ec5517a  start_thread
@     0x7f059dfdfdc3  __GI___clone
@              (nil)  (unknown)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
