### PR TITLE
[Enhancement] support incremental scan ranges  deployment at FE side

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -280,9 +280,4 @@ public class HdfsScanNode extends ScanNode {
     protected boolean supportTopNRuntimeFilter() {
         return true;
     }
-
-    @Override
-    public boolean isIncrementalScanRangesSupported() {
-        return true;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -106,7 +106,15 @@ public class HdfsScanNode extends ScanNode {
 
     @Override
     public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
-        return scanRangeSource.getAllOutputs();
+        if (maxScanRangeLength == 0) {
+            return scanRangeSource.getAllOutputs();
+        }
+        return scanRangeSource.getOutputs((int) maxScanRangeLength);
+    }
+
+    @Override
+    public boolean hasMoreScanRanges() {
+        return scanRangeSource.hasMoreOutput();
     }
 
     @Override
@@ -270,6 +278,11 @@ public class HdfsScanNode extends ScanNode {
 
     @Override
     protected boolean supportTopNRuntimeFilter() {
+        return true;
+    }
+
+    @Override
+    public boolean isIncrementalScanRangesSupported() {
         return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -100,6 +100,14 @@ public abstract class ScanNode extends PlanNode {
         return false;
     }
 
+    public boolean isIncrementalScanRangesSupported() {
+        return false;
+    }
+
+    public boolean hasMoreScanRanges() {
+        return false;
+    }
+
     /**
      * cast expr to SlotDescriptor type
      */

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -100,10 +100,6 @@ public abstract class ScanNode extends PlanNode {
         return false;
     }
 
-    public boolean isIncrementalScanRangesSupported() {
-        return false;
-    }
-
     public boolean hasMoreScanRanges() {
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -36,6 +36,7 @@ import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.qe.scheduler.assignment.FragmentAssignmentStrategyFactory;
 import com.starrocks.qe.scheduler.dag.ExecutionDAG;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.qe.scheduler.dag.JobSpec;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -256,6 +257,14 @@ public class CoordinatorPreprocessor {
 
         executionDAG.prepareCaptureVersion(enablePhasedSchedule);
         executionDAG.finalizeDAG();
+    }
+
+    public void assignIncrementalScanRangesToFragmentInstances(ExecutionFragment execFragment) throws UserException {
+        execFragment.getScanRangeAssignment().clear();
+        for (FragmentInstance instance : execFragment.getInstances()) {
+            instance.getNode2ScanRanges().clear();
+        }
+        fragmentAssignmentStrategyFactory.create(execFragment, workerProvider).assignFragmentToWorker(execFragment);
     }
 
     private void validateExecutionDAG() throws StarRocksPlannerException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -783,6 +783,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE = "connector_remote_file_async_queue_size";
     public static final String CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE = "connector_remote_file_async_task_size";
     public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = "enable_connector_incremental_scan_ranges";
+    public static final String CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE = "connector_incremental_scan_ranges_size";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -2130,6 +2131,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES)
     private boolean enableConnectorIncrementalScanRanges = false;
+
+    @VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE)
+    private int connectorIncrementalScanRangeSize = 1000;
 
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
@@ -4118,8 +4122,20 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return connectorRemoteFileAsyncTaskSize;
     }
 
+    public int getConnectorIncrementalScanRangeNumber() {
+        return connectorIncrementalScanRangeSize;
+    }
+
+    public void setConnectorIncrementalScanRangeNumber(int v) {
+        connectorIncrementalScanRangeSize = v;
+    }
+
     public boolean isEnableConnectorIncrementalScanRanges() {
         return enableConnectorIncrementalScanRanges;
+    }
+
+    public void setEnableConnectorIncrementalScanRanges(boolean v) {
+        enableConnectorIncrementalScanRanges = v;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -782,6 +782,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE = "connector_remote_file_async_queue_size";
     public static final String CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE = "connector_remote_file_async_task_size";
+    public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = "enable_connector_incremental_scan_ranges";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -2126,6 +2127,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE, flag = VariableMgr.INVISIBLE)
     private int connectorRemoteFileAsyncTaskSize = 4;
+
+    @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES)
+    private boolean enableConnectorIncrementalScanRanges = false;
 
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
@@ -4112,6 +4116,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getConnectorRemoteFileAsyncTaskSize() {
         return connectorRemoteFileAsyncTaskSize;
+    }
+
+    public boolean isEnableConnectorIncrementalScanRanges() {
+        return enableConnectorIncrementalScanRanges;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -131,7 +131,8 @@ public abstract class Coordinator {
 
     public abstract void cancel(PPlanFragmentCancelReason reason, String message);
 
-    public List<DeployState> assignIncrementalScanRangesToDeployStates(Deployer deployer, List<DeployState> deployStates) throws UserException {
+    public List<DeployState> assignIncrementalScanRangesToDeployStates(Deployer deployer, List<DeployState> deployStates)
+            throws UserException {
         return List.of();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -16,6 +16,7 @@ package com.starrocks.qe.scheduler;
 
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.common.Status;
+import com.starrocks.common.UserException;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.datacache.DataCacheSelectMetrics;
 import com.starrocks.planner.PlanFragment;
@@ -26,6 +27,7 @@ import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryStatisticsItem;
 import com.starrocks.qe.RowBatch;
+import com.starrocks.qe.scheduler.slot.DeployState;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.sql.plan.ExecPlan;
@@ -80,8 +82,8 @@ public abstract class Coordinator {
                                                 long warehouseId);
 
         Coordinator createRefreshDictionaryCacheScheduler(ConnectContext context, TUniqueId queryId,
-                                                DescriptorTable descTable, List<PlanFragment> fragments,
-                                                List<ScanNode> scanNodes);
+                                                          DescriptorTable descTable, List<PlanFragment> fragments,
+                                                          List<ScanNode> scanNodes);
     }
 
     // ------------------------------------------------------------------------------------
@@ -128,6 +130,10 @@ public abstract class Coordinator {
     }
 
     public abstract void cancel(PPlanFragmentCancelReason reason, String message);
+
+    public List<DeployState> assignIncrementalScanRangesToDeployStates(Deployer deployer, List<DeployState> deployStates) throws UserException {
+        return List.of();
+    }
 
     public abstract void onFinished();
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -204,6 +204,7 @@ public class Deployer {
                         fragment.getFragmentIndex(),
                         request,
                         instance.getWorker());
+                execution.setFragmentInstance(instance);
 
                 threeStageExecutionsToDeploy.get(stageIndex).add(execution);
 
@@ -249,6 +250,10 @@ public class Deployer {
         if (firstErrResult != null) {
             failureHandler.apply(firstErrResult.getStatus(), firstErrExecution, firstErrResult.getFailure());
         }
+    }
+
+    public TExecPlanFragmentParams createIncrementalScanRangesRequest(FragmentInstance instance) {
+        return tFragmentInstanceFactory.createIncrementalScanRanges(instance);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -39,6 +39,7 @@ import com.starrocks.thrift.TQueryQueueOptions;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 public class TFragmentInstanceFactory {
@@ -87,6 +88,17 @@ public class TFragmentInstanceFactory {
         toThriftFromCommonParams(result, instance.getExecFragment(), descTable, totalTableSinkDop);
         toThriftForUniqueParams(result, instance, accTabletSinkDop);
 
+        return result;
+    }
+
+    public TExecPlanFragmentParams createIncrementalScanRanges(FragmentInstance instance) {
+        TExecPlanFragmentParams result = new TExecPlanFragmentParams();
+        result.setProtocol_version(InternalServiceVersion.V1);
+        result.setParams(new TPlanFragmentExecParams());
+        result.params.setQuery_id(jobSpec.getQueryId());
+        result.params.setFragment_instance_id(instance.getInstanceId());
+        result.params.setPer_node_scan_ranges(instance.getNode2ScanRanges());
+        result.params.setPer_exch_num_senders(new HashMap<>());
         return result;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
@@ -57,7 +57,7 @@ public class BackendSelectorFactory {
 
         // The parameters of getScanRangeLocations may ignore, It doesn't take effect.
         int maxScanRangeLength = 0;
-        if (useIncrementalScanRanges && scanNode.isIncrementalScanRangesSupported()) {
+        if (useIncrementalScanRanges) {
             maxScanRangeLength = sessionVariable.getConnectorRemoteFileAsyncTaskSize();
         }
 
@@ -74,7 +74,7 @@ public class BackendSelectorFactory {
                 || scanNode instanceof OdpsScanNode || scanNode instanceof IcebergMetadataScanNode) {
             return new HDFSBackendSelector(scanNode, locations, assignment, workerProvider,
                     sessionVariable.getForceScheduleLocal(),
-                    sessionVariable.getHDFSBackendSelectorScanRangeShuffle());
+                    sessionVariable.getHDFSBackendSelectorScanRangeShuffle(), useIncrementalScanRanges);
         } else {
             boolean hasColocate = execFragment.isColocated();
             boolean hasBucket = execFragment.isLocalBucketShuffleJoin();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
@@ -58,7 +58,7 @@ public class BackendSelectorFactory {
         // The parameters of getScanRangeLocations may ignore, It doesn't take effect.
         int maxScanRangeLength = 0;
         if (useIncrementalScanRanges) {
-            maxScanRangeLength = sessionVariable.getConnectorRemoteFileAsyncTaskSize();
+            maxScanRangeLength = sessionVariable.getConnectorIncrementalScanRangeNumber();
         }
 
         List<TScanRangeLocations> locations = scanNode.getScanRangeLocations(maxScanRangeLength);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/FragmentAssignmentStrategyFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/FragmentAssignmentStrategyFactory.java
@@ -48,7 +48,7 @@ public class FragmentAssignmentStrategyFactory {
                     executionDAG.isGatherOutput(), random);
         } else {
             return new LocalFragmentAssignmentStrategy(connectContext, workerProvider, jobSpec.isEnablePipeline(),
-                    jobSpec.isLoadType());
+                    jobSpec.isLoadType(), jobSpec.isIncrementalScanRanges());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/LocalFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/LocalFragmentAssignmentStrategy.java
@@ -246,18 +246,6 @@ public class LocalFragmentAssignmentStrategy implements FragmentAssignmentStrate
         final int pipelineDop = fragment.getPipelineDop();
 
         FragmentScanRangeAssignment assignment = execFragment.getScanRangeAssignment();
-
-        if (useIncrementalScanRanges) {
-            for (ScanNode scanNode : execFragment.getScanNodes()) {
-                if (scanNode.isIncrementalScanRangesSupported()) {
-                    // TODO(yan): put some scan range for ending.
-                    for (ComputeNode computeNode : workerProvider.getAllWorkers()) {
-                        assignment.putAll(computeNode.getId(), scanNode.getId().asInt(), List.of());
-                    }
-                }
-            }
-        }
-
         assignment.forEach((workerId, scanRangesPerWorker) -> {
             // 1. Handle normal scan node firstly
             scanRangesPerWorker.forEach((scanId, scanRangesOfNode) -> {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -15,29 +15,45 @@
 package com.starrocks.qe.scheduler.dag;
 
 import com.starrocks.common.UserException;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.Deployer;
 import com.starrocks.qe.scheduler.slot.DeployState;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.thrift.TUniqueId;
 
+import java.util.ArrayList;
 import java.util.List;
 
 // all at once execution schedule only schedule once.
 public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
+    private Coordinator coordinator;
     private Deployer deployer;
     private ExecutionDAG dag;
 
     @Override
-    public void prepareSchedule(Deployer deployer, ExecutionDAG dag) {
+    public void prepareSchedule(Coordinator coordinator, Deployer deployer, ExecutionDAG dag) {
+        this.coordinator = coordinator;
         this.deployer = deployer;
         this.dag = dag;
     }
 
     @Override
     public void schedule() throws RpcException, UserException {
+        List<DeployState> states = new ArrayList<>();
         for (List<ExecutionFragment> executionFragments : dag.getFragmentsInTopologicalOrderFromRoot()) {
             final DeployState deployState = deployer.createFragmentExecStates(executionFragments);
             deployer.deployFragments(deployState);
+            states.add(deployState);
+        }
+
+        while (true) {
+            states = coordinator.assignIncrementalScanRangesToDeployStates(deployer, states);
+            if (states.isEmpty()) {
+                break;
+            }
+            for (DeployState state : states) {
+                deployer.deployFragments(state);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionSchedule.java
@@ -15,12 +15,13 @@
 package com.starrocks.qe.scheduler.dag;
 
 import com.starrocks.common.UserException;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.Deployer;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.thrift.TUniqueId;
 
 public interface ExecutionSchedule {
-    void prepareSchedule(Deployer deployer, ExecutionDAG dag);
+    void prepareSchedule(Coordinator coordinator, Deployer deployer, ExecutionDAG dag);
 
     void schedule() throws RpcException, UserException;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -95,6 +95,8 @@ public class FragmentInstanceExecState {
     private final TNetworkAddress address;
     private final long lastMissingHeartbeatTime;
 
+    private FragmentInstance fragmentInstance;
+
     /**
      * Create a fake backendExecState, only user for stream load profile.
      */
@@ -127,7 +129,6 @@ public class FragmentInstanceExecState {
                 request,
                 profile,
                 worker, address, worker.getLastMissingHeartbeatTime());
-
     }
 
     private FragmentInstanceExecState(JobSpec jobSpec,
@@ -482,5 +483,21 @@ public class FragmentInstanceExecState {
         public boolean isTerminal() {
             return this == FINISHED || this == FAILED;
         }
+    }
+
+    public FragmentInstance getFragmentInstance() {
+        return fragmentInstance;
+    }
+
+    public void setFragmentInstance(FragmentInstance fragmentInstance) {
+        this.fragmentInstance = fragmentInstance;
+    }
+
+    public TExecPlanFragmentParams getRequestToDeploy() {
+        return requestToDeploy;
+    }
+
+    public void setRequestToDeploy(TExecPlanFragmentParams requestToDeploy) {
+        this.requestToDeploy = requestToDeploy;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -93,6 +93,8 @@ public class JobSpec {
     private boolean needQueued = false;
     private boolean enableGroupLevelQueue = false;
 
+    private boolean incrementalScanRanges = false;
+
     public static class Factory {
         private Factory() {
         }
@@ -488,6 +490,14 @@ public class JobSpec {
         return planProtocol;
     }
 
+    public boolean isIncrementalScanRanges() {
+        return incrementalScanRanges;
+    }
+
+    public void setIncrementalScanRanges(boolean v) {
+        incrementalScanRanges = v;
+    }
+
     public void reset() {
         fragments.forEach(PlanFragment::reset);
     }
@@ -499,6 +509,7 @@ public class JobSpec {
             return GlobalStateMgr.getCurrentState().getGlobalSlotProvider();
         }
     }
+
     public boolean hasOlapTableSink() {
         for (PlanFragment fragment : fragments) {
             if (fragment.hasOlapTableSink()) {
@@ -507,6 +518,7 @@ public class JobSpec {
         }
         return false;
     }
+
     public static class Builder {
         private final JobSpec instance = new JobSpec();
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -132,7 +132,8 @@ public class HDFSBackendSelectorTest {
         );
 
         HDFSBackendSelector selector =
-                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider, false, false);
+                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider,
+                        false, false, false);
         selector.computeScanRangeAssignment();
 
         int avg = (scanRangeNumber * scanRangeSize) / hostNumber;
@@ -152,7 +153,8 @@ public class HDFSBackendSelectorTest {
                 true
         );
         selector =
-                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider, false, false);
+                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider,
+                        false, false, false);
         try {
             selector.computeScanRangeAssignment();
             Assert.fail();
@@ -198,7 +200,8 @@ public class HDFSBackendSelectorTest {
         );
 
         HDFSBackendSelector selector =
-                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider, false, false);
+                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider,
+                        false, false, false);
         selector.computeScanRangeAssignment();
 
         long avg = (scanRangeNumber * scanRangeSize) / hostNumber + 1;
@@ -245,7 +248,8 @@ public class HDFSBackendSelectorTest {
                 true
         );
         HDFSBackendSelector selector =
-                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider, false, false);
+                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider,
+                        false, false, false);
         HashRing hashRing = selector.makeHashRing();
         Assert.assertTrue(hashRing.policy().equals("ConsistentHash"));
         ConsistentHashRing consistentHashRing = (ConsistentHashRing) hashRing;
@@ -304,7 +308,8 @@ public class HDFSBackendSelectorTest {
         );
 
         HDFSBackendSelector selector =
-                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider, true, false);
+                new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider,
+                        true, false, false);
         selector.computeScanRangeAssignment();
 
         Map<Long, Long> stats = computeWorkerIdToReadBytes(assignment, scanNodeId);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/IncrementalDeployHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/IncrementalDeployHiveTest.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
+import com.starrocks.qe.scheduler.slot.DeployState;
+import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.THdfsScanRange;
+import com.starrocks.thrift.TPlanFragmentExecParams;
+import com.starrocks.thrift.TScanRangeParams;
+import com.starrocks.thrift.TUniqueId;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IncrementalDeployHiveTest extends SchedulerConnectorTestBase {
+
+    @Test
+    public void testSchedule() throws Exception {
+        String sql = "select * from hive0.file_split_db.file_split_tbl";
+        connectContext.getSessionVariable().setEnableConnectorIncrementalScanRanges(true);
+        connectContext.getSessionVariable().setConnectorIncrementalScanRangeNumber(20);
+        //        connectContext.getSessionVariable().setConnectorMaxSplitSize(1024 * 1024 * 1024);
+        List<TExecPlanFragmentParams> requests = new ArrayList<>();
+        // deploy
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+                System.out.println("----- deploy fragments ------");
+                final List<List<FragmentInstanceExecState>> state =
+                        deployState.getThreeStageExecutionsToDeploy();
+                for (List<FragmentInstanceExecState> execStates : state) {
+                    for (FragmentInstanceExecState execState : execStates) {
+                        {
+                            TPlanFragmentExecParams params = execState.getRequestToDeploy().params;
+                            for (List<TScanRangeParams> v : params.getPer_node_scan_ranges().values()) {
+                                for (TScanRangeParams p : v) {
+                                    System.out.println(p + ", " + System.identityHashCode(p));
+                                }
+                            }
+                        }
+                        // instance.node2ScanRanges is shared during incremental deployment.
+                        requests.add(execState.getRequestToDeploy().deepCopy());
+                    }
+                }
+            }
+        };
+        final DefaultCoordinator coordinator = startScheduling(sql);
+        Assert.assertTrue(coordinator.getJobSpec().isIncrementalScanRanges());
+        Map<TUniqueId, List<TScanRangeParams>> workload = new HashMap<>();
+        for (TExecPlanFragmentParams r : requests) {
+            TPlanFragmentExecParams params = r.params;
+            TUniqueId fragmentInstanceId = params.getFragment_instance_id();
+            if (params.getPer_node_scan_ranges().isEmpty()) {
+                continue;
+            }
+            List<TScanRangeParams> scanRanges = workload.computeIfAbsent(fragmentInstanceId, key -> new
+                    ArrayList<>());
+            for (List<TScanRangeParams> v : params.getPer_node_scan_ranges().values()) {
+                scanRanges.addAll(v);
+            }
+        }
+        // 3 nodes, each node has 1 instance.
+        Assert.assertEquals(workload.size(), 3);
+        Map<String, List<THdfsScanRange>> fileRangesMap = new HashMap<>();
+        for (Map.Entry<TUniqueId, List<TScanRangeParams>> kv : workload.entrySet()) {
+            System.out.println("----- checking fragment: " + kv.getKey() + "-----");
+            List<TScanRangeParams> v = kv.getValue();
+            for (int index = 0; index < v.size(); index++) {
+                TScanRangeParams p = v.get(index);
+                System.out.println(p + ", " + System.identityHashCode(p));
+                if (p.isPlaceholder()) {
+                    if (!p.has_more) {
+                        Assert.assertTrue((index + 1) == v.size());
+                    }
+                } else {
+                    THdfsScanRange sc = p.scan_range.hdfs_scan_range;
+                    String file = sc.relative_path;
+                    List<THdfsScanRange> ranges = fileRangesMap.computeIfAbsent(file, x -> new ArrayList<>());
+                    ranges.add(sc);
+                }
+            }
+        }
+
+        for (Map.Entry<String, List<THdfsScanRange>> kv : fileRangesMap.entrySet()) {
+            System.out.println("----- checking file: " + kv.getKey() + "-----");
+            List<THdfsScanRange> fileRangess = kv.getValue();
+            fileRangess.sort(new Comparator<THdfsScanRange>() {
+                @Override
+                public int compare(THdfsScanRange o1, THdfsScanRange o2) {
+                    return (int) (o1.offset - o2.offset);
+                }
+            });
+            for (int i = 0; i < fileRangess.size(); i++) {
+                THdfsScanRange f = fileRangess.get(i);
+                if (i == 0) {
+                    Assert.assertEquals(f.offset, 0);
+                } else if ((i + 1) == fileRangess.size()) {
+                    Assert.assertEquals(f.offset + f.length, f.file_length);
+                } else {
+                    THdfsScanRange nf = fileRangess.get(i + 1);
+                    Assert.assertEquals((f.offset + f.length), nf.offset);
+                }
+            }
+        }
+    }
+}

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -327,6 +327,8 @@ struct TQueryOptions {
 struct TScanRangeParams {
   1: required PlanNodes.TScanRange scan_range
   2: optional i32 volume_id = -1
+  3: optional bool placeholder = false
+  4: optional bool has_more = false;
 }
 
 // Parameters for a single execution instance of a particular TPlanFragment


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

### CoordinatorPreprocessor

Added `assignIncrementalScanRangesToFragmentInstances` interface, which recalculates the scan ranges of all fragment instances below a fragment.

Currently the distribution of `node2ScanRanges` is supported, but more complex data distributions such as `node + driver_seq -> scan range` are not supported for incremental deployment.

### ExecutionSchedule

We currently support two scheduling methods: all-at-once and phased. The difference is that they schedule different sets of fragment instances.

The modification to the code is that after each collection of fragment instances is scheduled, it immediately checks to see if there are any scan nodes left in the fragment instances that have not yet been scheduled. If there are, the scheduling process will continue.

The method used for subsequent scheduling is `coordinator.assignIncrementalScanRangesToDeployStates(deployer, states);`

### Coordinator

Adds the `assignIncrementalScanRangesToDeployStates` interface, which checks the scan node for more scan ranges based on the deploy states (i.e., the set of locally dispatched fragment instances).
- Checks all the following fragment instances against each deploy state.
- According to the fragment instances corresponding to these fragment instances, see if there are still scan nodes with scan ranges.
- If so, call coordinator preprocess to recalculate `node2ScanRanges` under fragment instances.
- Based on these fragment instances, regenerate the rpc request, and put it under the deploy state.

### Arch Diagram

![image](https://github.com/user-attachments/assets/460d64eb-acf5-49f7-aee9-e0cdf7db35fb)



Fixes #50196 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
