### PR TITLE
[BugFix] Refactor UserProperty to Separate Validation and Setting Logic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -121,7 +121,8 @@ public class UserProperty {
             String value = entry.second;
 
             if (key.equalsIgnoreCase(PROP_MAX_USER_CONNECTIONS)) {
-                setMaxConn(Long.parseLong(value));
+                long maxConn = checkMaxConn(value);
+                setMaxConn(maxConn);
             } else if (key.equalsIgnoreCase(PROP_DATABASE)) {
                 // we do not check database existence here, because we should
                 // check catalog existence first.

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -85,6 +85,7 @@ public class UserProperty {
         }
 
         String newDatabase = getDatabase();
+        String newCatalog = getCatalog();
         for (Pair<String, String> entry : properties) {
             String key = entry.first;
             String value = entry.second;
@@ -97,10 +98,12 @@ public class UserProperty {
                 newDatabase = value;
             } else if (key.equalsIgnoreCase(PROP_CATALOG)) {
                 checkCatalog(value);
+                newCatalog = value;
             } else if (key.startsWith(PROP_SESSION_PREFIX)) {
                 String sessionKey = key.substring(PROP_SESSION_PREFIX.length());
                 if (sessionKey.equalsIgnoreCase(PROP_CATALOG)) {
                     checkCatalog(value);
+                    newCatalog = value;
                 } else {
                     checkSessionVariable(sessionKey, value);
                 }
@@ -109,7 +112,7 @@ public class UserProperty {
             }
         }
         if (!newDatabase.equalsIgnoreCase(getDatabase())) {
-            checkDatabase(newDatabase);
+            checkDatabase(newCatalog, newDatabase);
         }
 
         newDatabase = getDatabase();
@@ -231,16 +234,16 @@ public class UserProperty {
 
     // check whether the database exist
     // we need to reset the database if it checks failed
-    private void checkDatabase(String newDatabase) {
+    private void checkDatabase(String newCatalog, String newDatabase) {
         if (newDatabase.equalsIgnoreCase(DATABASE_DEFAULT_VALUE)) {
             return;
         }
 
         // check whether the database exists
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        Database db = metadataMgr.getDb(getCatalog(), newDatabase);
+        Database db = metadataMgr.getDb(newCatalog, newDatabase);
         if (db == null) {
-            String catalogDbName = getCatalogDbName();
+            String catalogDbName = newCatalog + "." + newDatabase;
             throw new StarRocksConnectorException(catalogDbName + " not exists");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -90,23 +90,19 @@ public class UserProperty {
             String value = entry.second;
 
             if (key.equalsIgnoreCase(PROP_MAX_USER_CONNECTIONS)) {
-                long newMaxConn = checkMaxConn(value);
-                setMaxConn(newMaxConn);
+                checkMaxConn(value);
             } else if (key.equalsIgnoreCase(PROP_DATABASE)) {
                 // we do not check database existence here, because we should
                 // check catalog existence first.
                 newDatabase = value;
             } else if (key.equalsIgnoreCase(PROP_CATALOG)) {
                 checkCatalog(value);
-                setCatalog(value);
             } else if (key.startsWith(PROP_SESSION_PREFIX)) {
                 String sessionKey = key.substring(PROP_SESSION_PREFIX.length());
                 if (sessionKey.equalsIgnoreCase(PROP_CATALOG)) {
                     checkCatalog(value);
-                    setCatalog(value);
                 } else {
                     checkSessionVariable(sessionKey, value);
-                    setSessionVariable(sessionKey, value);
                 }
             } else {
                 throw new DdlException("Unknown user property(" + key + ")");
@@ -114,6 +110,31 @@ public class UserProperty {
         }
         if (!newDatabase.equalsIgnoreCase(getDatabase())) {
             checkDatabase(newDatabase);
+        }
+
+        newDatabase = getDatabase();
+        for (Pair<String, String> entry : properties) {
+            String key = entry.first;
+            String value = entry.second;
+
+            if (key.equalsIgnoreCase(PROP_MAX_USER_CONNECTIONS)) {
+                setMaxConn(Long.parseLong(value));
+            } else if (key.equalsIgnoreCase(PROP_DATABASE)) {
+                // we do not check database existence here, because we should
+                // check catalog existence first.
+                newDatabase = value;
+            } else if (key.equalsIgnoreCase(PROP_CATALOG)) {
+                setCatalog(value);
+            } else if (key.startsWith(PROP_SESSION_PREFIX)) {
+                String sessionKey = key.substring(PROP_SESSION_PREFIX.length());
+                if (sessionKey.equalsIgnoreCase(PROP_CATALOG)) {
+                    setCatalog(value);
+                } else {
+                    setSessionVariable(sessionKey, value);
+                }
+            }
+        }
+        if (!newDatabase.equalsIgnoreCase(getDatabase())) {
             setDatabase(newDatabase);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

In the event of a failed execution, the data of Leader and Follower is inconsistent. For example: alter user test_user set properties('session.query_timeout' = '600','properties_not_exists' = 'error');

## What I'm doing:

 - Refactored `UserProperty` class to separate the validation and setting of user properties.
 - Moved the setting of properties to a new loop after validation to ensure all properties are validated before any are set.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
