### PR TITLE
[BugFix] Fix like predicate dict rewrite error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
@@ -225,8 +225,7 @@ public class DictMappingRewriter {
 
         @Override
         public ScalarOperator visitLikePredicateOperator(LikePredicateOperator operator, RewriterContext context) {
-            operator.setChild(0, operator.getChild(0).accept(this, context));
-            return operator;
+            return rewriteForScalarOperator(operator, context);
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -833,6 +833,13 @@ public class LowCardinalityTest extends PlanTestBase {
     }
 
     @Test
+    public void testLike() throws Exception {
+        String sql = "select count(*) from supplier where S_ADDRESS like 'k' AND S_ADDRESS like S_COMMENT";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "DictDecode(12: S_ADDRESS, [<place-holder> = 'k'])");
+    }
+
+    @Test
     public void testScanPredicate() throws Exception {
         String sql;
         String plan;
@@ -1923,4 +1930,5 @@ public class LowCardinalityTest extends PlanTestBase {
             FeConstants.unitTestView = true;
         }
     }
+
 }


### PR DESCRIPTION
## Why I'm doing:
fix the pattern in lowcardinality column:

```
S_ADDRESS like 'k' AND S_ADDRESS like S_COMMENT
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
