### PR TITLE
[Enhancement] display method name of locker owner when slow lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
@@ -373,6 +373,7 @@ public class LockManager {
             readerInfo.addProperty("name", owner.getLocker().getThreadName());
             readerInfo.addProperty("heldFor", nowMs - owner.getLockAcquireTimeMs());
             readerInfo.addProperty("waitTime", owner.getLockAcquireTimeMs() - locker.getLockRequestTimeMs());
+            readerInfo.addProperty("locker", locker.getLockerStackTrace());
             readerInfo.add("stack", LogUtil.getStackTraceToJsonArray(
                     locker.getLockerThread(), 0, DEFAULT_STACK_RESERVE_LEVELS));
             ownerArray.add(readerInfo);


### PR DESCRIPTION
## Why I'm doing:
Want to know the lock scope when slow lock, for easier trouble shooting.
## What I'm doing:
display the method name which calls `new Locker()` when slow lock
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
