### PR TITLE
[Enhancement] add creator field for TASK and MV

### DIFF
--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -60,6 +60,7 @@ SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
          false},
         {"EXTRA_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"QUERY_REWRITE_STATUS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"OWNER", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 SchemaMaterializedViewsScanner::SchemaMaterializedViewsScanner()
@@ -118,7 +119,8 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
                            Slice(info.rows),
                            Slice(info.text),
                            Slice(info.extra_message),
-                           Slice(info.query_rewrite_status)};
+                           Slice(info.query_rewrite_status),
+                           Slice(info.owner)};
 
     for (const auto& [slot_id, index] : slot_id_map) {
         Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();

--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -60,7 +60,7 @@ SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
          false},
         {"EXTRA_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"QUERY_REWRITE_STATUS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"OWNER", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"CREATOR", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 SchemaMaterializedViewsScanner::SchemaMaterializedViewsScanner()
@@ -120,7 +120,7 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
                            Slice(info.text),
                            Slice(info.extra_message),
                            Slice(info.query_rewrite_status),
-                           Slice(info.owner)};
+                           Slice(info.creator)};
 
     for (const auto& [slot_id, index] : slot_id_map) {
         Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();

--- a/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
@@ -30,6 +30,7 @@ SchemaScanner::ColumnDesc SchemaTasksScanner::_s_tbls_columns[] = {
         {"DEFINITION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"EXPIRE_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(StringValue), true},
         {"PROPERTIES", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"OWNER", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 SchemaTasksScanner::SchemaTasksScanner()
@@ -62,11 +63,12 @@ DatumArray SchemaTasksScanner::_build_row() {
     Datum create_time = task.__isset.create_time && task.create_time > 0
                                 ? TimestampValue::create_from_unixtime(task.create_time, _runtime_state->timezone_obj())
                                 : kNullDatum;
+    if (!task.__isset.owner) {
+        task.__set_owner("");
+    }
 
-    return {
-            Slice(task.task_name),  create_time, Slice(task.schedule),   Slice(task.catalog), Slice(task.database),
-            Slice(task.definition), expire_time, Slice(task.properties),
-    };
+    return {Slice(task.task_name),  create_time, Slice(task.schedule),   Slice(task.catalog), Slice(task.database),
+            Slice(task.definition), expire_time, Slice(task.properties), Slice(task.owner)};
 }
 
 Status SchemaTasksScanner::fill_chunk(ChunkPtr* chunk) {

--- a/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
@@ -30,7 +30,7 @@ SchemaScanner::ColumnDesc SchemaTasksScanner::_s_tbls_columns[] = {
         {"DEFINITION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"EXPIRE_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(StringValue), true},
         {"PROPERTIES", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
-        {"OWNER", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"CREATOR", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 SchemaTasksScanner::SchemaTasksScanner()
@@ -63,12 +63,9 @@ DatumArray SchemaTasksScanner::_build_row() {
     Datum create_time = task.__isset.create_time && task.create_time > 0
                                 ? TimestampValue::create_from_unixtime(task.create_time, _runtime_state->timezone_obj())
                                 : kNullDatum;
-    if (!task.__isset.owner) {
-        task.__set_owner("");
-    }
 
     return {Slice(task.task_name),  create_time, Slice(task.schedule),   Slice(task.catalog), Slice(task.database),
-            Slice(task.definition), expire_time, Slice(task.properties), Slice(task.owner)};
+            Slice(task.definition), expire_time, Slice(task.properties), Slice(task.creator)};
 }
 
 Status SchemaTasksScanner::fill_chunk(ChunkPtr* chunk) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -53,6 +53,7 @@ public class MaterializedViewsSystemTable {
                                 ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(1024))
                         .column("QUERY_REWRITE_STATUS", ScalarType.createVarcharType(64))
+                        .column("OWNER", ScalarType.createVarchar(74))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -53,7 +53,7 @@ public class MaterializedViewsSystemTable {
                                 ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(1024))
                         .column("QUERY_REWRITE_STATUS", ScalarType.createVarcharType(64))
-                        .column("OWNER", ScalarType.createVarchar(64))
+                        .column("CREATOR", ScalarType.createVarchar(64))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -53,7 +53,7 @@ public class MaterializedViewsSystemTable {
                                 ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(1024))
                         .column("QUERY_REWRITE_STATUS", ScalarType.createVarcharType(64))
-                        .column("OWNER", ScalarType.createVarchar(74))
+                        .column("OWNER", ScalarType.createVarchar(64))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
@@ -56,7 +56,7 @@ public class TasksSystemTable {
                         .column("DEFINITION", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXPIRE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("PROPERTIES", ScalarType.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("OWNER", ScalarType.createVarchar(64))
+                        .column("CREATOR", ScalarType.createVarchar(64))
                         .build(), TSchemaTableType.SCH_TASKS);
     }
 
@@ -99,7 +99,11 @@ public class TasksSystemTable {
             info.setDefinition(task.getDefinition());
             info.setExpire_time(task.getExpireTime() / 1000);
             info.setProperties(task.getPropertiesString());
-            info.setOwner(task.getCreateUser());
+            if (task.getUserIdentity() != null) {
+                info.setCreator(task.getUserIdentity().toString());
+            } else {
+                info.setCreator(task.getCreateUser());
+            }
             result.add(info);
         }
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
@@ -13,17 +13,36 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.thrift.TTaskInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TasksSystemTable {
+
+    private static final Logger LOG = LogManager.getLogger(TasksSystemTable.class);
+
     public static SystemTable create() {
         return new SystemTable(SystemId.TASKS_ID,
                 "tasks",
@@ -37,6 +56,52 @@ public class TasksSystemTable {
                         .column("DEFINITION", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXPIRE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("PROPERTIES", ScalarType.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("OWNER", ScalarType.createVarchar(64))
                         .build(), TSchemaTableType.SCH_TASKS);
+    }
+
+    public static List<TTaskInfo> query(TGetTasksParams params) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        TaskManager taskManager = globalStateMgr.getTaskManager();
+        List<Task> taskList = taskManager.filterTasks(params);
+        List<TTaskInfo> result = Lists.newArrayList();
+        UserIdentity currentUser = null;
+        if (params.isSetCurrent_user_ident()) {
+            currentUser = UserIdentity.fromThrift(params.current_user_ident);
+        }
+
+        for (Task task : taskList) {
+            if (task.getDbName() == null) {
+                LOG.warn("Ignore the task db because information is incorrect: " + task);
+                continue;
+            }
+
+            try {
+                Authorizer.checkAnyActionOnOrInDb(currentUser, null, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                        task.getDbName());
+            } catch (AccessDeniedException e) {
+                continue;
+            }
+
+            TTaskInfo info = new TTaskInfo();
+            info.setTask_name(task.getName());
+            info.setCreate_time(task.getCreateTime() / 1000);
+            String scheduleStr = "UNKNOWN";
+            if (task.getType() != null) {
+                scheduleStr = task.getType().name();
+            }
+            if (task.getType() == Constants.TaskType.PERIODICAL) {
+                scheduleStr += task.getSchedule();
+            }
+            info.setSchedule(scheduleStr);
+            info.setCatalog(task.getCatalogName());
+            info.setDatabase(ClusterNamespace.getNameFromFullName(task.getDbName()));
+            info.setDefinition(task.getDefinition());
+            info.setExpire_time(task.getExpireTime() / 1000);
+            info.setProperties(task.getPropertiesString());
+            info.setOwner(task.getCreateUser());
+            result.add(info);
+        }
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -56,6 +56,7 @@ public class ShowMaterializedViewStatus {
     private long lastCheckTime;
     private String inactiveReason;
     private String queryRewriteStatus;
+    private String owner;
     private List<TaskRunStatus> lastJobTaskRunStatus;
 
     /**
@@ -64,6 +65,7 @@ public class ShowMaterializedViewStatus {
     public class RefreshJobStatus {
         private long taskId;
         private String taskName;
+        private String taskOwner;
         private Constants.TaskRunState refreshState;
         private long mvRefreshStartTime;
         private long mvRefreshEndTime;
@@ -199,6 +201,14 @@ public class ShowMaterializedViewStatus {
 
         public void setExtraMessage(ExtraMessage extraMessage) {
             this.extraMessage = extraMessage;
+        }
+
+        public String getTaskOwner() {
+            return taskOwner;
+        }
+
+        public void setTaskOwner(String taskOwner) {
+            this.taskOwner = taskOwner;
         }
     }
 
@@ -380,6 +390,7 @@ public class ShowMaterializedViewStatus {
 
         status.setTaskId(firstTaskRunStatus.getTaskId());
         status.setTaskName(firstTaskRunStatus.getTaskName());
+        status.setTaskOwner(firstTaskRunStatus.getUser());
 
         // extra message
         ExtraMessage extraMessage = new ExtraMessage();
@@ -457,6 +468,10 @@ public class ShowMaterializedViewStatus {
         this.queryRewriteStatus = queryRewriteStatus;
     }
 
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
     /**
      * Return the thrift of show materialized views command from be's request.
      */
@@ -509,6 +524,8 @@ public class ShowMaterializedViewStatus {
 
         // query_rewrite_status
         status.setQuery_rewrite_status(queryRewriteStatus);
+        // owner
+        status.setOwner(refreshJobStatus.getTaskOwner());
 
         return status;
     }
@@ -576,6 +593,8 @@ public class ShowMaterializedViewStatus {
                 GsonUtils.GSON.toJson(refreshJobStatus.getExtraMessage()));
         // query_rewrite_status
         addField(resultRow, queryRewriteStatus);
+        // owner
+        addField(resultRow, refreshJobStatus.getTaskOwner());
 
         return resultRow;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -68,6 +68,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.information.TaskRunsSystemTable;
+import com.starrocks.catalog.system.information.TasksSystemTable;
 import com.starrocks.catalog.system.sys.GrantsTo;
 import com.starrocks.catalog.system.sys.RoleEdges;
 import com.starrocks.catalog.system.sys.SysFeLocks;
@@ -136,9 +137,6 @@ import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
-import com.starrocks.scheduler.Constants;
-import com.starrocks.scheduler.Task;
-import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.TemporaryTableMgr;
@@ -797,49 +795,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TGetTaskInfoResult getTasks(TGetTasksParams params) throws TException {
         LOG.debug("get show task request: {}", params);
+
+        List<TTaskInfo> tasksResult = TasksSystemTable.query(params);
         TGetTaskInfoResult result = new TGetTaskInfoResult();
-        List<TTaskInfo> tasksResult = Lists.newArrayList();
         result.setTasks(tasksResult);
-
-        UserIdentity currentUser = null;
-        if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentity.fromThrift(params.current_user_ident);
-        }
-        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        TaskManager taskManager = globalStateMgr.getTaskManager();
-        List<Task> taskList = taskManager.filterTasks(params);
-
-        for (Task task : taskList) {
-            if (task.getDbName() == null) {
-                LOG.warn("Ignore the task db because information is incorrect: " + task);
-                continue;
-            }
-
-            try {
-                Authorizer.checkAnyActionOnOrInDb(currentUser, null, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
-                        task.getDbName());
-            } catch (AccessDeniedException e) {
-                continue;
-            }
-
-            TTaskInfo info = new TTaskInfo();
-            info.setTask_name(task.getName());
-            info.setCreate_time(task.getCreateTime() / 1000);
-            String scheduleStr = "UNKNOWN";
-            if (task.getType() != null) {
-                scheduleStr = task.getType().name();
-            }
-            if (task.getType() == Constants.TaskType.PERIODICAL) {
-                scheduleStr += task.getSchedule();
-            }
-            info.setSchedule(scheduleStr);
-            info.setCatalog(task.getCatalogName());
-            info.setDatabase(ClusterNamespace.getNameFromFullName(task.getDbName()));
-            info.setDefinition(task.getDefinition());
-            info.setExpire_time(task.getExpireTime() / 1000);
-            info.setProperties(task.getPropertiesString());
-            tasksResult.add(info);
-        }
 
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -65,7 +65,7 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
                     .column("text", ScalarType.createVarchar(1024))
                     .column("extra_message", ScalarType.createVarchar(1024))
                     .column("query_rewrite_status", ScalarType.createVarchar(64))
-                    .column("owner", ScalarType.createVarchar(64))
+                    .column("creator", ScalarType.createVarchar(64))
                     .build();
 
     private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -65,6 +65,7 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
                     .column("text", ScalarType.createVarchar(1024))
                     .column("extra_message", ScalarType.createVarchar(1024))
                     .column("query_rewrite_status", ScalarType.createVarchar(64))
+                    .column("owner", ScalarType.createVarchar(64))
                     .build();
 
     private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -116,9 +116,10 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.MATERIALIZED_VIEW_DEFINITION AS text, " +
                         "information_schema.materialized_views.extra_message AS extra_message, " +
                         "information_schema.materialized_views.query_rewrite_status AS query_rewrite_status, " +
-                        "information_schema.materialized_views.owner AS owner " +
+                        "information_schema.materialized_views.creator AS creator " +
                         "FROM information_schema.materialized_views " +
-                        "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND (information_schema.materialized_views.TABLE_NAME = 'mv1')",
+                        "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') " +
+                        "AND (information_schema.materialized_views.TABLE_NAME = 'mv1')",
                 AstToStringBuilder.toString(stmt.toSelectStmt()));
         checkShowMaterializedViewsStmt(stmt);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -115,7 +115,8 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.TABLE_ROWS AS rows, " +
                         "information_schema.materialized_views.MATERIALIZED_VIEW_DEFINITION AS text, " +
                         "information_schema.materialized_views.extra_message AS extra_message, " +
-                        "information_schema.materialized_views.query_rewrite_status AS query_rewrite_status " +
+                        "information_schema.materialized_views.query_rewrite_status AS query_rewrite_status, " +
+                        "information_schema.materialized_views.owner AS owner " +
                         "FROM information_schema.materialized_views " +
                         "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND (information_schema.materialized_views.TABLE_NAME = 'mv1')",
                 AstToStringBuilder.toString(stmt.toSelectStmt()));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1030,14 +1030,15 @@ public class ShowExecutorTest {
         Assert.assertEquals("", resultSet.getString(12));
         Assert.assertEquals("false", resultSet.getString(13));
         System.out.println(resultSet.getResultRows());
-        for (int i = 14; i < mvSchemaTable.size() - 4; i++) {
+        for (int i = 14; i < mvSchemaTable.size() - 5; i++) {
             System.out.println(i);
             Assert.assertEquals("", resultSet.getString(i));
         }
-        Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 4));
-        Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 3));
-        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 2));
-        Assert.assertEquals("VALID", resultSet.getString(mvSchemaTable.size() - 1));
+        Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 5));
+        Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 4));
+        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 3));
+        Assert.assertEquals("VALID", resultSet.getString(mvSchemaTable.size() - 2));
+        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 1));
         Assert.assertFalse(resultSet.next());
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -406,7 +406,7 @@ struct TMaterializedViewStatus {
     26: optional string extra_message
     27: optional string query_rewrite_status
 
-    28: optional string owner
+    28: optional string creator
 }
 
 struct TListPipesParams {
@@ -498,7 +498,7 @@ struct TTaskInfo {
     6: optional i64 expire_time
     7: optional string properties
     8: optional string catalog
-    9: optional string owner
+    9: optional string creator
 }
 
 struct TGetTaskInfoResult {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -496,6 +496,7 @@ struct TTaskInfo {
     6: optional i64 expire_time
     7: optional string properties
     8: optional string catalog
+    9: optional string owner
 }
 
 struct TGetTaskInfoResult {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -405,6 +405,8 @@ struct TMaterializedViewStatus {
 
     26: optional string extra_message
     27: optional string query_rewrite_status
+
+    28: optional string owner
 }
 
 struct TListPipesParams {


### PR DESCRIPTION
## Why I'm doing:

The `creator` information can be used to track the creation and usage of many tasks in a system, so that the maintainer of a database can manage these tasks.

## What I'm doing:

Add a field `creator` into `information_schema.tasks` and `information_schema.materialized_views` view.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
