### PR TITLE
[Enhancement] set required distribution flag in optExpression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -64,6 +64,7 @@ public class OptExpression {
 
     // the flag if its parent has required data distribution property for this expression
     private boolean existRequiredDistribution = true;
+
     private OptExpression() {
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -62,6 +62,8 @@ public class OptExpression {
 
     private Boolean isShortCircuit = false;
 
+    // the flag if its parent has required data distribution property for this expression
+    private boolean existRequiredDistribution = true;
     private OptExpression() {
     }
 
@@ -244,6 +246,14 @@ public class OptExpression {
 
     public String debugString(int limitLine) {
         return debugString("", "", limitLine);
+    }
+
+    public boolean isExistRequiredDistribution() {
+        return existRequiredDistribution;
+    }
+
+    public void setExistRequiredDistribution(boolean existRequiredDistribution) {
+        this.existRequiredDistribution = existRequiredDistribution;
     }
 
     private String debugString(String headlinePrefix, String detailPrefix, int limitLine) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRule.java
@@ -1,0 +1,129 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+
+import java.util.List;
+
+public class MarkParentRequiredDistributionRule implements TreeRewriteRule {
+
+    private static final Visitor VISITOR = new Visitor();
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        root.getOp().accept(VISITOR, root, false);
+        return root;
+    }
+
+    // If any OptExpression's child has global dict, we cannot change its distribution even if
+    // its parent didn't require anything. If we want to change its distribution, we also need to
+    // ensure the global dict should be reset correctly in the new distribution which is a tedious work.
+    // If no OptExpression's child has global dict, we just need consider the requirement from its parent.
+    private static class Visitor extends OptExpressionVisitor<Boolean, Boolean> {
+        private boolean visitChildren(List<OptExpression> children, Boolean existRequiredDistribution) {
+            boolean existGlobalDict = false;
+            for (OptExpression child : children) {
+                existGlobalDict |= child.getOp().accept(this, child, existRequiredDistribution);
+            }
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visit(OptExpression optExpression, Boolean existRequiredDistribution) {
+            boolean existGlobalDict = visitChildren(optExpression.getInputs(), existRequiredDistribution);
+            optExpression.setExistRequiredDistribution(existRequiredDistribution || existGlobalDict);
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visitPhysicalHashAggregate(OptExpression optExpression, Boolean existRequiredDistribution) {
+            PhysicalHashAggregateOperator aggregateOperator = (PhysicalHashAggregateOperator) optExpression.getOp();
+            boolean existGlobalDict;
+            if (aggregateOperator.getType().isAnyGlobal()) {
+                existGlobalDict = visitChildren(optExpression.getInputs(), true);
+            } else {
+                existGlobalDict = visitChildren(optExpression.getInputs(), existRequiredDistribution);
+            }
+            optExpression.setExistRequiredDistribution(existRequiredDistribution || existGlobalDict);
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visitPhysicalHashJoin(OptExpression optExpression, Boolean existRequiredDistribution) {
+            boolean existGlobalDict = visitChildren(optExpression.getInputs(), true);
+            optExpression.setExistRequiredDistribution(existRequiredDistribution || existGlobalDict);
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visitPhysicalNestLoopJoin(OptExpression optExpression, Boolean existRequiredDistribution) {
+            boolean existGlobalDict = visitChildren(optExpression.getInputs(), true);
+            optExpression.setExistRequiredDistribution(existRequiredDistribution || existGlobalDict);
+            return existGlobalDict;
+        }
+
+
+        @Override
+        public Boolean visitPhysicalDistribution(OptExpression optExpression, Boolean existRequiredDistribution) {
+            boolean existGlobalDict =  visitChildren(optExpression.getInputs(), false);
+            optExpression.setExistRequiredDistribution(true);
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visitPhysicalAnalytic(OptExpression optExpression, Boolean existRequiredDistribution) {
+            boolean existGlobalDict = visitChildren(optExpression.getInputs(), true);
+            optExpression.setExistRequiredDistribution(existRequiredDistribution || existGlobalDict);
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visitPhysicalTopN(OptExpression optExpression, Boolean existRequiredDistribution) {
+            boolean existGlobalDict;
+            PhysicalTopNOperator operator = (PhysicalTopNOperator) optExpression.getOp();
+            if (operator.getSortPhase().isFinal()) {
+                existGlobalDict = visitChildren(optExpression.getInputs(), true);
+            } else {
+                existGlobalDict = visitChildren(optExpression.getInputs(), existRequiredDistribution);
+            }
+            optExpression.setExistRequiredDistribution(existRequiredDistribution || existGlobalDict);
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visitPhysicalLimit(OptExpression optExpression, Boolean existRequiredDistribution) {
+            boolean existGlobalDict = visitChildren(optExpression.getInputs(), true);
+            optExpression.setExistRequiredDistribution(existRequiredDistribution);
+            return existGlobalDict;
+        }
+
+        @Override
+        public Boolean visitPhysicalOlapScan(OptExpression optExpression, Boolean existRequiredDistribution) {
+            PhysicalOlapScanOperator scanOperator = (PhysicalOlapScanOperator) optExpression.getOp();
+            boolean existGlobalDict = CollectionUtils.isNotEmpty(scanOperator.getGlobalDicts()) ||
+                    MapUtils.isNotEmpty(scanOperator.getGlobalDictsExpr());
+            optExpression.setExistRequiredDistribution(existRequiredDistribution || existGlobalDict);
+            return existGlobalDict;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -2424,6 +2424,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
                             "RuleBaseOptimize",
                             "CostBaseOptimize",
                             "PhysicalRewrite",
+                            "DynamicRewrite",
                             "PlanValidate",
                             "InputDependenciesChecker",
                             "TypeChecker",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRuleTest.java
@@ -1,0 +1,66 @@
+package com.starrocks.sql.optimizer.rule.tree;
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MarkParentRequiredDistributionRuleTest extends PlanTestBase {
+
+    @Test
+    public void testJoin() throws Exception {
+        String sql = "select count(*) from t1 join t2 on t1.v4 = t2.v7";
+        ExecPlan execPlan= getExecPlan(sql);
+        Assert.assertTrue(execPlan.getOptExpression(3).getOp() instanceof PhysicalHashJoinOperator);
+        Assert.assertFalse("No global dict exists. No requirement from parent, " +
+                        "we can change the output distribution of this join",
+                execPlan.getOptExpression( 3).isExistRequiredDistribution());
+
+        sql = "select count(*) from t1 join t2 on t1.v4 = t2.v7 group by t1.v4";
+        execPlan= getExecPlan(sql);
+        Assert.assertTrue(execPlan.getOptExpression(4).getOp() instanceof PhysicalHashJoinOperator);
+        Assert.assertTrue("Had requirement from parent, we can't change the output distribution of this join",
+                execPlan.getOptExpression( 4).isExistRequiredDistribution());
+
+        sql = "select count(*) from t1 join t2 on t1.v4 = t2.v7 join t3 on t1.v4 = t3.v11";
+        execPlan= getExecPlan(sql);
+        Assert.assertTrue(execPlan.getOptExpression(4).getOp() instanceof PhysicalHashJoinOperator);
+        Assert.assertTrue(execPlan.getOptExpression(8).getOp() instanceof PhysicalHashJoinOperator);
+
+        Assert.assertTrue("Had requirement from parent, we can't change the output distribution of this join",
+                execPlan.getOptExpression( 4).isExistRequiredDistribution());
+        Assert.assertFalse("No global dict exists. No requirement from parent, " +
+                        "we can't change the output distribution of this join",
+                execPlan.getOptExpression( 8).isExistRequiredDistribution());
+    }
+
+    @Test
+    public void testOrderBy() throws Exception {
+        String sql = "select * from (select * from t1 order by v4 limit 50) t where v5 = 1";
+        ExecPlan execPlan = getExecPlan(sql);
+
+        PhysicalTopNOperator partitionTopN = (PhysicalTopNOperator) execPlan.getOptExpression(1).getOp();
+        PhysicalTopNOperator finalTopN = (PhysicalTopNOperator) execPlan.getOptExpression(2).getOp();
+        Assert.assertTrue(partitionTopN.getSortPhase().isPartial());
+        Assert.assertTrue(finalTopN.getSortPhase().isFinal());
+        Assert.assertTrue(execPlan.getOptExpression(1).isExistRequiredDistribution());
+        Assert.assertFalse(execPlan.getOptExpression(2).isExistRequiredDistribution());
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRuleTest.java
@@ -26,28 +26,28 @@ public class MarkParentRequiredDistributionRuleTest extends PlanTestBase {
     @Test
     public void testJoin() throws Exception {
         String sql = "select count(*) from t1 join t2 on t1.v4 = t2.v7";
-        ExecPlan execPlan= getExecPlan(sql);
+        ExecPlan execPlan = getExecPlan(sql);
         Assert.assertTrue(execPlan.getOptExpression(3).getOp() instanceof PhysicalHashJoinOperator);
         Assert.assertFalse("No global dict exists. No requirement from parent, " +
                         "we can change the output distribution of this join",
-                execPlan.getOptExpression( 3).isExistRequiredDistribution());
+                execPlan.getOptExpression(3).isExistRequiredDistribution());
 
         sql = "select count(*) from t1 join t2 on t1.v4 = t2.v7 group by t1.v4";
-        execPlan= getExecPlan(sql);
+        execPlan = getExecPlan(sql);
         Assert.assertTrue(execPlan.getOptExpression(4).getOp() instanceof PhysicalHashJoinOperator);
         Assert.assertTrue("Had requirement from parent, we can't change the output distribution of this join",
-                execPlan.getOptExpression( 4).isExistRequiredDistribution());
+                execPlan.getOptExpression(4).isExistRequiredDistribution());
 
         sql = "select count(*) from t1 join t2 on t1.v4 = t2.v7 join t3 on t1.v4 = t3.v11";
-        execPlan= getExecPlan(sql);
+        execPlan = getExecPlan(sql);
         Assert.assertTrue(execPlan.getOptExpression(4).getOp() instanceof PhysicalHashJoinOperator);
         Assert.assertTrue(execPlan.getOptExpression(8).getOp() instanceof PhysicalHashJoinOperator);
 
         Assert.assertTrue("Had requirement from parent, we can't change the output distribution of this join",
-                execPlan.getOptExpression( 4).isExistRequiredDistribution());
+                execPlan.getOptExpression(4).isExistRequiredDistribution());
         Assert.assertFalse("No global dict exists. No requirement from parent, " +
                         "we can't change the output distribution of this join",
-                execPlan.getOptExpression( 8).isExistRequiredDistribution());
+                execPlan.getOptExpression(8).isExistRequiredDistribution());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/MarkParentRequiredDistributionRuleTest.java
@@ -1,5 +1,3 @@
-package com.starrocks.sql.optimizer.rule.tree;
-
 // Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@ package com.starrocks.sql.optimizer.rule.tree;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
 
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1936,7 +1936,7 @@ public class LowCardinalityTest extends PlanTestBase {
         String sql = "select coalesce(l.S_ADDRESS,l.S_NATIONKEY) from supplier l join supplier r on l.s_suppkey = r.s_suppkey";
         ExecPlan execPlan = getExecPlan(sql);
         Assert.assertTrue("joinNode is in the same fragment with a table contains global dict, " +
-                        "we cannot change its distribution", execPlan.getOptExpression( 3).isExistRequiredDistribution());
+                        "we cannot change its distribution", execPlan.getOptExpression(3).isExistRequiredDistribution());
         Assert.assertTrue("table contains global dict, we cannot change its distribution",
                 execPlan.getOptExpression(0).isExistRequiredDistribution());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1931,4 +1931,16 @@ public class LowCardinalityTest extends PlanTestBase {
         }
     }
 
+    @Test
+    public void testExistRequiredDistribution() throws Exception {
+        String sql = "select coalesce(l.S_ADDRESS,l.S_NATIONKEY) from supplier l join supplier r on l.s_suppkey = r.s_suppkey";
+        ExecPlan execPlan = getExecPlan(sql);
+        Assert.assertTrue("joinNode is in the same fragment with a table contains global dict, " +
+                        "we cannot change its distribution", execPlan.getOptExpression( 3).isExistRequiredDistribution());
+        Assert.assertTrue("table contains global dict, we cannot change its distribution",
+                execPlan.getOptExpression(0).isExistRequiredDistribution());
+
+        Assert.assertFalse("table doesn't contain global dict, we can change its distribution",
+                execPlan.getOptExpression(1).isExistRequiredDistribution());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2157,4 +2157,17 @@ public class LowCardinalityTest2 extends PlanTestBase {
             FeConstants.unitTestView = true;
         }
     }
+
+    @Test
+    public void testExistRequiredDistribution() throws Exception {
+        String sql = "select coalesce(l.S_ADDRESS,l.S_NATIONKEY) from supplier l join supplier r on l.s_suppkey = r.s_suppkey";
+        ExecPlan execPlan = getExecPlan(sql);
+        Assert.assertTrue("joinNode is in the same fragment with a table contains global dict, " +
+                "we cannot change its distribution", execPlan.getOptExpression(3).isExistRequiredDistribution());
+        Assert.assertTrue("table contains global dict, we cannot change its distribution",
+                execPlan.getOptExpression(0).isExistRequiredDistribution());
+
+        Assert.assertFalse("table doesn't contain global dict, we can change its distribution",
+                execPlan.getOptExpression(1).isExistRequiredDistribution());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
update the existRequiredDistribution value in optExpression. The next rules need it to determine if we can change the distribution to adjust the plan because of skew data, bad statistics or something else.

## What I'm doing:
- If the plan had been optimized by the global dict, we can't change the distribution in the plan.
- If the parent node had no requirement from its children, we can change the children's distribution.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
