### PR TITLE
[Enhancement] Get column statistics update time from BE for external table

### DIFF
--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -32,6 +32,7 @@ const int STATISTIC_BATCH_VERSION = 4;
 const int STATISTIC_EXTERNAL_VERSION = 5;
 const int STATISTIC_EXTERNAL_QUERY_VERSION = 6;
 const int STATISTIC_EXTERNAL_HISTOGRAM_VERSION = 7;
+const int STATISTIC_EXTERNAL_QUERY_VERSION_V2 = 8;
 
 StatisticResultWriter::StatisticResultWriter(BufferControlBlock* sinker,
                                              const std::vector<ExprContext*>& output_expr_ctxs,
@@ -159,6 +160,9 @@ StatusOr<TFetchDataResultPtr> StatisticResultWriter::_process_chunk(Chunk* chunk
                                   "Fill table statistic data failed");
     } else if (version == STATISTIC_EXTERNAL_HISTOGRAM_VERSION) {
         RETURN_IF_ERROR_WITH_WARN(_fill_statistic_histogram_external(version, result_columns, chunk, result.get()),
+                                  "Fill table statistic data failed");
+    } else if (version == STATISTIC_EXTERNAL_QUERY_VERSION_V2) {
+        RETURN_IF_ERROR_WITH_WARN(_fill_full_statistic_query_external_v2(version, result_columns, chunk, result.get()),
                                   "Fill table statistic data failed");
     }
     return result;
@@ -462,6 +466,47 @@ Status StatisticResultWriter::_fill_full_statistic_query_external(int version, c
         data_list[i].__set_nullCount(nullCounts.value(i));
         data_list[i].__set_max(maxColumn.value(i).to_string());
         data_list[i].__set_min(minColumn.value(i).to_string());
+    }
+
+    result->result_batch.rows.resize(num_rows);
+    result->result_batch.__set_statistic_version(version);
+
+    ThriftSerializer serializer(true, chunk->memory_usage());
+    for (int i = 0; i < num_rows; ++i) {
+        RETURN_IF_ERROR(serializer.serialize(&data_list[i], &result->result_batch.rows[i]));
+    }
+    return Status::OK();
+}
+
+Status StatisticResultWriter::_fill_full_statistic_query_external_v2(int version, const Columns& columns,
+                                                                     const Chunk* chunk, TFetchDataResult* result) {
+    SCOPED_TIMER(_serialize_timer);
+
+    // mapping with Data.thrift.TStatisticData
+    DCHECK(columns.size() == 9);
+
+    auto columnName = ColumnViewer<TYPE_VARCHAR>(columns[1]);
+    auto rowCounts = ColumnViewer<TYPE_BIGINT>(columns[2]);
+    auto dataSizes = ColumnViewer<TYPE_BIGINT>(columns[3]);
+    auto countDistincts = ColumnViewer<TYPE_BIGINT>(columns[4]);
+    auto nullCounts = ColumnViewer<TYPE_BIGINT>(columns[5]);
+    auto maxColumn = ColumnViewer<TYPE_VARCHAR>(columns[6]);
+    auto minColumn = ColumnViewer<TYPE_VARCHAR>(columns[7]);
+    auto updateTime = ColumnViewer<TYPE_DATETIME>(columns[8]);
+
+    std::vector<TStatisticData> data_list;
+    int num_rows = chunk->num_rows();
+
+    data_list.resize(num_rows);
+    for (int i = 0; i < num_rows; ++i) {
+        data_list[i].__set_columnName(columnName.value(i).to_string());
+        data_list[i].__set_rowCount(rowCounts.value(i));
+        data_list[i].__set_dataSize(dataSizes.value(i));
+        data_list[i].__set_countDistinct(countDistincts.value(i));
+        data_list[i].__set_nullCount(nullCounts.value(i));
+        data_list[i].__set_max(maxColumn.value(i).to_string());
+        data_list[i].__set_min(minColumn.value(i).to_string());
+        data_list[i].__set_updateTime(updateTime.value(i).to_string());
     }
 
     result->result_batch.rows.resize(num_rows);

--- a/be/src/runtime/statistic_result_writer.h
+++ b/be/src/runtime/statistic_result_writer.h
@@ -63,6 +63,9 @@ private:
     Status _fill_full_statistic_query_external(int version, const Columns& columns, const Chunk* chunk,
                                                TFetchDataResult* result);
 
+    Status _fill_full_statistic_query_external_v2(int version, const Columns& columns, const Chunk* chunk,
+                                                  TFetchDataResult* result);
+
     Status _fill_statistic_histogram_external(int version, const Columns& columns, const Chunk* chunk,
                                               TFetchDataResult* result);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorColumnStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorColumnStatsCacheLoader.java
@@ -135,6 +135,6 @@ public class ConnectorColumnStatsCacheLoader implements
 
         ColumnStatistic columnStatistic = ColumnBasicStatsCacheLoader.buildColumnStatistics(statisticData, splits[0],
                 splits[1], splits[3], statisticData.columnName, columnType);
-        return new ConnectorTableColumnStats(columnStatistic, statisticData.rowCount);
+        return new ConnectorTableColumnStats(columnStatistic, statisticData.rowCount, statisticData.updateTime);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableColumnStats.java
@@ -20,13 +20,15 @@ public class ConnectorTableColumnStats {
 
     private final ColumnStatistic columnStatistic;
     private final long rowCount;
+    private final String updateTime;
 
     private static final ConnectorTableColumnStats UNKNOWN =
-            new ConnectorTableColumnStats(ColumnStatistic.unknown(), -1);
+            new ConnectorTableColumnStats(ColumnStatistic.unknown(), -1, "");
 
-    public ConnectorTableColumnStats(ColumnStatistic columnStatistic, long rowCount) {
+    public ConnectorTableColumnStats(ColumnStatistic columnStatistic, long rowCount, String updateTime) {
         this.columnStatistic = columnStatistic;
         this.rowCount = rowCount;
+        this.updateTime = updateTime;
     }
 
     public static ConnectorTableColumnStats unknown() {
@@ -43,5 +45,9 @@ public class ConnectorTableColumnStats {
 
     public long getRowCount() {
         return rowCount;
+    }
+
+    public String getUpdateTime() {
+        return updateTime;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -696,7 +696,7 @@ public class MetadataMgr {
                 connectorTableColumnStats = new ConnectorTableColumnStats(
                         ColumnStatistic.buildFrom(columnStatisticList.get(i).getColumnStatistic()).
                                 setHistogram(histogram).build(),
-                        columnStatisticList.get(i).getRowCount());
+                        columnStatisticList.get(i).getRowCount(), columnStatisticList.get(i).getUpdateTime());
             } else {
                 connectorTableColumnStats = columnStatisticList.get(i);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -249,7 +249,8 @@ public class StatisticExecutor {
                 || version == StatsConstants.STATISTIC_BATCH_VERSION
                 || version == StatsConstants.STATISTIC_EXTERNAL_VERSION
                 || version == StatsConstants.STATISTIC_EXTERNAL_QUERY_VERSION
-                || version == StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION) {
+                || version == StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION
+                || version == StatsConstants.STATISTIC_EXTERNAL_QUERY_V2_VERSION) {
             TDeserializer deserializer = new TDeserializer(new TCompactProtocol.Factory());
             for (TResultBatch resultBatch : sqlResult) {
                 for (ByteBuffer bb : resultBatch.rows) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -33,7 +33,7 @@ import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_DATA_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION;
-import static com.starrocks.statistic.StatsConstants.STATISTIC_EXTERNAL_QUERY_VERSION;
+import static com.starrocks.statistic.StatsConstants.STATISTIC_EXTERNAL_QUERY_V2_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_HISTOGRAM_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_TABLE_VERSION;
 
@@ -58,10 +58,11 @@ public class StatisticSQLBuilder {
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";
 
-    private static final String QUERY_EXTERNAL_FULL_STATISTIC_TEMPLATE =
-            "SELECT cast(" + STATISTIC_EXTERNAL_QUERY_VERSION + " as INT), column_name,"
+    private static final String QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE =
+            "SELECT cast(" + STATISTIC_EXTERNAL_QUERY_V2_VERSION + " as INT), column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
-                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string)"
+                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string),"
+                    + " max(update_time)"
                     + " FROM " + StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
                     + " GROUP BY table_uuid, column_name";
@@ -147,7 +148,7 @@ public class StatisticSQLBuilder {
             context.put("predicate",
                     "table_uuid = \"" + tableUUID + "\"" + " and column_name in (" +
                             names.stream().map(c -> "\"" + c + "\"").collect(Collectors.joining(", ")) + ")");
-            querySQL.add(build(context, QUERY_EXTERNAL_FULL_STATISTIC_TEMPLATE));
+            querySQL.add(build(context, QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE));
         });
 
         return Joiner.on(" UNION ALL ").join(querySQL);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -30,6 +30,7 @@ public class StatsConstants {
     public static final int STATISTIC_EXTERNAL_VERSION = 5;
     public static final int STATISTIC_EXTERNAL_QUERY_VERSION = 6;
     public static final int STATISTIC_EXTERNAL_HISTOGRAM_VERSION = 7;
+    public static final int STATISTIC_EXTERNAL_QUERY_V2_VERSION = 8;
 
     public static final int STATISTICS_PARTITION_UPDATED_THRESHOLD = 10;
     public static final String STATISTICS_DB_NAME = "_statistics_";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
@@ -187,9 +187,9 @@ public class CachedStatisticStorageTest {
         ColumnStatistic columnStatistic1 = ColumnStatistic.builder().setDistinctValuesCount(888).build();
         ColumnStatistic columnStatistic2 = ColumnStatistic.builder().setDistinctValuesCount(999).build();
         ConnectorTableColumnStats connectorTableColumnStats1 =
-                new ConnectorTableColumnStats(columnStatistic1, 5);
+                new ConnectorTableColumnStats(columnStatistic1, 5, "2024-01-01 01:00:00");
         ConnectorTableColumnStats connectorTableColumnStats2 =
-                new ConnectorTableColumnStats(columnStatistic2, 5);
+                new ConnectorTableColumnStats(columnStatistic2, 5, "2024-01-01 02:00:00");
 
         new Expectations() {
             {
@@ -206,6 +206,8 @@ public class CachedStatisticStorageTest {
         Assert.assertEquals(999, columnStatistics.get(1).getColumnStatistic().getDistinctValuesCount(), 0.001);
         Assert.assertEquals(5, columnStatistics.get(0).getRowCount());
         Assert.assertEquals(5, columnStatistics.get(1).getRowCount());
+        Assert.assertEquals("2024-01-01 01:00:00", columnStatistics.get(0).getUpdateTime());
+        Assert.assertEquals("2024-01-01 02:00:00", columnStatistics.get(1).getUpdateTime());
     }
 
     @Test
@@ -293,10 +295,10 @@ public class CachedStatisticStorageTest {
         Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>> columnKeyOptionalMap = Maps.newHashMap();
         columnKeyOptionalMap.put(new ConnectorTableColumnKey(table.getUUID(), "c1"),
                 Optional.of(new ConnectorTableColumnStats(
-                        new ColumnStatistic(0, 10, 0, 20, 5), 5)));
+                        new ColumnStatistic(0, 10, 0, 20, 5), 5, "")));
         columnKeyOptionalMap.put(new ConnectorTableColumnKey(table.getUUID(), "c2"),
                 Optional.of(new ConnectorTableColumnStats(
-                        new ColumnStatistic(0, 100, 0, 200, 50), 50)));
+                        new ColumnStatistic(0, 100, 0, 200, 50), 50, "")));
 
         new MockUp<StatisticUtils>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -72,8 +72,8 @@ public class AnalyzeMgrTest {
             {
                 cachedStatisticStorage.getConnectorTableStatistics(table, ImmutableList.of("c1", "c2"));
                 result = ImmutableList.of(
-                        new ConnectorTableColumnStats(new ColumnStatistic(0, 10, 0, 20, 5), 5),
-                        new ConnectorTableColumnStats(new ColumnStatistic(0, 100, 0, 200, 50), 50)
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 10, 0, 20, 5), 5, ""),
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 100, 0, 200, 50), 50, "")
                 );
                 minTimes = 1;
             }
@@ -87,8 +87,8 @@ public class AnalyzeMgrTest {
             {
                 cachedStatisticStorage.getConnectorTableStatisticsSync(table, ImmutableList.of("c1", "c2"));
                 result = ImmutableList.of(
-                        new ConnectorTableColumnStats(new ColumnStatistic(0, 10, 0, 20, 5), 5),
-                        new ConnectorTableColumnStats(new ColumnStatistic(0, 100, 0, 200, 50), 50)
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 10, 0, 20, 5), 5, ""),
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 100, 0, 200, 50), 50, "")
                 );
                 minTimes = 1;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/MockHistogramStatisticStorage.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/MockHistogramStatisticStorage.java
@@ -377,7 +377,7 @@ public class MockHistogramStatisticStorage implements StatisticStorage {
             ColumnStatistic columnStatistic = ColumnStatistic.buildFrom(getColumnStatistic(table, col)).
                     setHistogram(histogram).build();
             long rowCount = tableRowCount.getOrDefault(table.getName(), -1);
-            connectorTableColumnStats.add(new ConnectorTableColumnStats(columnStatistic, rowCount));
+            connectorTableColumnStats.add(new ConnectorTableColumnStats(columnStatistic, rowCount, "2024-01-01 00:00:00"));
         }
         return connectorTableColumnStats;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -584,7 +584,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             @Mock
             public List<ConnectorTableColumnStats> getConnectorTableStatisticsSync(Table table, List<String> columns) {
                 return ImmutableList.of(new ConnectorTableColumnStats(new ColumnStatistic(1, 100, 0, 4, 100),
-                        100));
+                        100, ""));
             }
         };
 
@@ -706,7 +706,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             @Mock
             public List<ConnectorTableColumnStats> getConnectorTableStatisticsSync(Table table, List<String> columns) {
                 return ImmutableList.of(new ConnectorTableColumnStats(new ColumnStatistic(1, 100, 0, 4, 100),
-                        100));
+                        100, ""));
             }
         };
         statsJobs = StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(analyzeJob);
@@ -729,7 +729,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             @Mock
             public List<ConnectorTableColumnStats> getConnectorTableStatisticsSync(Table table, List<String> columns) {
                 return ImmutableList.of(new ConnectorTableColumnStats(new ColumnStatistic(1, 100, 0, 4, 100),
-                        100000000));
+                        100000000, ""));
             }
         };
 
@@ -814,7 +814,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             @Mock
             public List<ConnectorTableColumnStats> getConnectorTableStatisticsSync(Table table, List<String> columns) {
                 return ImmutableList.of(new ConnectorTableColumnStats(new ColumnStatistic(1, 100, 0, 4, 100),
-                        100));
+                        100, ""));
             }
         };
         new MockUp<DefaultTraits>() {
@@ -851,7 +851,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             @Mock
             public List<ConnectorTableColumnStats> getConnectorTableStatisticsSync(Table table, List<String> columns) {
                 return ImmutableList.of(new ConnectorTableColumnStats(new ColumnStatistic(1, 100, 0, 4, 100),
-                        100000000));
+                        100000000, ""));
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -137,14 +137,14 @@ public class StatisticsExecutorTest extends PlanTestBase {
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {
                 Assert.assertEquals(
-                        "SELECT cast(6 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
+                        "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as string)) as string), " +
-                                "cast(min(cast(min as string)) as string) FROM external_column_statistics " +
+                                "cast(min(cast(min as string)) as string), max(update_time) FROM external_column_statistics " +
                                 "WHERE table_uuid = \"hive0.partitioned_db.t1.0\" " +
                                 "and column_name in (\"c2\") GROUP BY table_uuid, column_name UNION ALL " +
-                                "SELECT cast(6 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
+                                "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as bigint)) as string), " +
-                                "cast(min(cast(min as bigint)) as string) " +
+                                "cast(min(cast(min as bigint)) as string), max(update_time) " +
                                 "FROM external_column_statistics WHERE table_uuid = \"hive0.partitioned_db.t1.0\"" +
                                 " and column_name in (\"c1\") GROUP BY table_uuid, column_name", sql);
                 return Lists.newArrayList();

--- a/test/sql/test_analyze_statistics/R/test_analyze_hive_stats
+++ b/test/sql/test_analyze_statistics/R/test_analyze_hive_stats
@@ -1,5 +1,11 @@
 -- name: test_analyze_hive_stats
-create external catalog analyze_hive_stats PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+create external catalog analyze_hive_stats PROPERTIES (
+     "type"="hive",
+     "hive.metastore.uris"="${hive_metastore_uris}",
+     "aws.s3.access_key"="${oss_ak}",
+     "aws.s3.secret_key"="${oss_sk}",
+     "aws.s3.endpoint"="${oss_endpoint}"
+ );
 -- result:
 -- !result
 analyze table analyze_hive_stats.hive_oss_db.hive_oss_par_parquet_snappy;
@@ -10,6 +16,12 @@ select count(1) from default_catalog._statistics_.external_column_statistics whe
 -- result:
 8
 -- !result
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 5, "desc": "wait fe cache stats finished"}
+  result=explain costs select * from analyze_hive_stats.hive_oss_db.hive_oss_par_parquet_snappy;
+  CHECK: re.search("col_int.*ESTIMATE", ${result}) != None
+} END LOOP
+
 analyze table analyze_hive_stats.hive_oss_db.hive_oss_par_parquet_snappy update histogram on col_int,col_string,col_date;
 -- result:
 [REGEX]OK

--- a/test/sql/test_analyze_statistics/T/test_analyze_hive_stats
+++ b/test/sql/test_analyze_statistics/T/test_analyze_hive_stats
@@ -1,11 +1,23 @@
 -- name: test_analyze_hive_stats
-create external catalog analyze_hive_stats PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+create external catalog analyze_hive_stats PROPERTIES (
+     "type"="hive",
+     "hive.metastore.uris"="${hive_metastore_uris}",
+     "aws.s3.access_key"="${oss_ak}",
+     "aws.s3.secret_key"="${oss_sk}",
+     "aws.s3.endpoint"="${oss_endpoint}"
+ );
 
 --analyze hive basic stats
 analyze table analyze_hive_stats.hive_oss_db.hive_oss_par_parquet_snappy;
 
 --check stats
 select count(1) from default_catalog._statistics_.external_column_statistics where catalog_name = 'analyze_hive_stats' and db_name = 'hive_oss_db' and table_name='hive_oss_par_parquet_snappy';
+--function: assert_explain_costs_contains('select * from analyze_hive_stats.hive_oss_db.hive_oss_par_parquet_snappy', 'ESTIMATE')
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 5, "desc": "wait fe cache stats finished"}
+  result=explain costs select * from analyze_hive_stats.hive_oss_db.hive_oss_par_parquet_snappy;
+  CHECK: re.search("col_int.*ESTIMATE", ${result}) != None
+} END LOOP
 
 --analyze hive histogram
 analyze table analyze_hive_stats.hive_oss_db.hive_oss_par_parquet_snappy update histogram on col_int,col_string,col_date;


### PR DESCRIPTION
## Why I'm doing:
get column statistics update time could help us known whether the cache is outdated
## What I'm doing:
Get column statistics update time from BE for external table
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
