### PR TITLE
[Enhancement] Implicit cast constant int=varchar optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -210,7 +210,8 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
                 (typeVariable.isNumericType() && typeConstant.isBoolean()) ||
                 (typeVariable.isDateType() && typeConstant.isNumericType()) ||
                 (typeVariable.isDateType() && typeConstant.isStringType()) ||
-                (typeVariable.isFixedPointType() && typeConstant.isStringType()) ||
+                (typeVariable.isFixedPointType() && typeConstant.isStringType() &&
+                        predicate.getBinaryType() == BinaryType.EQ) ||
                 (typeVariable.isBoolean() && typeConstant.isStringType()) ||
                 checkStringCastToNumber) {
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -210,6 +210,7 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
                 (typeVariable.isNumericType() && typeConstant.isBoolean()) ||
                 (typeVariable.isDateType() && typeConstant.isNumericType()) ||
                 (typeVariable.isDateType() && typeConstant.isStringType()) ||
+                (typeVariable.isFixedPointType() && typeConstant.isStringType()) ||
                 (typeVariable.isBoolean() && typeConstant.isStringType()) ||
                 checkStringCastToNumber) {
 


### PR DESCRIPTION
## Why I'm doing:
for a table like this
```sql
CREATE TABLE `test_cast` (
  `id` bigint(20) NULL COMMENT "",
  `user_id` bigint(20) NULL COMMENT "",
  `pt` date NOT NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`id`)
COMMENT "OLAP"
PARTITION BY date_trunc('day', pt)
DISTRIBUTED BY HASH(`id`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1"
); 
```

`where id='1111'` can be extremly slow when row number is huge.
Currently, the plan is like this:
`|      PREDICATES: CAST(3: id AS VARCHAR(1048576)) = '1111'   |`
sparse index is not hit due to `cast`
Currently, `id in ('1111')` is implicitly translated to `id in (1111)`
so `|      PREDICATES: id = 1111   |` is the better plan and be consistent with `in`
## What I'm doing:
add implicit cast like tinyint/smallint/int/bigint=varchar
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
