### PR TITLE
[Enhancement] optimize execution strategy under limited preaggregation mode

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -402,6 +402,9 @@ public:
 
     Status _create_aggregate_function(starrocks::RuntimeState* state, const TFunction& fn, bool is_result_nullable,
                                       const AggregateFunction** ret);
+    bool ht_need_consume() const { return _ht_need_consume; }
+
+    void set_ht_need_consume(bool ht_need_consume) { _ht_need_consume = ht_need_consume; }
 
     HashTableKeyAllocator _state_allocator;
 
@@ -428,6 +431,7 @@ protected:
     std::atomic<bool> _is_sink_complete = false;
     // only used in pipeline engine
     std::unique_ptr<LimitedPipelineChunkBuffer<AggStatistics>> _limited_buffer;
+    std::atomic<bool> _ht_need_consume = false;
 
     // Certain aggregates require a finalize step, which is the final step of the
     // aggregate after consuming all input rows. The finalize step converts the aggregate

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -402,9 +402,6 @@ public:
 
     Status _create_aggregate_function(starrocks::RuntimeState* state, const TFunction& fn, bool is_result_nullable,
                                       const AggregateFunction** ret);
-    bool ht_need_consume() const { return _ht_need_consume; }
-
-    void set_ht_need_consume(bool ht_need_consume) { _ht_need_consume = ht_need_consume; }
 
     HashTableKeyAllocator _state_allocator;
 
@@ -431,7 +428,6 @@ protected:
     std::atomic<bool> _is_sink_complete = false;
     // only used in pipeline engine
     std::unique_ptr<LimitedPipelineChunkBuffer<AggStatistics>> _limited_buffer;
-    std::atomic<bool> _ht_need_consume = false;
 
     // Certain aggregates require a finalize step, which is the final step of the
     // aggregate after consuming all input rows. The finalize step converts the aggregate

--- a/be/src/exec/chunk_buffer_memory_manager.h
+++ b/be/src/exec/chunk_buffer_memory_manager.h
@@ -34,7 +34,7 @@ public:
         } else {
             LOG(WARNING) << "invalid per_driver_mem_limit";
         }
-        size_t res = max_input_dop * _max_memory_usage_per_driver;
+        int64_t res = max_input_dop * _max_memory_usage_per_driver;
         if (res < _max_memory_usage) {
             _max_memory_usage = res;
         }
@@ -45,7 +45,7 @@ public:
         _buffered_num_rows += num_rows;
     }
 
-    size_t get_memory_limit_per_driver() const { return _max_memory_usage_per_driver; }
+    int64_t get_memory_limit_per_driver() const { return _max_memory_usage_per_driver; }
 
     int64_t get_memory_usage() const { return _memory_usage; }
 
@@ -66,9 +66,9 @@ public:
     }
 
 private:
-    std::atomic<size_t> _max_memory_usage{128UL * 1024 * 1024 * 1024}; // 128GB
-    size_t _max_memory_usage_per_driver = 128 * 1024 * 1024UL;         // 128MB
-    size_t _max_buffered_rows{};
+    std::atomic<int64_t> _max_memory_usage{128L * 1024 * 1024 * 1024}; // 128GB
+    int64_t _max_memory_usage_per_driver = 128 * 1024 * 1024L;         // 128MB
+    int64_t _max_buffered_rows{};
     std::atomic<int64_t> _memory_usage{};
     std::atomic<int64_t> _buffered_num_rows{};
     size_t _max_input_dop;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -68,8 +68,8 @@ void AggregateStreamingSinkOperator::set_execute_mode(int performance_level) {
             _limited_mem_state.limited_memory_size = _aggregator->hash_map_memory_usage();
         }
     }
-    if (_limited_mem_state.has_limited(*_aggregator) && !_aggregator->ht_need_consume()) {
-        _aggregator->set_ht_need_consume(true);
+    if (_limited_mem_state.has_limited(*_aggregator) && !_aggregator->is_streaming_all_states()) {
+        _aggregator->set_streaming_all_states(true);
     }
 }
 
@@ -306,7 +306,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk
 Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(const ChunkPtr& chunk, const size_t chunk_size) {
     if (_limited_mem_state.has_limited(*_aggregator)) {
         RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
-        _aggregator->set_ht_need_consume(true);
+        _aggregator->set_streaming_all_states(true);
     } else {
         RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk_size));
     }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -76,7 +76,7 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const Chu
     }};
     size_t chunk_size = chunk->num_rows();
     _aggregator->update_num_input_rows(chunk_size);
-    COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
+    COUNTER_UPDATE(_aggregator->input_row_count(), chunk_size);
 
     RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -35,7 +35,17 @@ public:
 
     bool has_output() const override { return false; }
     bool need_input() const override {
-        return !is_finished() && !_aggregator->is_streaming_all_states() && !_aggregator->is_chunk_buffer_full();
+        bool can_input = !_aggregator->ht_need_consume();
+        if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::LIMITED_MEM) {
+            // under limited aggregation mode, if the memory of aggregator exceeds limit,
+            // we should reject input and wait for the source side to consume all data in ht.
+            if (_limited_mem_state.has_limited(*_aggregator) && !_aggregator->ht_need_consume()) {
+                _aggregator->set_ht_need_consume(true);
+                can_input = false;
+            }
+        }
+        return !is_finished() && !_aggregator->is_streaming_all_states() && !_aggregator->is_chunk_buffer_full() &&
+               can_input;
     }
     bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     Status set_finishing(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -35,17 +35,16 @@ public:
 
     bool has_output() const override { return false; }
     bool need_input() const override {
-        bool can_input = !_aggregator->ht_need_consume();
+        bool can_input = !_aggregator->is_streaming_all_states();
         if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::LIMITED_MEM) {
             // under limited aggregation mode, if the memory of aggregator exceeds limit,
             // we should reject input and wait for the source side to consume all data in ht.
-            if (_limited_mem_state.has_limited(*_aggregator) && !_aggregator->ht_need_consume()) {
-                _aggregator->set_ht_need_consume(true);
+            if (_limited_mem_state.has_limited(*_aggregator) && !_aggregator->is_streaming_all_states()) {
+                _aggregator->set_streaming_all_states(true);
                 can_input = false;
             }
         }
-        return !is_finished() && !_aggregator->is_streaming_all_states() && !_aggregator->is_chunk_buffer_full() &&
-               can_input;
+        return !is_finished() && !_aggregator->is_chunk_buffer_full() && can_input;
     }
     bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     Status set_finishing(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -34,10 +34,6 @@ bool AggregateStreamingSourceOperator::has_output() const {
         return true;
     }
 
-    if (_aggregator->is_streaming_all_states()) {
-        return true;
-    }
-
     // There are four cases where chunk buffer is empty
     // case1: streaming mode is 'FORCE_STREAMING'
     // case2: streaming mode is 'AUTO'
@@ -105,7 +101,6 @@ Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(ChunkPtr* c
         if (!_aggregator->is_sink_complete()) {
             RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr, false));
         }
-        _aggregator->set_streaming_all_states(false);
         _aggregator->set_ht_need_consume(false);
     }
 


### PR DESCRIPTION
## Why I'm doing:

Currently, in limited streaming preaggregation mode, if the aggregator memory is exceeded during push_chunk, the current chunk will be sent to the downstream in streaming mode without aggregation. After the downstream consumes all data in the hash table and streaming buffer, the upstream will continue to accept input and aggregate again.

However, this check is a bit late. In fact, we can check before push_chunk and aggregate the chunk as much as possible, thereby reducing the amount of shuffle data.

## What I'm doing:

In this PR, I optimized the current strategy. When the aggregator memory reaches the limit, the aggregated data is sent to the downstream first and then the new data is re-aggregated, which can minimize the amount of shuffled data.


## test
the following query is based on ssb_100g data. I test it in a 1FE+1BE env.
```sql
set streaming_preaggregation_mode='limited';
set pipeline_dop=8;
update information_schema.be_configs set value="16777216" where name = "streaming_agg_limited_memory_size";
select year(lo_orderdate), percentile_cont(lo_orderkey, 0.5), percentile_cont(lo_custkey, 0.5) from lineorder group by year(lo_orderdate);
```

|  | baseline | after optimization |
| :-----| ----: | :----: |
| QueryTime| 51s206ms | 21s55ms |
| ShuffleRows | 4188265 | 1672 |


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5