### PR TITLE
[BugFix] fix select partition meta error in lake table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -97,9 +97,6 @@ public class CompactionMgr implements MemoryTrackable {
             }
             v.setCurrentVersion(currentVersion);
             v.setCompactionScore(compactionScore);
-            if (v.getCompactionVersion() == null) {
-                v.setCompactionVersion(new PartitionVersion(0, versionTime));
-            }
             return v;
         });
         if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatistics.java
@@ -54,7 +54,7 @@ public class PartitionStatistics {
 
     public PartitionStatistics(PartitionIdentifier partition) {
         this.partition = partition;
-        this.compactionVersion = null;
+        this.compactionVersion = new PartitionVersion(0 /* version */, System.currentTimeMillis() /* createTime */);
         this.nextCompactionTime = 0;
         this.punishFactor = 1;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/PartitionStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/PartitionStatisticsTest.java
@@ -58,4 +58,10 @@ public class PartitionStatisticsTest {
         statistics.setCompactionScoreAndAdjustPunishFactor(q4);
         assertEquals(1, statistics.getPunishFactor());
     }
+
+    @Test
+    public void testGetCompactionVersion() {
+        PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(100, 200, 300));
+        assertEquals(0, statistics.getCompactionVersion().getVersion());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
mysql> create table t2 (id int);
Query OK, 0 rows affected (0.04 sec)

mysql> alter table t2 compact;
Query OK, 0 rows affected (0.02 sec)

mysql> select * from information_schema.partitions_meta where db_name='test' and table_name='t2';
ERROR 1064 (HY000): FE RPC failure, address=TNetworkAddress(hostname=172.26.92.212, port=8012), reason=Internal error processing getPartitionsMeta, host: unknown
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
