### PR TITLE
[BugFix] Do not apply cardinality-preserving join pruning if there is no prunable joins

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -353,6 +353,9 @@ public class Optimizer {
 
     private void pruneTables(OptExpression tree, TaskContext rootTaskContext, ColumnRefSet requiredColumns) {
         if (rootTaskContext.getOptimizerContext().getSessionVariable().isEnableRboTablePrune()) {
+            if (!Utils.hasPrunableJoin(tree)) {
+                return;
+            }
             // PARTITION_PRUNE is required to run before ReorderJoinRule because ReorderJoinRule's
             // Statistics calculation on Operators depends on row count yielded by the PARTITION_PRUNE.
             ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -374,6 +374,16 @@ public class Utils {
         return count;
     }
 
+    public static boolean hasPrunableJoin(OptExpression expression) {
+        if (expression.getOp() instanceof LogicalJoinOperator) {
+            LogicalJoinOperator joinOp = expression.getOp().cast();
+            JoinOperator joinType = joinOp.getJoinType();
+            return joinType.isInnerJoin() || joinType.isCrossJoin() ||
+                    joinType.isLeftOuterJoin() || joinType.isRightOuterJoin();
+        }
+        return expression.getInputs().stream().anyMatch(Utils::hasPrunableJoin);
+    }
+
     public static boolean hasUnknownColumnsStats(OptExpression root) {
         Operator operator = root.getOp();
         if (operator instanceof LogicalScanOperator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CPJoinGardener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CPJoinGardener.java
@@ -337,7 +337,7 @@ public class CPJoinGardener extends OptExpressionVisitor<Boolean, Void> {
         // pruned and the retained Scan operator to the pruned Scan operator from missing the
         // referenced ColumnRef originates from the pruned Scan operator.
         for (OptExpression child : root.getInputs()) {
-            if (child.getOp() instanceof LogicalOlapScanOperator) {
+            if (child.getOp() instanceof LogicalScanOperator) {
                 int ordinal = scanNodeOrdinals.size();
                 scanNodeOrdinals.put(child, ordinal);
                 ordinalToScanNodes.add(child);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTest.java
@@ -797,4 +797,17 @@ public class TablePruningTest extends TablePruningTestBase {
         String plan = UtFrameUtils.explainLogicalPlan(ctx, sql);
         Assert.assertTrue(plan, plan.contains("CLONE"));
     }
+
+    @Test
+    public void testBug() throws Exception {
+        String sql = "select\n" +
+                "  cast(101 as int),\n" +
+                "  cast(1 as bigint),\n" +
+                "  dict_merge(`c_city`) as _dict_merge_ \n" +
+                "from customer[_META_]\n";
+        ctx.getSessionVariable().setEnableCboTablePrune(true);
+        ctx.getSessionVariable().setEnableRboTablePrune(true);
+        String plan = UtFrameUtils.explainLogicalPlan(ctx, sql);
+        Assert.assertTrue(plan, plan.contains("META-SCAN"));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
