### PR TITLE
[Refactor] Unify the getTable interface to LocalMetastore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -262,7 +262,7 @@ public abstract class AlterJobV2 implements Writable {
      */
     protected boolean checkTableStable(Database db) throws AlterCancelException {
         long unHealthyTabletId = TabletInvertedIndex.NOT_EXIST_VALUE;
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -73,7 +73,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         String newMvName = clause.getNewTableName();
         String oldMvName = table.getName();
 
-        if (db.getTable(newMvName) != null) {
+        if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), newMvName) != null) {
             throw new SemanticException("Materialized view [" + newMvName + "] is already used");
         }
         table.setName(newMvName);
@@ -349,7 +349,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             }
             try {
                 // check
-                Table mv = db.getTable(materializedView.getId());
+                Table mv = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), materializedView.getId());
                 if (mv == null) {
                     throw new DmlException(
                             "update meta failed. materialized view:" + materializedView.getName() + " not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -85,13 +85,13 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         // send task to be
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         List<Partition> partitions = Lists.newArrayList();
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
 
         if (db == null) {
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
 
-        LakeTable table = (LakeTable) db.getTable(tableName);
+        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (table == null) {
             throw new AlterCancelException("table does not exist, tableName:" + tableName);
         }
@@ -135,13 +135,13 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
 
     @Override
     protected void runRunningJob() throws AlterCancelException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database has been dropped
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
 
-        LakeTable table = (LakeTable) db.getTable(tableId);
+        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             // table has been dropped
             throw new AlterCancelException("table does not exist, tableId:" + tableId);
@@ -187,14 +187,14 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             return;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database has been dropped
             LOG.warn("database does not exist, dbId:" + dbId);
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
 
-        LakeTable table = (LakeTable) db.getTable(tableId);
+        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             // table has been dropped
             LOG.warn("table does not exist, tableId:" + tableId);
@@ -221,12 +221,12 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     }
 
     boolean readyToPublishVersion() throws AlterCancelException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database has been dropped
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
-        LakeTable table = (LakeTable) db.getTable(tableId);
+        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             // table has been dropped
             throw new AlterCancelException("table does not exist, tableId:" + tableId);
@@ -422,9 +422,9 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             return false;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
-            LakeTable table = (LakeTable) db.getTable(tableId);
+            LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table != null) {
                 Locker locker = new Locker();
                 locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.WRITE);
@@ -480,14 +480,14 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             restoreState(other);
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database has been dropped
             LOG.warn("database does not exist, dbId:" + dbId);
             return;
         }
 
-        LakeTable table = (LakeTable) db.getTable(tableId);
+        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -697,9 +697,10 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
         if (modifiedColumns.isEmpty()) {
             return;
         }
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         for (MvId mvId : tbl.getRelatedMaterializedViews()) {
-            MaterializedView mv = (MaterializedView) db.getTable(mvId.getId());
+            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), mvId.getId());
             if (mv == null) {
                 LOG.warn("Ignore materialized view {} does not exists", mvId);
                 continue;
@@ -1055,13 +1056,13 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
 
     @Nullable
     ReadLockedDatabase getReadLockedDatabase(long dbId) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         return db != null ? new ReadLockedDatabase(db) : null;
     }
 
     @Nullable
     WriteLockedDatabase getWriteLockedDatabase(long dbId) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         return db != null ? new WriteLockedDatabase(db) : null;
     }
 
@@ -1088,7 +1089,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
 
         @Nullable
         OlapTable getTable(long tableId) {
-            return (OlapTable) db.getTable(tableId);
+            return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -140,7 +140,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
     }
 
     private OlapTable checkAndGetTable(Database db, long tableId) throws AlterCancelException {
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             throw new AlterCancelException("table: " + tableId + " does not exist in database: " + db.getFullName());
         }
@@ -158,7 +158,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         Preconditions.checkState(jobState == JobState.PENDING, jobState);
 
         LOG.info("begin to send create temp partitions. job: {}", jobId);
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Database " + dbId + " does not exist");
         }
@@ -233,7 +233,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         List<Long> partitionLastVersion = Lists.newArrayList();
         List<String> tableColumnNames = Lists.newArrayList();
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("database id: " + dbId + " does not exist");
         }
@@ -314,12 +314,12 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         // must check if db or table still exist first.
         // or if table is dropped, the tasks will never be finished,
         // and the job will be in RUNNING state forever.
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -545,7 +545,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         Database db = null;
         Locker locker = new Locker();
         try {
-            db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 throw new AlterCancelException("database id:" + dbId + " does not exist");
             }
@@ -560,7 +560,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         }
 
         try {
-            Table table = db.getTable(tableId);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 throw new AlterCancelException("table:" + tableId + " does not exist in database:" + db.getFullName());
             }
@@ -605,12 +605,12 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Should replay all changes before this job's state transfer to PENDING.
      */
     private void replayPending(OptimizeJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
             return;
         }
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             // table may be dropped before replaying this log. just return
             return;
@@ -633,12 +633,12 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Should replay all changes in runPendingJob()
      */
     private void replayWaitingTxn(OptimizeJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
             return;
         }
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             // table may be dropped before replaying this log. just return
             return;
@@ -691,9 +691,9 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Should replay all changes in runRuningJob()
      */
     private void replayFinished(OptimizeJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
-            OlapTable tbl = (OlapTable) db.getTable(tableId);
+            OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (tbl != null) {
                 try (AutoCloseableLock ignore =
                             new AutoCloseableLock(new Locker(), db, Lists.newArrayList(tbl.getId()), LockType.WRITE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -252,7 +252,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         Preconditions.checkState(jobState == JobState.PENDING, jobState);
 
         LOG.info("begin to send create rollup replica tasks. job: {}", jobId);
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Database " + dbId + " does not exist");
         }
@@ -272,7 +272,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         }
         MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(totalReplicaNum);
         createReplicaLatch = countDownLatch;
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -380,7 +380,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
         // create all rollup replicas success.
         // add rollup index to globalStateMgr
-        tbl = (OlapTable) db.getTable(tableId);
+        tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -478,11 +478,11 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         }
 
         LOG.info("previous transactions are all finished, begin to send rollup tasks. job: {}", jobId);
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -641,12 +641,12 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         // must check if db or table still exist first.
         // or if table is dropped, the tasks will never be finished,
         // and the job will be in RUNNING state forever.
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -776,9 +776,9 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         AgentTaskQueue.removeBatchTask(rollupBatchTask, TTaskType.ALTER);
         // remove all rollup indexes, and set state to NORMAL
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
-            OlapTable tbl = (OlapTable) db.getTable(tableId);
+            OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (tbl != null) {
                 try (AutoCloseableLock ignore =
                             new AutoCloseableLock(new Locker(), db, Lists.newArrayList(tbl.getId()), LockType.WRITE)) {
@@ -808,13 +808,13 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * These changes should be same as changes in RollupHander.processAddRollup()
      */
     private void replayPending(RollupJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
             return;
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             // table may be dropped before replaying this log. just return
             return;
@@ -856,12 +856,12 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Should replay all changes in runPendingJob()
      */
     private void replayWaitingTxn(RollupJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
             return;
         }
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             // table may be dropped before replaying this log. just return
             return;
@@ -884,9 +884,9 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
      * Should replay all changes in runRuningJob()
      */
     private void replayFinished(RollupJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
-            OlapTable tbl = (OlapTable) db.getTable(tableId);
+            OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (tbl != null) {
                 Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
                 try (AutoCloseableLock ignore

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2057,7 +2057,8 @@ public class SchemaChangeHandler extends AlterHandler {
                                 TTabletMetaType metaType)
             throws DdlException {
         List<Partition> partitions = Lists.newArrayList();
-        OlapTable olapTable = (OlapTable) db.getTable(tableName);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), tableName);
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.READ);
@@ -2134,7 +2135,7 @@ public class SchemaChangeHandler extends AlterHandler {
         boolean hasChanged = false;
         boolean isModifiedSuccess = true;
 
-        OlapTable olapTable = (OlapTable) db.getTable(tableId);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (olapTable == null) {
             return false;
         }
@@ -2240,7 +2241,8 @@ public class SchemaChangeHandler extends AlterHandler {
                                              String tableName,
                                              List<String> partitionNames,
                                              Map<String, String> properties) throws DdlException {
-        OlapTable olapTable = (OlapTable) db.getTable(tableName);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), tableName);
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.READ);
         try {
@@ -2283,7 +2285,8 @@ public class SchemaChangeHandler extends AlterHandler {
                                                 TTabletMetaType metaType) throws DdlException {
         // be id -> Set<tablet id>
         Map<Long, Set<Long>> beIdToTabletId = Maps.newHashMap();
-        OlapTable olapTable = (OlapTable) db.getTable(tableName);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), tableName);
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.READ);
@@ -2369,7 +2372,8 @@ public class SchemaChangeHandler extends AlterHandler {
                                           TTabletMetaType metaType) throws DdlException {
         // be id -> <tablet id>
         Map<Long, Set<Long>> beIdToTabletSet = Maps.newHashMap();
-        OlapTable olapTable = (OlapTable) db.getTable(tableName);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), tableName);
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(olapTable.getId()), LockType.READ);
@@ -2456,7 +2460,7 @@ public class SchemaChangeHandler extends AlterHandler {
         TableProperty tableProperty;
         OlapTable olapTable;
         try {
-            Table table = db.getTable(tableName);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
             if (table == null) {
                 throw new DdlException(String.format("table:%s does not exist", tableName));
             }
@@ -2534,12 +2538,12 @@ public class SchemaChangeHandler extends AlterHandler {
         Preconditions.checkState(!Strings.isNullOrEmpty(dbName));
         Preconditions.checkState(!Strings.isNullOrEmpty(tableName));
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database[" + dbName + "] does not exist");
         }
 
-        Table table = db.getTable(tableName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (table == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
         }
@@ -2767,8 +2771,8 @@ public class SchemaChangeHandler extends AlterHandler {
         List<Index> indexes = info.getIndexes();
         long jobId = info.getJobId();
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-        Table table = db.getTable(tableId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         Preconditions.checkArgument(table instanceof OlapTable,
                 "Target of light schema change must be olap table");
         OlapTable olapTable = (OlapTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -293,7 +293,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     protected void runPendingJob() throws AlterCancelException {
         Preconditions.checkState(jobState == JobState.PENDING, jobState);
         LOG.info("begin to send create replica tasks. job: {}", jobId);
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
@@ -314,7 +314,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>(totalReplicaNum);
         createReplicaLatch = countDownLatch;
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -434,7 +434,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
         // create all replicas success.
         // add all shadow indexes to globalStateMgr
-        tbl = (OlapTable) db.getTable(tableId);
+        tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -510,11 +510,11 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
 
         LOG.info("previous transactions are all finished, begin to send schema change tasks. job: {}", jobId);
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Databasee " + dbId + " does not exist");
         }
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -702,12 +702,12 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         // must check if db or table still exist first.
         // or if table is dropped, the tasks will never be finished,
         // and the job will be in RUNNING state forever.
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AlterCancelException("Database " + dbId + " does not exist");
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
@@ -974,9 +974,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         AgentTaskQueue.removeBatchTask(schemaChangeBatchTask, TTaskType.ALTER);
         // remove all shadow indexes, and set state to NORMAL
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
-            OlapTable tbl = (OlapTable) db.getTable(tableId);
+            OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (tbl != null) {
                 Locker locker = new Locker();
                 locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tbl.getId()), LockType.WRITE);
@@ -1019,13 +1019,13 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
      * These changes should be same as changes in SchemaChangeHandler.createJob()
      */
     private void replayPending(SchemaChangeJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
             return;
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             // table may be dropped before replaying this log. just return
             return;
@@ -1070,12 +1070,12 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
      * Should replay all changes in runPendingJob()
      */
     private void replayWaitingTxn(SchemaChangeJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // database may be dropped before replaying this log. just return
             return;
         }
-        OlapTable tbl = (OlapTable) db.getTable(tableId);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (tbl == null) {
             // table may be dropped before replaying this log. just return
             return;
@@ -1100,10 +1100,10 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
      * Should replay all changes in runRuningJob()
      */
     private void replayFinished(SchemaChangeJobV2 replayedJob) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
 
-            OlapTable tbl = (OlapTable) db.getTable(tableId);
+            OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (tbl != null) {
                 Locker locker = new Locker();
                 locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tbl.getId()), LockType.WRITE);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
@@ -240,7 +240,7 @@ public class SystemHandler extends AlterHandler {
                             Locker locker = new Locker();
                             locker.lockDatabase(db, LockType.READ);
                             try {
-                                for (Table table : db.getTables()) {
+                                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                                     if (table instanceof OlapTable) {
                                         OlapTable olapTable = (OlapTable) table;
                                         PartitionInfo partitionInfo = olapTable.getPartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Analyzer.java
@@ -229,11 +229,11 @@ public class Analyzer {
     }
 
     public Table getTable(TableName tblName) {
-        Database db = globalState.globalStateMgr.getDb(tblName.getDb());
+        Database db = globalState.globalStateMgr.getLocalMetastore().getDb(tblName.getDb());
         if (db == null) {
             return null;
         }
-        return db.getTable(tblName.getTbl());
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName.getTbl());
     }
 
     public TupleDescriptor getTupleDesc(TupleId id) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -126,26 +126,22 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
     }
 
     public void normalization(ConnectContext connectContext) {
-        try {
-            if (Strings.isNullOrEmpty(catalog)) {
-                if (Strings.isNullOrEmpty(connectContext.getCurrentCatalog())) {
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalog);
-                }
-                catalog = connectContext.getCurrentCatalog();
+        if (Strings.isNullOrEmpty(catalog)) {
+            if (Strings.isNullOrEmpty(connectContext.getCurrentCatalog())) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalog);
             }
+            catalog = connectContext.getCurrentCatalog();
+        }
 
+        if (Strings.isNullOrEmpty(db)) {
+            db = connectContext.getDatabase();
             if (Strings.isNullOrEmpty(db)) {
-                db = connectContext.getDatabase();
-                if (Strings.isNullOrEmpty(db)) {
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
-                }
+                ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
             }
+        }
 
-            if (Strings.isNullOrEmpty(tbl)) {
-                throw new SemanticException("Table name is null");
-            }
-        } catch (AnalysisException e) {
-            throw new SemanticException(e.getMessage());
+        if (Strings.isNullOrEmpty(tbl)) {
+            throw new SemanticException("Table name is null");
         }
     }
 
@@ -251,8 +247,12 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         TableName tableName = (TableName) o;
         return Objects.equals(catalog, tableName.catalog)
                 && Objects.equals(tbl, tableName.tbl)

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -262,7 +262,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
 
         // check if db exist
         String dbName = stmt.getDbName();
-        Database db = globalStateMgr.getDb(dbName);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
         if (db == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
@@ -319,7 +319,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
             List<Table> backupTbls = Lists.newArrayList();
             for (TableRef tblRef : tblRefs) {
                 String tblName = tblRef.getName().getTbl();
-                Table tbl = db.getTable(tblName);
+                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
                 if (tbl == null) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tblName);
                     return;
@@ -519,7 +519,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     }
 
     public AbstractJob getAbstractJobByDbName(String dbName) throws DdlException {
-        Database db = globalStateMgr.getDb(dbName);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
         if (db == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -393,7 +393,7 @@ public class BackupJob extends AbstractJob {
     protected void checkBackupTables(Database db) {
         for (TableRef tableRef : tableRefs) {
             String tblName = tableRef.getName().getTbl();
-            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
+            Table tbl = globalStateMgr.getLocalMetastore().getTable(db.getFullName(), tblName);
             if (tbl == null) {
                 status = new Status(ErrCode.NOT_FOUND, "table " + tblName + " does not exist");
                 return;
@@ -473,7 +473,7 @@ public class BackupJob extends AbstractJob {
             // create snapshot tasks
             for (TableRef tblRef : tableRefs) {
                 String tblName = tblRef.getName().getTbl();
-                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                OlapTable tbl = (OlapTable) globalStateMgr.getLocalMetastore()
                             .getTable(db.getFullName(), tblName);
                 List<Partition> partitions = Lists.newArrayList();
                 if (tblRef.getPartitionNames() == null) {
@@ -509,7 +509,7 @@ public class BackupJob extends AbstractJob {
             List<Table> copiedTables = Lists.newArrayList();
             for (TableRef tableRef : tableRefs) {
                 String tblName = tableRef.getName().getTbl();
-                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                OlapTable tbl = (OlapTable) globalStateMgr.getLocalMetastore()
                             .getTable(db.getFullName(), tblName);
                 // only copy visible indexes
                 List<String> reservedPartitions = tableRef.getPartitionNames() == null ? null

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -393,7 +393,7 @@ public class BackupJob extends AbstractJob {
     protected void checkBackupTables(Database db) {
         for (TableRef tableRef : tableRefs) {
             String tblName = tableRef.getName().getTbl();
-            Table tbl = db.getTable(tblName);
+            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
             if (tbl == null) {
                 status = new Status(ErrCode.NOT_FOUND, "table " + tblName + " does not exist");
                 return;
@@ -449,7 +449,7 @@ public class BackupJob extends AbstractJob {
 
     private void prepareAndSendSnapshotTask() {
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB.increase(1L);
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             status = new Status(ErrCode.NOT_FOUND, "database " + dbId + " does not exist");
             return;
@@ -473,7 +473,8 @@ public class BackupJob extends AbstractJob {
             // create snapshot tasks
             for (TableRef tblRef : tableRefs) {
                 String tblName = tblRef.getName().getTbl();
-                OlapTable tbl = (OlapTable) db.getTable(tblName);
+                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), tblName);
                 List<Partition> partitions = Lists.newArrayList();
                 if (tblRef.getPartitionNames() == null) {
                     partitions.addAll(tbl.getPartitions());
@@ -508,7 +509,8 @@ public class BackupJob extends AbstractJob {
             List<Table> copiedTables = Lists.newArrayList();
             for (TableRef tableRef : tableRefs) {
                 String tblName = tableRef.getName().getTbl();
-                OlapTable tbl = (OlapTable) db.getTable(tblName);
+                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), tblName);
                 // only copy visible indexes
                 List<String> reservedPartitions = tableRef.getPartitionNames() == null ? null
                         : tableRef.getPartitionNames().getPartitionNames();

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -414,7 +414,7 @@ public class RestoreJob extends AbstractJob {
             return;
         }
 
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             status = new Status(ErrCode.NOT_FOUND, "database " + dbId + " has been dropped");
             return;
@@ -424,7 +424,8 @@ public class RestoreJob extends AbstractJob {
         locker.lockDatabase(db, LockType.READ);
         try {
             for (IdChain idChain : fileMapping.getMapping().keySet()) {
-                OlapTable tbl = (OlapTable) db.getTable(idChain.getTblId());
+                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), idChain.getTblId());
                 if (tbl == null) {
                     status = new Status(ErrCode.NOT_FOUND, "table " + idChain.getTblId() + " has been dropped");
                     return;
@@ -468,7 +469,7 @@ public class RestoreJob extends AbstractJob {
      */
     private void checkAndPrepareMeta() {
         MetricRepo.COUNTER_UNFINISHED_RESTORE_JOB.increase(1L);
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             status = new Status(ErrCode.NOT_FOUND, "database " + dbId + " does not exist");
             return;
@@ -488,7 +489,8 @@ public class RestoreJob extends AbstractJob {
         locker.lockDatabase(db, LockType.WRITE);
         try {
             for (BackupTableInfo tblInfo : jobInfo.tables.values()) {
-                Table tbl = db.getTable(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
+                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
                 if (tbl == null) {
                     continue;
                 }
@@ -523,7 +525,8 @@ public class RestoreJob extends AbstractJob {
             for (BackupTableInfo tblInfo : jobInfo.tables.values()) {
                 Table remoteTbl = backupMeta.getTable(tblInfo.name);
                 Preconditions.checkNotNull(remoteTbl);
-                Table localTbl = db.getTable(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
+                Table localTbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
                 if (localTbl != null) {
                     if (localTbl instanceof OlapTable && localTbl.hasAutoIncrementColumn()) {
                         // it must be !isReplay == true
@@ -731,7 +734,8 @@ public class RestoreJob extends AbstractJob {
 
             // generate create replica tasks for all restored partitions
             for (Pair<String, Partition> entry : restoredPartitions) {
-                OlapTable localTbl = (OlapTable) db.getTable(entry.first);
+                OlapTable localTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), entry.first);
                 Preconditions.checkNotNull(localTbl, localTbl.getName());
                 Partition restorePart = entry.second;
                 OlapTable remoteTbl = (OlapTable) backupMeta.getTable(entry.first);
@@ -862,7 +866,8 @@ public class RestoreJob extends AbstractJob {
         locker.lockDatabase(db, LockType.READ);
         try {
             for (IdChain idChain : fileMapping.getMapping().keySet()) {
-                OlapTable tbl = (OlapTable) db.getTable(idChain.getTblId());
+                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), idChain.getTblId());
                 PhysicalPartition part = tbl.getPhysicalPartition(idChain.getPartId());
                 MaterializedIndex index = part.getIndex(idChain.getIdxId());
                 LocalTablet tablet = (LocalTablet) index.getTablet(idChain.getTabletId());
@@ -1087,13 +1092,14 @@ public class RestoreJob extends AbstractJob {
     }
 
     private void replayCheckAndPrepareMeta() {
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.WRITE);
         try {
             // replay set all existing tables's state to RESTORE
             for (BackupTableInfo tblInfo : jobInfo.tables.values()) {
-                Table tbl = db.getTable(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
+                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
                 if (tbl == null) {
                     continue;
                 }
@@ -1121,7 +1127,8 @@ public class RestoreJob extends AbstractJob {
 
     protected void addRestoredPartitions(Database db, boolean modify) {
         for (Pair<String, Partition> entry : restoredPartitions) {
-            OlapTable localTbl = (OlapTable) db.getTable(entry.first);
+            OlapTable localTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getFullName(), entry.first);
             Partition restorePart = entry.second;
             OlapTable remoteTbl = (OlapTable) backupMeta.getTable(entry.first);
             RangePartitionInfo localPartitionInfo = (RangePartitionInfo) localTbl.getPartitionInfo();
@@ -1191,7 +1198,7 @@ public class RestoreJob extends AbstractJob {
         for (long dbId : dbToSnapshotInfos.keySet()) {
             List<SnapshotInfo> infos = dbToSnapshotInfos.get(dbId);
 
-            Database db = globalStateMgr.getDb(dbId);
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
             if (db == null) {
                 status = new Status(ErrCode.NOT_FOUND, "db " + dbId + " does not exist");
                 return;
@@ -1280,7 +1287,7 @@ public class RestoreJob extends AbstractJob {
             int currentBatchTaskNum = (batch == batchNum - 1) ? totalNum - index : taskNumPerBatch;
             for (int j = 0; j < currentBatchTaskNum; j++) {
                 SnapshotInfo info = beSnapshotInfos.get(index++);
-                Table tbl = db.getTable(info.getTblId());
+                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), info.getTblId());
                 if (tbl == null) {
                     status = new Status(ErrCode.NOT_FOUND, "restored table "
                             + info.getTabletId() + " does not exist");
@@ -1416,7 +1423,7 @@ public class RestoreJob extends AbstractJob {
     }
 
     private Status allTabletCommitted(boolean isReplay) {
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             return new Status(ErrCode.NOT_FOUND, "database " + dbId + " does not exist");
         }
@@ -1429,7 +1436,7 @@ public class RestoreJob extends AbstractJob {
             setTableStateToNormal(db);
 
             for (long tblId : restoredVersionInfo.rowKeySet()) {
-                Table tbl = db.getTable(tblId);
+                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tblId);
                 if (tbl == null) {
                     continue;
                 }
@@ -1475,7 +1482,8 @@ public class RestoreJob extends AbstractJob {
             locker.lockDatabase(db, LockType.READ);
             try {
                 for (BackupTableInfo tblInfo : jobInfo.tables.values()) {
-                    Table tbl = db.getTable(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
+                    Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getFullName(), jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
                     // skip to restore table ids
                     if (skipRestoreRemoteTableIds.contains(tblInfo.id)) {
                         continue;
@@ -1643,7 +1651,7 @@ public class RestoreJob extends AbstractJob {
         }
 
         // clean restored objs
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db != null) {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.WRITE);
@@ -1666,7 +1674,8 @@ public class RestoreJob extends AbstractJob {
 
                 // remove restored partitions
                 for (Pair<String, Partition> entry : restoredPartitions) {
-                    OlapTable restoreTbl = (OlapTable) db.getTable(entry.first);
+                    OlapTable restoreTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getFullName(), entry.first);
                     if (restoreTbl == null) {
                         continue;
                     }
@@ -1715,7 +1724,8 @@ public class RestoreJob extends AbstractJob {
             if (skipRestoreRemoteTableIds.contains(tblInfo.id)) {
                 continue;
             }
-            Table tbl = db.getTable(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
+            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getFullName(), jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
             if (tbl == null) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
@@ -213,13 +213,14 @@ public class MVRestoreUpdater {
 
         String remoteDbName = baseTableInfo.getDbName();
         String remoteTableName = baseTableInfo.getTableName();
-        Database baseTableDb = GlobalStateMgr.getCurrentState().getDb(remoteDbName);
+        Database baseTableDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(remoteDbName);
         if (baseTableDb == null) {
             LOG.warn(String.format("Materialized view %s can not find old base table's db name:%s.%s",
                     mv.getName(), remoteDbName, remoteTableName));
             return false;
         }
-        Table baseTable = baseTableDb.getTable(remoteTableName);
+        Table baseTable = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(baseTableDb.getFullName(), remoteTableName);
         if (baseTable == null) {
             LOG.warn(String.format("Materialized view %s can not find old base table:%s.%s",
                     mv.getName(), remoteDbName, remoteTableName));
@@ -249,14 +250,14 @@ public class MVRestoreUpdater {
         }
 
         String localDbName = mvBaseTableBackupInfo.getLocalDbName();
-        Database db = GlobalStateMgr.getCurrentState().getDb(localDbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(localDbName);
         String localTableName = mvBaseTableBackupInfo.getLocalTableName();
         if (db == null) {
             LOG.warn("BaseTable(local) {}'s db {} is not found, remote db/table: {}/{}",
                     localTableName, localDbName, remoteDbName, remoteTableName);
             return Pair.create(false, Optional.empty());
         }
-        Table localTable = db.getTable(localTableName);
+        Table localTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), localTableName);
         remoteToLocalTableName.put(remoteDbTblName, new TableName(db.getFullName(), localTableName));
         if (localTable == null) {
             LOG.warn("Materialized view {} can not find the base table {}, old base table name:{}",

--- a/fe/fe-core/src/main/java/com/starrocks/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/binlog/BinlogManager.java
@@ -226,12 +226,13 @@ public class BinlogManager {
 
 
     public boolean isBinlogAvailable(long dbId, long tableId) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (olapTable != null) {
                     return olapTable.getBinlogAvailableVersion().size() != 0;
                 }
@@ -246,12 +247,13 @@ public class BinlogManager {
     // the binlog is available
     // result : partitionId -> binlogAvailableVersion, null indicates the db or table is dropped
     public Map<Long, Long> getBinlogAvailableVersion(long dbId, long tableId) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (olapTable != null) {
                     return olapTable.getBinlogAvailableVersion();
                 }
@@ -268,12 +270,12 @@ public class BinlogManager {
         HashMap<Long, BinlogConfig> allTablesWithBinlogConfigMap = new HashMap<>();
         List<Long> allDbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
         for (Long dbId : allDbIds) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db != null) {
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    List<Table> tables = db.getTables();
+                    List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
                     for (Table table : tables) {
                         if (table.isOlapTable() && ((OlapTable) table).isBinlogEnabled()) {
                             allTablesWithBinlogConfigMap.put(table.getId(), ((OlapTable) table).getCurBinlogConfig());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -126,7 +126,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         Preconditions.checkState(!idToDatabase.containsKey(db.getId()));
 
         // db should be empty. all tables are recycled before
-        Preconditions.checkState(db.getTables().isEmpty());
+        Preconditions.checkState(GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId()).isEmpty());
 
         // erase db with same name
         eraseDatabaseWithSameName(db.getFullName());
@@ -832,7 +832,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             // we need to get olap table to get schema hash info
             // first find it in globalStateMgr. if not found, it should be in recycle bin
             OlapTable olapTable = null;
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 // just log. db should be in recycle bin
                 if (!idToDatabase.containsKey(dbId)) {
@@ -842,7 +842,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                     continue;
                 }
             } else {
-                olapTable = (OlapTable) db.getTable(tableId);
+                olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             }
 
             if (olapTable == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -126,7 +126,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         Preconditions.checkState(!idToDatabase.containsKey(db.getId()));
 
         // db should be empty. all tables are recycled before
-        Preconditions.checkState(GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId()).isEmpty());
+        Preconditions.checkState(db.getTables().isEmpty());
 
         // erase db with same name
         eraseDatabaseWithSameName(db.getFullName());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -57,7 +57,7 @@ public class CatalogUtils {
 
     // check table exist
     public static void checkTableExist(Database db, String tableName) throws DdlException {
-        Table table = db.getTable(tableName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (table == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
         }
@@ -115,12 +115,12 @@ public class CatalogUtils {
 
     // Used to temporarily disable some command on lake table and remove later.
     public static void checkIsLakeTable(String dbName, String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             return;
         }
 
-        Table table = db.getTable(tableName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (table == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -288,7 +288,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         fullSchemaTemp.addAll(updatedTable.fullSchema);
         dataColumnNamesTemp.addAll(updatedTable.dataColumnNames);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new StarRocksConnectorException("Not found database " + dbName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -992,7 +992,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * @return active or not
      */
     private boolean onReloadImpl() {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.warn("db:{} do not exist. materialized view id:{} name:{} should not exist", dbId, id, name);
             setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForDbNotExists(dbId));
@@ -1003,7 +1003,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             if (baseTableIds != null) {
                 // for compatibility
                 for (long tableId : baseTableIds) {
-                    Table table = db.getTable(tableId);
+                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                     if (table == null) {
                         setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(tableId));
                         return false;
@@ -1079,7 +1079,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     private void analyzePartitionInfo() {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
 
         if (partitionInfo.isUnPartitioned()) {
             return;
@@ -1840,7 +1840,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     String.format("Materialized view %s's base info is not found", this.name));
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             return new Status(Status.ErrCode.NOT_FOUND,
                     String.format("Materialized view %s's db %s is not found", this.name, this.dbId));
@@ -1989,7 +1989,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public synchronized ParseNode getDefineQueryParseNode() {
         if (this.defineQueryParseNode == null) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
@@ -73,7 +73,7 @@ public class MetadataViewer {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         SystemInfoService infoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
 
-        Database db = globalStateMgr.getDb(dbName);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exsit");
         }
@@ -81,7 +81,7 @@ public class MetadataViewer {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table tbl = db.getTable(tblName);
+            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
             if (tbl == null || tbl.getType() != TableType.OLAP) {
                 throw new DdlException("Table does not exist or is not OLAP table: " + tblName);
             }
@@ -202,7 +202,7 @@ public class MetadataViewer {
         List<List<String>> result = Lists.newArrayList();
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getDb(dbName);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exsit");
         }
@@ -210,7 +210,7 @@ public class MetadataViewer {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table tbl = db.getTable(tblName);
+            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
             if (tbl == null || !tbl.isNativeTableOrMaterializedView()) {
                 throw new DdlException("Table does not exist or is not native table: " + tblName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1016,11 +1016,11 @@ public class OlapTable extends Table {
             if (localMvId == null) {
                 continue;
             }
-            Database mvDb = GlobalStateMgr.getCurrentState().getDb(localMvId.getDbId());
+            Database mvDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(localMvId.getDbId());
             if (mvDb == null) {
                 continue;
             }
-            Table mvTable = mvDb.getTable(localMvId.getId());
+            Table mvTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(mvDb.getId(), localMvId.getId());
             if (mvTable == null) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -209,7 +209,7 @@ public class ResourceGroupClassifier {
         if (CollectionUtils.isNotEmpty(databaseIds)) {
             String str = databaseIds.stream()
                     .map(id ->
-                            Optional.ofNullable(GlobalStateMgr.getCurrentState().getDb(id))
+                            Optional.ofNullable(GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(id))
                                     .map(Database::getFullName)
                                     .orElse("unknown"))
                     .collect(Collectors.joining(","));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -394,7 +394,8 @@ public class TabletInvertedIndex implements MemoryTrackable {
                     if (creatingTableIds.containsKey(tableId)) {
                         continue;
                     }
-                    com.starrocks.catalog.Table table = db.getTable(tableId);
+                    com.starrocks.catalog.Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getId(), tableId);
                     if (table == null) {
                         table = recycleBin.getTable(dbId, tableId);
                         if (table != null) {
@@ -544,10 +545,11 @@ public class TabletInvertedIndex implements MemoryTrackable {
             long dbId = tabletMeta.getDbId();
             long tableId = tabletMeta.getTableId();
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db != null) {
                 // getTable is thread-safe for caller, lock free
-                com.starrocks.catalog.Table tbl = db.getTable(tableId);
+                com.starrocks.catalog.Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (tbl != null && tbl instanceof OlapTable) {
                     OlapTable olapTable = (OlapTable) tbl;
                     if (olapTable.getState() == OlapTable.OlapTableState.RESTORE) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -102,14 +102,14 @@ public class TabletStatMgr extends FrontendDaemon {
         long start = System.currentTimeMillis();
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
         for (Long dbId : dbIds) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.WRITE);
             try {
-                for (Table table : db.getTables()) {
+                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                     long totalRowCount = 0L;
                     if (!table.isNativeTableOrMaterializedView()) {
                         continue;
@@ -199,12 +199,12 @@ public class TabletStatMgr extends FrontendDaemon {
 
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
         for (Long dbId : dbIds) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
 
-            List<Table> tables = db.getTables();
+            List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
             for (Table table : tables) {
                 if (table.isCloudNativeTableOrMaterializedView()) {
                     updateLakeTableTabletStat(db, (OlapTable) table);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/UniqueConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/UniqueConstraint.java
@@ -22,7 +22,6 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.common.Pair;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.common.MetaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -65,7 +64,10 @@ public class UniqueConstraint {
         if (referencedTable != null) {
             targetTable = referencedTable;
         } else {
-            targetTable = MetaUtils.getTable(catalogName, dbName, tableName);
+            targetTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+            if (targetTable == null) {
+                throw new SemanticException("Table %s is not found", tableName);
+            }
         }
         List<String> result = new ArrayList<>(uniqueColumns.size());
         for (ColumnId columnId : uniqueColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
@@ -193,7 +193,8 @@ public class GrantsTo {
                         } else {
                             Database database;
                             if (CatalogMgr.isInternalCatalog(catalogName)) {
-                                database = GlobalStateMgr.getCurrentState().getDb(Long.parseLong(dbPEntryObject.getUUID()));
+                                database = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                            .getDb(Long.parseLong(dbPEntryObject.getUUID()));
                             } else {
                                 String dbName = ExternalCatalog.getDbNameFromUUID(dbPEntryObject.getUUID());
                                 database = metadataMgr.getDb(catalogName, dbName);
@@ -241,7 +242,7 @@ public class GrantsTo {
                         } else {
                             Database database;
                             if (CatalogMgr.isInternalCatalog(tablePEntryObject.getCatalogId())) {
-                                database = GlobalStateMgr.getCurrentState()
+                                database = GlobalStateMgr.getCurrentState().getLocalMetastore()
                                         .getDb(Long.parseLong(tablePEntryObject.getDatabaseUUID()));
                             } else {
                                 String dbName = ExternalCatalog.getDbNameFromUUID(tablePEntryObject.getDatabaseUUID());
@@ -261,7 +262,8 @@ public class GrantsTo {
                                 objects.addAll(expandAllTables(metadataMgr, catalogName, dbName, privEntry.getKey()));
                             } else {
                                 if (CatalogMgr.isInternalCatalog(tablePEntryObject.getCatalogId())) {
-                                    Table table = database.getTable((Long.parseLong(tablePEntryObject.getTableUUID())));
+                                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                .getTable(database.getId(), (Long.parseLong(tablePEntryObject.getTableUUID())));
                                     if (table == null) {
                                         continue;
                                     }
@@ -319,7 +321,7 @@ public class GrantsTo {
                     if (databaseId == PrivilegeBuiltinConstants.ALL_DATABASE_ID) {
                         List<String> dbNames = metadataMgr.listDbNames(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
                         for (String dbName : dbNames) {
-                            Database database = GlobalStateMgr.getCurrentState().getDb(dbName);
+                            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
                             if (database == null) {
                                 continue;
                             }
@@ -333,7 +335,7 @@ public class GrantsTo {
                             }
                         }
                     } else {
-                        Database database = GlobalStateMgr.getCurrentState().getDb(databaseId);
+                        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(databaseId);
                         if (database == null) {
                             continue;
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
@@ -85,7 +85,7 @@ public class SysObjectDependencies {
                     .orElse(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
             locker.lockDatabase(db, LockType.READ);
             try {
-                for (Table table : db.getTables()) {
+                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                     // If it is not a materialized view, we do not need to verify permissions
                     if (!table.isMaterializedView()) {
                         continue;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -507,7 +507,7 @@ public class TabletChecker extends FrontendDaemon {
         while (iter.hasNext()) {
             Map.Entry<Long, Map<Long, Set<PrioPart>>> dbEntry = iter.next();
             long dbId = dbEntry.getKey();
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 iter.remove();
                 continue;
@@ -518,7 +518,7 @@ public class TabletChecker extends FrontendDaemon {
             try {
                 for (Map.Entry<Long, Set<PrioPart>> tblEntry : dbEntry.getValue().entrySet()) {
                     long tblId = tblEntry.getKey();
-                    OlapTable tbl = (OlapTable) db.getTable(tblId);
+                    OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tblId);
                     if (tbl == null) {
                         deletedUrgentTable.add(Pair.create(dbId, tblId));
                         continue;
@@ -609,7 +609,7 @@ public class TabletChecker extends FrontendDaemon {
     public static RepairTabletInfo getRepairTabletInfo(String dbName, String tblName, List<String> partitions)
             throws DdlException {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getDb(dbName);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist");
         }
@@ -620,7 +620,7 @@ public class TabletChecker extends FrontendDaemon {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table tbl = db.getTable(tblName);
+            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
             if (tbl == null || tbl.getType() != TableType.OLAP) {
                 throw new DdlException("Table does not exist or is not OLAP table: " + tblName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1283,7 +1283,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             return true;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             return true;
         }
@@ -1291,7 +1291,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         Locker locker = new Locker();
         try {
             locker.lockDatabase(db, LockType.READ);
-            Table table = db.getTable(tblId);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tblId);
             if (table == null) {
                 return true;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1500,7 +1500,7 @@ public class TabletScheduler extends FrontendDaemon {
             long tabletId = schedCtx.getTabletId();
             long indexId = schedCtx.getIndexId();
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
@@ -1509,7 +1509,7 @@ public class TabletScheduler extends FrontendDaemon {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                tbl = db.getTable(tableId);
+                tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             } finally {
                 locker.unLockDatabase(db, LockType.READ);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/DbsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/DbsProcDir.java
@@ -83,9 +83,9 @@ public class DbsProcDir implements ProcDirInterface {
 
         Database db;
         try {
-            db = globalStateMgr.getDb(Long.parseLong(dbIdOrName));
+            db = globalStateMgr.getLocalMetastore().getDb(Long.parseLong(dbIdOrName));
         } catch (NumberFormatException e) {
-            db = globalStateMgr.getDb(dbIdOrName);
+            db = globalStateMgr.getLocalMetastore().getDb(dbIdOrName);
         }
 
         if (db == null) {
@@ -110,7 +110,7 @@ public class DbsProcDir implements ProcDirInterface {
         // get info
         List<List<Comparable>> dbInfos = new ArrayList<List<Comparable>>();
         for (String dbName : dbNames) {
-            Database db = globalStateMgr.getDb(dbName);
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
             if (db == null) {
                 continue;
             }
@@ -118,7 +118,7 @@ public class DbsProcDir implements ProcDirInterface {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                int tableNum = db.getTables().size();
+                int tableNum = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId()).size();
                 dbInfo.add(db.getId());
                 dbInfo.add(dbName);
                 dbInfo.add(tableNum);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/JobsDbProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/JobsDbProcDir.java
@@ -76,7 +76,7 @@ public class JobsDbProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid db id format: " + dbIdStr);
         }
 
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new AnalysisException("Database[" + dbId + "] does not exist.");
         }
@@ -98,7 +98,7 @@ public class JobsDbProcDir implements ProcDirInterface {
         }
 
         for (String name : names) {
-            Database db = globalStateMgr.getDb(name);
+            Database db = globalStateMgr.getLocalMetastore().getDb(name);
             result.addRow(Lists.newArrayList(String.valueOf(db.getId()), name));
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcUtils.java
@@ -24,7 +24,7 @@ public class ProcUtils {
         try {
             return Long.parseLong(dbIdOrName);
         } catch (NumberFormatException e) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbIdOrName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbIdOrName);
             if (db == null) {
                 throw new AnalysisException("Unknown database id or name \"" + dbIdOrName + "\"");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
@@ -125,7 +125,7 @@ public class StatisticProcDir implements ProcDirInterface {
                 // skip information_schema database
                 continue;
             }
-            Database db = globalStateMgr.getDb(dbId);
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
@@ -141,7 +141,7 @@ public class StatisticProcDir implements ProcDirInterface {
                 int dbTabletNum = 0;
                 int dbReplicaNum = 0;
 
-                for (Table table : db.getTables()) {
+                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                     if (!table.isNativeTableOrMaterializedView()) {
                         continue;
                     }
@@ -259,7 +259,7 @@ public class StatisticProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid db id format: " + dbIdStr);
         }
 
-        if (globalStateMgr.getDb(dbId) == null) {
+        if (globalStateMgr.getLocalMetastore().getDb(dbId) == null) {
             throw new AnalysisException("Invalid db id: " + dbIdStr);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TablesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TablesProcDir.java
@@ -52,6 +52,7 @@ import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.server.GlobalStateMgr;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -95,9 +96,9 @@ public class TablesProcDir implements ProcDirInterface {
         locker.lockDatabase(db, LockType.READ);
         try {
             try {
-                table = db.getTable(Long.parseLong(tableIdOrName));
+                table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), Long.parseLong(tableIdOrName));
             } catch (NumberFormatException e) {
-                table = db.getTable(tableIdOrName);
+                table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableIdOrName);
             }
         } finally {
             locker.unLockDatabase(db, LockType.READ);
@@ -119,7 +120,7 @@ public class TablesProcDir implements ProcDirInterface {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            for (Table table : db.getTables()) {
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                 List<Comparable> tableInfo = new ArrayList<Comparable>();
                 TableType tableType = table.getType();
                 tableInfo.add(table.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SmallFileMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SmallFileMgr.java
@@ -197,7 +197,7 @@ public class SmallFileMgr implements Writable {
 
     public void createFile(CreateFileStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist");
         }
@@ -207,7 +207,7 @@ public class SmallFileMgr implements Writable {
 
     public void dropFile(DropFileStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist");
         }
@@ -496,7 +496,7 @@ public class SmallFileMgr implements Writable {
     }
 
     public List<List<String>> getInfo(String dbName) throws DdlException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRepository.java
@@ -35,7 +35,6 @@
 package com.starrocks.connector.elasticsearch;
 
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
@@ -119,9 +118,7 @@ public class EsRepository extends FrontendDaemon {
         }
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
         for (Long dbId : dbIds) {
-            Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
-
-            List<Table> tables = database.getTables();
+            List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(dbId);
             for (Table table : tables) {
                 if (table.getType() == TableType.ELASTICSEARCH) {
                     registerTable((EsTable) table);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
@@ -184,12 +184,12 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
         GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
         MetadataMgr metadataMgr = gsm.getMetadataMgr();
         List<Database> databases = gsm.getLocalMetastore().getDbIds().stream()
-                .map(gsm::getDb)
+                .map(dbId -> GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId))
                 .filter(Objects::nonNull)
                 .filter(db -> !db.isSystemDatabase())
                 .collect(Collectors.toList());
         for (Database db : databases) {
-            List<HiveTable> tables = db.getTables().stream()
+            List<HiveTable> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId()).stream()
                     .filter(tbl -> tbl.getType() == Table.TableType.HIVE)
                     .map(tbl -> (HiveTable) tbl)
                     .collect(Collectors.toList());
@@ -199,7 +199,7 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
                             "in the background", db.getFullName(), table.getName(), table.getDbName(), table.getTableName());
                     // we didn't use db locks to prevent background tasks from affecting the query.
                     // So we need to check if the table to be refreshed exists.
-                    if (db.getTable(table.getId()) != null) {
+                    if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), table.getId()) != null) {
                         metadataMgr.refreshTable(table.getCatalogName(), db.getFullName(),
                                 table, Lists.newArrayList(), false);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/informationschema/InformationSchemaMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/informationschema/InformationSchemaMetadata.java
@@ -20,7 +20,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.connector.ConnectorMetadata;
-import com.starrocks.server.GlobalStateMgr;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,14 +45,13 @@ public class InformationSchemaMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listTableNames(String dbName) {
-        return GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTables(infoSchemaDb.getId()).stream().map(Table::getName).collect(Collectors.toList());
+        return infoSchemaDb.getTables().stream().map(Table::getName).collect(Collectors.toList());
     }
 
     @Override
     public Table getTable(String dbName, String tblName) {
         if (isInfoSchemaDb(dbName)) {
-            return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(infoSchemaDb.getFullName(), tblName);
+            return infoSchemaDb.getTable(tblName);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/informationschema/InformationSchemaMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/informationschema/InformationSchemaMetadata.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.server.GlobalStateMgr;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,13 +46,14 @@ public class InformationSchemaMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listTableNames(String dbName) {
-        return infoSchemaDb.getTables().stream().map(Table::getName).collect(Collectors.toList());
+        return GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTables(infoSchemaDb.getId()).stream().map(Table::getName).collect(Collectors.toList());
     }
 
     @Override
     public Table getTable(String dbName, String tblName) {
         if (isInfoSchemaDb(dbName)) {
-            return infoSchemaDb.getTable(tblName);
+            return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(infoSchemaDb.getFullName(), tblName);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
@@ -128,13 +128,13 @@ public class CheckConsistencyJob {
             return false;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(tabletMeta.getDbId());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tabletMeta.getDbId());
         if (db == null) {
             LOG.debug("db[{}] does not exist", tabletMeta.getDbId());
             return false;
         }
 
-        Table table = db.getTable(tabletMeta.getTableId());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tabletMeta.getTableId());
         if (table == null) {
             LOG.debug("table[{}] does not exist", tabletMeta.getTableId());
             return false;
@@ -254,13 +254,13 @@ public class CheckConsistencyJob {
             return -1;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(tabletMeta.getDbId());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tabletMeta.getDbId());
         if (db == null) {
             LOG.warn("db[{}] does not exist", tabletMeta.getDbId());
             return -1;
         }
 
-        Table table = db.getTable(tabletMeta.getTableId());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tabletMeta.getTableId());
         if (table == null) {
             LOG.warn("table[{}] does not exist", tabletMeta.getTableId());
             return -1;

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -301,7 +301,7 @@ public class ConsistencyChecker extends FrontendDaemon {
                 long startTime = System.currentTimeMillis();
                 try {
                     // sort tables
-                    List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
+                    List<Table> tables = globalStateMgr.getLocalMetastore().getTables(db.getId());
                     Queue<MetaObject> tableQueue = new PriorityQueue<>(Math.max(tables.size(), 1), COMPARATOR);
                     for (Table table : tables) {
                         // Only check the OLAP table who is in NORMAL state.

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -284,7 +284,7 @@ public class ConsistencyChecker extends FrontendDaemon {
                 // skip 'information_schema' database
                 continue;
             }
-            Database db = globalStateMgr.getDb(dbId);
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
@@ -301,7 +301,7 @@ public class ConsistencyChecker extends FrontendDaemon {
                 long startTime = System.currentTimeMillis();
                 try {
                     // sort tables
-                    List<Table> tables = db.getTables();
+                    List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
                     Queue<MetaObject> tableQueue = new PriorityQueue<>(Math.max(tables.size(), 1), COMPARATOR);
                     for (Table table : tables) {
                         // Only check the OLAP table who is in NORMAL state.
@@ -416,12 +416,13 @@ public class ConsistencyChecker extends FrontendDaemon {
     }
 
     public void replayFinishConsistencyCheck(ConsistencyCheckInfo info, GlobalStateMgr globalStateMgr) {
-        Database db = globalStateMgr.getDb(info.getDbId());
+        Database db = globalStateMgr.getLocalMetastore().getDb(info.getDbId());
         if (db == null) {
             LOG.warn("replay finish consistency check failed, db is null, info: {}", info);
             return;
         }
-        OlapTable table = (OlapTable) db.getTable(info.getTableId());
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), info.getTableId());
         if (table == null) {
             LOG.warn("replay finish consistency check failed, table is null, info: {}", info);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoad.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoad.java
@@ -76,7 +76,7 @@ public class CancelStreamLoad extends RestBaseAction {
         // FIXME(cmy)
         // checkWritePriv(authInfo.fullUserName, fullDbName);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("unknown database, database=" + dbName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetDdlStmtAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetDdlStmtAction.java
@@ -90,7 +90,7 @@ public class GetDdlStmtAction extends RestBaseAction {
             throw new DdlException("Missing params. Need database name and Table name");
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database[" + dbName + "] does not exist");
         }
@@ -102,7 +102,7 @@ public class GetDdlStmtAction extends RestBaseAction {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table table = db.getTable(tableName);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
             if (table == null) {
                 throw new DdlException("Table[" + tableName + "] does not exist");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
@@ -76,7 +76,7 @@ public class GetStreamLoadState extends RestBaseAction {
         // FIXME(cmy)
         // checkReadPriv(authInfo.fullUserName, fullDbName);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("unknown database, database=" + dbName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MigrationAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MigrationAction.java
@@ -96,7 +96,7 @@ public class MigrationAction extends RestBaseAction {
             throw new DdlException("Missing params. Need database name");
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database[" + dbName + "] does not exist");
         }
@@ -106,7 +106,7 @@ public class MigrationAction extends RestBaseAction {
         locker.lockDatabase(db, LockType.READ);
         try {
             if (!Strings.isNullOrEmpty(tableName)) {
-                Table table = db.getTable(tableName);
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
                 if (table == null) {
                     throw new DdlException("Table[" + tableName + "] does not exist");
                 }
@@ -135,7 +135,7 @@ public class MigrationAction extends RestBaseAction {
                 }
             } else {
                 // get all olap table
-                for (Table table : db.getTables()) {
+                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                     if (table.getType() != TableType.OLAP) {
                         continue;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RowCountAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RowCountAction.java
@@ -92,11 +92,11 @@ public class RowCountAction extends RestBaseAction {
 
         Map<String, Long> indexRowCountMap = Maps.newHashMap();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getDb(dbName);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database[" + dbName + "] does not exist");
         }
-        Table table = db.getTable(tableName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (table == null) {
             throw new DdlException("Table[" + tableName + "] does not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowDataAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowDataAction.java
@@ -69,7 +69,7 @@ public class ShowDataAction extends RestBaseAction {
         locker.lockDatabase(db, LockType.READ);
         try {
             // sort by table name
-            List<Table> tables = db.getTables();
+            List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
             for (Table table : tables) {
                 if (!table.isNativeTableOrMaterializedView()) {
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
@@ -173,10 +173,10 @@ public class ShowMetaInfoAction extends RestBaseAction {
 
         for (int i = 0; i < dbNames.size(); i++) {
             String dbName = dbNames.get(i);
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
 
             long totalSize = 0;
-            List<Table> tables = db.getTables();
+            List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
             for (int j = 0; j < tables.size(); j++) {
                 Table table = tables.get(j);
                 if (table.getType() != TableType.OLAP) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StorageTypeCheckAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StorageTypeCheckAction.java
@@ -49,6 +49,7 @@ import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.thrift.TStorageType;
 import io.netty.handler.codec.http.HttpMethod;
@@ -77,7 +78,7 @@ public class StorageTypeCheckAction extends RestBaseAction {
             throw new DdlException("Parameter db is missing");
         }
 
-        Database db = globalStateMgr.getDb(dbName);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist");
         }
@@ -86,7 +87,7 @@ public class StorageTypeCheckAction extends RestBaseAction {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            List<Table> tbls = db.getTables();
+            List<Table> tbls = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
             for (Table tbl : tbls) {
                 if (tbl.getType() != TableType.OLAP) {
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -150,7 +150,7 @@ public class TableQueryPlanAction extends RestBaseAction {
             // check privilege for select, otherwise return HTTP 401
             Authorizer.checkTableAction(ConnectContext.get().getCurrentUserIdentity(), ConnectContext.get().getCurrentRoleIds(),
                     dbName, tableName, PrivilegeType.SELECT);
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db == null) {
                 throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
                         "Database [" + dbName + "] " + "does not exists");
@@ -159,7 +159,7 @@ public class TableQueryPlanAction extends RestBaseAction {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                Table table = db.getTable(tableName);
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
                 if (table == null) {
                     throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
                             "Table [" + tableName + "] " + "does not exists");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableRowCountAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableRowCountAction.java
@@ -92,7 +92,7 @@ public class TableRowCountAction extends RestBaseAction {
             // check privilege for select, otherwise return HTTP 401
             Authorizer.checkTableAction(ConnectContext.get().getCurrentUserIdentity(), ConnectContext.get().getCurrentRoleIds(),
                     dbName, tableName, PrivilegeType.SELECT);
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db == null) {
                 throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
                         "Database [" + dbName + "] " + "does not exists");
@@ -100,7 +100,7 @@ public class TableRowCountAction extends RestBaseAction {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.WRITE);
             try {
-                Table table = db.getTable(tableName);
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
                 if (table == null) {
                     throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
                             "Table [" + tableName + "] " + "does not exists");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableSchemaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableSchemaAction.java
@@ -94,7 +94,7 @@ public class TableSchemaAction extends RestBaseAction {
             Authorizer.checkTableAction(ConnectContext.get().getCurrentUserIdentity(), ConnectContext.get().getCurrentRoleIds(),
                     dbName, tableName, PrivilegeType.SELECT);
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db == null) {
                 throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
                         "Database [" + dbName + "] " + "does not exists");
@@ -102,7 +102,7 @@ public class TableSchemaAction extends RestBaseAction {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                Table table = db.getTable(tableName);
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
                 if (table == null) {
                     throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
                             "Table [" + tableName + "] " + "does not exists");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -263,7 +263,7 @@ public class TransactionLoadAction extends RestBaseAction {
 
         if (null == sourceType) {
             String dbName = params.getDbName();
-            Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getDb(dbName))
+            Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName))
                     .orElseThrow(() -> new UserException(String.format("Database[%s] does not exist.", dbName)));
 
             TransactionState txnState = GlobalStateMgr.getCurrentState()

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TriggerAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TriggerAction.java
@@ -78,7 +78,7 @@ public class TriggerAction extends RestBaseAction {
             return;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             response.appendContent("Database[" + dbName + "] does not exist");
             writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
@@ -94,7 +94,7 @@ public class TriggerAction extends RestBaseAction {
             locker.lockDatabase(db, LockType.READ);
             try {
                 if (!Strings.isNullOrEmpty(tableName)) {
-                    table = db.getTable(tableName);
+                    table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
                 }
 
                 if (table == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
@@ -68,14 +68,15 @@ public class BypassWriteTransactionHandler implements TransactionOperationHandle
         Body requestBody = txnOperationParams.getBody();
         LOG.info("Handle bypass write transaction, label: {}", label);
 
-        Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getDb(dbName))
+        Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName))
                 .orElseThrow(() -> new UserException(String.format("Database[%s] does not exist.", dbName)));
 
         TransactionResult result;
         switch (txnOperation) {
             case TXN_BEGIN:
-                Table table = Optional.ofNullable(db.getTable(tableName))
-                        .orElseThrow(() -> new UserException(
+                Table table = Optional.ofNullable(GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getFullName(), tableName))
+                            .orElseThrow(() -> new UserException(
                                 String.format("Table[%s.%s] does not exist.", dbName, tableName)));
                 result = handleBeginTransaction(db, table, label, sourceType, timeoutMillis);
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithoutChannelHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithoutChannelHandler.java
@@ -64,7 +64,7 @@ public class TransactionWithoutChannelHandler implements TransactionOperationHan
         Long timeoutMillis = txnOperationParams.getTimeoutMillis();
         LOG.info("Handle transaction without channel info, label: {}", label);
 
-        Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getDb(dbName))
+        Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName))
                 .orElseThrow(() -> new UserException(String.format("Database[%s] does not exist.", dbName)));
 
         TransactionResult result = null;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TableBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TableBaseAction.java
@@ -88,7 +88,7 @@ public abstract class TableBaseAction extends RestBaseAction {
                 PrivilegeType.SELECT
         );
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (null == db || !Optional.ofNullable(db.getCatalogName())
                 .orElse(DEFAULT_INTERNAL_CATALOG_NAME).equalsIgnoreCase(catalogName)) {
             throw new StarRocksHttpException(
@@ -99,7 +99,7 @@ public abstract class TableBaseAction extends RestBaseAction {
         final Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table table = db.getTable(tableName);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
             if (null == table) {
                 throw new StarRocksHttpException(
                         HttpResponseStatus.NOT_FOUND, ErrorCode.ERR_BAD_TABLE_ERROR.formatErrorMsg(tableName)

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
@@ -82,7 +82,7 @@ public class LakeBackupJob extends BackupJob {
     protected void checkBackupTables(Database db) {
         for (TableRef tableRef : tableRefs) {
             String tblName = tableRef.getName().getTbl();
-            Table tbl = db.getTable(tblName);
+            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
             if (tbl == null) {
                 status = new Status(Status.ErrCode.NOT_FOUND, "table " + tblName + " does not exist");
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -124,7 +124,8 @@ public class LakeRestoreJob extends RestoreJob {
         for (IdChain idChain : fileMapping.getMapping().keySet()) {
             LakeTablet tablet = null;
             try {
-                OlapTable tbl = (OlapTable) db.getTable(idChain.getTblId());
+                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), idChain.getTblId());
                 Partition part = tbl.getPartition(idChain.getPartId());
                 MaterializedIndex index = part.getIndex(idChain.getIdxId());
                 tablet = (LakeTablet) index.getTablet(idChain.getTabletId());
@@ -154,7 +155,8 @@ public class LakeRestoreJob extends RestoreJob {
         }
         request.restoreInfos = Lists.newArrayList();
         for (SnapshotInfo info : beSnapshotInfos) {
-            OlapTable tbl = (OlapTable) db.getTable(info.getTblId());
+            OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), info.getTblId());
             if (tbl == null) {
                 status = new Status(Status.ErrCode.NOT_FOUND, "restored table "
                         + info.getTblId() + " does not exist");
@@ -289,7 +291,8 @@ public class LakeRestoreJob extends RestoreJob {
     @Override
     protected void addRestoredPartitions(Database db, boolean modify) {
         for (Pair<String, Partition> entry : restoredPartitions) {
-            OlapTable localTbl = (OlapTable) db.getTable(entry.first);
+            OlapTable localTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getFullName(), entry.first);
             Partition restorePart = entry.second;
             OlapTable remoteTbl = (OlapTable) backupMeta.getTable(entry.first);
             RangePartitionInfo localPartitionInfo = (RangePartitionInfo) localTbl.getPartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -256,7 +256,7 @@ public class CompactionScheduler extends Daemon {
     }
 
     private CompactionJob startCompaction(PartitionIdentifier partitionIdentifier) {
-        Database db = stateMgr.getDb(partitionIdentifier.getDbId());
+        Database db = stateMgr.getLocalMetastore().getDb(partitionIdentifier.getDbId());
         if (db == null) {
             compactionManager.removePartition(partitionIdentifier);
             return null;
@@ -273,7 +273,8 @@ public class CompactionScheduler extends Daemon {
 
         try {
             // lake table or lake materialized view
-            table = (OlapTable) db.getTable(partitionIdentifier.getTableId());
+            table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), partitionIdentifier.getTableId());
             // Compact a table of SCHEMA_CHANGE state does not make much sense, because the compacted data
             // will not be used after the schema change job finished.
             if (table != null && table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE) {
@@ -401,7 +402,7 @@ public class CompactionScheduler extends Daemon {
             throws UserException {
         List<TabletCommitInfo> commitInfoList = job.buildTabletCommitInfo();
 
-        Database db = stateMgr.getDb(partition.getDbId());
+        Database db = stateMgr.getLocalMetastore().getDb(partition.getDbId());
         if (db == null) {
             throw new MetaNotFoundException("database not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -70,13 +70,13 @@ public class AutovacuumDaemon extends FrontendDaemon {
     protected void runAfterCatalogReady() {
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
         for (Long dbId : dbIds) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
 
             List<Table> tables = new ArrayList<>();
-            for (Table table : db.getTables()) {
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                 if (table.isCloudNativeTableOrMaterializedView()) {
                     tables.add(table);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -473,12 +473,13 @@ public class LeaderImpl {
             long tableId = task.getTableId();
             long indexId = task.getIndexId();
             long backendId = task.getBackendId();
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db != null) {
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                    OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getId(), tableId);
                     if (olapTable != null) {
                         MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                         if (indexMeta != null) {
@@ -504,7 +505,7 @@ public class LeaderImpl {
         long backendId = pushTask.getBackendId();
         long signature = task.getSignature();
         long transactionId = ((PushTask) task).getTransactionId();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             AgentTaskQueue.removeTask(backendId, TTaskType.REALTIME_PUSH, signature);
             return;
@@ -539,7 +540,7 @@ public class LeaderImpl {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.WRITE);
         try {
-            OlapTable olapTable = (OlapTable) db.getTable(tableId);
+            OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (olapTable == null) {
                 throw new MetaNotFoundException("cannot find table[" + tableId + "] when push finished");
             }
@@ -771,7 +772,7 @@ public class LeaderImpl {
             }
 
             long dbId = tabletMeta.getDbId();
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 LOG.warn("db does not exist. db id: {}", dbId);
                 return;
@@ -892,7 +893,7 @@ public class LeaderImpl {
         }
 
         // checkTblAuth(ConnectContext.get().getCurrentUserIdentity(), fullDbName, tableName, PrivPredicate.SELECT);
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             TStatus status = new TStatus(TStatusCode.NOT_FOUND);
             status.setError_msgs(Lists.newArrayList("db not exist"));
@@ -904,7 +905,7 @@ public class LeaderImpl {
         try {
             locker.lockDatabase(db, LockType.READ);
 
-            Table table = db.getTable(tableName);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
             if (table == null) {
                 TStatus status = new TStatus(TStatusCode.NOT_FOUND);
                 status.setError_msgs(Lists.newArrayList("table " + tableName + " not exist"));
@@ -1214,7 +1215,7 @@ public class LeaderImpl {
             return response;
         }
 
-        Database db = globalStateMgr.getDb(request.getDb_id());
+        Database db = globalStateMgr.getLocalMetastore().getDb(request.getDb_id());
         if (db == null) {
             TStatus status = new TStatus(TStatusCode.NOT_FOUND);
             status.setError_msgs(Lists.newArrayList("db not exist"));
@@ -1273,7 +1274,7 @@ public class LeaderImpl {
             return response;
         }
 
-        Database db = globalStateMgr.getDb(request.getDb_id());
+        Database db = globalStateMgr.getLocalMetastore().getDb(request.getDb_id());
         if (db == null) {
             TStatus status = new TStatus(TStatusCode.NOT_FOUND);
             status.setError_msgs(Lists.newArrayList("db not exist or already deleted"));
@@ -1339,7 +1340,7 @@ public class LeaderImpl {
             return response;
         }
 
-        Database db = globalStateMgr.getDb(request.getDb_id());
+        Database db = globalStateMgr.getLocalMetastore().getDb(request.getDb_id());
         if (db == null) {
             TStatus status = new TStatus(TStatusCode.NOT_FOUND);
             status.setError_msgs(Lists.newArrayList("db not exist or already deleted"));

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1229,11 +1229,12 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 }
 
                 // 3. There are some limitations for primary table, details in migratableTablet()
-                Database db = GlobalStateMgr.getCurrentState().getDb(tabletMeta.getDbId());
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tabletMeta.getDbId());
                 if (db == null) {
                     continue;
                 }
-                OlapTable table = (OlapTable) db.getTable(tabletMeta.getTableId());
+                OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tabletMeta.getTableId());
                 if (table == null) {
                     continue;
                 }
@@ -1292,7 +1293,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         BackendTabletsInfo backendTabletsInfo = new BackendTabletsInfo(backendId);
         backendTabletsInfo.setBad(true);
         for (Long dbId : tabletRecoveryMap.keySet()) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
@@ -1308,7 +1309,8 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     }
                     long tabletId = tabletIds.get(i);
                     long tableId = tabletMeta.getTableId();
-                    OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                    OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getId(), tableId);
                     if (olapTable == null) {
                         continue;
                     }
@@ -1388,12 +1390,13 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 long partitionId =
                         tabletMeta != null ? tabletMeta.getPartitionId() : TabletInvertedIndex.NOT_EXIST_VALUE;
 
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                 if (db == null) {
                     continue;
                 }
 
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }
@@ -1449,12 +1452,13 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 long dbId = tabletMeta != null ? tabletMeta.getDbId() : TabletInvertedIndex.NOT_EXIST_VALUE;
                 long tableId = tabletMeta != null ? tabletMeta.getTableId() : TabletInvertedIndex.NOT_EXIST_VALUE;
 
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                 if (db == null) {
                     continue;
                 }
 
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }
@@ -1504,12 +1508,13 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 long dbId = tabletMeta != null ? tabletMeta.getDbId() : TabletInvertedIndex.NOT_EXIST_VALUE;
                 long tableId = tabletMeta != null ? tabletMeta.getTableId() : TabletInvertedIndex.NOT_EXIST_VALUE;
 
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                 if (db == null) {
                     continue;
                 }
 
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }
@@ -1564,12 +1569,13 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 long tableId = tabletMeta.getTableId();
                 long indexId = tabletMeta.getIndexId();
 
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                 if (db == null) {
                     continue;
                 }
 
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }
@@ -1611,12 +1617,12 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
             List<Long> tablets = cell.getValue();
             Long dbId = tableToDb.get(tableId);
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }
 
-            OlapTable olapTable = (OlapTable) db.getTable(tableId);
+            OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (olapTable == null) {
                 continue;
             }
@@ -1682,13 +1688,14 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 long dbId = tabletMeta != null ? tabletMeta.getDbId() : TabletInvertedIndex.NOT_EXIST_VALUE;
                 long tableId = tabletMeta != null ? tabletMeta.getTableId() : TabletInvertedIndex.NOT_EXIST_VALUE;
 
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                 if (db == null) {
                     continue;
                 }
 
                 boolean needToCheck = false;
-                OlapTable olapTable = (OlapTable) db.getTable(tableId);
+                OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
@@ -100,7 +100,7 @@ public class LoadJobMVListener implements LoadJobListener {
             return;
         }
         for (long tableId : transactionState.getTableIdList()) {
-            Table table = db.getTable(tableId);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 LOG.warn("failed to get transaction tableId {} when pending refresh.", tableId);
                 return;
@@ -141,7 +141,8 @@ public class LoadJobMVListener implements LoadJobListener {
         while (mvIdIterator.hasNext()) {
             MvId mvId = mvIdIterator.next();
             Database mvDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
-            MaterializedView materializedView = (MaterializedView) mvDb.getTable(mvId.getId());
+            MaterializedView materializedView = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(mvId.getDbId(), mvId.getId());
             if (materializedView == null) {
                 LOG.warn("materialized view {} does not exists.", mvId.getId());
                 mvIdIterator.remove();
@@ -153,7 +154,7 @@ public class LoadJobMVListener implements LoadJobListener {
                                 "db:{}, mv:{}", table.getName(), mvDb.getFullName(),
                         materializedView.getName());
                 GlobalStateMgr.getCurrentState().getLocalMetastore().refreshMaterializedView(
-                        mvDb.getFullName(), mvDb.getTable(mvId.getId()).getName(), false, null,
+                        mvDb.getFullName(), materializedView.getName(), false, null,
                         Constants.TaskRunPriority.NORMAL.value(), true, false);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
@@ -80,7 +80,7 @@ public class LoadJobStatsListener implements LoadJobListener {
             List<Table> tables = transactionState.getIdToTableCommitInfos().values().stream()
                     .map(x -> x.getTableId())
                     .distinct()
-                    .map(db::getTable)
+                    .map(tableId -> GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId))
                     .filter(Objects::nonNull)
                     .filter(t -> !t.isMaterializedView()) // skip mvs since its stats will be triggered after refresh
                     .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
@@ -59,6 +59,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.PartitionNames;
@@ -168,7 +169,8 @@ public class BrokerFileGroup implements Writable {
     // This will parse the input DataDescription to list for BrokerFileInfo
     public void parse(Database db, DataDescription dataDescription) throws DdlException {
         // tableId
-        Table table = db.getTable(dataDescription.getTableName());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), dataDescription.getTableName());
         if (table == null) {
             throw new DdlException("Unknown table " + dataDescription.getTableName()
                     + " in database " + db.getOriginName());
@@ -237,7 +239,7 @@ public class BrokerFileGroup implements Writable {
         if (dataDescription.isLoadFromTable()) {
             String srcTableName = dataDescription.getSrcTableName();
             // src table should be hive table
-            Table srcTable = db.getTable(srcTableName);
+            Table srcTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), srcTableName);
             if (srcTable == null) {
                 throw new DdlException("Unknown table " + srcTableName + " in database " + db.getOriginName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -176,12 +176,12 @@ public class DeleteMgr implements Writable, MemoryTrackable {
         String dbName = stmt.getTableName().getDb();
         String tableName = stmt.getTableName().getTbl();
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Db does not exist. name: " + dbName);
         }
 
-        Table table = db.getTable(tableName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (table == null) {
             throw new DdlException("Table does not exist. name: " + tableName);
         }
@@ -722,7 +722,7 @@ public class DeleteMgr implements Writable, MemoryTrackable {
     // show delete stmt
     public List<List<Comparable>> getDeleteInfosByDb(long dbId) {
         LinkedList<List<Comparable>> infos = new LinkedList<List<Comparable>>();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             return infos;
         }
@@ -816,11 +816,11 @@ public class DeleteMgr implements Writable, MemoryTrackable {
     }
 
     public void updateTableDeleteInfo(GlobalStateMgr globalStateMgr, long dbId, long tableId) {
-        Database db = globalStateMgr.getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             return;
         }
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -240,7 +240,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
 
     public void setJob(ExportStmt stmt) throws UserException {
         String dbName = stmt.getTblName().getDb();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist");
         }
@@ -266,7 +266,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
         this.columnNames = stmt.getColumnNames();
 
         this.dbId = db.getId();
-        this.exportTable = db.getTable(stmt.getTblName().getTbl());
+        this.exportTable = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), stmt.getTblName().getTbl());
         if (exportTable == null) {
             throw new DdlException("Table " + stmt.getTblName().getTbl() + " does not exist");
         }
@@ -993,10 +994,10 @@ public class ExportJob implements Writable, GsonPostProcessable {
         GlobalStateMgr stateMgr = GlobalStateMgr.getCurrentState();
         Database db = null;
         if (stateMgr.getMetadata() != null) {
-            db = stateMgr.getDb(dbId);
+            db = stateMgr.getLocalMetastore().getDb(dbId);
         }
         if (db != null) {
-            exportTable = db.getTable(tableId);
+            exportTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         }
 
         int count = in.readInt();
@@ -1086,10 +1087,10 @@ public class ExportJob implements Writable, GsonPostProcessable {
         GlobalStateMgr stateMgr = GlobalStateMgr.getCurrentState();
         Database db = null;
         if (stateMgr.getMetadata() != null) {
-            db = stateMgr.getDb(dbId);
+            db = stateMgr.getLocalMetastore().getDb(dbId);
         }
         if (db != null) {
-            exportTable = db.getTable(tableId);
+            exportTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -134,7 +134,7 @@ public class ExportMgr implements MemoryTrackable {
     }
 
     public ExportJob getExportJob(String dbName, UUID queryId) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         MetaUtils.checkDbNullAndReport(db, dbName);
         long dbId = db.getId();
         ExportJob matchedJob = null;
@@ -234,7 +234,7 @@ public class ExportMgr implements MemoryTrackable {
                 TableName tableName = job.getTableName();
                 if (tableName == null || tableName.getTbl().equals("DUMMY")) {
                     // forward compatibility, no table name is saved before
-                    Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                     if (db == null) {
                         continue;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -215,7 +215,7 @@ public class InsertOverwriteJobRunner {
         }
         job.setTmpPartitionIds(tmpPartitionIds);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
@@ -292,7 +292,7 @@ public class InsertOverwriteJobRunner {
         }
         GlobalStateMgr state = GlobalStateMgr.getCurrentState();
         String targetDb = insertStmt.getTableName().getDb();
-        Database db = state.getDb(targetDb);
+        Database db = state.getLocalMetastore().getDb(targetDb);
         List<Long> sourcePartitionIds = job.getSourcePartitionIds();
         try {
             AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(olapTable);
@@ -344,7 +344,7 @@ public class InsertOverwriteJobRunner {
 
     private void createTempPartitions() throws DdlException {
         long createPartitionStartTimestamp = System.currentTimeMillis();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
@@ -366,7 +366,7 @@ public class InsertOverwriteJobRunner {
     private void gc(boolean isReplay) {
         LOG.info("start to garbage collect");
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
@@ -376,7 +376,7 @@ public class InsertOverwriteJobRunner {
         }
 
         try {
-            Table table = db.getTable(tableId);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 throw new DmlException("table:%d does not exist in database:%s", tableId, db.getFullName());
             }
@@ -416,7 +416,7 @@ public class InsertOverwriteJobRunner {
     }
 
     private void doCommit(boolean isReplay) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
@@ -487,7 +487,7 @@ public class InsertOverwriteJobRunner {
         Preconditions.checkState(job.getJobState() == InsertOverwriteJobState.OVERWRITE_RUNNING);
         Preconditions.checkState(insertStmt != null);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
@@ -522,7 +522,7 @@ public class InsertOverwriteJobRunner {
     }
 
     private OlapTable checkAndGetTable(Database db, long tableId) {
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             throw new DmlException("table:% does not exist in database:%s", tableId, db.getFullName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -464,7 +464,7 @@ public class Load {
         if (GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb() != null) {
             for (Map.Entry<Long, Database> entry : GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().entrySet()) {
                 Database db = entry.getValue();
-                if (db.getTable(tbl.getId()) != null) {
+                if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tbl.getId()) != null) {
                     dbName = db.getFullName();
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -298,7 +298,7 @@ public class OlapDeleteJob extends DeleteJob {
      */
     public void checkAndUpdateQuorum() throws MetaNotFoundException {
         long dbId = deleteInfo.getDbId();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("can not find database " + dbId + " when commit delete");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
@@ -66,7 +66,7 @@ public class PartitionUtils {
         boolean success = false;
         try {
             // should check whether targetTable exists
-            Table tmpTable = db.getTable(targetTable.getId());
+            Table tmpTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), targetTable.getId());
             if (tmpTable == null) {
                 throw new DdlException("create partition failed because target table does not exist");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -247,7 +247,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 FileGroupAggKey aggKey = entry.getKey();
                 List<BrokerFileGroup> brokerFileGroups = entry.getValue();
                 long tableId = aggKey.getTableId();
-                OlapTable table = (OlapTable) db.getTable(tableId);
+                OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                 if (table == null) {
                     LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                             .add("database_id", dbId)

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -153,7 +153,7 @@ public class InsertLoadJob extends LoadJob {
     }
 
     public AuthorizationInfo gatherAuthInfo() throws MetaNotFoundException {
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
@@ -192,13 +192,13 @@ public class InsertLoadJob extends LoadJob {
 
     @Override
     public Set<String> getTableNamesForShow() {
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (database == null) {
             return Sets.newHashSet(String.valueOf(tableId));
         }
         // The database will not be locked in here.
         // The getTable is a thread-safe method called without read lock of database
-        Table table = database.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
         if (table == null) {
             return Sets.newHashSet(String.valueOf(tableId));
         }
@@ -207,11 +207,11 @@ public class InsertLoadJob extends LoadJob {
 
     @Override
     public Set<String> getTableNames(boolean noThrow) throws MetaNotFoundException {
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        Table table = database.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
         if (table == null) {
             if (noThrow) {
                 return Sets.newHashSet();
@@ -224,12 +224,12 @@ public class InsertLoadJob extends LoadJob {
 
     @Override
     public boolean hasTxn() {
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (database == null) {
             return true;
         }
 
-        Table table = database.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
         if (table == null) {
             return true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -256,7 +256,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     public Database getDb() throws MetaNotFoundException {
         // get db
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("Database " + dbId + " already has been deleted");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -301,7 +301,7 @@ public class LoadLoadingTask extends LoadTask {
             throw new LoadException(String.format("db: %s-%d has been dropped", db.getFullName(), db.getId()));
         }
 
-        if (database.getTable(table.getId()) == null) {
+        if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), table.getId()) == null) {
             throw new LoadException(String.format("table: %s-%d has been dropped from db: %s-%d",
                     table.getName(), table.getId(), db.getFullName(), db.getId()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -154,7 +154,7 @@ public class LoadMgr implements Writable, MemoryTrackable {
     }
 
     public void alterLoadJob(AlterLoadStmt stmt) throws DdlException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(stmt.getDbName());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(stmt.getDbName());
         if (db == null) {
             throw new DdlException("Db does not exist. name: " + stmt.getDbName());
         }
@@ -237,7 +237,7 @@ public class LoadMgr implements Writable, MemoryTrackable {
                                                int estimateFileNum, long estimateFileSize, TLoadJobType type, long timeout,
                                                Coordinator coordinator) throws UserException {
         // get db id
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             throw new MetaNotFoundException("Database[" + dbName + "] does not exist");
         }
@@ -262,7 +262,7 @@ public class LoadMgr implements Writable, MemoryTrackable {
     }
 
     public void cancelLoadJob(CancelLoadStmt stmt) throws DdlException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(stmt.getDbName());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(stmt.getDbName());
         if (db == null) {
             throw new DdlException("Db does not exist. name: " + stmt.getDbName());
         }
@@ -662,7 +662,7 @@ public class LoadMgr implements Writable, MemoryTrackable {
 
     private Database checkDb(String dbName) throws DdlException {
         // get db
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             LOG.warn("Database {} does not exist", dbName);
             throw new DdlException("Database[" + dbName + "] does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -88,7 +88,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
     }
 
     public boolean checkDatabaseExists() {
-        return GlobalStateMgr.getCurrentState().getDb(LOADS_HISTORY_DB_NAME) != null;
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(LOADS_HISTORY_DB_NAME) != null;
     }
 
     public static void createTable() throws UserException {
@@ -98,9 +98,8 @@ public class LoadsHistorySyncer extends FrontendDaemon {
 
     public static boolean correctTable() {
         int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
-        int replica = GlobalStateMgr.getCurrentState()
-                .mayGetDb(LOADS_HISTORY_DB_NAME)
-                .flatMap(db -> db.mayGetTable(LOADS_HISTORY_TABLE_NAME))
+        int replica = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .mayGetTable(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME)
                 .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
                 .orElse((short) 1);
         if (numBackends < 3) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -492,7 +492,8 @@ public class SparkLoadJob extends BulkLoadJob {
 
                 for (Map.Entry<Long, Set<Long>> entry : tableToLoadPartitions.entrySet()) {
                     long tableId = entry.getKey();
-                    OlapTable table = (OlapTable) db.getTable(tableId);
+                    OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getId(), tableId);
                     if (table == null) {
                         LOG.warn("table does not exist. id: {}", tableId);
                         continue;
@@ -821,7 +822,7 @@ public class SparkLoadJob extends BulkLoadJob {
     public void afterVisible(TransactionState txnState, boolean txnOperated) {
         super.afterVisible(txnState, txnOperated);
         // collect table-level metrics after spark load job finished
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (null == db) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -156,7 +156,7 @@ public class SparkLoadPendingTask extends LoadTask {
     }
 
     private void createEtlJobConf() throws LoadException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new LoadException("db does not exist. id: " + dbId);
         }
@@ -173,7 +173,7 @@ public class SparkLoadPendingTask extends LoadTask {
                 FileGroupAggKey aggKey = entry.getKey();
                 long tableId = aggKey.getTableId();
 
-                OlapTable table = (OlapTable) db.getTable(tableId);
+                OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                 if (table == null) {
                     throw new LoadException("table does not exist. id: " + tableId);
                 }
@@ -224,7 +224,7 @@ public class SparkLoadPendingTask extends LoadTask {
                 continue;
             }
 
-            OlapTable table = (OlapTable) db.getTable(tableId);
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 throw new LoadException("table does not exist. id: " + tableId);
             }
@@ -571,7 +571,8 @@ public class SparkLoadPendingTask extends LoadTask {
         Map<String, String> hiveTableProperties = Maps.newHashMap();
         if (fileGroup.isLoadFromTable()) {
             long srcTableId = fileGroup.getSrcTableId();
-            HiveTable srcHiveTable = (HiveTable) db.getTable(srcTableId);
+            HiveTable srcHiveTable = (HiveTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), srcTableId);
             if (srcHiveTable == null) {
                 throw new LoadException("table does not exist. id: " + srcTableId);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -133,7 +133,7 @@ public class Pipe implements GsonPostProcessable {
 
     public static Pipe fromStatement(long id, CreatePipeStmt stmt) {
         PipeName pipeName = stmt.getPipeName();
-        long dbId = GlobalStateMgr.getCurrentState().getDb(pipeName.getDbName()).getId();
+        long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(pipeName.getDbName()).getId();
         PipeId pipeId = new PipeId(dbId, id);
         Pipe res = new Pipe(pipeId, pipeName.getPipeName(), stmt.getTargetTable(), stmt.getDataSource(),
                 stmt.getInsertSql());
@@ -314,7 +314,7 @@ public class Pipe implements GsonPostProcessable {
             long taskId = GlobalStateMgr.getCurrentState().getNextId();
             PipeId pipeId = getPipeId();
             String uniqueName = PipeTaskDesc.genUniqueTaskName(getName(), taskId, 0);
-            String dbName = GlobalStateMgr.getCurrentState().mayGetDb(pipeId.getDbId())
+            String dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(pipeId.getDbId())
                     .map(Database::getOriginName)
                     .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_DB_ERROR));
             String sqlTask = FilePipeSource.buildInsertSql(this, piece, uniqueName);

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
@@ -184,7 +184,7 @@ public class PipeManager {
     }
 
     private Pair<Long, String> resolvePipeNameUnlock(PipeName name) {
-        long dbId = GlobalStateMgr.getCurrentState().mayGetDb(name.getDbName())
+        long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(name.getDbName())
                 .map(Database::getId)
                 .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_NO_DB_ERROR));
         return Pair.create(dbId, name.getPipeName());

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -60,7 +60,7 @@ public class RepoCreator {
     }
 
     public boolean checkDatabaseExists() {
-        return GlobalStateMgr.getCurrentState().getDb(FileListTableRepo.FILE_LIST_DB_NAME) != null;
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(FileListTableRepo.FILE_LIST_DB_NAME) != null;
     }
 
     public static void createTable() throws UserException {
@@ -71,8 +71,7 @@ public class RepoCreator {
     public static boolean correctTable() {
         int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
         int replica = GlobalStateMgr.getCurrentState()
-                .mayGetDb(FileListTableRepo.FILE_LIST_DB_NAME)
-                .flatMap(db -> db.mayGetTable(FileListTableRepo.FILE_LIST_TABLE_NAME))
+                .getLocalMetastore().mayGetTable(FileListTableRepo.FILE_LIST_DB_NAME, FileListTableRepo.FILE_LIST_TABLE_NAME)
                 .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
                 .orElse((short) 1);
         if (numBackends < 3) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -466,12 +466,12 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     public static KafkaRoutineLoadJob fromCreateStmt(CreateRoutineLoadStmt stmt) throws UserException {
         // check db and table
-        Database db = GlobalStateMgr.getCurrentState().getDb(stmt.getDBName());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(stmt.getDBName());
         if (db == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, stmt.getDBName());
         }
 
-        Table table = db.getTable(stmt.getTableName());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), stmt.getTableName());
         if (table == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, stmt.getTableName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -171,12 +171,12 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tRoutineLoadTask.setId(queryId);
         tRoutineLoadTask.setJob_id(routineLoadJob.getId());
         tRoutineLoadTask.setTxn_id(txnId);
-        Database database = GlobalStateMgr.getCurrentState().getDb(routineLoadJob.getDbId());
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(routineLoadJob.getDbId());
         if (database == null) {
             throw new MetaNotFoundException("database " + routineLoadJob.getDbId() + " does not exist");
         }
         tRoutineLoadTask.setDb(database.getFullName());
-        Table tbl = database.getTable(routineLoadJob.getTableId());
+        Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), routineLoadJob.getTableId());
         if (tbl == null) {
             throw new MetaNotFoundException("table " + routineLoadJob.getTableId() + " does not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -412,7 +412,7 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
 
     public static PulsarRoutineLoadJob fromCreateStmt(CreateRoutineLoadStmt stmt) throws UserException {
         // check db and table
-        Database db = GlobalStateMgr.getCurrentState().getDb(stmt.getDBName());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(stmt.getDBName());
         if (db == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, stmt.getDBName());
         }
@@ -422,7 +422,7 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
         locker.lockDatabase(db, LockType.READ);
         try {
             unprotectedCheckMeta(db, stmt.getTableName(), stmt.getRoutineLoadDesc());
-            Table table = db.getTable(stmt.getTableName());
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), stmt.getTableName());
             Load.checkMergeCondition(stmt.getMergeConditionStr(), (OlapTable) table, table.getFullSchema(), false);
             tableId = table.getId();
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -109,12 +109,12 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
         tRoutineLoadTask.setId(queryId);
         tRoutineLoadTask.setJob_id(routineLoadJob.getId());
         tRoutineLoadTask.setTxn_id(txnId);
-        Database database = GlobalStateMgr.getCurrentState().getDb(routineLoadJob.getDbId());
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(routineLoadJob.getDbId());
         if (database == null) {
             throw new MetaNotFoundException("database " + routineLoadJob.getDbId() + " does not exist");
         }
         tRoutineLoadTask.setDb(database.getFullName());
-        Table tbl = database.getTable(routineLoadJob.getTableId());
+        Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), routineLoadJob.getTableId());
         if (tbl == null) {
             throw new MetaNotFoundException("table " + routineLoadJob.getTableId() + " does not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -512,7 +512,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     }
 
     public String getDbFullName() throws MetaNotFoundException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
@@ -524,11 +524,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     }
 
     public String getTableName() throws MetaNotFoundException {
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (database == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
-        Table table = database.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
         if (table == null) {
             throw new MetaNotFoundException("Failed to find table " + tableId + " in db " + dbId);
         }
@@ -856,12 +856,12 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     }
 
     public TExecPlanFragmentParams plan(TUniqueId loadId, long txnId, String label) throws UserException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("db " + dbId + " does not exist");
         }
 
-        Table table = db.getTable(this.tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), this.tableId);
         if (table == null) {
             throw new MetaNotFoundException("table " + this.tableId + " does not exist");
         }
@@ -1287,7 +1287,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
     protected static void unprotectedCheckMeta(Database db, String tblName, RoutineLoadDesc routineLoadDesc)
             throws UserException {
-        Table table = db.getTable(tblName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
 
         if (table instanceof MaterializedView) {
             throw new AnalysisException(String.format(
@@ -1421,7 +1421,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
     public void update() throws UserException {
         // check if db and table exist
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
                     .add("db_id", dbId)
@@ -1440,7 +1440,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         }
 
         // check table belong to database
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id).add("db_id", dbId)
                     .add("table_id", tableId)
@@ -1495,13 +1495,13 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     protected abstract String getStatistic();
 
     public List<String> getShowInfo() {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         Table tbl = null;
         if (db != null) {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                tbl = db.getTable(tableId);
+                tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             } finally {
                 locker.unLockDatabase(db, LockType.READ);
             }
@@ -1585,7 +1585,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     }
 
     public List<String> getShowStatistic() {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         readLock();
         try {
             List<String> row = Lists.newArrayList();
@@ -2000,13 +2000,13 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     }
 
     public TRoutineLoadJobInfo toThrift() {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         Table tbl = null;
         if (db != null) {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                tbl = db.getTable(tableId);
+                tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             } finally {
                 locker.unLockDatabase(db, LockType.READ);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -508,7 +508,7 @@ public class RoutineLoadMgr implements Writable, MemoryTrackable {
                 sortRoutineLoadJob(result);
             } else {
                 long dbId = 0L;
-                Database database = GlobalStateMgr.getCurrentState().getDb(dbFullName);
+                Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbFullName);
                 if (database == null) {
                     throw new MetaNotFoundException("failed to find database by dbFullName " + dbFullName);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -175,7 +175,7 @@ public class StreamLoadMgr implements MemoryTrackable {
         locker.lockDatabase(db, LockType.READ);
         try {
             unprotectedCheckMeta(db, tableName);
-            table = db.getTable(tableName);
+            table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         } finally {
             locker.unLockDatabase(db, LockType.READ);
         }
@@ -192,7 +192,8 @@ public class StreamLoadMgr implements MemoryTrackable {
             throws UserException {
         // init stream load task
         long id = GlobalStateMgr.getCurrentState().getNextId();
-        StreamLoadTask streamLoadTask = new StreamLoadTask(id, db, (OlapTable) db.getTable(tableName),
+        StreamLoadTask streamLoadTask = new StreamLoadTask(id, db,
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName),
                 label, user, clientIp, timeoutMillis, System.currentTimeMillis(), isRoutineLoad, warehouseId);
         return streamLoadTask;
     }
@@ -205,7 +206,7 @@ public class StreamLoadMgr implements MemoryTrackable {
         locker.lockDatabase(db, LockType.READ);
         try {
             unprotectedCheckMeta(db, tableName);
-            table = db.getTable(tableName);
+            table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         } finally {
             locker.unLockDatabase(db, LockType.READ);
         }
@@ -223,7 +224,7 @@ public class StreamLoadMgr implements MemoryTrackable {
             throw new AnalysisException("Table name must be specified when calling /begin/transaction/ first time");
         }
 
-        Table table = db.getTable(tblName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
         if (table == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tblName);
         }
@@ -248,7 +249,7 @@ public class StreamLoadMgr implements MemoryTrackable {
     }
 
     public Database checkDbName(String dbName) throws UserException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             LOG.warn("Database {} does not exist", dbName);
             throw new UserException("Database[" + dbName + "] does not exist");
@@ -502,7 +503,7 @@ public class StreamLoadMgr implements MemoryTrackable {
                 }
 
                 long dbId = 0L;
-                Database database = GlobalStateMgr.getCurrentState().getDb(dbFullName);
+                Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbFullName);
                 if (database == null) {
                     throw new MetaNotFoundException("failed to find database by dbFullName " + dbFullName);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1254,14 +1254,14 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     }
 
     public OlapTable getTable() throws MetaNotFoundException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("Database " + dbId + "has been deleted");
         }
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            OlapTable table = (OlapTable) db.getTable(tableId);
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 throw new MetaNotFoundException("Failed to find table " + tableId + " in db " + dbId);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/InternalCatalogMemoryTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/InternalCatalogMemoryTracker.java
@@ -34,7 +34,7 @@ public class InternalCatalogMemoryTracker implements MemoryTrackable {
         long estimateSize = 0L;
         List<Database> databases = new ArrayList<>(GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().values());
         for (Database database : databases) {
-            List<Table> tables = database.getTables();
+            List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(database.getId());
             for (Table table : tables) {
                 Collection<Partition> partitions = table.getPartitions();
                 Iterator<Partition> iterator = partitions.iterator();
@@ -51,7 +51,7 @@ public class InternalCatalogMemoryTracker implements MemoryTrackable {
         long estimateCount = 0;
         List<Database> databases = new ArrayList<>(GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().values());
         for (Database database : databases) {
-            List<Table> tables = database.getTables();
+            List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(database.getId());
             for (Table table : tables) {
                 Collection<Partition> partitions = table.getPartitions();
                 estimateCount += partitions.size();

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -104,10 +104,10 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
         }
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getDb(mvId.getDbId());
+        Database db = globalStateMgr.getLocalMetastore().getDb(mvId.getDbId());
         if (db != null) {
             dbNameOpt = Optional.of(db.getFullName());
-            Table table = db.getTable(mvId.getId());
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
             if (table != null) {
                 mvNameOpt = Optional.of(table.getName());
                 return true;
@@ -159,8 +159,9 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
 
         // histogram metrics
         try {
-            Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
-            MaterializedView mv = (MaterializedView) db.getTable(mvId.getId());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
+            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), mvId.getId());
             histRefreshJobDuration = metricRegistry.histogram(MetricRegistry.name("mv_refresh_duration",
                         db.getFullName(), mv.getName()));
         } catch (Exception e) {
@@ -214,11 +215,11 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     "current materialized view's row count") {
             @Override
             public Long getValue() {
-                Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
                 if (db == null) {
                     return 0L;
                 }
-                Table table = db.getTable(mvId.getId());
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
                 if (table == null || !table.isMaterializedView()) {
                     return 0L;
                 }
@@ -238,11 +239,11 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     "current materialized view's storage size") {
             @Override
             public Long getValue() {
-                Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
                 if (db == null) {
                     return 0L;
                 }
-                Table table = db.getTable(mvId.getId());
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
                 if (table == null || !table.isMaterializedView()) {
                     return 0L;
                 }
@@ -262,11 +263,11 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     "current materialized view's inactive or not, 0: active, 1: inactive") {
             @Override
             public Integer getValue() {
-                Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
                 if (db == null) {
                     return 0;
                 }
-                Table table = db.getTable(mvId.getId());
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
                 if (table == null || !table.isMaterializedView()) {
                     return 0;
                 }
@@ -284,11 +285,11 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     "current materialized view's partition count, 0 if the materialized view is not partitioned") {
             @Override
             public Integer getValue() {
-                Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
                 if (db == null) {
                     return 0;
                 }
-                Table table = db.getTable(mvId.getId());
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
                 if (table == null || !table.isMaterializedView()) {
                     return 0;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -827,13 +827,13 @@ public final class MetricRepo {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames();
         for (String dbName : dbNames) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (null == db) {
                 continue;
             }
 
             // NOTE: avoid holding database lock here, since we only read all tables, and immutable fields of table
-            for (Table table : db.getTables()) {
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                 long tableId = table.getId();
                 String tableName = table.getName();
 
@@ -875,7 +875,7 @@ public final class MetricRepo {
                 "database_num", MetricUnit.OPERATIONS, "count of database");
         int dbNum = 0;
         for (String dbName : dbNames) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (null == db) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -62,7 +62,8 @@ public class MVMetaVersionRepairer {
                 LOG.warn("mv db {} not found", mvId.getDbId());
                 continue;
             }
-            MaterializedView mv = (MaterializedView) mvDb.getTable(mvId.getId());
+            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(mvDb.getId(), mvId.getId());
             if (mv == null) {
                 LOG.warn("mv {} not found", mvId.getId());
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
@@ -88,7 +88,7 @@ public interface MVRepairHandler {
         }
 
         for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
-            Table table = db.getTable(tableCommitInfo.getTableId());
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableCommitInfo.getTableId());
             if (table == null || !(table instanceof OlapTable) || table.getRelatedMaterializedViews().isEmpty()) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -228,7 +228,7 @@ public class EditLog {
                 case OperationType.OP_DROP_TABLE:
                 case OperationType.OP_DROP_TABLE_V2: {
                     DropInfo info = (DropInfo) journal.getData();
-                    Database db = globalStateMgr.getDb(info.getDbId());
+                    Database db = globalStateMgr.getLocalMetastore().getDb(info.getDbId());
                     if (db == null) {
                         LOG.warn("failed to get db[{}]", info.getDbId());
                         break;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/BinlogScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/BinlogScanNode.java
@@ -141,7 +141,7 @@ public class BinlogScanNode extends ScanNode {
                 if (dbId == -1) {
                     TabletMeta meta = invertedIndex.getTabletMeta(tablet.getId());
                     dbId = meta.getDbId();
-                    dbName = GlobalStateMgr.getCurrentState().getDb(dbId).getFullName();
+                    dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId).getFullName();
                 }
 
                 long tabletId = tablet.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
@@ -199,7 +199,7 @@ public class DbPEntryObject implements PEntryObject {
             return "ALL DATABASES";
         } else {
             if (CatalogMgr.isInternalCatalog(catalogId)) {
-                Database database = GlobalStateMgr.getCurrentState().getDb(Long.parseLong(uuid));
+                Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(Long.parseLong(uuid));
                 if (database == null) {
                     throw new MetaNotFoundException("Can't find database : " + uuid);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/FunctionPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/FunctionPEntryObject.java
@@ -158,7 +158,7 @@ public class FunctionPEntryObject implements PEntryObject {
             if (databaseId == PrivilegeBuiltinConstants.ALL_DATABASE_ID) {
                 return "ALL FUNCTIONS IN ALL DATABASES";
             } else {
-                Database database = GlobalStateMgr.getCurrentState().getDb(databaseId);
+                Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(databaseId);
                 if (database == null) {
                     throw new MetaNotFoundException("Can't find database : " + databaseId);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/NativeAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/NativeAccessController.java
@@ -20,10 +20,11 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.ast.pipe.PipeName;
-import com.starrocks.sql.common.MetaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -364,7 +365,10 @@ public class NativeAccessController implements AccessController {
         if (dbName == null) {
             databaseId = PrivilegeBuiltinConstants.GLOBAL_FUNCTION_DEFAULT_DATABASE_ID;
         } else {
-            Database database = MetaUtils.getDatabase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName);
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            if (database == null) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
             databaseId = database.getId();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/NativeAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/NativeAccessController.java
@@ -365,7 +365,8 @@ public class NativeAccessController implements AccessController {
         if (dbName == null) {
             databaseId = PrivilegeBuiltinConstants.GLOBAL_FUNCTION_DEFAULT_DATABASE_ID;
         } else {
-            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            Database database = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName);
             if (database == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PipePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PipePEntryObject.java
@@ -56,7 +56,7 @@ public class PipePEntryObject implements PEntryObject {
             pipeId = PrivilegeBuiltinConstants.ALL_PIPES_ID;
         } else {
             String dbName = tokens.get(0);
-            Database database = mgr.getDb(dbName);
+            Database database = mgr.getLocalMetastore().getDb(dbName);
             if (database == null) {
                 throw new PrivObjNotFoundException("cannot find db: " + dbName);
             }
@@ -129,7 +129,7 @@ public class PipePEntryObject implements PEntryObject {
                     .map(Pipe::getDbAndName)
                     .collect(Collectors.toList());
             for (Pair<Long, String> dbAndName : ListUtils.emptyIfNull(dbAndNames)) {
-                Optional<Database> db = GlobalStateMgr.getCurrentState().mayGetDb(dbAndName.first);
+                Optional<Database> db = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(dbAndName.first);
                 db.ifPresent(database -> objects.add(
                         Lists.newArrayList(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                                 database.getFullName(), dbAndName.second)));
@@ -206,7 +206,7 @@ public class PipePEntryObject implements PEntryObject {
                 return Optional.empty();
             }
             long dbId = Long.parseLong(getDbUUID());
-            return GlobalStateMgr.getCurrentState().mayGetDb(dbId);
+            return GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(dbId);
         } catch (NumberFormatException e) {
             return Optional.empty();
         }
@@ -227,7 +227,7 @@ public class PipePEntryObject implements PEntryObject {
             sb.append("ALL ").append("DATABASES");
         } else {
             String dbName;
-            Database database = GlobalStateMgr.getCurrentState().getDb(Long.parseLong(getDbUUID()));
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(Long.parseLong(getDbUUID()));
             if (database == null) {
                 throw new MetaNotFoundException("Cannot find database : " + getDbUUID());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
@@ -275,8 +275,8 @@ public class TablePEntryObject implements PEntryObject {
             } else {
                 String tblName = null;
                 if (CatalogMgr.isInternalCatalog(catalogId)) {
-                    Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                            Long.parseLong(getDatabaseUUID()), Long.parseLong(getTableUUID()));
+                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(Long.parseLong(getDatabaseUUID()), Long.parseLong(getTableUUID()));
                     if (table == null) {
                         throw new MetaNotFoundException("Cannot find table : " + tableUUID);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/starrocks/RangerStarRocksAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/starrocks/RangerStarRocksAccessController.java
@@ -129,7 +129,7 @@ public class RangerStarRocksAccessController extends RangerAccessController {
     public void checkAnyActionOnAnyTable(UserIdentity currentUser, Set<Long> roleIds, String catalog, String db)
             throws AccessDeniedException {
         Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalog, db);
-        for (Table table : database.getTables()) {
+        for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(database.getId())) {
             try {
                 hasPermission(
                         RangerStarRocksResource.builder()
@@ -187,7 +187,7 @@ public class RangerStarRocksAccessController extends RangerAccessController {
 
     @Override
     public void checkAnyActionOnAnyView(UserIdentity currentUser, Set<Long> roleIds, String db) throws AccessDeniedException {
-        Database database = GlobalStateMgr.getServingState().getDb(db);
+        Database database = GlobalStateMgr.getServingState().getLocalMetastore().getDb(db);
         for (Table table : database.getViews()) {
             try {
                 hasPermission(
@@ -235,7 +235,7 @@ public class RangerStarRocksAccessController extends RangerAccessController {
     @Override
     public void checkAnyActionOnAnyMaterializedView(UserIdentity currentUser, Set<Long> roleIds, String db)
             throws AccessDeniedException {
-        Database database = GlobalStateMgr.getServingState().getDb(db);
+        Database database = GlobalStateMgr.getServingState().getLocalMetastore().getDb(db);
         for (Table table : database.getMaterializedViews()) {
             try {
                 hasPermission(
@@ -282,7 +282,7 @@ public class RangerStarRocksAccessController extends RangerAccessController {
 
     @Override
     public void checkAnyActionOnAnyFunction(UserIdentity currentUser, Set<Long> roleIds, String db) throws AccessDeniedException {
-        Database database = GlobalStateMgr.getServingState().getDb(db);
+        Database database = GlobalStateMgr.getServingState().getLocalMetastore().getDb(db);
         for (Function function : database.getFunctions()) {
             try {
                 hasPermission(
@@ -329,8 +329,8 @@ public class RangerStarRocksAccessController extends RangerAccessController {
     @Override
     public void checkActionInDb(UserIdentity userIdentity, Set<Long> roleIds, String db, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        Database database = GlobalStateMgr.getCurrentState().getDb(db);
-        for (Table table : database.getTables()) {
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(db);
+        for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(database.getId())) {
             if (table.isOlapView()) {
                 checkViewAction(userIdentity, roleIds, new TableName(database.getFullName(), table.getName()), privilegeType);
             } else if (table.isMaterializedView()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -243,7 +243,7 @@ public class DDLStmtExecutor {
                             .getGlobalFunctionMgr()
                             .userAddFunction(stmt.getFunction(), stmt.shouldReplaceIfExists());
                 } else {
-                    Database db = context.getGlobalStateMgr().getDb(name.getDb());
+                    Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(name.getDb());
                     if (db == null) {
                         ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, name.getDb());
                     }
@@ -260,7 +260,7 @@ public class DDLStmtExecutor {
                 if (name.isGlobalFunction()) {
                     context.getGlobalStateMgr().getGlobalFunctionMgr().userDropFunction(stmt.getFunctionSearchDesc());
                 } else {
-                    Database db = context.getGlobalStateMgr().getDb(name.getDb());
+                    Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(name.getDb());
                     if (db == null) {
                         ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, name.getDb());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -572,7 +572,7 @@ public class ReplicationJob implements GsonPostProcessable {
         long tableDataSize;
         Map<Long, PartitionInfo> partitionInfos = Maps.newHashMap();
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(request.database_id);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(request.database_id);
         if (db == null) {
             throw new MetaNotFoundException("Database " + request.database_id + " not found");
         }
@@ -580,7 +580,7 @@ public class ReplicationJob implements GsonPostProcessable {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table table = db.getTable(request.table_id);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), request.table_id);
             if (table == null) {
                 throw new MetaNotFoundException(
                         "Table " + request.table_id + " in database " + db.getFullName() + " not found");
@@ -830,8 +830,8 @@ public class ReplicationJob implements GsonPostProcessable {
         }
 
         if (txnState.getTransactionStatus() == TransactionStatus.PREPARE) {
-            Database db = GlobalStateMgr.getServingState().getDb(databaseId);
-            if (db == null || db.getTable(tableId) == null) {
+            Database db = GlobalStateMgr.getServingState().getLocalMetastore().getDb(databaseId);
+            if (db == null || GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId) == null) {
                 abortTransaction("Table is deleted");
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -93,7 +93,8 @@ public class MVActiveChecker extends FrontendDaemon {
     private void process() {
         Collection<Database> dbs = GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().values();
         for (Database db : CollectionUtils.emptyIfNull(dbs)) {
-            for (Table table : CollectionUtils.emptyIfNull(db.getTables())) {
+            for (Table table : CollectionUtils.emptyIfNull(
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId()))) {
                 if (table.isMaterializedView()) {
                     MaterializedView mv = (MaterializedView) table;
                     if (!mv.isActive()) {
@@ -124,7 +125,7 @@ public class MVActiveChecker extends FrontendDaemon {
         }
 
         long dbId = mv.getDbId();
-        Optional<String> dbName = GlobalStateMgr.getCurrentState().mayGetDb(dbId).map(Database::getFullName);
+        Optional<String> dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(dbId).map(Database::getFullName);
         if (!dbName.isPresent()) {
             LOG.warn("[MVActiveChecker] cannot activate MV {} since database {} not found", mv.getName(), dbId);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -792,7 +792,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         LOG.info("start to update meta for mv:{}", materializedView.getName());
 
         // check
-        Table mv = db.getTable(materializedView.getId());
+        Table mv = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), materializedView.getId());
         if (mv == null) {
             throw new DmlException(
                     "update meta failed. materialized view:" + materializedView.getName() + " not exist");
@@ -849,12 +849,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Map<String, String> properties = context.getProperties();
         // NOTE: mvId is set in Task's properties when creating
         long mvId = Long.parseLong(properties.get(MV_ID));
-        db = GlobalStateMgr.getCurrentState().getDb(context.ctx.getDatabase());
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(context.ctx.getDatabase());
         if (db == null) {
             LOG.warn("database {} do not exist when refreshing materialized view:{}", context.ctx.getDatabase(), mvId);
             throw new DmlException("database " + context.ctx.getDatabase() + " do not exist.");
         }
-        Table table = db.getTable(mvId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId);
         if (table == null) {
             LOG.warn("materialized view:{} in database:{} do not exist when refreshing", mvId,
                     context.ctx.getDatabase());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -171,13 +171,13 @@ public class TaskRun implements Comparable<TaskRun> {
         try {
             // NOTE: mvId is set in Task's properties when creating
             long mvId = Long.parseLong(properties.get(MV_ID));
-            Database database = GlobalStateMgr.getCurrentState().getDb(ctx.getDatabase());
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(ctx.getDatabase());
             if (database == null) {
                 LOG.warn("database {} do not exist when refreshing materialized view:{}", ctx.getDatabase(), mvId);
                 return newProperties;
             }
 
-            Table table = database.getTable(mvId);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), mvId);
             if (table == null) {
                 LOG.warn("materialized view:{} in database:{} do not exist when refreshing", mvId,
                         ctx.getDatabase());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -92,7 +92,7 @@ public class TableKeeper {
     }
 
     public boolean checkDatabaseExists() {
-        return GlobalStateMgr.getCurrentState().getDb(databaseName) != null;
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(databaseName) != null;
     }
 
     public void createTable() throws UserException {
@@ -102,8 +102,7 @@ public class TableKeeper {
     public void correctTable() {
         int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
         int replica = GlobalStateMgr.getCurrentState()
-                .mayGetDb(databaseName)
-                .flatMap(db -> db.mayGetTable(tableName))
+                .getLocalMetastore().mayGetTable(databaseName, tableName)
                 .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
                 .orElse((short) 1);
         if (numBackends < tableReplicas) {
@@ -143,8 +142,7 @@ public class TableKeeper {
 
     private Optional<OlapTable> mayGetTable() {
         return GlobalStateMgr.getCurrentState()
-                .mayGetDb(databaseName)
-                .flatMap(db -> db.mayGetTable(tableName))
+                .getLocalMetastore().mayGetTable(databaseName, tableName)
                 .flatMap(x -> Optional.of((OlapTable) x));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
@@ -125,7 +125,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
 
     // TODO recover the entire job state, include execution plan
     public void restore() {
-        Table table = GlobalStateMgr.getCurrentState().getDb(dbId).getTable(viewId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, viewId);
         Preconditions.checkState(table != null && table.isMaterializedView());
         this.view = (MaterializedView) table;
         this.serializedState = JobState.INIT;
@@ -232,7 +232,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
         // Build connection context
         this.connectContext = StatisticUtils.buildConnectContext();
         this.connectContext.setNeedQueued(false);
-        Database db = GlobalStateMgr.getCurrentState().getDb(view.getDbId());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(view.getDbId());
         this.connectContext.getSessionVariable().setQueryTimeoutS(MV_QUERY_TIMEOUT);
         if (db != null) {
             this.connectContext.setDatabase(db.getFullName());
@@ -365,7 +365,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
     private void setMVMaintenanceTasksInfo(TMVMaintenanceTasks request,
                                            MVMaintenanceTask task) {
         // Request information
-        String dbName = GlobalStateMgr.getCurrentState().getDb(view.getDbId()).getFullName();
+        String dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(view.getDbId()).getFullName();
 
         request.setDb_name(dbName);
         request.setMv_name(view.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceTask.java
@@ -59,7 +59,7 @@ public class MVMaintenanceTask {
     public static MVMaintenanceTask build(MVMaintenanceJob job, long taskId, TNetworkAddress beRpcAddr,
                                           List<TExecPlanFragmentParams> fragmentInstances) {
         MVMaintenanceTask task = new MVMaintenanceTask();
-        task.dbName = GlobalStateMgr.getCurrentState().getDb(job.getView().getDbId()).getFullName();
+        task.dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(job.getView().getDbId()).getFullName();
         task.job = job;
         task.beRpcAddr = beRpcAddr;
         task.taskId = taskId;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -259,7 +259,7 @@ public abstract class MVPCTRefreshPartitioner {
         }
         try {
             // check
-            Table mv = db.getTable(materializedView.getId());
+            Table mv = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), materializedView.getId());
             if (mv == null) {
                 throw new DmlException("drop partition failed. mv:" + materializedView.getName() + " not exist");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/TxnBasedEpochCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/TxnBasedEpochCoordinator.java
@@ -129,7 +129,7 @@ class TxnBasedEpochCoordinator implements EpochCoordinator {
     private void commitEpoch(MVEpoch epoch) {
         LOG.info("commitEpoch: {}", epoch);
         long dbId = mvMaintenanceJob.getView().getDbId();
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
 
         try {
             epoch.onCommitting();

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -248,7 +248,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -2044,26 +2043,6 @@ public class GlobalStateMgr {
         };
     }
 
-    public Database getDb(String name) {
-        return localMetastore.getDb(name);
-    }
-
-    public Optional<Table> mayGetTable(long dbId, long tableId) {
-        return mayGetDb(dbId).flatMap(db -> db.tryGetTable(tableId));
-    }
-
-    public Optional<Database> mayGetDb(String name) {
-        return Optional.ofNullable(localMetastore.getDb(name));
-    }
-
-    public Optional<Database> mayGetDb(long dbId) {
-        return Optional.ofNullable(localMetastore.getDb(dbId));
-    }
-
-    public Database getDb(long dbId) {
-        return localMetastore.getDb(dbId);
-    }
-
     public EditLog getEditLog() {
         return editLog;
     }
@@ -2086,11 +2065,11 @@ public class GlobalStateMgr {
     }
 
     public SchemaChangeHandler getSchemaChangeHandler() {
-        return (SchemaChangeHandler) this.alterJobMgr.getSchemaChangeHandler();
+        return this.alterJobMgr.getSchemaChangeHandler();
     }
 
     public MaterializedViewHandler getRollupHandler() {
-        return (MaterializedViewHandler) this.alterJobMgr.getMaterializedViewHandler();
+        return this.alterJobMgr.getMaterializedViewHandler();
     }
 
     public BackupHandler getBackupHandler() {
@@ -2452,7 +2431,7 @@ public class GlobalStateMgr {
         try {
             // sort all dbs
             for (long dbId : localMetastore.getDbIds()) {
-                Database db = getDb(dbId);
+                Database db = localMetastore.getDb(dbId);
                 Preconditions.checkNotNull(db);
                 lockedDbMap.put(dbId, db);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -521,14 +521,6 @@ public class MetadataMgr {
         return connectorTable;
     }
 
-    public Table getTable(Long databaseId, Long tableId) {
-        Database database = localMetastore.getDb(databaseId);
-        if (database == null) {
-            return null;
-        }
-        return database.getTable(tableId);
-    }
-
     public TableVersionRange getTableVersionRange(String dbName, Table table,
                                                   Optional<ConnectorTableVersion> startVersion,
                                                   Optional<ConnectorTableVersion> endVersion) {
@@ -547,7 +539,7 @@ public class MetadataMgr {
 
     public Optional<Table> getTable(BaseTableInfo baseTableInfo) {
         if (baseTableInfo.isInternalCatalog()) {
-            return Optional.ofNullable(getTable(baseTableInfo.getDbId(), baseTableInfo.getTableId()));
+            return Optional.ofNullable(localMetastore.getTable(baseTableInfo.getDbId(), baseTableInfo.getTableId()));
         } else {
             return Optional.ofNullable(
                     getTable(baseTableInfo.getCatalogName(), baseTableInfo.getDbName(), baseTableInfo.getTableName()));
@@ -588,7 +580,7 @@ public class MetadataMgr {
         if (database == null) {
             return null;
         }
-        return database.getTable(tableId);
+        return localMetastore.getTable(database.getId(), tableId);
     }
 
     public boolean tableExists(String catalogName, String dbName, String tblName) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -150,12 +150,12 @@ public class InformationSchemaDataSource {
         AuthDbRequestResult result = getAuthDbRequestResult(request.getAuth_info());
 
         for (String dbName : result.authorizedDbs) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db != null) {
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    List<Table> allTables = db.getTables();
+                    List<Table> allTables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
                     for (Table table : allTables) {
                         try {
                             Authorizer.checkAnyActionOnTableLikeObject(result.currentUser,
@@ -257,11 +257,11 @@ public class InformationSchemaDataSource {
         AuthDbRequestResult result = getAuthDbRequestResult(request.getAuth_info());
 
         for (String dbName : result.authorizedDbs) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db == null) {
                 continue;
             }
-            List<Table> allTables = db.getTables();
+            List<Table> allTables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
             for (Table table : allTables) {
                 try {
                     Authorizer.checkAnyActionOnTableLikeObject(result.currentUser,
@@ -529,7 +529,7 @@ public class InformationSchemaDataSource {
                     for (Map.Entry<Long, UUID> entry : tableMap.entrySet()) {
                         UUID sessionId = entry.getValue();
                         Long tableId = entry.getKey();
-                        Table table = db.getTable(tableId);
+                        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                         if (table != null) {
                             TTableInfo info = new TTableInfo();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -40,7 +40,7 @@ import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_BF_COLUMNS;
 public class AlterTableStatementAnalyzer {
     public static void analyze(AlterTableStmt statement, ConnectContext context) {
         TableName tbl = statement.getTbl();
-        MetaUtils.normalizationTableName(context, tbl);
+        tbl.normalization(context);
         MetaUtils.checkNotSupportCatalog(tbl.getCatalog(), "ALTER");
 
         List<AlterClause> alterClauseList = statement.getAlterClauseList();
@@ -50,7 +50,11 @@ public class AlterTableStatementAnalyzer {
 
         checkAlterOpConflict(alterClauseList);
 
-        Database db = MetaUtils.getDatabase(context, tbl);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tbl.getCatalog(), tbl.getDb());
+        if (db == null) {
+            throw new SemanticException("Database %s is not found", tbl.getCatalogAndDb());
+        }
+
         if (alterClauseList.stream().map(AlterClause::getOpType).anyMatch(AlterOpType::needCheckCapacity)) {
             try {
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkClusterCapacity();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -207,7 +207,7 @@ public class AnalyzerUtils {
             dbName = context.getDatabase();
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             return null;
         }
@@ -384,7 +384,7 @@ public class AnalyzerUtils {
                 return;
             }
 
-            Database db = session.getGlobalStateMgr().getDb(dbName);
+            Database db = session.getGlobalStateMgr().getLocalMetastore().getDb(dbName);
             if (db == null) {
                 return;
             }
@@ -1113,9 +1113,9 @@ public class AnalyzerUtils {
     public static Set<TableName> getAllTableNamesForAnalyzeJobStmt(long dbId, long tableId) {
         Set<TableName> tableNames = Sets.newHashSet();
         if (StatsConstants.DEFAULT_ALL_ID != tableId && StatsConstants.DEFAULT_ALL_ID != dbId) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db != null && !db.isSystemDatabase()) {
-                Table table = db.getTable(tableId);
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                 if (table != null && table.isOlapOrCloudNativeTable()) {
                     tableNames.add(new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                             db.getFullName(), table.getName()));
@@ -1134,9 +1134,9 @@ public class AnalyzerUtils {
     }
 
     private static void getTableNamesInDb(Set<TableName> tableNames, Long id) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(id);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(id);
         if (db != null && !db.isSystemDatabase()) {
-            for (Table table : db.getTables()) {
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                 if (table == null || !table.isOlapOrCloudNativeTable()) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizationAnalyzer.java
@@ -45,7 +45,6 @@ import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.ast.pipe.PipeName;
-import com.starrocks.sql.common.MetaUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -229,7 +228,7 @@ public class AuthorizationAnalyzer {
                         funcPrivTokenList.add(new Pair<>(PrivilegeBuiltinConstants.ALL_DATABASE_ID,
                                 PrivilegeBuiltinConstants.ALL_FUNCTIONS_ID));
                     } else {
-                        Database database = GlobalStateMgr.getServingState().getDb(tokens.get(0));
+                        Database database = GlobalStateMgr.getServingState().getLocalMetastore().getDb(tokens.get(0));
                         if (database == null) {
                             throw new SemanticException("Database %s is not found", tokens.get(0));
                         }
@@ -262,7 +261,7 @@ public class AuthorizationAnalyzer {
                         FunctionSearchDesc searchDesc = new FunctionSearchDesc(functionName,
                                 argsDef.getArgTypes(), argsDef.isVariadic());
 
-                        Database db = GlobalStateMgr.getCurrentState().getDb(functionName.getDb());
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(functionName.getDb());
                         long databaseID = db.getId();
                         Function function = db.getFunction(searchDesc);
 
@@ -346,10 +345,10 @@ public class AuthorizationAnalyzer {
                             tableName = new TableName(tokens.get(0), tokens.get(1), tokens.get(2));
                         } else if (tokens.size() == 2) {
                             tableName = new TableName(tokens.get(0), tokens.get(1));
-                            MetaUtils.normalizationTableName(session, tableName);
+                            tableName.normalization(session);
                         } else if (tokens.size() == 1) {
                             tableName = new TableName("", tokens.get(0));
-                            MetaUtils.normalizationTableName(session, tableName);
+                            tableName.normalization(session);
                         } else {
                             throw new SemanticException(
                                     "Invalid grant statement with error privilege object " + tokens);
@@ -366,7 +365,7 @@ public class AuthorizationAnalyzer {
                             tableName = new TableName(tokens.get(0), tokens.get(1));
                         } else if (tokens.size() == 1) {
                             tableName = new TableName("", tokens.get(0));
-                            MetaUtils.normalizationTableName(session, tableName);
+                            tableName.normalization(session);
                         } else {
                             throw new SemanticException(
                                     "Invalid grant statement with error privilege object " + tokens);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -36,7 +36,6 @@ import com.starrocks.sql.ast.MultiRangePartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RangePartitionDesc;
-import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.parser.ParsingException;
 
 import java.util.HashMap;
@@ -88,7 +87,7 @@ public class CTASAnalyzer {
         }
 
         TableName tableNameObject = createTableStmt.getDbTbl();
-        MetaUtils.normalizationTableName(session, tableNameObject);
+        tableNameObject.normalization(session);
         CreateTableAnalyzer.analyzeEngineName(createTableStmt, tableNameObject.getCatalog());
 
         for (int i = 0; i < allFields.size(); i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CancelAlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CancelAlterTableStatementAnalyzer.java
@@ -19,14 +19,13 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CancelAlterTableStmt;
-import com.starrocks.sql.common.MetaUtils;
 
 public class CancelAlterTableStatementAnalyzer {
 
     public static void analyze(CancelAlterTableStmt statement, ConnectContext context) {
-        MetaUtils.normalizationTableName(context, statement.getDbTableName());
+        statement.getDbTableName().normalization(context);
         // Check db.
-        if (context.getGlobalStateMgr().getDb(statement.getDbName()) == null) {
+        if (context.getGlobalStateMgr().getLocalMetastore().getDb(statement.getDbName()) == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, statement.getDbName());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
@@ -16,12 +16,12 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.TableName;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateTemporaryTableLikeStmt;
@@ -35,14 +35,17 @@ public class CreateTableLikeAnalyzer {
 
     public static void analyze(CreateTableLikeStmt stmt, ConnectContext context) {
         TableName existedDbTbl = stmt.getExistedDbTbl();
-        MetaUtils.normalizationTableName(context, stmt.getDbTbl());
-        MetaUtils.normalizationTableName(context, existedDbTbl);
+        stmt.getDbTbl().normalization(context);
+        existedDbTbl.normalization(context);
         String tableName = stmt.getTableName();
         FeNameFormat.checkTableName(tableName);
 
         MetaUtils.checkNotSupportCatalog(existedDbTbl.getCatalog(), "CREATE TABLE LIKE");
-        Database db = MetaUtils.getDatabase(context, existedDbTbl);
-        Table table = MetaUtils.getTable(existedDbTbl);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(existedDbTbl.getCatalog(),
+                existedDbTbl.getDb(), existedDbTbl.getTbl());
+        if (table == null) {
+            throw new SemanticException("Table %s is not found", tableName);
+        }
 
         List<String> createTableStmt = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
@@ -63,7 +63,7 @@ public class DropStmtAnalyzer {
 
         @Override
         public Void visitDropTableStatement(DropTableStmt statement, ConnectContext context) {
-            MetaUtils.normalizationTableName(context, statement.getTableNameObject());
+            statement.getTableNameObject().normalization(context);
 
             // check catalog
             String catalogName = statement.getCatalogName();
@@ -116,7 +116,7 @@ public class DropStmtAnalyzer {
         @Override
         public Void visitDropTemporaryTableStatement(DropTemporaryTableStmt statement, ConnectContext context) {
             statement.setSessionId(context.getSessionId());
-            MetaUtils.normalizationTableName(context, statement.getTableNameObject());
+            statement.getTableNameObject().normalization(context);
 
             // check catalog
             String catalogName = statement.getCatalogName();
@@ -166,7 +166,7 @@ public class DropStmtAnalyzer {
                         context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                         PrivilegeType.DROP.name(), ObjectType.DATABASE.name(), dbName);
             } else if (dbName.equalsIgnoreCase(SysDb.DATABASE_NAME)) {
-                Database db = GlobalStateMgr.getCurrentState().getDb(SysDb.DATABASE_NAME.toLowerCase());
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(SysDb.DATABASE_NAME.toLowerCase());
                 if (db.getId() == SystemId.SYS_DB_ID) {
                     AccessDeniedException.reportAccessDenied(context.getCurrentCatalog(),
                             context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
@@ -197,7 +197,7 @@ public class DropStmtAnalyzer {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_FUNC_ERROR, funcDesc.toString());
                 }
             } else {
-                Database db = GlobalStateMgr.getCurrentState().getDb(functionName.getDb());
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(functionName.getDb());
                 if (db != null) {
                     func = db.getFunction(statement.getFunctionSearchDesc());
                     if (func == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExportStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExportStmtAnalyzer.java
@@ -68,7 +68,7 @@ public class ExportStmtAnalyzer {
             GlobalStateMgr mgr = context.getGlobalStateMgr();
             TableName tableName = statement.getTableRef().getName();
             // make sure catalog, db, table
-            MetaUtils.normalizationTableName(context, tableName);
+            tableName.normalization(context);
             Table table = MetaUtils.getSessionAwareTable(context, null, tableName);
             if (table.getType() == Table.TableType.OLAP &&
                     (((OlapTable) table).getState() == OlapTable.OlapTableState.RESTORE ||

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1515,11 +1515,11 @@ public class ExpressionAnalyzer {
                 throw new SemanticException("dict_mapping function first param table_name should be 'db.tbl' or 'tbl' format");
             }
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(tableName.getDb());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tableName.getDb());
             if (db == null) {
                 throw new SemanticException("Database %s is not found", tableName.getDb());
             }
-            Table table = db.getTable(tableName.getTbl());
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName.getTbl());
             if (table == null) {
                 throw new SemanticException("dict table %s is not found", tableName.getTbl());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/LoadStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/LoadStmtAnalyzer.java
@@ -124,14 +124,15 @@ public class LoadStmtAnalyzer {
                 if (etlJobType == EtlJobType.SPARK && database != null) {
                     for (DataDescription dataDescription : dataDescriptions) {
                         String tableName = dataDescription.getTableName();
-                        Database db = GlobalStateMgr.getCurrentState().getDb(database);
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(database);
                         if (db == null) {
                             continue;
                         }
                         Locker locker = new Locker();
                         locker.lockDatabase(db, LockType.READ);
                         try {
-                            Table table = db.getTable(tableName);
+                            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getFullName(), tableName);
                             if (table == null) {
                                 continue;
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -418,7 +418,7 @@ public class QueryAnalyzer {
                 }
 
                 TableName resolveTableName = relation.getResolveTableName();
-                MetaUtils.normalizationTableName(session, resolveTableName);
+                resolveTableName.normalization(session);
                 if (aliasSet.contains(resolveTableName)) {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_NONUNIQ_TABLE,
                             relation.getResolveTableName().getTbl());
@@ -1284,7 +1284,7 @@ public class QueryAnalyzer {
     public Table resolveTable(TableRelation tableRelation) {
         TableName tableName = tableRelation.getName();
         try {
-            MetaUtils.normalizationTableName(session, tableName);
+            tableName.normalization(session);
             String catalogName = tableName.getCatalog();
             String dbName = tableName.getDb();
             String tbName = tableName.getTbl();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RecoverPartitionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RecoverPartitionAnalyzer.java
@@ -17,11 +17,10 @@ package com.starrocks.sql.analyzer;
 import com.starrocks.analysis.TableName;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.RecoverPartitionStmt;
-import com.starrocks.sql.common.MetaUtils;
 
 public class RecoverPartitionAnalyzer {
     public static void analyze(RecoverPartitionStmt statement, ConnectContext context) {
         TableName tbl = statement.getDbTblName();
-        MetaUtils.normalizationTableName(context, tbl);
+        tbl.normalization(context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RecoverTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RecoverTableAnalyzer.java
@@ -17,12 +17,11 @@ package com.starrocks.sql.analyzer;
 import com.starrocks.analysis.TableName;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.RecoverTableStmt;
-import com.starrocks.sql.common.MetaUtils;
 
 public class RecoverTableAnalyzer {
 
     public static void analyze(RecoverTableStmt statement, ConnectContext context) {
         TableName tableName = statement.getTableNameObject();
-        MetaUtils.normalizationTableName(context, tableName);
+        tableName.normalization(context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RefreshTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RefreshTableStatementAnalyzer.java
@@ -24,7 +24,6 @@ import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.DdlStmt;
 import com.starrocks.sql.ast.RefreshTableStmt;
-import com.starrocks.sql.common.MetaUtils;
 
 public class RefreshTableStatementAnalyzer {
     public static void analyze(RefreshTableStmt statement, ConnectContext context) {
@@ -45,7 +44,7 @@ public class RefreshTableStatementAnalyzer {
         @Override
         public Void visitRefreshTableStatement(RefreshTableStmt statement, ConnectContext context) {
             TableName tableName = statement.getTableName();
-            MetaUtils.normalizationTableName(context, tableName);
+            tableName.normalization(context);
             String catalogName = tableName.getCatalog();
             String dbName = tableName.getDb();
             String tblName = tableName.getTbl();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -84,7 +84,7 @@ public class ResourceGroupAnalyzer {
 
                     List<Long> databaseIds = new ArrayList<>();
                     for (String name : databases) {
-                        Database db = GlobalStateMgr.getCurrentState().getDb(name);
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(name);
                         if (db == null) {
                             throw new SemanticException(String.format("Specified database not exists: %s", name));
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowAlterStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowAlterStmtAnalyzer.java
@@ -68,7 +68,7 @@ public class ShowAlterStmtAnalyzer {
 
         private void handleShowAlterTable(ShowAlterStmt statement, ConnectContext context) throws SemanticException {
             // build proc path
-            @Nonnull Database db = context.getGlobalStateMgr().getDb(statement.getDbName());
+            @Nonnull Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(statement.getDbName());
             ShowAlterStmt.AlterType type = statement.getType();
             StringBuilder sb = new StringBuilder();
             sb.append("/jobs/");
@@ -102,7 +102,7 @@ public class ShowAlterStmtAnalyzer {
             }
             statement.setDbName(dbName);
             // Check db.
-            if (context.getGlobalStateMgr().getDb(dbName) == null) {
+            if (context.getGlobalStateMgr().getLocalMetastore().getDb(dbName) == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -332,7 +332,7 @@ public class ShowStmtAnalyzer {
         }
 
         private void descInternalCatalogTable(DescribeStmt node, ConnectContext context) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(node.getDb());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(node.getDb());
             if (db == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, node.getDb());
             }
@@ -348,7 +348,7 @@ public class ShowStmtAnalyzer {
                 }
                 //if getTable not find table, may be is statement "desc materialized-view-name"
                 if (table == null) {
-                    for (Table tb : db.getTables()) {
+                    for (Table tb : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                         if (tb.getType() == Table.TableType.OLAP) {
                             OlapTable olapTable = (OlapTable) tb;
                             for (MaterializedIndexMeta mvMeta : olapTable.getVisibleIndexMetas()) {
@@ -535,7 +535,7 @@ public class ShowStmtAnalyzer {
             if (statement.getWhereClause() != null) {
                 analyzeSubPredicate(filterMap, statement.getWhereClause());
             }
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowTabletStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowTabletStmtAnalyzer.java
@@ -94,7 +94,7 @@ public class ShowTabletStmtAnalyzer {
             // order by
             List<OrderByElement> orderByElements = statement.getOrderByElements();
             if (orderByElements != null && !orderByElements.isEmpty()) {
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
                 if (db == null) {
                     throw new SemanticException("Database %s is not found", dbName);
                 }
@@ -103,7 +103,7 @@ public class ShowTabletStmtAnalyzer {
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    table = db.getTable(tableName);
+                    table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
                     if (table == null) {
                         throw new SemanticException("Table %s is not found", tableName);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
@@ -19,12 +19,11 @@ import com.google.common.base.Strings;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.TruncateTableStmt;
-import com.starrocks.sql.common.MetaUtils;
 
 public class TruncateTableAnalyzer {
 
     public static void analyze(TruncateTableStmt statement, ConnectContext context) {
-        MetaUtils.normalizationTableName(context, statement.getTblRef().getName());
+        statement.getTblRef().getName().normalization(context);
         if (statement.getTblRef().hasExplicitAlias()) {
             throw new SemanticException("Not support truncate table with alias");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.View;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterViewClause;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -28,7 +29,6 @@ import com.starrocks.sql.ast.ColWithComment;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.common.MetaUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -67,7 +67,11 @@ public class ViewAnalyzer {
             final String tableName = stmt.getTableName().getTbl();
             FeNameFormat.checkTableName(tableName);
 
-            Table table = MetaUtils.getTable(stmt.getTableName());
+            Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(stmt.getTableName().getCatalog(),
+                    stmt.getTableName().getDb(), stmt.getTableName().getTbl());
+            if (table == null) {
+                throw new SemanticException("Table %s is not found", tableName);
+            }
             if (table.isConnectorView()) {
                 throw new SemanticException("cannot alter connector view");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExportStmt.java
@@ -178,11 +178,11 @@ public class ExportStmt extends StatementBase {
     }
 
     public void checkTable(GlobalStateMgr globalStateMgr) {
-        Database db = globalStateMgr.getDb(tblName.getDb());
+        Database db = globalStateMgr.getLocalMetastore().getDb(tblName.getDb());
         if (db == null) {
             throw new SemanticException("Db does not exist. name: " + tblName.getDb());
         }
-        Table table = db.getTable(tblName.getTbl());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName.getTbl());
         if (table == null) {
             throw new SemanticException("Table[" + tblName.getTbl() + "] does not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
@@ -65,12 +65,12 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
         long tableId = basicStatsMeta.getTableId();
         List<String> columns = basicStatsMeta.getColumns();
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + dbId);
         }
         row.set(0, db.getOriginName());
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + tableId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowHistogramStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowHistogramStatsMetaStmt.java
@@ -62,12 +62,12 @@ public class ShowHistogramStatsMetaStmt extends ShowStmt {
         long dbId = histogramStatsMeta.getDbId();
         long tableId = histogramStatsMeta.getTableId();
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + dbId);
         }
         row.set(0, db.getOriginName());
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + tableId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/ShowPipeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/ShowPipeStmt.java
@@ -69,7 +69,7 @@ public class ShowPipeStmt extends ShowStmt {
      * NOTE: Must be consistent with the META_DATA
      */
     public static void handleShow(List<Comparable> row, Pipe pipe) {
-        Optional<Database> db = GlobalStateMgr.getCurrentState().mayGetDb(pipe.getPipeId().getDbId());
+        Optional<Database> db = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(pipe.getPipeId().getDbId());
         row.add(db.map(Database::getFullName).orElse(""));
         row.add(String.valueOf(pipe.getPipeId().getId()));
         row.add(pipe.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
@@ -80,7 +80,7 @@ public class SqlWithIdUtils {
             long dbId = Long.parseLong(dbStr.substring(0, dbStr.indexOf(COMMON_SUFFIX)));
             Database db = dbMap.get(dbId);
             if (db == null) {
-                db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                 if (db == null) {
                     throw new SemanticException("Can not find db id: %s", dbId);
                 }
@@ -90,7 +90,7 @@ public class SqlWithIdUtils {
             long tableId = Long.parseLong(tableStr.substring(7, tableStr.indexOf(COMMON_SUFFIX)));
             Table table = tableMap.get(tableId);
             if (table == null) {
-                table = db.getTable(tableId);
+                table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                 if (table == null) {
                     throw new SemanticException("Can not find table id: %s in db: %s", tableId, db.getOriginName());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -716,11 +716,11 @@ public class SyncPartitionUtils {
         }
         Expr expr = mv.getPartitionRefTableExprs().get(0);
 
-        Database baseDb = GlobalStateMgr.getCurrentState().getDb(tableName.getDb());
+        Database baseDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tableName.getDb());
         if (baseDb == null) {
             return;
         }
-        Table baseTable = baseDb.getTable(tableName.getTbl());
+        Table baseTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(baseDb.getFullName(), tableName.getTbl());
         if (baseTable == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -657,7 +657,7 @@ public class MvRewritePreprocessor {
                 long dbId = indexMeta.getDbId();
                 String viewDefineSql = indexMeta.getViewDefineSql();
                 String mvName = olapTable.getIndexNameById(indexId);
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
 
                 // distribution info
                 DistributionInfo baseTableDistributionInfo = olapTable.getDefaultDistributionInfo();
@@ -865,7 +865,7 @@ public class MvRewritePreprocessor {
 
         // Add mv info into dump info
         if (context.getDumpInfo() != null) {
-            String dbName = GlobalStateMgr.getCurrentState().getDb(mv.getDbId()).getFullName();
+            String dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId()).getFullName();
             context.getDumpInfo().addTable(dbName, mv);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -101,9 +101,9 @@ public class MetaFunctions {
     }
 
     public static Pair<Database, Table> inspectTable(TableName tableName) {
-        Database db = GlobalStateMgr.getCurrentState().mayGetDb(tableName.getDb())
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(tableName.getDb())
                 .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_DB_ERROR, tableName.getDb()));
-        Table table = db.tryGetTable(tableName.getTbl())
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetTable(tableName.getDb(), tableName.getTbl())
                 .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName));
         ConnectContext connectContext = ConnectContext.get();
         try {
@@ -167,7 +167,7 @@ public class MetaFunctions {
         Optional<Database> mayDb;
         Table table = inspectExternalTable(tableName);
         if (table.isNativeTableOrMaterializedView()) {
-            mayDb = GlobalStateMgr.getCurrentState().mayGetDb(tableName.getDb());
+            mayDb = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(tableName.getDb());
         } else {
             mayDb = Optional.empty();
         }
@@ -179,7 +179,7 @@ public class MetaFunctions {
             Set<MvId> relatedMvs = table.getRelatedMaterializedViews();
             JsonArray array = new JsonArray();
             for (MvId mv : SetUtils.emptyIfNull(relatedMvs)) {
-                String mvName = GlobalStateMgr.getCurrentState().mayGetTable(mv.getDbId(), mv.getId())
+                String mvName = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetTable(mv.getDbId(), mv.getId())
                         .map(Table::getName)
                         .orElse(null);
                 JsonObject obj = new JsonObject();
@@ -246,7 +246,7 @@ public class MetaFunctions {
         ConnectContext connectContext = ConnectContext.get();
         authOperatorPrivilege();
         String currentDb = connectContext.getDatabase();
-        Database db = GlobalStateMgr.getCurrentState().mayGetDb(connectContext.getDatabase())
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().mayGetDb(connectContext.getDatabase())
                 .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_DB_ERROR, currentDb));
         String json = GlobalStateMgr.getCurrentState().getPipeManager().getPipesOfDb(db.getId());
         return ConstantOperator.createVarchar(json);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -136,9 +136,9 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                                                  LogicalOlapScanOperator olapScanOperator,
                                                  OptExpression input) {
         // Fetch mv from catalog again since table from olap scan operator is copied.
-        Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
         Preconditions.checkState(db != null, "Database not found: %s", mvId.getDbId());
-        Table table = db.getTable(mvId.getId());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
         Preconditions.checkState(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;
         MvPlanContext mvPlanContext = MvUtils.getMVPlanContext(connectContext, mv, true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -174,12 +174,12 @@ public class MvUtils {
         }
         Set<Table> newMvs = Sets.newHashSet();
         for (MvId mvId : newMvIds) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
             if (db == null) {
                 logMVPrepare("Cannot find database from mvId:{}", mvId);
                 continue;
             }
-            Table table = db.getTable(mvId.getId());
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
             if (table == null) {
                 logMVPrepare("Cannot find materialized view from mvId:{}", mvId);
                 continue;
@@ -1151,7 +1151,8 @@ public class MvUtils {
         }
         // inactive related asynchronous mvs
         for (MvId mvId : olapTable.getRelatedMaterializedViews()) {
-            MaterializedView mv = (MaterializedView) db.getTable(mvId.getId());
+            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), mvId.getId());
             if (mv == null) {
                 LOG.warn("Ignore materialized view {} does not exists", mvId);
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -164,8 +164,8 @@ public class CacheDictManager implements IDictManager, MemoryTrackable {
 
         Set<Long> dbIds = ConnectContext.get().getCurrentSqlDbIds();
         for (Long id : dbIds) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(id);
-            if (db != null && db.getTable(tableId) != null) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(id);
+            if (db != null && GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId) != null) {
                 columnIdentifier.setDbId(db.getId());
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
@@ -130,9 +130,9 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
     }
 
     private ColumnStatistic convert2ColumnStatistics(TStatisticData statisticData) throws AnalysisException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(statisticData.dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(statisticData.dbId);
         MetaUtils.checkDbNullAndReport(db, String.valueOf(statisticData.dbId));
-        Table table = db.getTable(statisticData.tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), statisticData.tableId);
         if (!(table instanceof OlapTable)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, statisticData.tableId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -118,9 +118,9 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
     }
 
     private Histogram convert2Histogram(TStatisticData statisticData) throws AnalysisException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(statisticData.dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(statisticData.dbId);
         MetaUtils.checkDbNullAndReport(db, String.valueOf(statisticData.dbId));
-        Table table = db.getTable(statisticData.tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), statisticData.tableId);
         if (!(table instanceof OlapTable)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, statisticData.tableId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -267,7 +267,7 @@ public class PlanFragmentBuilder {
         // Create a fake table sink here, replaced it after created the MV
         PartitionInfo partitionInfo = LocalMetastore.buildPartitionInfo(createStmt);
         long mvId = GlobalStateMgr.getCurrentState().getNextId();
-        long dbId = GlobalStateMgr.getCurrentState().getDb(createStmt.getTableName().getDb()).getId();
+        long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(createStmt.getTableName().getDb()).getId();
         MaterializedView view = GlobalStateMgr.getCurrentState().getMaterializedViewMgr()
                 .createSinkTable(createStmt, partitionInfo, mvId, dbId);
         TupleDescriptor tupleDesc = buildTupleDesc(execPlan, view);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -123,8 +123,8 @@ public class BasicStatsMeta implements Writable {
     }
 
     public double getHealthy() {
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
-        OlapTable table = (OlapTable) database.getTable(tableId);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
         long totalPartitionCount = table.getPartitions().size();
 
         long tableRowCount = 1L;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
@@ -105,7 +105,7 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
 
     @Override
     public String getDbName() throws MetaNotFoundException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + dbId);
         }
@@ -114,11 +114,11 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
 
     @Override
     public String getTableName() throws MetaNotFoundException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + dbId);
         }
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + tableId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeStatus.java
@@ -27,7 +27,6 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.common.MetaUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -114,7 +113,7 @@ public class NativeAnalyzeStatus implements AnalyzeStatus, Writable {
 
     @Override
     public String getDbName() throws MetaNotFoundException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + dbId);
         }
@@ -123,11 +122,11 @@ public class NativeAnalyzeStatus implements AnalyzeStatus, Writable {
 
     @Override
     public String getTableName() throws MetaNotFoundException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + dbId);
         }
-        Table table = db.getTable(tableId);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + tableId);
         }
@@ -205,7 +204,7 @@ public class NativeAnalyzeStatus implements AnalyzeStatus, Writable {
         if (dbId == StatsConstants.DEFAULT_ALL_ID) {
             dbName = "*";
         } else {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             dbName = db.getOriginName();
         }
         String tableName;
@@ -213,7 +212,11 @@ public class NativeAnalyzeStatus implements AnalyzeStatus, Writable {
             tableName = "*";
         } else {
             try {
-                tableName = MetaUtils.getTable(dbId, tableId).getName();
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
+                if (table == null) {
+                    throw new SemanticException("Table %s is not found", tableId);
+                }
+                tableName = table.getName();
             } catch (SemanticException e) {
                 tableName = "<tableId : " + tableId + ">";
                 status = StatsConstants.ScheduleStatus.FAILED;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -235,8 +235,8 @@ public class StatisticUtils {
         }
 
         for (String dbName : COLLECT_DATABASES_BLACKLIST) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-            if (null != db && null != db.getTable(tableId)) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            if (null != db && null != GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId)) {
                 return true;
             }
         }
@@ -248,7 +248,7 @@ public class StatisticUtils {
         if (FeConstants.runningUnitTest) {
             return true;
         }
-        Database db = GlobalStateMgr.getCurrentState().getDb(StatsConstants.STATISTICS_DB_NAME);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
         List<String> tableNameList = Lists.newArrayList(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME,
                 StatsConstants.FULL_STATISTICS_TABLE_NAME, StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME,
                 StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME);
@@ -260,7 +260,7 @@ public class StatisticUtils {
 
         for (String tableName : tableNameList) {
             // check table
-            Table table = db.getTable(tableName);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
             if (table == null) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -59,33 +59,34 @@ public class StatisticsCollectJobFactory {
             List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
 
             for (Long dbId : dbIds) {
-                Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
                 if (null == db || StatisticUtils.statisticDatabaseBlackListCheck(db.getFullName())) {
                     continue;
                 }
 
-                for (Table table : db.getTables()) {
+                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                     createJob(statsJobs, nativeAnalyzeJob, db, table, null, null);
                 }
             }
         } else if (StatsConstants.DEFAULT_ALL_ID == nativeAnalyzeJob.getTableId()
                 && StatsConstants.DEFAULT_ALL_ID != nativeAnalyzeJob.getDbId()) {
             // all table
-            Database db = GlobalStateMgr.getCurrentState().getDb(nativeAnalyzeJob.getDbId());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(nativeAnalyzeJob.getDbId());
             if (null == db) {
                 return Collections.emptyList();
             }
 
-            for (Table table : db.getTables()) {
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
                 createJob(statsJobs, nativeAnalyzeJob, db, table, null, null);
             }
         } else {
             // database or table is null mean database/table has been dropped
-            Database db = GlobalStateMgr.getCurrentState().getDb(nativeAnalyzeJob.getDbId());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(nativeAnalyzeJob.getDbId());
             if (db == null) {
                 return Collections.emptyList();
             }
-            createJob(statsJobs, nativeAnalyzeJob, db, db.getTable(nativeAnalyzeJob.getTableId()),
+            createJob(statsJobs, nativeAnalyzeJob, db, GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(db.getId(), nativeAnalyzeJob.getTableId()),
                     nativeAnalyzeJob.getColumns(), nativeAnalyzeJob.getColumnTypes());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -61,7 +61,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
     }
 
     private boolean checkDatabaseExist() {
-        return GlobalStateMgr.getCurrentState().getDb(StatsConstants.STATISTICS_DB_NAME) != null;
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME) != null;
     }
 
     private boolean createDatabase() {
@@ -78,9 +78,9 @@ public class StatisticsMetaManager extends FrontendDaemon {
     }
 
     private boolean checkTableExist(String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(StatsConstants.STATISTICS_DB_NAME);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
         Preconditions.checkState(db != null);
-        return db.getTable(tableName) != null;
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName) != null;
     }
 
     private boolean checkReplicateNormal(String tableName) {
@@ -92,9 +92,9 @@ public class StatisticsMetaManager extends FrontendDaemon {
             return true;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(StatsConstants.STATISTICS_DB_NAME);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
         Preconditions.checkState(db != null);
-        OlapTable table = (OlapTable) db.getTable(tableName);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         Preconditions.checkState(table != null);
         if (table.isCloudNativeTableOrMaterializedView()) {
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -301,12 +301,12 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
      *      And because alter request report success, it means that we can increase replica's version to X.
      */
     public void handleFinishAlterTask() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(getDbId());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(getDbId());
         if (db == null) {
             throw new MetaNotFoundException("database " + getDbId() + " does not exist");
         }
 
-        OlapTable tbl = (OlapTable) db.getTable(getTableId());
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), getTableId());
         if (tbl == null) {
             throw new MetaNotFoundException("tbl " + getTableId() + " does not exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportPendingTask.java
@@ -80,7 +80,7 @@ public class ExportPendingTask extends PriorityLeaderTask {
         }
 
         long dbId = job.getDbId();
-        db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             job.cancelInternal(ExportFailMsg.CancelType.RUN_FAIL, "database does not exist");
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -189,7 +189,7 @@ public class PublishVersionTask extends AgentTask {
             LOG.warn("backend not found or no replicas on backend, backendid={}", backendId);
             return;
         }
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.warn("db not found dbid={}", dbId);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -419,7 +419,7 @@ public class DatabaseTransactionMgr {
             txnSpan.addEvent("commit_start");
 
             for (Long tableId : transactionState.getTableIdList()) {
-                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+                Table table = globalStateMgr.getLocalMetastore().getTable(db.getId(), tableId);
                 if (table == null) {
                     // this can happen when tableId == -1 (tablet being dropping)
                     // or table really not exist.
@@ -551,12 +551,12 @@ public class DatabaseTransactionMgr {
 
         LOG.info("transaction:[{}] successfully rollback", transactionState);
 
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             return;
         }
         for (Long tableId : transactionState.getTableIdList()) {
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+            Table table = globalStateMgr.getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 continue;
             }
@@ -888,7 +888,7 @@ public class DatabaseTransactionMgr {
             // check each table involved in transaction
             for (TableCommitInfo tableCommitInfo : txn.getIdToTableCommitInfos().values()) {
                 long tableId = tableCommitInfo.getTableId();
-                OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+                OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getTable(db.getId(), tableId);
                 // table maybe dropped between commit and publish, ignore it
                 // it will be processed in finishTransaction
                 if (table == null) {
@@ -1231,7 +1231,7 @@ public class DatabaseTransactionMgr {
         while (tableCommitInfoIterator.hasNext()) {
             TableCommitInfo tableCommitInfo = tableCommitInfoIterator.next();
             long tableId = tableCommitInfo.getTableId();
-            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+            OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getTable(db.getId(), tableId);
             // table maybe dropped between commit and publish, ignore this error
             if (table == null) {
                 transactionState.removeTable(tableId);
@@ -1615,7 +1615,7 @@ public class DatabaseTransactionMgr {
         List<List<String>> infos = new ArrayList<List<String>>();
         readLock();
         try {
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
             if (db == null) {
                 throw new AnalysisException("Database[" + dbId + "] does not exist");
             }
@@ -1658,7 +1658,7 @@ public class DatabaseTransactionMgr {
     private void updateCatalogAfterCommitted(TransactionState transactionState, Database db) {
         for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
             long tableId = tableCommitInfo.getTableId();
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+            Table table = globalStateMgr.getLocalMetastore().getTable(db.getId(), tableId);
             TransactionLogApplier applier = txnLogApplierFactory.create(table);
             applier.applyCommitLog(transactionState, tableCommitInfo);
         }
@@ -1666,7 +1666,7 @@ public class DatabaseTransactionMgr {
 
     private boolean updateCatalogAfterVisible(TransactionState transactionState, Database db) {
         for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableCommitInfo.getTableId());
+            Table table = globalStateMgr.getLocalMetastore().getTable(db.getId(), tableCommitInfo.getTableId());
             // table may be dropped by force after transaction committed
             // so that it will be a visible edit log after drop table
             if (table == null) {
@@ -1985,7 +1985,7 @@ public class DatabaseTransactionMgr {
             throws TransactionException {
         List<TransactionStateListener> stateListeners = Lists.newArrayList();
         for (Long tableId : transactionState.getTableIdList()) {
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
+            Table table = globalStateMgr.getLocalMetastore().getTable(database.getId(), tableId);
             if (table == null) {
                 // this can happen when tableId == -1 (tablet being dropping)
                 // or table really not exist.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -283,7 +283,7 @@ public class GlobalTransactionMgr implements MemoryTrackable {
     public void commitPreparedTransaction(long dbId, long transactionId, long timeoutMillis)
             throws UserException {
 
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.warn("Database {} does not exist", dbId);
             throw new UserException("Database[" + dbId + "] does not exist");
@@ -697,7 +697,7 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         for (long dbId : dbIds) {
             List<Comparable> info = new ArrayList<Comparable>();
             info.add(dbId);
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -283,7 +283,7 @@ public class GlobalTransactionMgr implements MemoryTrackable {
     public void commitPreparedTransaction(long dbId, long transactionId, long timeoutMillis)
             throws UserException {
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.warn("Database {} does not exist", dbId);
             throw new UserException("Database[" + dbId + "] does not exist");
@@ -697,7 +697,7 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         for (long dbId : dbIds) {
             List<Comparable> info = new ArrayList<Comparable>();
             info.add(dbId);
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db == null) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -90,7 +90,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
     public void applyVisibleLog(TransactionState txnState, TableCommitInfo commitInfo, Database db) {
         Set<Long> errorReplicaIds = txnState.getErrorReplicas();
         long tableId = table.getId();
-        OlapTable table = (OlapTable) db.getTable(tableId);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
             LOG.warn("table {} is dropped, ignore", tableId);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -292,7 +292,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
     public void postAbort(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
                           List<TabletFailInfo> failedTablets) {
         txnState.clearAutomaticPartitionSnapshot();
-        Database db = GlobalStateMgr.getCurrentState().getDb(txnState.getDbId());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(txnState.getDbId());
         if (db != null) {
             Locker locker = new Locker();
             locker.lockTablesWithIntensiveDbLock(db, txnState.getTableIdList(), LockType.READ);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -427,7 +427,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         long txnId = txnState.getTransactionId();
         long dbId = txnState.getDbId();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.info("the database of transaction {} has been deleted", txnId);
             try {
@@ -482,7 +482,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
         // version -> shadowTablets
         long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
         try {
-            OlapTable table = (OlapTable) db.getTable(tableId);
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 // table has been dropped
                 return true;
@@ -655,7 +655,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             }
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
 
         if (db == null) {
             LOG.info("the database of transaction batch {} has been deleted", txnStateBatch);
@@ -768,7 +768,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tableId), LockType.READ);
         try {
-            OlapTable table = (OlapTable) db.getTable(tableId);
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
             if (table == null) {
                 txnState.removeTable(tableCommitInfo.getTableId());
                 LOG.info("Removed non-exist table {} from transaction {}. txn_id={}", tableId, txnLabel, txnId);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.server.GlobalStateMgr;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -97,7 +98,8 @@ public class TransactionChecker {
     public static TransactionChecker create(TransactionState txn, Database db) {
         List<PartitionChecker> partitions = new ArrayList<>();
         for (TableCommitInfo tableCommitInfo : txn.getIdToTableCommitInfos().values()) {
-            OlapTable table = (OlapTable) db.getTable(tableCommitInfo.getTableId());
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), tableCommitInfo.getTableId());
             if (table == null || table.isCloudNativeTableOrMaterializedView()) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -918,7 +918,7 @@ public class TransactionState implements Writable {
 
     public boolean checkCanFinish() {
         // finishChecker may require refresh if table/partition is dropped, or index is changed caused by Alter job
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             // consider txn finished if db is dropped
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/UpdateDbUsedDataQuotaDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/UpdateDbUsedDataQuotaDaemon.java
@@ -61,7 +61,7 @@ public class UpdateDbUsedDataQuotaDaemon extends FrontendDaemon {
         List<Long> dbIdList = globalStateMgr.getLocalMetastore().getDbIds();
         GlobalTransactionMgr globalTransactionMgr = globalStateMgr.getGlobalTransactionMgr();
         for (Long dbId : dbIdList) {
-            Database db = globalStateMgr.getDb(dbId);
+            Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
             if (db == null) {
                 LOG.warn("Database [" + dbId + "] doese not exist, skip to update database used data quota");
                 continue;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -79,14 +79,14 @@ public class AlterJobV2Test {
         UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.schema_change_test(k1 int, k2 int, k3 int) " +
-                        "distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
-                .withTable("CREATE TABLE test.segmentv2(k1 int, k2 int, v1 int sum) " +
-                        "distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
-                .withTable("CREATE TABLE test.properties_change_test(k1 int, v1 int) " +
-                        "primary key(k1) distributed by hash(k1) properties('replication_num' = '1');")
-                .withTable("CREATE TABLE modify_column_test(k1 int, k2 int, k3 int) ENGINE = OLAP " +
-                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.schema_change_test(k1 int, k2 int, k3 int) " +
+                                "distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
+                    .withTable("CREATE TABLE test.segmentv2(k1 int, k2 int, v1 int sum) " +
+                                "distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
+                    .withTable("CREATE TABLE test.properties_change_test(k1 int, v1 int) " +
+                                "primary key(k1) distributed by hash(k1) properties('replication_num' = '1');")
+                    .withTable("CREATE TABLE modify_column_test(k1 int, k2 int, k3 int) ENGINE = OLAP " +
+                                "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
     }
 
     @AfterClass
@@ -116,7 +116,7 @@ public class AlterJobV2Test {
         // 3. check show alter table column
         String showAlterStmtStr = "show alter table column from test;";
         ShowAlterStmt showAlterStmt =
-                (ShowAlterStmt) UtFrameUtils.parseStmtWithNewParser(showAlterStmtStr, connectContext);
+                    (ShowAlterStmt) UtFrameUtils.parseStmtWithNewParser(showAlterStmtStr, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showAlterStmt, connectContext);
         System.out.println(showResultSet.getMetaData());
         System.out.println(showResultSet.getResultRows());
@@ -133,7 +133,7 @@ public class AlterJobV2Test {
         for (AlterJobV2 alterJobV2 : alterJobs.values()) {
             while (!alterJobV2.getJobState().isFinalState()) {
                 System.out.println(
-                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
+                            "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
                 Thread.sleep(1000);
             }
             System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
@@ -142,7 +142,7 @@ public class AlterJobV2Test {
         // 3. check show alter table column
         String showAlterStmtStr = "show alter table rollup from test;";
         ShowAlterStmt showAlterStmt =
-                (ShowAlterStmt) UtFrameUtils.parseStmtWithNewParser(showAlterStmtStr, connectContext);
+                    (ShowAlterStmt) UtFrameUtils.parseStmtWithNewParser(showAlterStmtStr, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showAlterStmt, connectContext);
         System.out.println(showResultSet.getMetaData());
         System.out.println(showResultSet.getResultRows());
@@ -160,7 +160,7 @@ public class AlterJobV2Test {
         // 3. check enable persistent index
         String showCreateTableStr = "show create table test.properties_change_test;";
         ShowCreateTableStmt showCreateTableStmt =
-                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateTableStr, connectContext);
+                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateTableStr, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         System.out.println(showResultSet.getMetaData());
         System.out.println(showResultSet.getResultRows());
@@ -175,7 +175,7 @@ public class AlterJobV2Test {
 
         // 5. check enable persistent index
         showCreateTableStmt =
-                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateTableStr, connectContext);
+                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateTableStr, connectContext);
         showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         System.out.println(showResultSet.getMetaData());
         System.out.println(showResultSet.getResultRows());
@@ -185,10 +185,10 @@ public class AlterJobV2Test {
     public void testModifyRelatedColumnWithMv() {
         try {
             String sql = "CREATE MATERIALIZED VIEW test.mv2 DISTRIBUTED BY HASH(k1) " +
-                    " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') AS SELECT k1, k2 FROM modify_column_test";
+                        " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') AS SELECT k1, k2 FROM modify_column_test";
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .createMaterializedView((CreateMaterializedViewStatement) statementBase);
+                        .createMaterializedView((CreateMaterializedViewStatement) statementBase);
 
             // modify column which define in mv
             String alterStmtStr = "alter table test.modify_column_test modify column k2 varchar(10)";
@@ -196,7 +196,8 @@ public class AlterJobV2Test {
             DDLStmtExecutor.execute(alterTableStmt, connectContext);
 
             waitForSchemaChangeAlterJobFinish();
-            MaterializedView mv2 = (MaterializedView) GlobalStateMgr.getCurrentState().getDb("test").getTable("mv2");
+            MaterializedView mv2 =
+                        (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("mv2");
             Assert.assertFalse(mv2.isActive());
         } catch (Exception e) {
             e.printStackTrace();
@@ -209,21 +210,21 @@ public class AlterJobV2Test {
     public void testModifyWithSelectStarMV1() throws Exception {
         try {
             starRocksAssert.withTable("CREATE TABLE modify_column_test3(k1 int, k2 int, k3 int) ENGINE = OLAP " +
-                    "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
+                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
             String sql = "CREATE MATERIALIZED VIEW test.mv3 DISTRIBUTED BY HASH(k1) " +
-                    " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') " +
-                    "AS SELECT * FROM modify_column_test3";
+                        " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') " +
+                        "AS SELECT * FROM modify_column_test3";
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .createMaterializedView((CreateMaterializedViewStatement) statementBase);
+                        .createMaterializedView((CreateMaterializedViewStatement) statementBase);
 
             String alterStmtStr = "alter table test.modify_column_test3 modify column k2 varchar(20)";
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
             DDLStmtExecutor.execute(alterTableStmt, connectContext);
 
             waitForSchemaChangeAlterJobFinish();
-            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState()
-                    .getDb("test").getTable("mv3");
+            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getDb("test").getTable("mv3");
             Assert.assertTrue(!mv.isActive());
         } finally {
             starRocksAssert.dropTable("modify_column_test3");
@@ -235,13 +236,13 @@ public class AlterJobV2Test {
     public void testModifyWithSelectStarMV2() throws Exception {
         try {
             starRocksAssert.withTable("CREATE TABLE testModifyWithSelectStarMV2(k1 int, k2 int, k3 int) ENGINE = OLAP " +
-                    "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
+                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
             String sql = "CREATE MATERIALIZED VIEW test.mv6 DISTRIBUTED BY HASH(k1) " +
-                    " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') " +
-                    "AS SELECT * FROM testModifyWithSelectStarMV2";
+                        " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') " +
+                        "AS SELECT * FROM testModifyWithSelectStarMV2";
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .createMaterializedView((CreateMaterializedViewStatement) statementBase);
+                        .createMaterializedView((CreateMaterializedViewStatement) statementBase);
 
             String alterStmtStr = "alter table test.testModifyWithSelectStarMV2 add column k4 bigint";
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
@@ -249,7 +250,7 @@ public class AlterJobV2Test {
 
             waitForSchemaChangeAlterJobFinish();
             MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState()
-                    .getDb("test").getTable("mv6");
+                        .getLocalMetastore().getDb("test").getTable("mv6");
             Assert.assertTrue(mv.isActive());
         } catch (Exception e) {
             e.printStackTrace();
@@ -264,13 +265,13 @@ public class AlterJobV2Test {
     public void testModifyWithSelectStarMV3() throws Exception {
         try {
             starRocksAssert.withTable("CREATE TABLE modify_column_test5(k1 int, k2 int, k3 int) ENGINE = OLAP " +
-                    "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
+                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
             String sql = "CREATE MATERIALIZED VIEW test.mv5 DISTRIBUTED BY HASH(k1) " +
-                    " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') " +
-                    "AS SELECT * FROM modify_column_test5";
+                        " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') " +
+                        "AS SELECT * FROM modify_column_test5";
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .createMaterializedView((CreateMaterializedViewStatement) statementBase);
+                        .createMaterializedView((CreateMaterializedViewStatement) statementBase);
 
             String alterStmtStr = "alter table test.modify_column_test5 drop column k2";
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
@@ -278,7 +279,7 @@ public class AlterJobV2Test {
 
             waitForSchemaChangeAlterJobFinish();
             MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState()
-                    .getDb("test").getTable("mv5");
+                        .getLocalMetastore().getDb("test").getTable("mv5");
             Assert.assertTrue(!mv.isActive());
         } catch (Exception e) {
             Assert.fail();
@@ -291,23 +292,24 @@ public class AlterJobV2Test {
     public void testModifyWithExpr() throws Exception {
         try {
             starRocksAssert.withTable("CREATE TABLE modify_column_test4(k1 int, k2 int, k3 int) ENGINE = OLAP " +
-                    "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
+                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
             String sql = "CREATE MATERIALIZED VIEW test.mv4 DISTRIBUTED BY HASH(k1) " +
-                    " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') AS SELECT k1, k2 + 1 FROM modify_column_test4";
+                        " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1')" +
+                        " AS SELECT k1, k2 + 1 FROM modify_column_test4";
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .createMaterializedView((CreateMaterializedViewStatement) statementBase);
+                        .createMaterializedView((CreateMaterializedViewStatement) statementBase);
 
             {
                 // modify column which not define in mv
                 String alterStmtStr = "alter table test.modify_column_test4 modify column k3 varchar(10)";
                 AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr,
-                        connectContext);
+                            connectContext);
                 DDLStmtExecutor.execute(alterTableStmt, connectContext);
 
                 waitForSchemaChangeAlterJobFinish();
                 MaterializedView mv = (MaterializedView) GlobalStateMgr
-                        .getCurrentState().getDb("test").getTable("mv4");
+                            .getCurrentState().getLocalMetastore().getDb("test").getTable("mv4");
                 Assert.assertTrue(mv.isActive());
             }
 
@@ -315,12 +317,12 @@ public class AlterJobV2Test {
                 // modify column which define in mv
                 String alterStmtStr = "alter table test.modify_column_test4 modify column k2 varchar(30) ";
                 AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr,
-                        connectContext);
+                            connectContext);
                 DDLStmtExecutor.execute(alterTableStmt, connectContext);
 
                 waitForSchemaChangeAlterJobFinish();
                 MaterializedView mv = (MaterializedView) GlobalStateMgr
-                        .getCurrentState().getDb("test").getTable("mv4");
+                            .getCurrentState().getLocalMetastore().getDb("test").getTable("mv4");
                 Assert.assertFalse(mv.isActive());
                 System.out.println(mv.getInactiveReason());
                 Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: k2"));
@@ -337,10 +339,10 @@ public class AlterJobV2Test {
     public void testModifyUnRelatedColumnWithMv() {
         try {
             String sql = "CREATE MATERIALIZED VIEW test.mv1 DISTRIBUTED BY HASH(k1) " +
-                    " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') AS SELECT k1, k2 FROM modify_column_test";
+                        " BUCKETS 10 REFRESH ASYNC properties('replication_num' = '1') AS SELECT k1, k2 FROM modify_column_test";
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .createMaterializedView((CreateMaterializedViewStatement) statementBase);
+                        .createMaterializedView((CreateMaterializedViewStatement) statementBase);
 
             // modify column which not define in mv
             String alterStmtStr = "alter table test.modify_column_test modify column k3 varchar(10)";
@@ -348,7 +350,8 @@ public class AlterJobV2Test {
             DDLStmtExecutor.execute(alterTableStmt, connectContext);
 
             waitForSchemaChangeAlterJobFinish();
-            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getDb("test").getTable("mv1");
+            MaterializedView mv =
+                        (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("mv1");
             Assert.assertTrue(mv.isActive());
         } catch (Exception e) {
             e.printStackTrace();
@@ -359,7 +362,7 @@ public class AlterJobV2Test {
     @Test
     public void test() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.schema_change_test_load(k1 int, k2 int, k3 int) " +
-                "distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+                    "distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
 
         String alterStmtStr = "alter table test.schema_change_test_load add column k4 int default '1'";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
@@ -377,7 +380,7 @@ public class AlterJobV2Test {
         srMetaBlockReader.close();
 
         AlterJobV2 alterJobV2New =
-                GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2().get(alterJobV2Old.jobId);
+                    GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2().get(alterJobV2Old.jobId);
 
         Assert.assertEquals(alterJobV2Old.jobId, alterJobV2New.jobId);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
@@ -71,25 +71,25 @@ public class AlterTableTest {
     @Test(expected = AnalysisException.class)
     public void testAlterTableBucketSize() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_alter_bucket_size (\n" +
-                "event_day DATE,\n" +
-                "site_id INT DEFAULT '10',\n" +
-                "city_code VARCHAR(100),\n" +
-                "user_name VARCHAR(32) DEFAULT '',\n" +
-                "pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                "PARTITION BY RANGE(event_day)(\n" +
-                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
-                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
-                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
-                "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
-                ")\n" +
-                "DISTRIBUTED BY RANDOM\n" +
-                "PROPERTIES(\n" +
-                "\t\"replication_num\" = \"1\",\n" +
-                "    \"storage_medium\" = \"SSD\",\n" +
-                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
-                ");");
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "city_code VARCHAR(100),\n" +
+                    "user_name VARCHAR(32) DEFAULT '',\n" +
+                    "pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                    "PARTITION BY RANGE(event_day)(\n" +
+                    "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                    "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                    "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                    "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "PROPERTIES(\n" +
+                    "\t\"replication_num\" = \"1\",\n" +
+                    "    \"storage_medium\" = \"SSD\",\n" +
+                    "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_alter_bucket_size SET (\"bucket_size\" = \"-1\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
@@ -99,31 +99,31 @@ public class AlterTableTest {
     @Test
     public void testAlterTableStorageCoolDownTTL() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_alter_cool_down_ttl (\n" +
-                "event_day DATE,\n" +
-                "site_id INT DEFAULT '10',\n" +
-                "city_code VARCHAR(100),\n" +
-                "user_name VARCHAR(32) DEFAULT '',\n" +
-                "pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                "PARTITION BY RANGE(event_day)(\n" +
-                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
-                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
-                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
-                "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                "PROPERTIES(\n" +
-                "\t\"replication_num\" = \"1\",\n" +
-                "    \"storage_medium\" = \"SSD\",\n" +
-                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
-                ");");
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "city_code VARCHAR(100),\n" +
+                    "user_name VARCHAR(32) DEFAULT '',\n" +
+                    "pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                    "PARTITION BY RANGE(event_day)(\n" +
+                    "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                    "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                    "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                    "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                    "PROPERTIES(\n" +
+                    "\t\"replication_num\" = \"1\",\n" +
+                    "    \"storage_medium\" = \"SSD\",\n" +
+                    "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_alter_cool_down_ttl SET (\"storage_cooldown_ttl\" = \"3 day\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test").getTable("test_alter_cool_down_ttl");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("test_alter_cool_down_ttl");
         OlapTable olapTable = (OlapTable) table;
         String storageCooldownTtl = olapTable.getTableProperty().getProperties().get("storage_cooldown_ttl");
         Assert.assertEquals("3 day", storageCooldownTtl);
@@ -134,25 +134,25 @@ public class AlterTableTest {
     @Test(expected = AnalysisException.class)
     public void testAlterTableStorageCoolDownTTLExcept() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_alter_cool_down_ttl_2 (\n" +
-                "event_day DATE,\n" +
-                "site_id INT DEFAULT '10',\n" +
-                "city_code VARCHAR(100),\n" +
-                "user_name VARCHAR(32) DEFAULT '',\n" +
-                "pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                "PARTITION BY RANGE(event_day)(\n" +
-                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
-                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
-                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
-                "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                "PROPERTIES(\n" +
-                "\t\"replication_num\" = \"1\",\n" +
-                "    \"storage_medium\" = \"SSD\",\n" +
-                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
-                ");");
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "city_code VARCHAR(100),\n" +
+                    "user_name VARCHAR(32) DEFAULT '',\n" +
+                    "pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                    "PARTITION BY RANGE(event_day)(\n" +
+                    "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                    "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                    "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                    "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                    "PROPERTIES(\n" +
+                    "\t\"replication_num\" = \"1\",\n" +
+                    "    \"storage_medium\" = \"SSD\",\n" +
+                    "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_alter_cool_down_ttl_2 SET (\"storage_cooldown_ttl\" = \"abc\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
@@ -162,27 +162,28 @@ public class AlterTableTest {
     @Test
     public void testAlterTableStorageCoolDownTTLPartition() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_alter_cool_down_ttl_partition (\n" +
-                "event_day DATE,\n" +
-                "site_id INT DEFAULT '10',\n" +
-                "city_code VARCHAR(100),\n" +
-                "user_name VARCHAR(32) DEFAULT '',\n" +
-                "pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                "PARTITION BY RANGE(event_day)(\n" +
-                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
-                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
-                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
-                "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                "PROPERTIES(\n" +
-                "\t\"replication_num\" = \"1\",\n" +
-                "    \"storage_medium\" = \"SSD\",\n" +
-                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
-                ");");
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "city_code VARCHAR(100),\n" +
+                    "user_name VARCHAR(32) DEFAULT '',\n" +
+                    "pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                    "PARTITION BY RANGE(event_day)(\n" +
+                    "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                    "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                    "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                    "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                    "PROPERTIES(\n" +
+                    "\t\"replication_num\" = \"1\",\n" +
+                    "    \"storage_medium\" = \"SSD\",\n" +
+                    "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
-        Table table = GlobalStateMgr.getCurrentState().getDb("test").getTable("test_alter_cool_down_ttl_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_alter_cool_down_ttl_partition");
         OlapTable olapTable = (OlapTable) table;
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
         DataProperty p20200321 = rangePartitionInfo.getDataProperty(olapTable.getPartition("p20200321").getId());
@@ -195,7 +196,7 @@ public class AlterTableTest {
         Assert.assertEquals("9999-12-31 23:59:59", TimeUtils.longToTimeString(p20200324.getCooldownTimeMs()));
 
         String sql = "ALTER TABLE test_alter_cool_down_ttl_partition\n" +
-                "MODIFY PARTITION (*) SET(\"storage_cooldown_ttl\" = \"2 day\", \"storage_medium\" = \"SSD\");";
+                    "MODIFY PARTITION (*) SET(\"storage_cooldown_ttl\" = \"2 day\", \"storage_medium\" = \"SSD\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         AlterJobExecutor alterJobExecutor = new AlterJobExecutor();
         alterJobExecutor.process(alterTableStmt, ctx);
@@ -214,33 +215,34 @@ public class AlterTableTest {
     @Test
     public void testAlterTablePartitionTTLInvalid() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_partition_live_number (\n" +
-                "event_day DATE,\n" +
-                "site_id INT DEFAULT '10',\n" +
-                "city_code VARCHAR(100),\n" +
-                "user_name VARCHAR(32) DEFAULT '',\n" +
-                "pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                "PARTITION BY RANGE(event_day)(\n" +
-                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
-                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
-                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
-                "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                "PROPERTIES(\n" +
-                "\t\"replication_num\" = \"1\",\n" +
-                "    \"storage_medium\" = \"SSD\",\n" +
-                "    \"partition_live_number\" = \"2\"\n" +
-                ");");
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "city_code VARCHAR(100),\n" +
+                    "user_name VARCHAR(32) DEFAULT '',\n" +
+                    "pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                    "PARTITION BY RANGE(event_day)(\n" +
+                    "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                    "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                    "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                    "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                    "PROPERTIES(\n" +
+                    "\t\"replication_num\" = \"1\",\n" +
+                    "    \"storage_medium\" = \"SSD\",\n" +
+                    "    \"partition_live_number\" = \"2\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_partition_live_number SET(\"partition_live_number\" = \"-1\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
         Set<Pair<Long, Long>> ttlPartitionInfo = GlobalStateMgr.getCurrentState()
-                .getDynamicPartitionScheduler().getTtlPartitionInfo();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("test_partition_live_number");
+                    .getDynamicPartitionScheduler().getTtlPartitionInfo();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table =
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition_live_number");
         Assert.assertFalse(ttlPartitionInfo.contains(new Pair<>(db.getId(), table.getId())));
         sql = "ALTER TABLE test_partition_live_number SET(\"partition_live_number\" = \"1\");";
         alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
@@ -251,65 +253,67 @@ public class AlterTableTest {
     @Test
     public void testAlterTablePartitionStorageMedium() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_partition_storage_medium (\n" +
-                "event_day DATE,\n" +
-                "site_id INT DEFAULT '10',\n" +
-                "city_code VARCHAR(100),\n" +
-                "user_name VARCHAR(32) DEFAULT '',\n" +
-                "pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                "PARTITION BY RANGE(event_day)(\n" +
-                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
-                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
-                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
-                "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                "PROPERTIES(\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");");
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "city_code VARCHAR(100),\n" +
+                    "user_name VARCHAR(32) DEFAULT '',\n" +
+                    "pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                    "PARTITION BY RANGE(event_day)(\n" +
+                    "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                    "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                    "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                    "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                    "PROPERTIES(\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE test_partition_storage_medium SET(\"default.storage_medium\" = \"SSD\");";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable olapTable = (OlapTable) db.getTable("test_partition_storage_medium");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_partition_storage_medium");
         Assert.assertTrue(olapTable.getStorageMedium().equals("SSD"));
     }
 
     @Test
     public void testAlterTableStorageType() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE test_storage_type (\n" +
-                "event_day DATE,\n" +
-                "site_id INT DEFAULT '10',\n" +
-                "city_code VARCHAR(100),\n" +
-                "user_name VARCHAR(32) DEFAULT '',\n" +
-                "pv BIGINT DEFAULT '2'\n" +
-                ")\n" +
-                "PRIMARY KEY(event_day, site_id, city_code, user_name)\n" +
-                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                "PROPERTIES(\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"storage_type\" = \"column_with_row\"\n" +
-                ");");
+                    "event_day DATE,\n" +
+                    "site_id INT DEFAULT '10',\n" +
+                    "city_code VARCHAR(100),\n" +
+                    "user_name VARCHAR(32) DEFAULT '',\n" +
+                    "pv BIGINT DEFAULT '2'\n" +
+                    ")\n" +
+                    "PRIMARY KEY(event_day, site_id, city_code, user_name)\n" +
+                    "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                    "PROPERTIES(\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"storage_type\" = \"column_with_row\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
 
         String sql1 = "ALTER TABLE test_storage_type SET(\"storage_type\" = \"column\");";
         AnalysisException e1 =
-                Assert.assertThrows(AnalysisException.class, () -> UtFrameUtils.parseStmtWithNewParser(sql1, ctx));
+                    Assert.assertThrows(AnalysisException.class, () -> UtFrameUtils.parseStmtWithNewParser(sql1, ctx));
         Assert.assertTrue(e1.getMessage().contains("Can't change storage type"));
         String sql2 = "ALTER TABLE test_storage_type SET(\"storage_type\" = \"column_with_row\");";
         AnalysisException e2 =
-                Assert.assertThrows(AnalysisException.class, () -> UtFrameUtils.parseStmtWithNewParser(sql2, ctx));
+                    Assert.assertThrows(AnalysisException.class, () -> UtFrameUtils.parseStmtWithNewParser(sql2, ctx));
         Assert.assertTrue(e2.getMessage().contains("Can't change storage type"));
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable olapTable = (OlapTable) db.getTable("test_storage_type");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_storage_type");
         Assert.assertTrue(olapTable.getStorageType().equals(TStorageType.COLUMN_WITH_ROW));
     }
 
     public void testAlterTableLocationProp() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
@@ -317,22 +321,22 @@ public class AlterTableTest {
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
-                ":" + backend.getHeartbeatPort() + "' set ('" +
-                AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:rack1')";
+                    ":" + backend.getHeartbeatPort() + "' set ('" +
+                    AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:rack1')";
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(modifyBackendPropSqlStr, connectContext),
-                connectContext);
+                    connectContext);
 
         String sql = "CREATE TABLE test.`test_location_alter` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         starRocksAssert.withTable(sql);
 
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
@@ -341,48 +345,50 @@ public class AlterTableTest {
 
         // ** test alter table location to rack:*
         sql = "ALTER TABLE test.`test_location_alter` SET ('" +
-                PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:*');";
+                    PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:*');";
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, connectContext),
-                connectContext);
-        Assert.assertEquals("rack", ((OlapTable) testDb.getTable("test_location_alter"))
-                .getLocation().keySet().stream().findFirst().get());
-        Assert.assertEquals("*", ((OlapTable) testDb.getTable("test_location_alter"))
-                .getLocation().get("rack").stream().findFirst().get());
+                    connectContext);
+        Assert.assertEquals("rack", ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "test_location_alter"))
+                    .getLocation().keySet().stream().findFirst().get());
+        Assert.assertEquals("*", ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "test_location_alter"))
+                    .getLocation().get("rack").stream().findFirst().get());
 
         // ** test alter table location to nil
         sql = "ALTER TABLE test.`test_location_alter` SET ('" +
-                PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = '');";
+                    PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = '');";
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, connectContext),
-                connectContext);
-        Assert.assertNull(((OlapTable) testDb.getTable("test_location_alter"))
-                .getLocation());
+                    connectContext);
+        Assert.assertNull(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "test_location_alter"))
+                    .getLocation());
 
         // ** test replay from edit log: alter to rack:*
         LocalMetastore localMetastoreFollower = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
         localMetastoreFollower.load(initialImage.getMetaBlockReader());
         ModifyTablePropertyOperationLog info = (ModifyTablePropertyOperationLog)
-                UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TABLE_PROPERTIES);
+                    UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TABLE_PROPERTIES);
         localMetastoreFollower.replayModifyTableProperty(OperationType.OP_ALTER_TABLE_PROPERTIES, info);
         OlapTable olapTable = (OlapTable) localMetastoreFollower.getDb("test")
-                .getTable("test_location_alter");
+                    .getTable("test_location_alter");
         System.out.println(olapTable.getLocation());
         Assert.assertEquals(1, olapTable.getLocation().size());
         Assert.assertTrue(olapTable.getLocation().containsKey("rack"));
 
-
         // ** test replay from edit log: alter to nil
         info = (ModifyTablePropertyOperationLog)
-                UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TABLE_PROPERTIES);
+                    UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TABLE_PROPERTIES);
         localMetastoreFollower.replayModifyTableProperty(OperationType.OP_ALTER_TABLE_PROPERTIES, info);
         olapTable = (OlapTable) localMetastoreFollower.getDb("test")
-                .getTable("test_location_alter");
+                    .getTable("test_location_alter");
         System.out.println(olapTable.getLocation());
         Assert.assertNull(olapTable.getLocation());
     }
 
     @Test
     public void testAlterColocateTableLocationProp() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
@@ -390,29 +396,30 @@ public class AlterTableTest {
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
-                ":" + backend.getHeartbeatPort() + "' set ('" +
-                AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:rack1')";
+                    ":" + backend.getHeartbeatPort() + "' set ('" +
+                    AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:rack1')";
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(modifyBackendPropSqlStr, connectContext),
-                connectContext);
+                    connectContext);
 
         String sql = "CREATE TABLE test.`test_location_colocate_alter1` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\",\n" +
-                "    \"colocate_with\" = \"cg1\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\",\n" +
+                    "    \"colocate_with\" = \"cg1\"\n" +
+                    ");";
         starRocksAssert.withTable(sql);
 
-        OlapTable olapTable = (OlapTable) testDb.getTable("test_location_colocate_alter1");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "test_location_colocate_alter1");
         Assert.assertNull(olapTable.getLocation());
 
         sql = "ALTER TABLE test.`test_location_colocate_alter1` SET ('" +
-                PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:*');";
+                    PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:*');";
         try {
             DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, connectContext), connectContext);
         } catch (DdlException e) {
@@ -422,7 +429,7 @@ public class AlterTableTest {
 
     @Test
     public void testAlterLocationPropTableToColocate() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
@@ -430,28 +437,29 @@ public class AlterTableTest {
         List<Long> backendIds = systemInfoService.getBackendIds();
         Backend backend = systemInfoService.getBackend(backendIds.get(0));
         String modifyBackendPropSqlStr = "alter system modify backend '" + backend.getHost() +
-                ":" + backend.getHeartbeatPort() + "' set ('" +
-                AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:rack1')";
+                    ":" + backend.getHeartbeatPort() + "' set ('" +
+                    AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:rack1')";
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(modifyBackendPropSqlStr, connectContext),
-                connectContext);
+                    connectContext);
 
         String sql = "CREATE TABLE test.`test_location_colocate_alter2` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ");";
         starRocksAssert.withTable(sql);
 
-        OlapTable olapTable = (OlapTable) testDb.getTable("test_location_colocate_alter2");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "test_location_colocate_alter2");
         Assert.assertTrue(olapTable.getLocation().containsKey("*"));
 
         sql = "ALTER TABLE test.`test_location_colocate_alter1` SET ('" +
-                PropertyAnalyzer.PROPERTIES_COLOCATE_WITH + "' = 'cg1');";
+                    PropertyAnalyzer.PROPERTIES_COLOCATE_WITH + "' = 'cg1');";
         try {
             DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, connectContext), connectContext);
         } catch (DdlException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -144,107 +144,107 @@ public class AlterTest {
         starRocksAssert = new StarRocksAssert(connectContext);
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
+                    .withTable("CREATE TABLE test.tbl1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
 
-                .withTable("CREATE TABLE test.tbl2\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
+                    .withTable("CREATE TABLE test.tbl2\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
 
-                .withTable("CREATE TABLE test.tbl3\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
+                    .withTable("CREATE TABLE test.tbl3\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
 
-                .withTable("CREATE TABLE test.tbl4\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01'),\n" +
-                        "    PARTITION p3 values less than('2020-04-01'),\n" +
-                        "    PARTITION p4 values less than('2020-05-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES" +
-                        "(" +
-                        "    'replication_num' = '1',\n" +
-                        "    'in_memory' = 'false',\n" +
-                        "    'storage_medium' = 'SSD',\n" +
-                        "    'storage_cooldown_time' = '9999-12-31 00:00:00'\n" +
-                        ");")
-                .withTable("CREATE TABLE t_recharge_detail(\n" +
-                        "    id bigint  ,\n" +
-                        "    user_id  bigint  ,\n" +
-                        "    recharge_money decimal(32,2) , \n" +
-                        "    province varchar(20) not null,\n" +
-                        "    dt varchar(20) not null\n" +
-                        ") ENGINE=OLAP\n" +
-                        "DUPLICATE KEY(id)\n" +
-                        "PARTITION BY LIST (dt,province) (\n" +
-                        "   PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\")),\n" +
-                        "   PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\"))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10 \n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"in_memory\" = \"false\"\n" +
-                        ");")
-                .withTable("CREATE TABLE test.site_access_date_trunc (\n" +
-                        "    event_day DATETIME NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('day', event_day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                        "PROPERTIES(\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_time_slice (\n" +
-                        "    event_day datetime,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY time_slice(event_day, interval 1 day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\n" +
-                        "    \"partition_live_number\" = \"3\",\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE test.tbl4\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01'),\n" +
+                                "    PARTITION p3 values less than('2020-04-01'),\n" +
+                                "    PARTITION p4 values less than('2020-05-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES" +
+                                "(" +
+                                "    'replication_num' = '1',\n" +
+                                "    'in_memory' = 'false',\n" +
+                                "    'storage_medium' = 'SSD',\n" +
+                                "    'storage_cooldown_time' = '9999-12-31 00:00:00'\n" +
+                                ");")
+                    .withTable("CREATE TABLE t_recharge_detail(\n" +
+                                "    id bigint  ,\n" +
+                                "    user_id  bigint  ,\n" +
+                                "    recharge_money decimal(32,2) , \n" +
+                                "    province varchar(20) not null,\n" +
+                                "    dt varchar(20) not null\n" +
+                                ") ENGINE=OLAP\n" +
+                                "DUPLICATE KEY(id)\n" +
+                                "PARTITION BY LIST (dt,province) (\n" +
+                                "   PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\")),\n" +
+                                "   PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\"))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(`id`) BUCKETS 10 \n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"in_memory\" = \"false\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE test.site_access_date_trunc (\n" +
+                                "    event_day DATETIME NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                                "PROPERTIES(\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_time_slice (\n" +
+                                "    event_day datetime,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY time_slice(event_day, interval 1 day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\n" +
+                                "    \"partition_live_number\" = \"3\",\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");");
     }
 
     @AfterClass
@@ -276,19 +276,19 @@ public class AlterTest {
 
     private static void createMaterializedView(String sql) throws Exception {
         CreateMaterializedViewStatement createMaterializedViewStatement =
-                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMaterializedViewStatement);
     }
 
     private static void dropMaterializedView(String sql) throws Exception {
         DropMaterializedViewStmt dropMaterializedViewStmt =
-                (DropMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    (DropMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropMaterializedView(dropMaterializedViewStmt);
     }
 
     private static void alterMaterializedView(String sql, boolean expectedException) throws Exception {
         AlterMaterializedViewStmt alterMaterializedViewStmt =
-                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().alterMaterializedView(alterMaterializedViewStmt);
             if (expectedException) {
@@ -304,12 +304,12 @@ public class AlterTest {
 
     private static void refreshMaterializedView(String sql) throws Exception {
         RefreshMaterializedViewStatement refreshMaterializedViewStatement =
-                (RefreshMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    (RefreshMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .refreshMaterializedView(refreshMaterializedViewStatement.getMvName().getDb(),
-                            refreshMaterializedViewStatement.getMvName().getTbl(), false, null,
-                            Constants.TaskRunPriority.LOWEST.value(), false, true);
+                        .refreshMaterializedView(refreshMaterializedViewStatement.getMvName().getDb(),
+                                    refreshMaterializedViewStatement.getMvName().getTbl(), false, null,
+                                    Constants.TaskRunPriority.LOWEST.value(), false, true);
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
@@ -318,7 +318,7 @@ public class AlterTest {
 
     private static void cancelRefreshMaterializedView(String sql, boolean expectedException) throws Exception {
         CancelRefreshMaterializedViewStmt cancelRefresh =
-                (CancelRefreshMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    (CancelRefreshMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().cancelRefreshMaterializedView(cancelRefresh);
             if (expectedException) {
@@ -359,36 +359,36 @@ public class AlterTest {
     @Test
     public void testRenameMaterializedView() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withTable("CREATE TABLE test.testTable1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.testTable1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String sql = "create materialized view mv1 " +
-                "partition by k1 " +
-                "distributed by hash(k2) " +
-                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select k1, k2 from test.testTable1;";
+                    "partition by k1 " +
+                    "distributed by hash(k2) " +
+                    "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select k1, k2 from test.testTable1;";
         createMaterializedView(sql);
         String alterStmt = "alter materialized view test.mv1 rename mv2";
         alterMaterializedView(alterStmt, false);
-        MaterializedView materializedView = (MaterializedView) GlobalStateMgr.getCurrentState().
-                getDb("test").getTable("mv2");
+        MaterializedView materializedView = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().
+                    getDb("test").getTable("mv2");
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         Task task = taskManager.getTask(TaskBuilder.getMvTaskName(materializedView.getId()));
         Assert.assertEquals("insert overwrite `mv2` SELECT `test`.`testTable1`.`k1`, `test`.`testTable1`.`k2`\n" +
-                "FROM `test`.`testTable1`", task.getDefinition());
+                    "FROM `test`.`testTable1`", task.getDefinition());
         ConnectContext.get().setCurrentUserIdentity(UserIdentity.ROOT);
         ConnectContext.get().setCurrentRoleIds(UserIdentity.ROOT);
         dropMaterializedView("drop materialized view test.mv2");
@@ -397,45 +397,45 @@ public class AlterTest {
     @Test
     public void testCouldNotFindMaterializedView() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withTable("CREATE TABLE test.testTable1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withTable("CREATE TABLE test.testTable2\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.testTable1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withTable("CREATE TABLE test.testTable2\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String sql = "create materialized view mv1 " +
-                "partition by k1 " +
-                "distributed by hash(k2) " +
-                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select k1, k2 from test.testTable1;";
+                    "partition by k1 " +
+                    "distributed by hash(k2) " +
+                    "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select k1, k2 from test.testTable1;";
         createMaterializedView(sql);
         starRocksAssert.getCtx().setCurrentRoleIds(GlobalStateMgr.getCurrentState().getAuthorizationMgr().getRoleIdsByUser(
-                starRocksAssert.getCtx().getCurrentUserIdentity()));
+                    starRocksAssert.getCtx().getCurrentUserIdentity()));
         dropMaterializedView("drop materialized view test.mv1");
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test").getTable("testTable1");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("testTable1");
         // this for mock olapTable.getIndexNameById(mvIdx.getId()) == Null
         table.deleteIndexInfo("testTable1");
         try {
@@ -449,19 +449,19 @@ public class AlterTest {
     @Test
     public void testRenameTable() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withTable("CREATE TABLE test.testRenameTable1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.testRenameTable1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String alterStmt = "alter table test.testRenameTable1 rename testRenameTable2";
         alterTableWithNewParser(alterStmt, false);
     }
@@ -469,27 +469,27 @@ public class AlterTest {
     @Test
     public void testChangeMaterializedViewRefreshScheme() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withTable("CREATE TABLE test.testTable2\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.testTable2\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String sql = "create materialized view mv1 " +
-                "partition by k1 " +
-                "distributed by hash(k2) " +
-                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select k1, k2 from test.testTable2;";
+                    "partition by k1 " +
+                    "distributed by hash(k2) " +
+                    "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select k1, k2 from test.testTable2;";
         createMaterializedView(sql);
         String alterStmt = "alter materialized view mv1 refresh async EVERY(INTERVAL 1 minute)";
         alterMaterializedView(alterStmt, false);
@@ -503,61 +503,61 @@ public class AlterTest {
     @Test
     public void testRefreshMaterializedView() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withTable("CREATE TABLE test.testTable3\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.testTable3\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String sql = "create materialized view mv1 " +
-                "partition by k1 " +
-                "distributed by hash(k2) " +
-                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select k1, k2 from test.testTable3;";
+                    "partition by k1 " +
+                    "distributed by hash(k2) " +
+                    "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select k1, k2 from test.testTable3;";
         createMaterializedView(sql);
         String alterStmt = "refresh materialized view test.mv1";
         refreshMaterializedView(alterStmt);
         starRocksAssert.getCtx().setCurrentRoleIds(GlobalStateMgr.getCurrentState().getAuthorizationMgr().getRoleIdsByUser(
-                starRocksAssert.getCtx().getCurrentUserIdentity()));
+                    starRocksAssert.getCtx().getCurrentUserIdentity()));
         dropMaterializedView("drop materialized view test.mv1");
     }
 
     @Test
     public void testCancelRefreshMaterializedView() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withTable("CREATE TABLE test.testTable4\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.testTable4\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String sql = "create materialized view mv1 " +
-                "partition by k1 " +
-                "distributed by hash(k2) " +
-                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select k1, k2 from test.testTable4;";
+                    "partition by k1 " +
+                    "distributed by hash(k2) " +
+                    "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select k1, k2 from test.testTable4;";
         starRocksAssert.getCtx().setCurrentRoleIds(GlobalStateMgr.getCurrentState().getAuthorizationMgr().getRoleIdsByUser(
-                starRocksAssert.getCtx().getCurrentUserIdentity()));
+                    starRocksAssert.getCtx().getCurrentUserIdentity()));
         createMaterializedView(sql);
         String alterStmt = "refresh materialized view test.mv1";
         refreshMaterializedView(alterStmt);
@@ -567,12 +567,12 @@ public class AlterTest {
 
     @Test
     public void testConflictAlterOperations() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("tbl1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
 
         String stmt =
-                "alter table test.tbl1 add partition p3 values less than('2020-04-01'), " +
-                        "add partition p4 values less than('2020-05-01')";
+                    "alter table test.tbl1 add partition p3 values less than('2020-04-01'), " +
+                                "add partition p4 values less than('2020-05-01')";
         alterTableWithNewParser(stmt, true);
 
         stmt = "alter table test.tbl1 add partition p3 values less than('2020-04-01'), drop partition p4";
@@ -600,12 +600,12 @@ public class AlterTest {
         // enable dynamic partition
         // not adding the `start` property so that it won't drop the origin partition p1, p2 and p3
         stmt = "alter table test.tbl1 set (\n" +
-                "'dynamic_partition.enable' = 'true',\n" +
-                "'dynamic_partition.time_unit' = 'DAY',\n" +
-                "'dynamic_partition.end' = '3',\n" +
-                "'dynamic_partition.prefix' = 'p',\n" +
-                "'dynamic_partition.buckets' = '3'\n" +
-                " );";
+                    "'dynamic_partition.enable' = 'true',\n" +
+                    "'dynamic_partition.time_unit' = 'DAY',\n" +
+                    "'dynamic_partition.end' = '3',\n" +
+                    "'dynamic_partition.prefix' = 'p',\n" +
+                    "'dynamic_partition.buckets' = '3'\n" +
+                    " );";
         alterTableWithNewParser(stmt, false);
 
         Assert.assertTrue(tbl.getTableProperty().getDynamicPartitionProperty().isEnabled());
@@ -613,12 +613,12 @@ public class AlterTest {
 
         // add partition when dynamic partition is enable
         stmt = "alter table test.tbl1 add partition p3 values less than('2020-04-01') " +
-                "distributed by hash(k2) buckets 4 PROPERTIES ('replication_num' = '1')";
+                    "distributed by hash(k2) buckets 4 PROPERTIES ('replication_num' = '1')";
         alterTableWithNewParser(stmt, true);
 
         // add temp partition when dynamic partition is enable
         stmt = "alter table test.tbl1 add temporary partition tp3 values less than('2020-04-01') " +
-                "distributed by hash(k2) buckets 4 PROPERTIES ('replication_num' = '1')";
+                    "distributed by hash(k2) buckets 4 PROPERTIES ('replication_num' = '1')";
         alterTableWithNewParser(stmt, false);
         Assert.assertEquals(1, tbl.getTempPartitions().size());
 
@@ -629,7 +629,7 @@ public class AlterTest {
 
         // add partition when dynamic partition is disable
         stmt = "alter table test.tbl1 add partition p3 values less than('2020-04-01') " +
-                "distributed by hash(k2) buckets 4";
+                    "distributed by hash(k2) buckets 4";
         alterTableWithNewParser(stmt, false);
 
         // set table's default replication num
@@ -646,25 +646,25 @@ public class AlterTest {
         Assert.assertEquals(Short.valueOf("1"), Short.valueOf(tbl.getPartitionInfo().getReplicationNum(p1.getId())));
 
         // set un-partitioned table's real replication num
-        OlapTable tbl2 = (OlapTable) db.getTable("tbl2");
+        OlapTable tbl2 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl2");
         Partition partition = tbl2.getPartition(tbl2.getName());
         Assert.assertEquals(Short.valueOf("1"),
-                Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
+                    Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
         // partition replication num and table default replication num are updated at the same time in unpartitioned table
         stmt = "alter table test.tbl2 set ('replication_num' = '3');";
         alterTableWithNewParser(stmt, false);
         Assert.assertEquals(Short.valueOf("3"),
-                Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
+                    Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
         Assert.assertEquals(Short.valueOf("3"), tbl2.getDefaultReplicationNum());
         stmt = "alter table test.tbl2 set ('default.replication_num' = '2');";
         alterTableWithNewParser(stmt, false);
         Assert.assertEquals(Short.valueOf("2"),
-                Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
+                    Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
         Assert.assertEquals(Short.valueOf("2"), tbl2.getDefaultReplicationNum());
         stmt = "alter table test.tbl2 modify partition tbl2 set ('replication_num' = '1');";
         alterTableWithNewParser(stmt, false);
         Assert.assertEquals(Short.valueOf("1"),
-                Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
+                    Short.valueOf(tbl2.getPartitionInfo().getReplicationNum(partition.getId())));
         Assert.assertEquals(Short.valueOf("1"), tbl2.getDefaultReplicationNum());
 
         Thread.sleep(5000); // sleep to wait dynamic partition scheduler run
@@ -677,8 +677,8 @@ public class AlterTest {
         alterTableWithNewParser(stmt, false);
 
         stmt = "alter table test.tbl1 " +
-                "add TEMPORARY partition p5 values [('2020-04-10'), ('2020-05-10')) ('replication_num' = '1') " +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 3 PROPERTIES('replication_num' = '1');";
+                    "add TEMPORARY partition p5 values [('2020-04-10'), ('2020-05-10')) ('replication_num' = '1') " +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 3 PROPERTIES('replication_num' = '1');";
         alterTableWithNewParser(stmt, false);
         //rename table
         stmt = "alter table test.tbl1 rename newTableName";
@@ -688,8 +688,8 @@ public class AlterTest {
     // test batch update range partitions' properties
     @Test
     public void testBatchUpdatePartitionProperties() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl4 = (OlapTable) db.getTable("tbl4");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl4 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl4");
         Partition p1 = tbl4.getPartition("p1");
         Partition p2 = tbl4.getPartition("p2");
         Partition p3 = tbl4.getPartition("p3");
@@ -700,12 +700,12 @@ public class AlterTest {
         List<Partition> partitionList = Lists.newArrayList(p1, p2, p4);
         for (Partition partition : partitionList) {
             Assert.assertEquals(Short.valueOf("1"),
-                    Short.valueOf(tbl4.getPartitionInfo().getReplicationNum(partition.getId())));
+                        Short.valueOf(tbl4.getPartitionInfo().getReplicationNum(partition.getId())));
         }
         alterTableWithNewParser(stmt, false);
         for (Partition partition : partitionList) {
             Assert.assertEquals(Short.valueOf("3"),
-                    Short.valueOf(tbl4.getPartitionInfo().getReplicationNum(partition.getId())));
+                        Short.valueOf(tbl4.getPartitionInfo().getReplicationNum(partition.getId())));
         }
         Assert.assertEquals(Short.valueOf("1"), Short.valueOf(tbl4.getPartitionInfo().getReplicationNum(p3.getId())));
 
@@ -743,7 +743,7 @@ public class AlterTest {
         alterTableWithNewParser(stmt, false);
         for (Partition partition : partitionList) {
             Assert.assertEquals(Short.valueOf("1"),
-                    Short.valueOf(tbl4.getPartitionInfo().getReplicationNum(partition.getId())));
+                        Short.valueOf(tbl4.getPartitionInfo().getReplicationNum(partition.getId())));
         }
     }
 
@@ -763,8 +763,8 @@ public class AlterTest {
         alterTable(stmt, false);
         Thread.sleep(5000); // sleep to wait dynamic partition scheduler run
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("tbl3");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl3");
         Assert.assertEquals(4, tbl.getPartitionNames().size());
         Assert.assertNull(tbl.getPartition("p1"));
         Assert.assertNull(tbl.getPartition("p2"));
@@ -778,11 +778,11 @@ public class AlterTest {
         for (AlterJobV2 alterJobV2 : alterJobs.values()) {
             while (!alterJobV2.getJobState().isFinalState()) {
                 System.out.println(
-                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
+                            "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
                 Thread.sleep(1000);
             }
             System.out.println(alterJobV2.getType() + " alter job " + alterJobV2.getJobId() + " is done. state: " +
-                    alterJobV2.getJobState());
+                        alterJobV2.getJobState());
             Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
         checkTableStateToNormal(tb);
@@ -792,36 +792,36 @@ public class AlterTest {
     public void testSetDynamicPropertiesInNormalTable() throws Exception {
         String tableName = "no_dynamic_table";
         String createOlapTblStmt = "CREATE TABLE test.`" + tableName + "` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");";
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ");";
         createTable(createOlapTblStmt);
         String alterStmt = "alter table test." + tableName + " set (\"dynamic_partition.enable\" = \"true\");";
         alterTableWithNewParserAndExceptionMsg(alterStmt, "Table test.no_dynamic_table is not a dynamic partition table.");
         // test set dynamic properties in a no dynamic partition table
         String stmt = "alter table test." + tableName + " set (\n" +
-                "'dynamic_partition.enable' = 'true',\n" +
-                "'dynamic_partition.time_unit' = 'DAY',\n" +
-                "'dynamic_partition.start' = '-3',\n" +
-                "'dynamic_partition.end' = '3',\n" +
-                "'dynamic_partition.prefix' = 'p',\n" +
-                "'dynamic_partition.buckets' = '3'\n" +
-                " );";
+                    "'dynamic_partition.enable' = 'true',\n" +
+                    "'dynamic_partition.time_unit' = 'DAY',\n" +
+                    "'dynamic_partition.start' = '-3',\n" +
+                    "'dynamic_partition.end' = '3',\n" +
+                    "'dynamic_partition.prefix' = 'p',\n" +
+                    "'dynamic_partition.buckets' = '3'\n" +
+                    " );";
         alterTableWithNewParser(stmt, false);
     }
 
@@ -829,30 +829,30 @@ public class AlterTest {
     public void testSetDynamicPropertiesInDynamicPartitionTable() throws Exception {
         String tableName = "dynamic_table";
         String createOlapTblStmt = "CREATE TABLE test.`" + tableName + "` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");";
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");";
 
         createTable(createOlapTblStmt);
         String alterStmt1 = "alter table test." + tableName + " set (\"dynamic_partition.enable\" = \"false\");";
@@ -873,32 +873,32 @@ public class AlterTest {
     public void testDynamicPartitionTableMetaFailed() throws Exception {
         String tableName = "dynamic_table_test";
         String createOlapTblStmt = "CREATE TABLE test.`" + tableName + "` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");";
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");";
         createTable(createOlapTblStmt);
-        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test").getTable(tableName);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable(tableName);
         olapTable.getTableProperty().getProperties().remove("dynamic_partition.end");
         olapTable.getTableProperty().gsonPostProcess();
     }
@@ -906,52 +906,52 @@ public class AlterTest {
     @Test
     public void testSwapTable() throws Exception {
         String stmt1 = "CREATE TABLE test.replace1\n" +
-                "(\n" +
-                "    k1 int, k2 int, k3 int sum\n" +
-                ")\n" +
-                "AGGREGATE KEY(k1, k2)\n" +
-                "DISTRIBUTED BY HASH(k1) BUCKETS 10\n" +
-                "rollup (\n" +
-                "r1(k1),\n" +
-                "r2(k2, k3)\n" +
-                ")\n" +
-                "PROPERTIES(\"replication_num\" = \"1\");";
+                    "(\n" +
+                    "    k1 int, k2 int, k3 int sum\n" +
+                    ")\n" +
+                    "AGGREGATE KEY(k1, k2)\n" +
+                    "DISTRIBUTED BY HASH(k1) BUCKETS 10\n" +
+                    "rollup (\n" +
+                    "r1(k1),\n" +
+                    "r2(k2, k3)\n" +
+                    ")\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\");";
 
         String stmt2 = "CREATE TABLE test.r1\n" +
-                "(\n" +
-                "    k1 int, k2 int\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k1) BUCKETS 11\n" +
-                "PROPERTIES(\"replication_num\" = \"1\");";
+                    "(\n" +
+                    "    k1 int, k2 int\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k1) BUCKETS 11\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\");";
 
         String stmt3 = "CREATE TABLE test.replace2\n" +
-                "(\n" +
-                "    k1 int, k2 int\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k1) BUCKETS 11\n" +
-                "PROPERTIES(\"replication_num\" = \"1\");";
+                    "(\n" +
+                    "    k1 int, k2 int\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k1) BUCKETS 11\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\");";
 
         String stmt4 = "CREATE TABLE test.replace3\n" +
-                "(\n" +
-                "    k1 int, k2 int, k3 int sum\n" +
-                ")\n" +
-                "PARTITION BY RANGE(k1)\n" +
-                "(\n" +
-                "\tPARTITION p1 values less than(\"100\"),\n" +
-                "\tPARTITION p2 values less than(\"200\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
-                "rollup (\n" +
-                "r3(k1),\n" +
-                "r4(k2, k3)\n" +
-                ")\n" +
-                "PROPERTIES(\"replication_num\" = \"1\");";
+                    "(\n" +
+                    "    k1 int, k2 int, k3 int sum\n" +
+                    ")\n" +
+                    "PARTITION BY RANGE(k1)\n" +
+                    "(\n" +
+                    "\tPARTITION p1 values less than(\"100\"),\n" +
+                    "\tPARTITION p2 values less than(\"200\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
+                    "rollup (\n" +
+                    "r3(k1),\n" +
+                    "r4(k2, k3)\n" +
+                    ")\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\");";
 
         createTable(stmt1);
         createTable(stmt2);
         createTable(stmt3);
         createTable(stmt4);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         // name conflict
         String replaceStmt = "ALTER TABLE test.replace1 SWAP WITH r1";
@@ -959,25 +959,27 @@ public class AlterTest {
 
         // replace1 with replace2
         replaceStmt = "ALTER TABLE test.replace1 SWAP WITH replace2";
-        OlapTable replace1 = (OlapTable) db.getTable("replace1");
-        OlapTable replace2 = (OlapTable) db.getTable("replace2");
+        OlapTable replace1 =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "replace1");
+        OlapTable replace2 =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "replace2");
         Assert.assertEquals(3,
-                replace1.getPartition("replace1").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
-                        .size());
+                    replace1.getPartition("replace1").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                                .size());
         Assert.assertEquals(1,
-                replace2.getPartition("replace2").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
-                        .size());
+                    replace2.getPartition("replace2").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                                .size());
 
         alterTableWithNewParser(replaceStmt, false);
 
-        replace1 = (OlapTable) db.getTable("replace1");
-        replace2 = (OlapTable) db.getTable("replace2");
+        replace1 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "replace1");
+        replace2 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "replace2");
         Assert.assertEquals(1,
-                replace1.getPartition("replace1").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
-                        .size());
+                    replace1.getPartition("replace1").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                                .size());
         Assert.assertEquals(3,
-                replace2.getPartition("replace2").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
-                        .size());
+                    replace2.getPartition("replace2").getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                                .size());
         Assert.assertEquals("replace1", replace1.getIndexNameById(replace1.getBaseIndexId()));
         Assert.assertEquals("replace2", replace2.getIndexNameById(replace2.getBaseIndexId()));
     }
@@ -989,34 +991,34 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20140104\") EVERY (INTERVAL 1 DAY)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20140104\") EVERY (INTERVAL 1 DAY)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition ADD\n" +
-                "    PARTITIONS START (\"2017-01-03\") END (\"2017-01-07\") EVERY (interval 1 day)";
+                    "    PARTITIONS START (\"2017-01-03\") END (\"2017-01-07\") EVERY (interval 1 day)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         Assert.assertNotNull(table.getPartition("p20170103"));
         Assert.assertNotNull(table.getPartition("p20170104"));
@@ -1037,34 +1039,34 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "DISTRIBUTED BY RANDOM BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "DISTRIBUTED BY RANDOM BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
         Optional<Partition> partition = table.getPartitions().stream().findFirst();
         Assert.assertTrue(partition.isPresent());
         Assert.assertEquals(table.getPhysicalPartitions().size(), 1);
 
         GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 1,
-                WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                    WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(partition.get().getSubPartitions().size(), 2);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 2);
 
         GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 2,
-                WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                    WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(partition.get().getSubPartitions().size(), 4);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 4);
 
@@ -1090,33 +1092,33 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20140104\") EVERY (INTERVAL 1 DAY)\n" +
-                ")\n" +
-                "DISTRIBUTED BY RANDOM BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20140104\") EVERY (INTERVAL 1 DAY)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY RANDOM BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
         Assert.assertEquals(table.getPhysicalPartitions().size(), 3);
 
         Partition partition = table.getPartition("p20140101");
         Assert.assertNotNull(partition);
 
         GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition, 1,
-                WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                    WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 4);
         Assert.assertEquals(partition.getSubPartitions().size(), 2);
 
@@ -1124,7 +1126,7 @@ public class AlterTest {
         Assert.assertNotNull(partition);
 
         GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition, 2,
-                WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                    WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 6);
         Assert.assertEquals(partition.getSubPartitions().size(), 3);
 
@@ -1140,29 +1142,29 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
         Optional<Partition> partition = table.getPartitions().stream().findFirst();
         Assert.assertTrue(partition.isPresent());
         Assert.assertEquals(table.getPhysicalPartitions().size(), 1);
 
         GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 1,
-                WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                    WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     @Test
@@ -1192,33 +1194,33 @@ public class AlterTest {
     public void testCatalogAddPartitions5Day() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition ADD\n" +
-                "    PARTITIONS START (\"2017-01-03\") END (\"2017-01-15\") EVERY (interval 5 day)";
+                    "    PARTITIONS START (\"2017-01-03\") END (\"2017-01-15\") EVERY (interval 5 day)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         Assert.assertNotNull(table.getPartition("p20170103"));
         Assert.assertNotNull(table.getPartition("p20170108"));
@@ -1233,31 +1235,31 @@ public class AlterTest {
     public void testCatalogAddPartitionsDayConflictException() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition_exception (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20140104\") EVERY (INTERVAL 1 DAY)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20140104\") EVERY (INTERVAL 1 DAY)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition_exception ADD\n" +
-                "    PARTITIONS START (\"2014-01-01\") END (\"2014-01-04\") EVERY (interval 1 day)";
+                    "    PARTITIONS START (\"2014-01-01\") END (\"2014-01-04\") EVERY (interval 1 day)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exception", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exception", addPartitionClause);
     }
 
     @Test
@@ -1265,33 +1267,33 @@ public class AlterTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         Config.enable_create_partial_partition_in_batch = true;
         String createSQL = "CREATE TABLE test.test_partition_week (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition_week ADD\n" +
-                "    PARTITIONS START (\"2017-03-25\") END (\"2017-04-10\") EVERY (interval 1 week)";
+                    "    PARTITIONS START (\"2017-03-25\") END (\"2017-04-10\") EVERY (interval 1 week)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_week", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_week", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition_week");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition_week");
 
         Assert.assertNotNull(table.getPartition("p2017_12"));
         Assert.assertNotNull(table.getPartition("p2017_13"));
@@ -1307,33 +1309,33 @@ public class AlterTest {
     public void testCatalogAddPartitionsWeekWithCheck() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition_week (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition_week ADD\n" +
-                "    PARTITIONS START (\"2017-03-20\") END (\"2017-04-10\") EVERY (interval 1 week)";
+                    "    PARTITIONS START (\"2017-03-20\") END (\"2017-04-10\") EVERY (interval 1 week)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_week", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_week", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition_week");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition_week");
 
         Assert.assertNotNull(table.getPartition("p2017_12"));
         Assert.assertNotNull(table.getPartition("p2017_13"));
@@ -1351,33 +1353,33 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition ADD\n" +
-                "    PARTITIONS START (\"2017-01-01\") END (\"2017-04-01\") EVERY (interval 1 month)";
+                    "    PARTITIONS START (\"2017-01-01\") END (\"2017-04-01\") EVERY (interval 1 month)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         Assert.assertNotNull(table.getPartition("p201701"));
         Assert.assertNotNull(table.getPartition("p201702"));
@@ -1396,33 +1398,33 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition ADD\n" +
-                "    PARTITIONS START (\"2017-01-01\") END (\"2020-01-01\") EVERY (interval 1 YEAR)";
+                    "    PARTITIONS START (\"2017-01-01\") END (\"2020-01-01\") EVERY (interval 1 YEAR)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         Assert.assertNotNull(table.getPartition("p2017"));
         Assert.assertNotNull(table.getPartition("p2018"));
@@ -1441,33 +1443,33 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      k2 INT,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 INT,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition ADD\n" +
-                "    PARTITIONS START (\"1\") END (\"4\") EVERY (1)";
+                    "    PARTITIONS START (\"1\") END (\"4\") EVERY (1)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         Assert.assertNotNull(table.getPartition("p1"));
         Assert.assertNotNull(table.getPartition("p2"));
@@ -1486,39 +1488,39 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         try {
             String alterSQL = "ALTER TABLE test_partition ADD\n" +
-                    "          PARTITIONS START (\"2014-01-01\") END (\"2014-01-06\") EVERY (interval 1 day);";
+                        "          PARTITIONS START (\"2014-01-01\") END (\"2014-01-06\") EVERY (interval 1 day);";
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
             AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                        .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
             Assert.fail();
         } catch (AnalysisException ex) {
 
         }
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         Assert.assertNull(table.getPartition("p20140101"));
         Assert.assertNull(table.getPartition("p20140102"));
@@ -1534,39 +1536,39 @@ public class AlterTest {
 
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test_partition_0day (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140104\") END (\"20150104\") EVERY (INTERVAL 1 YEAR)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140104\") END (\"20150104\") EVERY (INTERVAL 1 YEAR)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         try {
             String alterSQL = "ALTER TABLE test_partition_0day ADD\n" +
-                    "          PARTITIONS START (\"2014-01-01\") END (\"2014-01-06\") EVERY (interval 0 day);";
+                        "          PARTITIONS START (\"2014-01-01\") END (\"2014-01-06\") EVERY (interval 0 day);";
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
             AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_0day", addPartitionClause);
+                        .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_0day", addPartitionClause);
             Assert.fail();
         } catch (AnalysisException ex) {
 
         }
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition_0day");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition_0day");
 
         Assert.assertNull(table.getPartition("p20140101"));
         Assert.assertNull(table.getPartition("p20140102"));
@@ -1585,39 +1587,39 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test_partition (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition ADD\n" +
-                "         START (\"2015-01-01\") END (\"2015-01-06\") EVERY (interval 1 day);";
+                    "         START (\"2015-01-01\") END (\"2015-01-06\") EVERY (interval 1 day);";
         try {
             AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
             AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
             GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                        .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
             Assert.fail();
         } catch (AnalysisException ex) {
 
         }
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         Assert.assertNull(table.getPartition("p20140101"));
         Assert.assertNull(table.getPartition("p20140102"));
@@ -1632,41 +1634,41 @@ public class AlterTest {
     public void testCatalogAddPartitionsIfNotExist() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test_partition_exists (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL =
-                "ALTER TABLE test_partition_exists ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-01')";
+                    "ALTER TABLE test_partition_exists ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-01')";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists", addPartitionClause);
 
         String alterSQL2 =
-                "ALTER TABLE test_partition_exists ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-02')";
+                    "ALTER TABLE test_partition_exists ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-02')";
         AlterTableStmt alterTableStmt2 = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL2, ctx);
         AddPartitionClause addPartitionClause2 = (AddPartitionClause) alterTableStmt2.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists", addPartitionClause2);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists", addPartitionClause2);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition_exists");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition_exists");
 
         Assert.assertEquals(2, table.getPartitions().size());
 
@@ -1679,41 +1681,41 @@ public class AlterTest {
     public void testCatalogAddPartitionsSameNameShouldNotThrowError() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test_partition_exists2 (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL =
-                "ALTER TABLE test_partition_exists2 ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-01')";
+                    "ALTER TABLE test_partition_exists2 ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-01')";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists2", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists2", addPartitionClause);
 
         String alterSQL2 =
-                "ALTER TABLE test_partition_exists2 ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-01')";
+                    "ALTER TABLE test_partition_exists2 ADD PARTITION IF NOT EXISTS p20210701 VALUES LESS THAN ('2021-07-01')";
         AlterTableStmt alterTableStmt2 = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL2, ctx);
         AddPartitionClause addPartitionClause2 = (AddPartitionClause) alterTableStmt2.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists2", addPartitionClause2);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists2", addPartitionClause2);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition_exists2");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition_exists2");
 
         Assert.assertEquals(2, table.getPartitions().size());
 
@@ -1726,39 +1728,39 @@ public class AlterTest {
     public void testCatalogAddPartitionsShouldThrowError() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test_partition_exists3 (\n" +
-                "      k2 DATE,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(k2, k3)\n" +
-                "PARTITION BY RANGE (k2) (\n" +
-                "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      k2 DATE,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(k2, k3)\n" +
+                    "PARTITION BY RANGE (k2) (\n" +
+                    "    START (\"20140101\") END (\"20150101\") EVERY (INTERVAL 1 YEAR)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_partition_exists3 ADD PARTITION p20210701 VALUES LESS THAN ('2021-07-01')";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists3", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists3", addPartitionClause);
 
         String alterSQL2 = "ALTER TABLE test_partition_exists3 ADD PARTITION p20210701 VALUES LESS THAN ('2021-07-01')";
         AlterTableStmt alterTableStmt2 = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL2, ctx);
         AddPartitionClause addPartitionClause2 = (AddPartitionClause) alterTableStmt2.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists3", addPartitionClause2);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_exists3", addPartitionClause2);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition_exists3");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition_exists3");
 
         Assert.assertEquals(2, ((OlapTable) table).getPartitions().size());
 
@@ -1771,14 +1773,14 @@ public class AlterTest {
     public void testRenameDb() throws Exception {
         String createUserSql = "CREATE USER 'testuser' IDENTIFIED BY ''";
         CreateUserStmt createUserStmt =
-                (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(createUserSql, starRocksAssert.getCtx());
+                    (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(createUserSql, starRocksAssert.getCtx());
         AuthenticationMgr authenticationManager =
-                starRocksAssert.getCtx().getGlobalStateMgr().getAuthenticationMgr();
+                    starRocksAssert.getCtx().getGlobalStateMgr().getAuthenticationMgr();
         authenticationManager.createUser(createUserStmt);
 
         String sql = "grant ALTER on database test to testuser";
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx()),
-                starRocksAssert.getCtx());
+                    starRocksAssert.getCtx());
 
         UserIdentity testUser = new UserIdentity("testuser", "%");
         testUser.analyze();
@@ -1786,13 +1788,13 @@ public class AlterTest {
         starRocksAssert.getCtx().setQualifiedUser("testuser");
         starRocksAssert.getCtx().setCurrentUserIdentity(testUser);
         starRocksAssert.getCtx().setCurrentRoleIds(
-                GlobalStateMgr.getCurrentState().getAuthorizationMgr().getRoleIdsByUser(testUser));
+                    GlobalStateMgr.getCurrentState().getAuthorizationMgr().getRoleIdsByUser(testUser));
         starRocksAssert.getCtx().setRemoteIP("%");
 
         starRocksAssert.withDatabase("test_to_rename");
         String renameDb = "alter database test_to_rename rename test_to_rename_2";
         AlterDatabaseRenameStatement renameDbStmt =
-                (AlterDatabaseRenameStatement) UtFrameUtils.parseStmtWithNewParser(renameDb, starRocksAssert.getCtx());
+                    (AlterDatabaseRenameStatement) UtFrameUtils.parseStmtWithNewParser(renameDb, starRocksAssert.getCtx());
         DDLStmtExecutor.execute(renameDbStmt, starRocksAssert.getCtx());
     }
 
@@ -1800,38 +1802,38 @@ public class AlterTest {
     public void testAddMultiItemListPartition() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10) not null,\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (dt,province) (\n" +
-                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
-                "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10) not null,\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (dt,province) (\n" +
+                    "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
+                    "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> values = Lists.newArrayList("2022-04-01", "shandong");
         List<List<String>> multiValues = Lists.newArrayList();
         multiValues.add(values);
         PartitionDesc partitionDesc = new MultiItemListPartitionDesc(false, "p3", multiValues, new HashMap<>());
         AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_partition");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_partition");
 
         AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
         analyzer.analyze(Util.getOrCreateConnectContext(), addPartitionClause);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
 
         ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
         Map<Long, List<List<String>>> idToValues = partitionInfo.getIdToMultiValues();
@@ -1850,15 +1852,15 @@ public class AlterTest {
     public void testModifyPartitionBucket() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE modify_bucket (\n" +
-                "  chuangyi varchar(65533) NULL COMMENT \"创意\",\n" +
-                "  guanggao varchar(65533) NULL COMMENT \"广告\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(chuangyi, guanggao)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(chuangyi, guanggao) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");";
+                    "  chuangyi varchar(65533) NULL COMMENT \"创意\",\n" +
+                    "  guanggao varchar(65533) NULL COMMENT \"广告\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(chuangyi, guanggao)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(chuangyi, guanggao) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ");";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         String stmt = "alter table modify_bucket set (\"dynamic_partition.buckets\" = \"10\");\n";
@@ -1870,34 +1872,35 @@ public class AlterTest {
     public void testAddSingleItemListPartition() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (province) (\n" +
-                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
-                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (province) (\n" +
+                    "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                    "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> values = Lists.newArrayList("shanxi", "shanghai");
         PartitionDesc partitionDesc = new SingleItemListPartitionDesc(false, "p3", values, new HashMap<>());
         AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
-        OlapTable table = (OlapTable) db.getTable("test_partition");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition");
         AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
         analyzer.analyze(Util.getOrCreateConnectContext(), addPartitionClause);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition", addPartitionClause);
         ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
         Map<Long, List<String>> idToValues = partitionInfo.getIdToValues();
 
@@ -1915,25 +1918,26 @@ public class AlterTest {
     public void testSingleItemPartitionPersistInfo() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (province) (\n" +
-                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (province) (\n" +
+                    "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_partition");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition");
         ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
 
         long dbId = db.getId();
@@ -1946,8 +1950,8 @@ public class AlterTest {
         boolean isInMemory = partitionInfo.getIsInMemory(partitionId);
         boolean isTempPartition = false;
         ListPartitionPersistInfo partitionPersistInfoOut = new ListPartitionPersistInfo(dbId, tableId, partition,
-                dataProperty, replicationNum, isInMemory, isTempPartition, values, new ArrayList<>(),
-                partitionInfo.getDataCacheInfo(partitionId));
+                    dataProperty, replicationNum, isInMemory, isTempPartition, values, new ArrayList<>(),
+                    partitionInfo.getDataCacheInfo(partitionId));
 
         // write log
         File file = new File("./test_serial.log");
@@ -1992,25 +1996,26 @@ public class AlterTest {
     public void testMultiItemPartitionPersistInfo() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10) not null,\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (dt , province) (\n" +
-                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\"))\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10) not null,\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (dt , province) (\n" +
+                    "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\"))\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_partition");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition");
         ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
 
         long dbId = db.getId();
@@ -2023,8 +2028,8 @@ public class AlterTest {
         boolean isInMemory = partitionInfo.getIsInMemory(partitionId);
         boolean isTempPartition = false;
         ListPartitionPersistInfo partitionPersistInfoOut = new ListPartitionPersistInfo(dbId, tableId, partition,
-                dataProperty, replicationNum, isInMemory, isTempPartition, new ArrayList<>(), multiValues,
-                partitionInfo.getDataCacheInfo(partitionId));
+                    dataProperty, replicationNum, isInMemory, isTempPartition, new ArrayList<>(), multiValues,
+                    partitionInfo.getDataCacheInfo(partitionId));
 
         // write log
         File file = new File("./test_serial.log");
@@ -2073,61 +2078,61 @@ public class AlterTest {
     public void testAddSingleListPartitionSamePartitionNameShouldThrowError() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition_1 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (province) (\n" +
-                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
-                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (province) (\n" +
+                    "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                    "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> values = Lists.newArrayList("shanxi", "heilongjiang");
         PartitionDesc partitionDesc = new SingleItemListPartitionDesc(false, "p1", values, new HashMap<>());
         AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
 
-        Table table = db.getTable("test_partition_1");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition_1");
         AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
         analyzer.analyze(Util.getOrCreateConnectContext(), addPartitionClause);
 
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_1", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_1", addPartitionClause);
     }
 
     @Test(expected = SemanticException.class)
     public void testAddMultiListPartitionSamePartitionNameShouldThrowError() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition_2 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10) not null,\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (dt,province) (\n" +
-                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
-                "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10) not null,\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (dt,province) (\n" +
+                    "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
+                    "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> values1 = Lists.newArrayList("2022-04-01", "beijing");
         List<String> values2 = Lists.newArrayList("2022-04-01", "chongqing");
@@ -2137,41 +2142,41 @@ public class AlterTest {
         PartitionDesc partitionDesc = new MultiItemListPartitionDesc(false, "p1", multiValues, new HashMap<>());
         AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
 
-        Table table = db.getTable("test_partition_2");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition_2");
         AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
         analyzer.analyze(Util.getOrCreateConnectContext(), addPartitionClause);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_2", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_partition_2", addPartitionClause);
     }
 
     @Test(expected = SemanticException.class)
     public void testAddSingleListPartitionSamePartitionValueShouldThrowError() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition_3 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (province) (\n" +
-                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
-                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (province) (\n" +
+                    "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                    "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> values = Lists.newArrayList("beijing", "chongqing");
         PartitionDesc partitionDesc = new SingleItemListPartitionDesc(false, "p3", values, new HashMap<>());
         AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
-        Table table = db.getTable("test_partition_3");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition_3");
         AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
         analyzer.analyze(Util.getOrCreateConnectContext(), addPartitionClause);
     }
@@ -2180,25 +2185,25 @@ public class AlterTest {
     public void testAddMultiItemListPartitionSamePartitionValueShouldThrowError() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition_4 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10) not null,\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "ENGINE=olap\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (dt, province) (\n" +
-                "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
-                "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10) not null,\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "ENGINE=olap\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (dt, province) (\n" +
+                    "     PARTITION p1 VALUES IN ((\"2022-04-01\", \"beijing\"),(\"2022-04-01\", \"chongqing\")),\n" +
+                    "     PARTITION p2 VALUES IN ((\"2022-04-01\", \"shanghai\")) \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> values = Lists.newArrayList("2022-04-01", "shanghai");
         List<List<String>> multiValues = Lists.newArrayList();
@@ -2206,7 +2211,7 @@ public class AlterTest {
         PartitionDesc partitionDesc = new MultiItemListPartitionDesc(false, "p3", multiValues, new HashMap<>());
         AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDesc, null, new HashMap<>(), false);
 
-        Table table = db.getTable("test_partition_4");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_partition_4");
         AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
         analyzer.analyze(Util.getOrCreateConnectContext(), addPartitionClause);
     }
@@ -2214,16 +2219,16 @@ public class AlterTest {
     @Test
     public void testCatalogAddColumn() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    v1 int \n" +
-                        ")\n" +
-                        "DUPLICATE KEY(`k1`)" +
-                        "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("tbl1");
+                    .withTable("CREATE TABLE test.tbl1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    v1 int \n" +
+                                ")\n" +
+                                "DUPLICATE KEY(`k1`)" +
+                                "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
 
         String stmt = "alter table test.tbl1 add column k2 int";
         alterTableWithNewParser(stmt, false);
@@ -2245,7 +2250,7 @@ public class AlterTest {
     @Test
     public void testCatalogAddColumns() throws Exception {
         String stmt = "alter table test.tbl1 add column (`col1` int(11) not null default \"0\" comment \"\", "
-                + "`col2` int(11) not null default \"0\" comment \"\") in `testTable`;";
+                    + "`col2` int(11) not null default \"0\" comment \"\") in `testTable`;";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());
         AddColumnsClause clause = (AddColumnsClause) alterTableStmt.getAlterClauseList().get(0);
         Assert.assertEquals(2, clause.getColumns().size());
@@ -2253,7 +2258,7 @@ public class AlterTest {
         Assert.assertEquals("testTable", clause.getRollupName());
 
         stmt = "alter table test.tbl1 add column (`col1` int(11) not null default \"0\" comment \"\", "
-                + "`col2` int(11) not null default \"0\" comment \"\");";
+                    + "`col2` int(11) not null default \"0\" comment \"\");";
         alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());
         clause = (AddColumnsClause) alterTableStmt.getAlterClauseList().get(0);
         Assert.assertEquals(null, clause.getRollupName());
@@ -2264,35 +2269,35 @@ public class AlterTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         starRocksAssert.withDatabase("test2");
         String createSQL = "CREATE TABLE test2.site_access(\n" +
-                "    event_day datetime,\n" +
-                "    site_id INT DEFAULT '10',\n" +
-                "    city_code VARCHAR(100),\n" +
-                "    user_name VARCHAR(32) DEFAULT '',\n" +
-                "    pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                "PARTITION BY date_trunc('day', event_day)(\n" +
-                " START (\"2023-03-27\") END (\"2023-03-30\") EVERY (INTERVAL 1 day)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                "PROPERTIES(\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ");";
+                    "    event_day datetime,\n" +
+                    "    site_id INT DEFAULT '10',\n" +
+                    "    city_code VARCHAR(100),\n" +
+                    "    user_name VARCHAR(32) DEFAULT '',\n" +
+                    "    pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                    "PARTITION BY date_trunc('day', event_day)(\n" +
+                    " START (\"2023-03-27\") END (\"2023-03-30\") EVERY (INTERVAL 1 day)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                    "PROPERTIES(\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ");";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test2");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test2");
 
         String sql = "alter table test2.site_access add TEMPORARY partitions " +
-                "START (\"2023-03-27\") END (\"2023-03-30\") EVERY (INTERVAL 1 day);";
+                    "START (\"2023-03-27\") END (\"2023-03-30\") EVERY (INTERVAL 1 day);";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
 
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "site_access", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "site_access", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test2")
-                .getTable("site_access");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test2")
+                    .getTable("site_access");
         OlapTable olapTable = (OlapTable) table;
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
@@ -2303,14 +2308,14 @@ public class AlterTest {
     @Test
     public void testCatalogDropColumn() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.tbl1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String stmt = "alter table test.tbl1 drop column k2 from `testRollup`";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());
         DropColumnClause clause = (DropColumnClause) alterTableStmt.getAlterClauseList().get(0);
@@ -2411,9 +2416,9 @@ public class AlterTest {
         TruncatePartitionClause clause = new TruncatePartitionClause(partitionNames);
         cList.add(clause);
         AlterJobMgr alter = new AlterJobMgr(
-                new SchemaChangeHandler(),
-                new MaterializedViewHandler(),
-                new SystemHandler());
+                    new SchemaChangeHandler(),
+                    new MaterializedViewHandler(),
+                    new SystemHandler());
         TableName tableName = new TableName("test_db", "test_table");
         AlterTableStmt stmt = new AlterTableStmt(tableName, cList);
         DDLStmtExecutor.execute(stmt, starRocksAssert.getCtx());
@@ -2439,7 +2444,7 @@ public class AlterTest {
     public void testAutoPartitionTableUnsupported2() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE site_access_time_slice\n" +
-                "ADD PARTITIONS START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 1 day)";
+                    "ADD PARTITIONS START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 1 day)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
@@ -2448,7 +2453,7 @@ public class AlterTest {
     public void testAutoPartitionTableUnsupported3() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE site_access_date_trunc\n" +
-                "ADD PARTITIONS START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 2 day)";
+                    "ADD PARTITIONS START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 2 day)";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(ctx, alterTableStmt);
     }
@@ -2456,43 +2461,44 @@ public class AlterTest {
     @Test
     public void testAlterMvWithResourceGroup() throws Exception {
         starRocksAssert.executeResourceGroupDdlSql("create resource group if not exists mv_rg" +
-                "   with (" +
-                "   'cpu_core_limit' = '10'," +
-                "   'mem_limit' = '20%'," +
-                "   'concurrency_limit' = '11'," +
-                "   'type' = 'mv'" +
-                "    );");
+                    "   with (" +
+                    "   'cpu_core_limit' = '10'," +
+                    "   'mem_limit' = '20%'," +
+                    "   'concurrency_limit' = '11'," +
+                    "   'type' = 'mv'" +
+                    "    );");
         starRocksAssert.useDatabase("test")
-                .withMaterializedView("CREATE MATERIALIZED VIEW `mv2` (a comment \"a1\", b comment \"b2\", c)\n" +
-                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
-                        "DISTRIBUTED BY HASH(a) BUCKETS 12\n" +
-                        "REFRESH ASYNC\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"replicated_storage\" = \"true\",\n" +
-                        "\"resource_group\" = \"mv_rg\",\n" +
-                        "\"storage_medium\" = \"HDD\"\n" +
-                        ")\n" +
-                        "AS SELECT k1, k2, v1 from test.tbl1");
-        MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getDb("test").getTable("mv2");
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `mv2` (a comment \"a1\", b comment \"b2\", c)\n" +
+                                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                                "DISTRIBUTED BY HASH(a) BUCKETS 12\n" +
+                                "REFRESH ASYNC\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"replicated_storage\" = \"true\",\n" +
+                                "\"resource_group\" = \"mv_rg\",\n" +
+                                "\"storage_medium\" = \"HDD\"\n" +
+                                ")\n" +
+                                "AS SELECT k1, k2, v1 from test.tbl1");
+        MaterializedView mv =
+                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("mv2");
         Assert.assertEquals("mv_rg", mv.getTableProperty().getResourceGroup());
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER MATERIALIZED VIEW mv2\n" +
-                "set (\"resource_group\" =\"\" )";
+                    "set (\"resource_group\" =\"\" )";
         AlterMaterializedViewStmt alterTableStmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterMaterializedView(alterTableStmt);
         Assert.assertEquals("", mv.getTableProperty().getResourceGroup());
         sql = "ALTER MATERIALIZED VIEW mv2\n" +
-                "set (\"resource_group\" =\"not_exist_rg\" )";
+                    "set (\"resource_group\" =\"not_exist_rg\" )";
         AlterMaterializedViewStmt alterTableStmt2 =
-                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                    (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         Assert.assertThrows("resource_group not_exist_rg does not exist.",
-                SemanticException.class,
-                () -> GlobalStateMgr.getCurrentState().getLocalMetastore().alterMaterializedView(alterTableStmt2));
+                    SemanticException.class,
+                    () -> GlobalStateMgr.getCurrentState().getLocalMetastore().alterMaterializedView(alterTableStmt2));
         sql = "ALTER MATERIALIZED VIEW mv2\n" +
-                "set (\"resource_group\" =\"mv_rg\" )";
+                    "set (\"resource_group\" =\"mv_rg\" )";
         AlterMaterializedViewStmt alterTableStmt3 =
-                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                    (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterMaterializedView(alterTableStmt3);
         Assert.assertEquals("mv_rg", mv.getTableProperty().getResourceGroup());
 
@@ -2504,7 +2510,7 @@ public class AlterTest {
         };
         sql = "ALTER MATERIALIZED VIEW mv2 set (\"warehouse\" = \"w1\")";
         AlterMaterializedViewStmt alterTableStmt4 =
-                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                    (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterMaterializedView(alterTableStmt4);
         Assert.assertEquals(1L, mv.getWarehouseId());
     }
@@ -2512,19 +2518,19 @@ public class AlterTest {
     @Test(expected = ErrorReportException.class)
     public void testAlterListPartitionUseBatchBuildPartition() throws Exception {
         starRocksAssert.useDatabase("test").withTable("CREATE TABLE t2 (\n" +
-                "    dt datetime  not null,\n" +
-                "    user_id  bigint  not null,\n" +
-                "    recharge_money decimal(32,2) not null, \n" +
-                "    province varchar(20) not null,\n" +
-                "    id varchar(20) not null\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(dt)\n" +
-                "PARTITION BY (dt)\n" +
-                "DISTRIBUTED BY HASH(`dt`) BUCKETS 10 \n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"in_memory\" = \"false\"\n" +
-                ");");
+                    "    dt datetime  not null,\n" +
+                    "    user_id  bigint  not null,\n" +
+                    "    recharge_money decimal(32,2) not null, \n" +
+                    "    province varchar(20) not null,\n" +
+                    "    id varchar(20) not null\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(dt)\n" +
+                    "PARTITION BY (dt)\n" +
+                    "DISTRIBUTED BY HASH(`dt`) BUCKETS 10 \n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"in_memory\" = \"false\"\n" +
+                    ");");
         ConnectContext ctx = starRocksAssert.getCtx();
         String sql = "ALTER TABLE t2 ADD PARTITIONS START (\"2021-01-04\") END (\"2021-01-06\") EVERY (INTERVAL 1 DAY);";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
@@ -2538,25 +2544,25 @@ public class AlterTest {
         {
             // inner table
             starRocksAssert.useDatabase("test").withMaterializedView("create materialized view if not exists `fk_mv_1` " +
-                    "refresh manual " +
-                    "as " +
-                    "select t1.event_day, t1.site_id, t2.user_name " +
-                    "from site_access_date_trunc t1 join site_access_time_slice t2 " +
-                    "on t1.site_id = t2.site_id");
+                        "refresh manual " +
+                        "as " +
+                        "select t1.event_day, t1.site_id, t2.user_name " +
+                        "from site_access_date_trunc t1 join site_access_time_slice t2 " +
+                        "on t1.site_id = t2.site_id");
             connectContext.executeSql("alter materialized view fk_mv_1 set " +
-                    "( 'unique_constraints'='site_access_date_trunc.site_id'); ");
+                        "( 'unique_constraints'='site_access_date_trunc.site_id'); ");
             connectContext.executeSql("alter materialized view fk_mv_1 set " +
-                    "( 'foreign_key_constraints'='site_access_time_slice(site_id)" +
-                    " REFERENCES site_access_date_trunc(site_id)'); ");
+                        "( 'foreign_key_constraints'='site_access_time_slice(site_id)" +
+                        " REFERENCES site_access_date_trunc(site_id)'); ");
             while (true) {
                 ModifyTablePropertyOperationLog modifyMvLog =
-                        (ModifyTablePropertyOperationLog) UtFrameUtils.PseudoJournalReplayer.
-                                replayNextJournal(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES);
+                            (ModifyTablePropertyOperationLog) UtFrameUtils.PseudoJournalReplayer.
+                                        replayNextJournal(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES);
                 Assert.assertNotNull(modifyMvLog);
                 if (modifyMvLog.getProperties().containsKey("foreign_key_constraints")) {
                     Assert.assertEquals("default_catalog.10001.10133(site_id) " +
-                                    "REFERENCES default_catalog.10001.10118(site_id)",
-                            modifyMvLog.getProperties().get("foreign_key_constraints"));
+                                            "REFERENCES default_catalog.10001.10118(site_id)",
+                                modifyMvLog.getProperties().get("foreign_key_constraints"));
                     break;
                 }
             }
@@ -2565,24 +2571,24 @@ public class AlterTest {
         {
             // external table
             starRocksAssert.withMaterializedView("create materialized view if not exists `fk_mv_2` " +
-                    "refresh manual " +
-                    "as " +
-                    "select t1.l_orderkey, t1.l_partkey, t2.o_totalprice " +
-                    "from hive0.tpch.lineitem t1 join hive0.tpch.orders t2 " +
-                    "on t1.l_orderkey = t2.o_orderkey");
+                        "refresh manual " +
+                        "as " +
+                        "select t1.l_orderkey, t1.l_partkey, t2.o_totalprice " +
+                        "from hive0.tpch.lineitem t1 join hive0.tpch.orders t2 " +
+                        "on t1.l_orderkey = t2.o_orderkey");
             connectContext.executeSql("alter materialized view fk_mv_2 set " +
-                    "( 'unique_constraints'='hive0.tpch.orders.o_orderkey'); ");
+                        "( 'unique_constraints'='hive0.tpch.orders.o_orderkey'); ");
             connectContext.executeSql("alter materialized view fk_mv_2 set " +
-                    "( 'foreign_key_constraints'='hive0.tpch.lineitem(l_orderkey) " +
-                    "REFERENCES hive0.tpch.orders(o_orderkey)'); ");
+                        "( 'foreign_key_constraints'='hive0.tpch.lineitem(l_orderkey) " +
+                        "REFERENCES hive0.tpch.orders(o_orderkey)'); ");
             while (true) {
                 ModifyTablePropertyOperationLog modifyMvLog =
-                        (ModifyTablePropertyOperationLog) UtFrameUtils.PseudoJournalReplayer.
-                                replayNextJournal(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES);
+                            (ModifyTablePropertyOperationLog) UtFrameUtils.PseudoJournalReplayer.
+                                        replayNextJournal(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES);
                 Assert.assertNotNull(modifyMvLog);
                 if (modifyMvLog.getProperties().containsKey("foreign_key_constraints")) {
                     Assert.assertEquals("hive0.tpch.lineitem:0(l_orderkey) REFERENCES hive0.tpch.orders:0(o_orderkey)",
-                            modifyMvLog.getProperties().get("foreign_key_constraints"));
+                                modifyMvLog.getProperties().get("foreign_key_constraints"));
                     break;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/BatchRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/BatchRollupJobTest.java
@@ -92,9 +92,9 @@ public class BatchRollupJobTest {
         Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
         Assert.assertEquals(3, alterJobs.size());
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("db1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
         Assert.assertNotNull(db);
-        OlapTable tbl = (OlapTable) db.getTable("tbl1");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         Assert.assertNotNull(tbl);
 
         // 3 rollup jobs may be finished in the loop, so only check the final state at last.
@@ -138,9 +138,9 @@ public class BatchRollupJobTest {
         Assert.assertEquals(3, alterJobs.size());
         List<Long> jobIds = Lists.newArrayList(alterJobs.keySet());
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("db1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
         Assert.assertNotNull(db);
-        OlapTable tbl = (OlapTable) db.getTable("tbl2");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl2");
         Assert.assertNotNull(tbl);
         Assert.assertEquals(OlapTableState.ROLLUP, tbl.getState());
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/CompactionHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/CompactionHandlerTest.java
@@ -52,25 +52,26 @@ public class CompactionHandlerTest {
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase(GlobalStateMgrTestUtil.testDb1)
-                .useDatabase(GlobalStateMgrTestUtil.testDb1);
+                    .useDatabase(GlobalStateMgrTestUtil.testDb1);
 
         starRocksAssert.withTable("CREATE TABLE testTable1\n" +
-                "(\n" +
-                "    v1 date,\n" +
-                "    v2 int,\n" +
-                "    v3 int\n" +
-                ")\n" +
-                "DUPLICATE KEY(`v1`)\n" +
-                "PARTITION BY RANGE(v1)\n" +
-                "(\n" +
-                "    PARTITION p1 values less than('2020-02-01'),\n" +
-                "    PARTITION p2 values less than('2020-03-01')\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(v1) BUCKETS 3\n" +
-                "PROPERTIES('replication_num' = '1');");
+                    "(\n" +
+                    "    v1 date,\n" +
+                    "    v2 int,\n" +
+                    "    v3 int\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(`v1`)\n" +
+                    "PARTITION BY RANGE(v1)\n" +
+                    "(\n" +
+                    "    PARTITION p1 values less than('2020-02-01'),\n" +
+                    "    PARTITION p2 values less than('2020-03-01')\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(v1) BUCKETS 3\n" +
+                    "PROPERTIES('replication_num' = '1');");
 
-        db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
@@ -50,7 +50,7 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.MetadataMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.thrift.TStorageMedium;
@@ -178,14 +178,14 @@ public class LakeTableAlterDataCachePartitionDurationTest {
         properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION, "7 months");
         ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
 
-        new MockUp<MetadataMgr>() {
+        new MockUp<LocalMetastore>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(String dbName) {
                 return db;
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(String dbName, String tblName) {
                 return table;
             }
         };
@@ -213,14 +213,14 @@ public class LakeTableAlterDataCachePartitionDurationTest {
         properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION, "2 days");
         ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
 
-        new MockUp<MetadataMgr>() {
+        new MockUp<LocalMetastore>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(String dbName) {
                 return db;
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(String dbName, String tblName) {
                 return table;
             }
         };
@@ -243,14 +243,14 @@ public class LakeTableAlterDataCachePartitionDurationTest {
         Map<String, String> properties = new HashMap<>();
         properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION, "4 hours");
         ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
-        new MockUp<MetadataMgr>() {
+        new MockUp<LocalMetastore>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(String dbName) {
                 return db;
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(String dbName, String tblName) {
                 return table;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -76,8 +76,9 @@ public class LakeTableSchemaChangeJobTest {
     private static LakeTable createTable(ConnectContext connectContext, String sql) throws Exception {
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb(createTableStmt.getDbName());
-        return (LakeTable) db.getTable(createTableStmt.getTableName());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(createTableStmt.getDbName());
+        return (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), createTableStmt.getTableName());
     }
 
     private static void alterTable(ConnectContext connectContext, String sql) throws Exception {
@@ -101,9 +102,9 @@ public class LakeTableSchemaChangeJobTest {
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
         connectContext.setDatabase(DB_NAME);
-        db = GlobalStateMgr.getServingState().getDb(DB_NAME);
+        db = GlobalStateMgr.getServingState().getLocalMetastore().getDb(DB_NAME);
         table = createTable(connectContext, "CREATE TABLE t0(c0 INT) duplicate key(c0) distributed by hash(c0) buckets "
-                + NUM_BUCKETS);
+                    + NUM_BUCKETS);
         Config.enable_fast_schema_evolution_in_share_data_mode = false;
         alterTable(connectContext, "ALTER TABLE t0 ADD COLUMN c1 DOUBLE");
         schemaChangeJob = getAlterJob(table);
@@ -152,7 +153,7 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public Warehouse getWarehouse(long warehouseId) {
                 return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID,
-                        WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+                            WarehouseManager.DEFAULT_WAREHOUSE_NAME);
             }
 
             @Mock
@@ -413,7 +414,7 @@ public class LakeTableSchemaChangeJobTest {
         Assert.assertNotNull(partition);
         Assert.assertEquals(3, partition.getNextVersion());
         List<MaterializedIndex> shadowIndexes =
-                partition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW);
+                    partition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW);
         Assert.assertEquals(1, shadowIndexes.size());
 
         // Does not support cancel job in FINISHED_REWRITING state.
@@ -435,8 +436,8 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                        long newVersion, long warehouseId)
-                    throws
-                    RpcException {
+                        throws
+                        RpcException {
                 throw new RpcException("publish version failed", "127.0.0.1");
             }
         };
@@ -468,7 +469,7 @@ public class LakeTableSchemaChangeJobTest {
         Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, schemaChangeJob.getJobState());
 
         List<MaterializedIndex> shadowIndexes =
-                partition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW);
+                    partition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW);
         Assert.assertEquals(1, shadowIndexes.size());
 
         // The partition's visible version has not catch up with the commit version of this schema change job now.
@@ -520,7 +521,7 @@ public class LakeTableSchemaChangeJobTest {
         Assert.assertEquals(0, shadowIndexes.size());
 
         List<MaterializedIndex> normalIndexes =
-                partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
+                    partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
         Assert.assertEquals(1, normalIndexes.size());
         MaterializedIndex normalIndex = normalIndexes.get(0);
 
@@ -557,7 +558,7 @@ public class LakeTableSchemaChangeJobTest {
             schemaChangeJob.runPendingJob();
         });
         Assert.assertTrue(exception.getMessage().contains(
-                "concurrent transaction detected while adding shadow index, please re-run the alter table command"));
+                    "concurrent transaction detected while adding shadow index, please re-run the alter table command"));
         Assert.assertEquals(AlterJobV2.JobState.PENDING, schemaChangeJob.getJobState());
         Assert.assertEquals(10101L, schemaChangeJob.getWatershedTxnId());
 
@@ -571,14 +572,14 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public Warehouse getWarehouseAllowNull(long warehouseId) {
                 return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID,
-                        WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+                            WarehouseManager.DEFAULT_WAREHOUSE_NAME);
             }
         };
 
         SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
 
         LakeTableSchemaChangeJob alterJobV2 =
-                new LakeTableSchemaChangeJob(12345L, db.getId(), table.getId(), table.getName(), 10);
+                    new LakeTableSchemaChangeJob(12345L, db.getId(), table.getId(), table.getName(), 10);
         alterJobV2.addIndexSchema(1L, 2L, "a", (short) 1, Lists.newArrayList());
 
         schemaChangeHandler.addAlterJobV2(alterJobV2);
@@ -603,7 +604,7 @@ public class LakeTableSchemaChangeJobTest {
         schemaChangeJob.setIsCancelling(true);
         schemaChangeJob.runPendingJob();
         schemaChangeJob.setIsCancelling(false);
-     
+
         schemaChangeJob.setWaitingCreatingReplica(true);
         schemaChangeJob.cancel("");
         schemaChangeJob.setWaitingCreatingReplica(false);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -75,8 +75,9 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeTable() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
@@ -88,8 +89,9 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeTableFinish() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
@@ -119,8 +121,9 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeTableFailed() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
@@ -157,15 +160,16 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         Assert.assertEquals(JobState.CANCELLED, optimizeJob.getJobState());
 
         OnlineOptimizeJobV2 replayOptimizeJob = new OnlineOptimizeJobV2(
-                optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+                    optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
         replayOptimizeJob.replay(optimizeJob);
     }
 
     @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
@@ -214,8 +218,9 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeReplay() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
@@ -223,7 +228,7 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         OnlineOptimizeJobV2 optimizeJob = (OnlineOptimizeJobV2) alterJobsV2.values().stream().findAny().get();
 
         OnlineOptimizeJobV2 replayOptimizeJob = new OnlineOptimizeJobV2(
-                optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+                    optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
 
         replayOptimizeJob.replay(optimizeJob);
         Assert.assertEquals(JobState.PENDING, replayOptimizeJob.getJobState());
@@ -260,8 +265,9 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeReplayPartialSuccess() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable("testTable2");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "testTable2");
 
         String stmt = "alter table testTable2 distributed by hash(v1)";
         AlterTableStmt alterStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());
@@ -270,9 +276,8 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         Assert.assertEquals(1, alterJobsV2.size());
         OnlineOptimizeJobV2 optimizeJob = (OnlineOptimizeJobV2) alterJobsV2.values().stream().findAny().get();
 
-
         OnlineOptimizeJobV2 replayOptimizeJob = new OnlineOptimizeJobV2(
-                optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+                    optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
 
         replayOptimizeJob.replay(optimizeJob);
         Assert.assertEquals(JobState.PENDING, replayOptimizeJob.getJobState());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
@@ -147,8 +147,9 @@ public class OptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeTable() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
@@ -160,8 +161,9 @@ public class OptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeTableFinish() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
@@ -201,8 +203,9 @@ public class OptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeTableFailed() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
@@ -239,15 +242,16 @@ public class OptimizeJobV2Test extends DDLTestBase {
         Assert.assertEquals(JobState.CANCELLED, optimizeJob.getJobState());
 
         OptimizeJobV2 replayOptimizeJob = new OptimizeJobV2(
-                optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+                    optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
         replayOptimizeJob.replay(optimizeJob);
     }
 
     @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
@@ -296,8 +300,9 @@ public class OptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeReplay() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable7);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
@@ -305,7 +310,7 @@ public class OptimizeJobV2Test extends DDLTestBase {
         OptimizeJobV2 optimizeJob = (OptimizeJobV2) alterJobsV2.values().stream().findAny().get();
 
         OptimizeJobV2 replayOptimizeJob = new OptimizeJobV2(
-                optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+                    optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
 
         replayOptimizeJob.replay(optimizeJob);
         Assert.assertEquals(JobState.PENDING, replayOptimizeJob.getJobState());
@@ -342,8 +347,9 @@ public class OptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeReplayPartialSuccess() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable("testTable2");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "testTable2");
 
         String stmt = "alter table testTable2 distributed by hash(v1)";
         AlterTableStmt alterStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());
@@ -352,9 +358,8 @@ public class OptimizeJobV2Test extends DDLTestBase {
         Assert.assertEquals(1, alterJobsV2.size());
         OptimizeJobV2 optimizeJob = (OptimizeJobV2) alterJobsV2.values().stream().findAny().get();
 
-
         OptimizeJobV2 replayOptimizeJob = new OptimizeJobV2(
-                optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+                    optimizeJob.getJobId(), db.getId(), olapTable.getId(), olapTable.getName(), 1000);
 
         replayOptimizeJob.replay(optimizeJob);
         Assert.assertEquals(JobState.PENDING, replayOptimizeJob.getJobState());
@@ -387,8 +392,9 @@ public class OptimizeJobV2Test extends DDLTestBase {
     @Test
     public void testOptimizeFailedByVersion() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable("testTable2");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "testTable2");
 
         String stmt = "alter table testTable2 distributed by hash(v1)";
         AlterTableStmt alterStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -92,12 +92,12 @@ public class RollupJobV2Test extends DDLTestBase {
     public void setUp() throws Exception {
         super.setUp();
         clause = new AddRollupClause(GlobalStateMgrTestUtil.testRollupIndex2, Lists.newArrayList("v1"), null,
-                GlobalStateMgrTestUtil.testTable1, null);
+                    GlobalStateMgrTestUtil.testTable1, null);
         AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(null);
         analyzer.analyze(null, clause);
 
         clause2 = new AddRollupClause(GlobalStateMgrTestUtil.testRollupIndex3, Lists.newArrayList("v1", "v2"), null,
-                GlobalStateMgrTestUtil.testTable1, null);
+                    GlobalStateMgrTestUtil.testTable1, null);
         analyzer.analyze(null, clause2);
 
         AgentTaskQueue.clearAllTasks();
@@ -114,15 +114,16 @@ public class RollupJobV2Test extends DDLTestBase {
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
         alterClauses.add(clause2);
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
 
         materializedViewHandler.runAfterCatalogReady();
 
         assertEquals(Config.max_running_rollup_job_num_per_table,
-                materializedViewHandler.getTableRunningJobMap().get(olapTable.getId()).size());
+                    materializedViewHandler.getTableRunningJobMap().get(olapTable.getId()).size());
         assertEquals(2, alterJobsV2.size());
         assertEquals(OlapTableState.ROLLUP, olapTable.getState());
     }
@@ -132,8 +133,9 @@ public class RollupJobV2Test extends DDLTestBase {
         MaterializedViewHandler materializedViewHandler = GlobalStateMgr.getCurrentState().getRollupHandler();
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         assertEquals(1, alterJobsV2.size());
@@ -148,8 +150,9 @@ public class RollupJobV2Test extends DDLTestBase {
         // add a rollup job
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
@@ -191,8 +194,9 @@ public class RollupJobV2Test extends DDLTestBase {
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
 
         materializedViewHandler.process(alterClauses, db, olapTable);
@@ -245,7 +249,7 @@ public class RollupJobV2Test extends DDLTestBase {
 
     @Test
     public void testSerializeOfRollupJob() throws IOException,
-            AnalysisException {
+                AnalysisException {
         Config.enable_materialized_view = true;
         // prepare file
         String fileName = "./RollupJobV2Test";
@@ -257,13 +261,13 @@ public class RollupJobV2Test extends DDLTestBase {
         List<Column> columns = Lists.newArrayList();
         String mvColumnName = MVUtils.MATERIALIZED_VIEW_NAME_PREFIX + "bitmap_union_" + "c1";
         Column column = new Column(mvColumnName, Type.BITMAP, false, AggregateType.BITMAP_UNION, false,
-                new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "");
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "");
         columns.add(column);
         RollupJobV2 rollupJobV2 = new RollupJobV2(1, 1, 1, "test", 1, 1,
-                1, "test", "rollup", 0, columns, null, 1, 1,
-                KeysType.AGG_KEYS, keysCount,
-                new OriginStatement("create materialized view rollup as select bitmap_union(to_bitmap(c1)) from test",
-                        0), "", false);
+                    1, "test", "rollup", 0, columns, null, 1, 1,
+                    KeysType.AGG_KEYS, keysCount,
+                    new OriginStatement("create materialized view rollup as select bitmap_union(to_bitmap(c1)) from test",
+                                0), "", false);
 
         // write rollup job
         rollupJobV2.write(out);
@@ -278,7 +282,7 @@ public class RollupJobV2Test extends DDLTestBase {
         assertEquals(1, resultColumns.size());
         Column resultColumn1 = resultColumns.get(0);
         assertEquals(mvColumnName,
-                resultColumn1.getName());
+                    resultColumn1.getName());
         Assert.assertTrue(resultColumn1.getDefineExpr() instanceof FunctionCallExpr);
         FunctionCallExpr resultFunctionCall = (FunctionCallExpr) resultColumn1.getDefineExpr();
         assertEquals("to_bitmap", resultFunctionCall.getFnName().getFunction());
@@ -289,8 +293,9 @@ public class RollupJobV2Test extends DDLTestBase {
         MaterializedViewHandler materializedViewHandler = GlobalStateMgr.getCurrentState().getRollupHandler();
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         assertEquals(1, alterJobsV2.size());
@@ -306,8 +311,9 @@ public class RollupJobV2Test extends DDLTestBase {
         // add a rollup job
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         alterClauses.add(clause);
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
         materializedViewHandler.process(alterClauses, db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
@@ -318,7 +324,7 @@ public class RollupJobV2Test extends DDLTestBase {
         rollupJob.setIsCancelling(true);
         rollupJob.runPendingJob();
         rollupJob.setIsCancelling(false);
-     
+
         rollupJob.setWaitingCreatingReplica(true);
         rollupJob.cancel("");
         rollupJob.setWaitingCreatingReplica(false);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -81,38 +81,38 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         //create tables
         String createAggTblStmtStr = "CREATE TABLE IF NOT EXISTS test.sc_agg (\n" + "user_id LARGEINT NOT NULL,\n"
-                + "date DATE NOT NULL,\n" + "city VARCHAR(20),\n" + "age SMALLINT,\n" + "sex TINYINT,\n"
-                + "last_visit_date DATETIME REPLACE DEFAULT '1970-01-01 00:00:00',\n" + "cost BIGINT SUM DEFAULT '0',\n"
-                + "max_dwell_time INT MAX DEFAULT '0',\n" + "min_dwell_time INT MIN DEFAULT '99999')\n"
-                + "AGGREGATE KEY(user_id, date, city, age, sex)\n" + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
+                    + "date DATE NOT NULL,\n" + "city VARCHAR(20),\n" + "age SMALLINT,\n" + "sex TINYINT,\n"
+                    + "last_visit_date DATETIME REPLACE DEFAULT '1970-01-01 00:00:00',\n" + "cost BIGINT SUM DEFAULT '0',\n"
+                    + "max_dwell_time INT MAX DEFAULT '0',\n" + "min_dwell_time INT MIN DEFAULT '99999')\n"
+                    + "AGGREGATE KEY(user_id, date, city, age, sex)\n" + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
+                    + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
         createTable(createAggTblStmtStr);
 
         String createUniqTblStmtStr = "CREATE TABLE IF NOT EXISTS test.sc_uniq (\n" + "user_id LARGEINT NOT NULL,\n"
-                + "username VARCHAR(50) NOT NULL,\n" + "city VARCHAR(20),\n" + "age SMALLINT,\n" + "sex TINYINT,\n"
-                + "phone LARGEINT,\n" + "address VARCHAR(500),\n" + "register_time DATETIME)\n"
-                + "UNIQUE  KEY(user_id, username)\n" + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
+                    + "username VARCHAR(50) NOT NULL,\n" + "city VARCHAR(20),\n" + "age SMALLINT,\n" + "sex TINYINT,\n"
+                    + "phone LARGEINT,\n" + "address VARCHAR(500),\n" + "register_time DATETIME)\n"
+                    + "UNIQUE  KEY(user_id, username)\n" + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
+                    + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
         createTable(createUniqTblStmtStr);
 
         String createDupTblStmtStr = "CREATE TABLE IF NOT EXISTS test.sc_dup (\n" + "timestamp DATETIME,\n"
-                + "type INT,\n" + "error_code INT,\n" + "error_msg VARCHAR(1024),\n" + "op_id BIGINT,\n"
-                + "op_time DATETIME)\n" + "DUPLICATE  KEY(timestamp, type)\n" + "DISTRIBUTED BY HASH(type) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
+                    + "type INT,\n" + "error_code INT,\n" + "error_msg VARCHAR(1024),\n" + "op_id BIGINT,\n"
+                    + "op_time DATETIME)\n" + "DUPLICATE  KEY(timestamp, type)\n" + "DISTRIBUTED BY HASH(type) BUCKETS 1\n"
+                    + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
 
         createTable(createDupTblStmtStr);
 
         String createDupTbl2StmtStr = "CREATE TABLE IF NOT EXISTS test.sc_dup2 (\n" + "timestamp DATETIME,\n"
-                + "type INT,\n" + "error_code INT,\n" + "error_msg VARCHAR(1024),\n" + "op_id BIGINT,\n"
-                + "op_time DATETIME)\n" + "DUPLICATE  KEY(timestamp, type)\n" + "DISTRIBUTED BY HASH(type) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
+                    + "type INT,\n" + "error_code INT,\n" + "error_msg VARCHAR(1024),\n" + "op_id BIGINT,\n"
+                    + "op_time DATETIME)\n" + "DUPLICATE  KEY(timestamp, type)\n" + "DISTRIBUTED BY HASH(type) BUCKETS 1\n"
+                    + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
 
         createTable(createDupTbl2StmtStr);
 
         String createPKTblStmtStr = "CREATE TABLE IF NOT EXISTS test.sc_pk (\n" + "timestamp DATETIME,\n"
-                + "type INT,\n" + "error_code INT,\n" + "error_msg VARCHAR(1024),\n" + "op_id BIGINT,\n"
-                + "op_time DATETIME)\n" + "PRIMARY  KEY(timestamp, type)\n" + "DISTRIBUTED BY HASH(type) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
+                    + "type INT,\n" + "error_code INT,\n" + "error_msg VARCHAR(1024),\n" + "op_id BIGINT,\n"
+                    + "op_time DATETIME)\n" + "PRIMARY  KEY(timestamp, type)\n" + "DISTRIBUTED BY HASH(type) BUCKETS 1\n"
+                    + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
 
         createTable(createPKTblStmtStr);
 
@@ -127,8 +127,9 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             LOG.info("alter job {} is done. state: {}", alterJobV2.getJobId(), alterJobV2.getJobState());
             Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(alterJobV2.getDbId());
-            OlapTable tbl = (OlapTable) db.getTable(alterJobV2.getTableId());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(alterJobV2.getDbId());
+            OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), alterJobV2.getTableId());
             while (tbl.getState() != OlapTable.OlapTableState.NORMAL) {
                 Thread.sleep(1000);
             }
@@ -139,8 +140,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     public void testAggAddOrDropColumn() throws Exception {
         LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("sc_agg");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_agg");
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -246,8 +247,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("sc_uniq");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_uniq");
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -304,8 +305,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("sc_dup");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_dup");
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
@@ -360,8 +361,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     @Test
     public void testModifyTableAddOrDropColumns() {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("sc_dup2");
+        Database db = globalStateMgr.getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_dup2");
         Map<Long, AlterJobV2> alterJobs = globalStateMgr.getSchemaChangeHandler().getAlterJobsV2();
 
         // origin columns
@@ -374,25 +375,25 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         List<Index> newIndexes = tbl.getCopiedIndexes();
 
         Assertions.assertDoesNotThrow(
-                () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 100, 100,
-                                indexToNewSchemaId, false));
+                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 100, 100,
+                                            indexToNewSchemaId, false));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         Assertions.assertDoesNotThrow(
-                () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 101, 101,
-                                indexToNewSchemaId, true));
+                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 101, 101,
+                                            indexToNewSchemaId, true));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         OlapTableState beforeState = tbl.getState();
         tbl.setState(OlapTableState.ROLLUP);
         Assertions.assertThrows(DdlException.class,
-                () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 102, 102, indexToNewSchemaId,
-                                false));
+                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 102, 102, indexToNewSchemaId,
+                                            false));
         tbl.setState(beforeState);
     }
 
@@ -401,8 +402,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("sc_pk");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_pk");
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tbl.getId()), LockType.READ);
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -58,7 +58,7 @@ import com.starrocks.common.SchemaVersionAndHash;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.MetadataMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.DDLTestBase;
@@ -254,18 +254,17 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         properties.put(DynamicPartitionProperty.BUCKETS, "30");
         alterClauses.add(new ModifyTablePropertiesClause(properties));
         Database db = CatalogMocker.mockDb();
-        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getId(), CatalogMocker.TEST_TBL2_ID);
+        OlapTable olapTable = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
         olapTable.setUseFastSchemaEvolution(false);
 
-        new MockUp<MetadataMgr>() {
+        new MockUp<LocalMetastore>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(String dbName) {
                 return db;
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(String dbName, String tblName) {
                 return olapTable;
             }
         };
@@ -334,17 +333,16 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         alterClauses.add(new ModifyTablePropertiesClause(properties));
 
         Database db = CatalogMocker.mockDb();
-        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getId(), CatalogMocker.TEST_TBL2_ID);
+        OlapTable olapTable = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
 
-        new MockUp<MetadataMgr>() {
+        new MockUp<LocalMetastore>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(String dbName) {
                 return db;
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(String dbName, String tblName) {
                 return olapTable;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -118,8 +118,9 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
     @Test
     public void testAddSchemaChange() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
 
         schemaChangeHandler.process(alterTableStmt.getAlterClauseList(), db, olapTable);
         Map<Long, AlterJobV2> alterJobsV2 = schemaChangeHandler.getAlterJobsV2();
@@ -131,8 +132,9 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
     @Test
     public void testSchemaChange1() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         olapTable.setUseFastSchemaEvolution(false);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
 
@@ -185,8 +187,9 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
     @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         olapTable.setUseFastSchemaEvolution(false);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
 
@@ -251,7 +254,8 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         properties.put(DynamicPartitionProperty.BUCKETS, "30");
         alterClauses.add(new ModifyTablePropertiesClause(properties));
         Database db = CatalogMocker.mockDb();
-        OlapTable olapTable = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), CatalogMocker.TEST_TBL2_ID);
         olapTable.setUseFastSchemaEvolution(false);
 
         new MockUp<MetadataMgr>() {
@@ -322,7 +326,7 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
     }
 
     public void modifyDynamicPartitionWithoutTableProperty(String propertyKey, String propertyValue, String expectErrMsg)
-            throws UserException {
+                throws UserException {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
         ArrayList<AlterClause> alterClauses = new ArrayList<>();
         Map<String, String> properties = new HashMap<>();
@@ -330,7 +334,8 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         alterClauses.add(new ModifyTablePropertiesClause(properties));
 
         Database db = CatalogMocker.mockDb();
-        OlapTable olapTable = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), CatalogMocker.TEST_TBL2_ID);
 
         new MockUp<MetadataMgr>() {
             @Mock
@@ -353,14 +358,14 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
     @Test
     public void testModifyDynamicPartitionWithoutTableProperty() throws AlterJobException, UserException {
         modifyDynamicPartitionWithoutTableProperty(DynamicPartitionProperty.ENABLE, "false",
-                "not a dynamic partition table");
+                    "not a dynamic partition table");
         modifyDynamicPartitionWithoutTableProperty(DynamicPartitionProperty.TIME_UNIT, "day",
-                DynamicPartitionProperty.ENABLE);
+                    DynamicPartitionProperty.ENABLE);
         modifyDynamicPartitionWithoutTableProperty(DynamicPartitionProperty.END, "3", DynamicPartitionProperty.ENABLE);
         modifyDynamicPartitionWithoutTableProperty(DynamicPartitionProperty.PREFIX, "p",
-                DynamicPartitionProperty.ENABLE);
+                    DynamicPartitionProperty.ENABLE);
         modifyDynamicPartitionWithoutTableProperty(DynamicPartitionProperty.BUCKETS, "30",
-                DynamicPartitionProperty.ENABLE);
+                    DynamicPartitionProperty.ENABLE);
     }
 
     @Test
@@ -411,7 +416,7 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
             @Mock
             public Warehouse getWarehouse(long warehouseId) {
                 return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID,
-                        WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+                            WarehouseManager.DEFAULT_WAREHOUSE_NAME);
             }
 
             @Mock
@@ -424,19 +429,19 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, starRocksAssert.getCtx());
         ReorderColumnsClause clause = (ReorderColumnsClause) alterTableStmt.getAlterClauseList().get(0);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
 
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
         AlterJobV2 alterJobV2 = schemaChangeHandler.analyzeAndCreateJob(Lists.newArrayList(clause), db, olapTable);
         Assert.assertEquals(0L, alterJobV2.warehouseId);
 
-
         new MockUp<WarehouseManager>() {
             @Mock
             public Warehouse getWarehouse(long warehouseId) {
                 return new DefaultWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID,
-                        WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+                            WarehouseManager.DEFAULT_WAREHOUSE_NAME);
             }
 
             @Mock
@@ -456,8 +461,9 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
     @Test
     public void testCancelPendingJobWithFlag() throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
-        Database db = GlobalStateMgr.getCurrentState().getDb(GlobalStateMgrTestUtil.testDb1);
-        OlapTable olapTable = (OlapTable) db.getTable(GlobalStateMgrTestUtil.testTable1);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         olapTable.setUseFastSchemaEvolution(false);
         Partition testPartition = olapTable.getPartition(GlobalStateMgrTestUtil.testTable1);
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -137,11 +137,11 @@ public class AccessTestUtil {
 
         new Expectations(db) {
             {
-                db.getTable("testTable");
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "testTable");
                 minTimes = 0;
                 result = olapTable;
 
-                db.getTable("emptyTable");
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "emptyTable");
                 minTimes = 0;
                 result = null;
 
@@ -168,19 +168,19 @@ public class AccessTestUtil {
 
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb("testDb");
+                globalStateMgr.getLocalMetastore().getDb("testDb");
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb("emptyDb");
+                globalStateMgr.getLocalMetastore().getDb("emptyDb");
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = new Database();
 
-                globalStateMgr.getDb("emptyCluster");
+                globalStateMgr.getLocalMetastore().getDb("emptyCluster");
                 minTimes = 0;
                 result = null;
             }
@@ -277,11 +277,11 @@ public class AccessTestUtil {
 
         new Expectations(db) {
             {
-                db.getTable("t");
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t");
                 minTimes = 0;
                 result = table;
 
-                db.getTable("emptyTable");
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "emptyTable");
                 minTimes = 0;
                 result = null;
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -137,11 +137,11 @@ public class AccessTestUtil {
 
         new Expectations(db) {
             {
-                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "testTable");
+                db.getTable("testTable");
                 minTimes = 0;
                 result = olapTable;
 
-                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "emptyTable");
+                db.getTable("emptyTable");
                 minTimes = 0;
                 result = null;
 
@@ -166,6 +166,7 @@ public class AccessTestUtil {
 
         Database db = mockDb("testDb");
 
+        /*
         new Expectations(globalStateMgr) {
             {
                 globalStateMgr.getLocalMetastore().getDb("testDb");
@@ -185,6 +186,8 @@ public class AccessTestUtil {
                 result = null;
             }
         };
+
+         */
         return globalStateMgr;
     }
 
@@ -277,11 +280,11 @@ public class AccessTestUtil {
 
         new Expectations(db) {
             {
-                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t");
+                db.getTable("t");
                 minTimes = 0;
                 result = table;
 
-                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "emptyTable");
+                db.getTable("emptyTable");
                 minTimes = 0;
                 result = null;
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CTASAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CTASAutoTabletTest.java
@@ -49,7 +49,7 @@ public class CTASAutoTabletTest {
         PseudoCluster cluster = PseudoCluster.getInstance();
         cluster.runSql("db_for_auto_tablets",
                 "create table test_table1 (k1 bigint, k2 bigint, v0 string) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1);");
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_for_auto_tablets");
         if (db == null) {
             return;
         }
@@ -63,7 +63,7 @@ public class CTASAutoTabletTest {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            OlapTable table = (OlapTable) db.getTable("test_table1");
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table1");
             if (table == null) {
                 return;
             }
@@ -72,7 +72,7 @@ public class CTASAutoTabletTest {
             }
 
             // ctas1
-            table = (OlapTable) db.getTable("ctas1");
+            table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "ctas1");
             if (table == null) {
                 return;
             }
@@ -81,7 +81,7 @@ public class CTASAutoTabletTest {
             }
 
             // ctas2
-            table = (OlapTable) db.getTable("ctas2");
+            table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "ctas2");
             if (table == null) {
                 return;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateSyncMaterializedViewTest.java
@@ -198,12 +198,12 @@ public class CreateSyncMaterializedViewTest {
                 .useDatabase("test");
         starRocksAssert.withView("create view test.view_to_tbl1 as select * from test.tbl1;");
         currentState = GlobalStateMgr.getCurrentState();
-        testDb = currentState.getDb("test");
+        testDb = currentState.getLocalMetastore().getDb("test");
     }
 
     private Table getTable(String dbName, String mvName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(mvName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName);
         Assert.assertNotNull(table);
         return table;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -54,11 +54,11 @@ public class CreateTableAutoTabletTest {
         PseudoCluster cluster = PseudoCluster.getInstance();
         cluster.runSql("db_for_auto_tablets",
                 "create table test_table1 (pk bigint NOT NULL, v0 string not null) primary KEY (pk) DISTRIBUTED BY HASH(pk) PROPERTIES(\"replication_num\" = \"3\", \"storage_medium\" = \"SSD\");");
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_for_auto_tablets");
         if (db == null) {
             return;
         }
-        OlapTable table = (OlapTable) db.getTable("test_table1");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table1");
         if (table == null) {
             return;
         }
@@ -100,12 +100,12 @@ public class CreateTableAutoTabletTest {
                         " PARTITION BY RANGE(pk2) (START (\"2022-08-01\") END (\"2022-08-10\") EVERY (INTERVAL 1 day))" +
                         " DISTRIBUTED BY HASH(pk1)" +
                         " PROPERTIES (\"replication_num\" = \"3\", \"storage_medium\" = \"SSD\");");
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_for_auto_tablets");
         if (db == null) {
             return;
         }
 
-        OlapTable table = (OlapTable) db.getTable("test_table2");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table2");
         if (table == null) {
             return;
         }
@@ -150,12 +150,12 @@ public class CreateTableAutoTabletTest {
                         "   'dynamic_partition.end' = '3'," +
                         "   'dynamic_partition.prefix' = 'p');");
         Thread.sleep(1000); // wait for the dynamic partition created
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_for_auto_tablets");
         if (db == null) {
             return;
         }
 
-        OlapTable table = (OlapTable) db.getTable("test_auto_tablets_of_dynamic_partition");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_auto_tablets_of_dynamic_partition");
         if (table == null) {
             return;
         }
@@ -197,12 +197,12 @@ public class CreateTableAutoTabletTest {
                         "   'dynamic_partition.buckets' = '3'," +
                         "   'dynamic_partition.prefix' = 'p');");
         Thread.sleep(1000); // wait for the dynamic partition created
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_for_auto_tablets");
         if (db == null) {
             return;
         }
 
-        OlapTable table = (OlapTable) db.getTable("test_modify_dynamic_partition_property");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_modify_dynamic_partition_property");
         if (table == null) {
             return;
         }
@@ -244,12 +244,12 @@ public class CreateTableAutoTabletTest {
                         "  PROPERTIES (" +
                         "   'replication_num' = '1'," +
                         "   'colocate_with' = 'g1');");
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_for_auto_tablets");
         if (db == null) {
             return;
         }
 
-        OlapTable table = (OlapTable) db.getTable("colocate_partition");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "colocate_partition");
         if (table == null) {
             return;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/MaterializedViewAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/MaterializedViewAutoTabletTest.java
@@ -48,7 +48,7 @@ public class MaterializedViewAutoTabletTest {
         PseudoCluster cluster = PseudoCluster.getInstance();
         cluster.runSql("db_for_auto_tablets",
                 "create table test_table1 (k1 bigint, v0 int) DUPLICATE KEY (k1) DISTRIBUTED BY HASH(k1);");
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_for_auto_tablets");
         if (db == null) {
             return;
         }
@@ -59,7 +59,7 @@ public class MaterializedViewAutoTabletTest {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            OlapTable table = (OlapTable) db.getTable("test_table1");
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table1");
             if (table == null) {
                 return;
             }
@@ -67,7 +67,7 @@ public class MaterializedViewAutoTabletTest {
                 bucketNum1 += partition.getDistributionInfo().getBucketNum();
             }
 
-            table = (OlapTable) db.getTable("mv1");
+            table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
             if (table == null) {
                 return;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
@@ -86,14 +86,14 @@ public class RefreshMaterializedViewStatementTest {
     @Test
     public void testRefreshMaterializedView() throws Exception {
 
-        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getDb("test");
+        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb("test");
         starRocksAssert.withMaterializedView("create materialized view mv1 distributed by hash(`c1`) " +
                 " refresh manual" +
                 " as select c1, sum(c3) as total from table_name_tmp_1 group by c1");
         cluster.runSql("test", "insert into table_name_tmp_1 values(1, \"str1\", 100)");
-        Table table = db.getTable("table_name_tmp_1");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "table_name_tmp_1");
         Assert.assertNotNull(table);
-        Table t2 = db.getTable("mv1");
+        Table t2 = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
         Assert.assertNotNull(t2);
         MaterializedView mv1 = (MaterializedView) t2;
         cluster.runSql("test", "refresh materialized view mv1 with sync mode");

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -531,7 +531,7 @@ public class ResourceGroupStmtTest {
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
         starRocksAssert.getCtx().setRemoteIP(remoteIp);
         {
-            long dbId = GlobalStateMgr.getCurrentState().getDb("db1").getId();
+            long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1").getId();
             Set<Long> dbIds = ImmutableSet.of(dbId);
             TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                     starRocksAssert.getCtx(),
@@ -540,7 +540,7 @@ public class ResourceGroupStmtTest {
             Assert.assertEquals("rg5", wg.getName());
         }
         {
-            long dbId = GlobalStateMgr.getCurrentState().getDb("db2").getId();
+            long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2").getId();
             Set<Long> dbIds = ImmutableSet.of(dbId);
             TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                     starRocksAssert.getCtx(),
@@ -551,8 +551,8 @@ public class ResourceGroupStmtTest {
         }
         {
             Set<Long> dbIds = ImmutableSet.of(
-                    GlobalStateMgr.getCurrentState().getDb("db1").getId(),
-                    GlobalStateMgr.getCurrentState().getDb("db2").getId());
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1").getId(),
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2").getId());
             TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                     starRocksAssert.getCtx(),
                     ResourceGroupClassifier.QueryType.SELECT,
@@ -773,7 +773,7 @@ public class ResourceGroupStmtTest {
 
         // Prefer the short query group regardless its classifier weight is the lowest.
         String qualifiedUser = "rt_rg_user";
-        long dbId = GlobalStateMgr.getCurrentState().getDb("db1").getId();
+        long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1").getId();
         Set<Long> dbs = ImmutableSet.of(dbId);
         starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -97,7 +97,7 @@ public class ShowCreateMaterializedViewStmtTest {
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(createMvSql, ctx);
         GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
         currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStatement) statementBase);
-        Table table = currentState.getDb("test").getTable("mv9");
+        Table table = currentState.getLocalMetastore().getDb("test").getTable("mv9");
         List<String> createTableStmt = Lists.newArrayList();
         AstToStringBuilder.getDdlStmt(table, createTableStmt, null, null, false, true);
         Assert.assertEquals("CREATE MATERIALIZED VIEW `mv9` (`k1`, `k2`)\n" +
@@ -125,7 +125,7 @@ public class ShowCreateMaterializedViewStmtTest {
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(createMvSql, ctx);
         GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
         currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStatement) statementBase);
-        Table table = currentState.getDb("test").getTable("mv10");
+        Table table = currentState.getLocalMetastore().getDb("test").getTable("mv10");
         List<String> createTableStmt = Lists.newArrayList();
         AstToStringBuilder.getDdlStmt(table, createTableStmt, null, null, false, true);
         Assert.assertEquals("CREATE MATERIALIZED VIEW `mv10` (`c1`, `c2`)\n" +
@@ -154,7 +154,7 @@ public class ShowCreateMaterializedViewStmtTest {
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(createMvSql, ctx);
         GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
         currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStatement) statementBase);
-        Table table = currentState.getDb("test").getTable("mv8");
+        Table table = currentState.getLocalMetastore().getDb("test").getTable("mv8");
         List<String> createTableStmt = Lists.newArrayList();
         AstToStringBuilder.getDdlStmt(table, createTableStmt, null, null, false, true);
         Assert.assertEquals(createTableStmt.get(0),

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
@@ -189,14 +189,14 @@ public class ShowCreateViewStmtTest {
             CreateViewStmt createViewStmt = (CreateViewStmt) UtFrameUtils.parseStmtWithNewParser(testcase[1], ctx);
             GlobalStateMgr.getCurrentState().getLocalMetastore().createView(createViewStmt);
 
-            List<Table> views = GlobalStateMgr.getCurrentState().getDb(createViewStmt.getDbName()).getViews();
+            List<Table> views = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(createViewStmt.getDbName()).getViews();
             List<String> res = Lists.newArrayList();
             AstToStringBuilder.getDdlStmt(createViewStmt.getDbName(), views.get(0), res,
                     null, null, false, false, false);
 
             Assert.assertEquals(testcase[2], res.get(0));
 
-            GlobalStateMgr.getCurrentState().getDb(createViewStmt.getDbName()).dropTable(createViewStmt.getTable());
+            GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(createViewStmt.getDbName()).dropTable(createViewStmt.getTable());
         }
     }
 
@@ -208,7 +208,7 @@ public class ShowCreateViewStmtTest {
         CreateViewStmt createViewStmt = (CreateViewStmt) UtFrameUtils.parseStmtWithNewParser(createViewSql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createView(createViewStmt);
 
-        List<Table> views = GlobalStateMgr.getCurrentState().getDb(createViewStmt.getDbName()).getViews();
+        List<Table> views = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(createViewStmt.getDbName()).getViews();
         List<String> res = Lists.newArrayList();
         AstToStringBuilder.getDdlStmt(createViewStmt.getDbName(), views.get(0), res,
                 null, null, false, false, false);
@@ -276,7 +276,7 @@ public class ShowCreateViewStmtTest {
 
     @Test
     public void testDdlComment() {
-        List<Table> tables = GlobalStateMgr.getCurrentState().getDb("test").getTables();
+        List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTables();
         Table commentTest = tables.stream().filter(table -> table.getName().equals("comment_test")).findFirst().get();
         List<String> res = Lists.newArrayList();
         AstToStringBuilder.getDdlStmt("test", commentTest, res,
@@ -287,7 +287,7 @@ public class ShowCreateViewStmtTest {
 
     @Test
     public void testDdlStorageType() {
-        List<Table> tables = GlobalStateMgr.getCurrentState().getDb("test").getTables();
+        List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTables();
         Table storageTest = tables.stream().filter(table -> table.getName().equals("storage_test")).findFirst().get();
         List<String> res = Lists.newArrayList();
         AstToStringBuilder.getDdlStmt("storage_test", storageTest, res,

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
@@ -19,7 +19,6 @@ package com.starrocks.analysis;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
-import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
@@ -53,28 +52,6 @@ public class ShowDbStmtTest {
             {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), anyString);
                 minTimes = 0;
-            }
-        };
-
-        // mock globalStateMgr.
-        globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getLocalMetastore().getDb("testCluster:testDb");
-                minTimes = 0;
-                result = db;
-
-                globalStateMgr.getLocalMetastore().getDb("testCluster:emptyDb");
-                minTimes = 0;
-                result = null;
-
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
@@ -51,7 +51,7 @@ public class ShowDbStmtTest {
         Database db = new Database();
         new Expectations(db) {
             {
-                db.getTable(anyString);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), anyString);
                 minTimes = 0;
             }
         };
@@ -60,11 +60,11 @@ public class ShowDbStmtTest {
         globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb("testCluster:testDb");
+                globalStateMgr.getLocalMetastore().getDb("testCluster:testDb");
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb("testCluster:emptyDb");
+                globalStateMgr.getLocalMetastore().getDb("testCluster:emptyDb");
                 minTimes = 0;
                 result = null;
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDeleteTest.java
@@ -16,7 +16,6 @@ package com.starrocks.analysis;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
-import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
@@ -47,28 +46,6 @@ public class ShowDeleteTest {
             {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), anyString);
                 minTimes = 0;
-            }
-        };
-
-        // mock globalStateMgr.
-        globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getLocalMetastore().getDb("testCluster:testDb");
-                minTimes = 0;
-                result = db;
-
-                globalStateMgr.getLocalMetastore().getDb("testCluster:emptyDb");
-                minTimes = 0;
-                result = null;
-
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDeleteTest.java
@@ -45,7 +45,7 @@ public class ShowDeleteTest {
         Database db = new Database();
         new Expectations(db) {
             {
-                db.getTable(anyString);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), anyString);
                 minTimes = 0;
             }
         };
@@ -54,11 +54,11 @@ public class ShowDeleteTest {
         globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb("testCluster:testDb");
+                globalStateMgr.getLocalMetastore().getDb("testCluster:testDb");
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb("testCluster:emptyDb");
+                globalStateMgr.getLocalMetastore().getDb("testCluster:emptyDb");
                 minTimes = 0;
                 result = null;
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
@@ -20,10 +20,9 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
@@ -122,18 +121,18 @@ public class UseMaterializedViewTest {
     public void testDropMaterializedView() {
         String sql = "drop materialized view mv_to_drop";
         try {
-            Database database = starRocksAssert.getCtx().getGlobalStateMgr().getDb("test");
+            Database database = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb("test");
             Assert.assertTrue(database != null);
-            Table table = database.getTable("mv_to_drop");
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "mv_to_drop");
             Assert.assertTrue(table != null);
             MaterializedView materializedView = (MaterializedView) table;
             long baseTableId = materializedView.getBaseTableInfos().iterator().next().getTableId();
-            OlapTable baseTable = ((OlapTable) database.getTable(baseTableId));
+            OlapTable baseTable = ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), baseTableId));
             Assert.assertEquals(2, baseTable.getRelatedMaterializedViews().size());
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
             stmtExecutor.execute();
-            table = database.getTable("mv_to_drop");
+            table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "mv_to_drop");
             Assert.assertTrue(table == null);
             Assert.assertEquals(1, baseTable.getRelatedMaterializedViews().size());
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -152,7 +152,7 @@ public class BackupHandlerTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = db;
             }
@@ -164,8 +164,8 @@ public class BackupHandlerTest {
         if (rootDir != null) {
             try {
                 Files.walk(Paths.get(Config.tmp_dir),
-                                FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
-                        .forEach(File::delete);
+                                        FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
+                            .forEach(File::delete);
             } catch (IOException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
@@ -185,7 +185,7 @@ public class BackupHandlerTest {
 
     @Test
     public void testCreateAndDropRepository(
-            @Mocked GlobalStateMgr globalStateMgr, @Mocked BrokerMgr brokerMgr, @Mocked EditLog editLog) throws Exception {
+                @Mocked GlobalStateMgr globalStateMgr, @Mocked BrokerMgr brokerMgr, @Mocked EditLog editLog) throws Exception {
         setUpMocker(globalStateMgr, brokerMgr, editLog);
         new Expectations() {
             {
@@ -221,7 +221,8 @@ public class BackupHandlerTest {
 
             @Mock
             public Status getSnapshotInfoFile(String label, String backupTimestamp, List<BackupJobInfo> infos) {
-                OlapTable tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
+                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), CatalogMocker.TEST_TBL_NAME);
                 List<Table> tbls = Lists.newArrayList();
                 tbls.add(tbl);
                 Map<Long, SnapshotInfo> snapshotInfos = Maps.newHashMap();
@@ -230,15 +231,15 @@ public class BackupHandlerTest {
                         for (Tablet tablet : idx.getTablets()) {
                             List<String> files = Lists.newArrayList();
                             SnapshotInfo sinfo = new SnapshotInfo(db.getId(), tbl.getId(), part.getId(), idx.getId(),
-                                    tablet.getId(), -1, 0, "./path", files);
+                                        tablet.getId(), -1, 0, "./path", files);
                             snapshotInfos.put(tablet.getId(), sinfo);
                         }
                     }
                 }
 
                 BackupJobInfo info = BackupJobInfo.fromCatalog(System.currentTimeMillis(),
-                        "ss2", CatalogMocker.TEST_DB_NAME,
-                        CatalogMocker.TEST_DB_ID, tbls, snapshotInfos);
+                            "ss2", CatalogMocker.TEST_DB_NAME,
+                            CatalogMocker.TEST_DB_ID, tbls, snapshotInfos);
                 infos.add(info);
                 return Status.OK;
             }
@@ -255,7 +256,7 @@ public class BackupHandlerTest {
         // add repo
         handler = new BackupHandler(globalStateMgr);
         CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", "broker", "bos://location",
-                Maps.newHashMap());
+                    Maps.newHashMap());
         try {
             handler.createRepository(stmt);
         } catch (DdlException e) {
@@ -267,7 +268,7 @@ public class BackupHandlerTest {
         List<TableRef> tblRefs = Lists.newArrayList();
         tblRefs.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
         BackupStmt backupStmt = new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label1"), "repo", tblRefs,
-                null);
+                    null);
         try {
             handler.process(backupStmt);
         } catch (DdlException e1) {
@@ -278,7 +279,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotTask
         BackupJob backupJob = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
         SnapshotTask snapshotTask = new SnapshotTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, false);
+                    0, 0, 0, 0, 0, 0, 1, false);
         TFinishTaskRequest request = new TFinishTaskRequest();
         List<String> snapshotFiles = Lists.newArrayList();
         request.setSnapshot_files(snapshotFiles);
@@ -289,7 +290,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotUploadTask
         Map<String, String> srcToDestPath = Maps.newHashMap();
         UploadTask uploadTask = new UploadTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath, null, null);
+                    srcToDestPath, null, null);
         request = new TFinishTaskRequest();
         Map<Long, List<String>> tabletFiles = Maps.newHashMap();
         request.setTablet_files(tabletFiles);
@@ -325,8 +326,8 @@ public class BackupHandlerTest {
         List<TableRef> tblRefs1 = Lists.newArrayList();
         tblRefs1.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL3_NAME), null));
         BackupStmt backupStmt1 =
-                new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1,
-                        null);
+                    new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1,
+                                null);
         try {
             handler.process(backupStmt1);
         } catch (DdlException e1) {
@@ -337,7 +338,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotTask
         BackupJob backupJob1 = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
         SnapshotTask snapshotTask1 = new SnapshotTask(null, 0, 0, backupJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, false);
+                    0, 0, 0, 0, 0, 0, 1, false);
         TFinishTaskRequest request1 = new TFinishTaskRequest();
         List<String> snapshotFiles1 = Lists.newArrayList();
         request1.setSnapshot_files(snapshotFiles1);
@@ -348,7 +349,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotUploadTask
         Map<String, String> srcToDestPath1 = Maps.newHashMap();
         UploadTask uploadTask1 = new UploadTask(null, 0, 0, backupJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath1, null, null);
+                    srcToDestPath1, null, null);
         request1 = new TFinishTaskRequest();
         Map<Long, List<String>> tabletFiles1 = Maps.newHashMap();
         request1.setTablet_files(tabletFiles1);
@@ -386,7 +387,7 @@ public class BackupHandlerTest {
         Map<String, String> properties = Maps.newHashMap();
         properties.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "ss2"), "repo", tblRefs2,
-                properties);
+                    properties);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt, new ConnectContext());
         } catch (SemanticException e2) {
@@ -404,7 +405,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotTask
         RestoreJob restoreJob = (RestoreJob) handler.getJob(CatalogMocker.TEST_DB_ID);
         snapshotTask = new SnapshotTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, true);
+                    0, 0, 0, 0, 0, 0, 1, true);
         request = new TFinishTaskRequest();
         request.setSnapshot_path("./snapshot/path");
         request.setTask_status(new TStatus(TStatusCode.OK));
@@ -412,7 +413,7 @@ public class BackupHandlerTest {
 
         // handleDownloadSnapshotTask
         DownloadTask downloadTask = new DownloadTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath, null, null);
+                    srcToDestPath, null, null);
         request = new TFinishTaskRequest();
         List<Long> downloadedTabletIds = Lists.newArrayList();
         request.setDownloaded_tablet_ids(downloadedTabletIds);
@@ -421,7 +422,7 @@ public class BackupHandlerTest {
 
         // handleDirMoveTask
         DirMoveTask dirMoveTask = new DirMoveTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0, 0,
-                0, "", 0, true);
+                    0, "", 0, true);
         request = new TFinishTaskRequest();
         request.setTask_status(new TStatus(TStatusCode.OK));
         handler.handleDirMoveTask(dirMoveTask, request);
@@ -464,7 +465,7 @@ public class BackupHandlerTest {
         Map<String, String> properties1 = Maps.newHashMap();
         properties1.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt1 = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs3,
-                properties1);
+                    properties1);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt1, new ConnectContext());
         } catch (SemanticException e2) {
@@ -482,7 +483,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotTask
         RestoreJob restoreJob1 = (RestoreJob) handler.getJob(CatalogMocker.TEST_DB_ID);
         snapshotTask1 = new SnapshotTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, true);
+                    0, 0, 0, 0, 0, 0, 1, true);
         request1 = new TFinishTaskRequest();
         request1.setSnapshot_path("./snapshot/path1");
         request1.setTask_status(new TStatus(TStatusCode.OK));
@@ -490,7 +491,7 @@ public class BackupHandlerTest {
 
         // handleDownloadSnapshotTask
         DownloadTask downloadTask1 = new DownloadTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath1, null, null);
+                    srcToDestPath1, null, null);
         request1 = new TFinishTaskRequest();
         List<Long> downloadedTabletIds1 = Lists.newArrayList();
         request1.setDownloaded_tablet_ids(downloadedTabletIds1);
@@ -499,7 +500,7 @@ public class BackupHandlerTest {
 
         // handleDirMoveTask
         DirMoveTask dirMoveTask1 = new DirMoveTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0, 0,
-                0, "", 0, true);
+                    0, "", 0, true);
         request1 = new TFinishTaskRequest();
         request1.setTask_status(new TStatus(TStatusCode.OK));
         handler.handleDirMoveTask(dirMoveTask1, request1);
@@ -594,7 +595,6 @@ public class BackupHandlerTest {
         handler = new BackupHandler(globalStateMgr);
         BackupJob runningJob = new BackupJob("running_job", 1, "test_db", new ArrayList<>(), 10000, globalStateMgr, 1);
         handler.dbIdToBackupOrRestoreJob.put(runningJob.getDbId(), runningJob);
-
 
         UtFrameUtils.PseudoImage pseudoImage = new UtFrameUtils.PseudoImage();
         handler.saveBackupHandlerV2(pseudoImage.getImageWriter());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -122,7 +122,7 @@ public class BackupJobMaterializedViewTest {
     private EditLog editLog;
 
     private Repository repo = new Repository(repoId, "repo", false, "my_repo",
-            new BlobStorage("broker", Maps.newHashMap()));
+                new BlobStorage("broker", Maps.newHashMap()));
 
     @BeforeAll
     public static void start() {
@@ -141,7 +141,7 @@ public class BackupJobMaterializedViewTest {
             File backupDir = new File(path.toString());
             if (backupDir.exists()) {
                 Files.walk(path, FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
-                        .forEach(File::delete);
+                            .forEach(File::delete);
             }
         }
     }
@@ -156,11 +156,11 @@ public class BackupJobMaterializedViewTest {
         Deencapsulation.setField(globalStateMgr, "backupHandler", backupHandler);
 
         db = UnitTestUtil.createDbWithMaterializedView(dbId, tblId, partId, idxId, tabletId,
-                backendId, version, KeysType.DUP_KEYS);
+                    backendId, version, KeysType.DUP_KEYS);
 
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
 
@@ -239,14 +239,18 @@ public class BackupJobMaterializedViewTest {
                 List<String> partNames = Lists.newArrayList(backupTbl.getPartitionNames());
                 Assert.assertNotNull(backupTbl);
                 Assert.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
-                        ((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
+                            ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getId(), tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames,
+                                        true));
             }
             {
                 OlapTable backupTbl = (OlapTable) backupMeta.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
                 List<String> partNames = Lists.newArrayList(backupTbl.getPartitionNames());
                 Assert.assertNotNull(backupTbl);
                 Assert.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
-                        ((OlapTable) db.getTable(tblId + 1)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
+                            ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getId(), tblId + 1)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames,
+                                        true));
             }
         }
 
@@ -271,7 +275,7 @@ public class BackupJobMaterializedViewTest {
             Assert.assertTrue(task instanceof SnapshotTask);
             SnapshotTask snapshotTask = (SnapshotTask) task;
             TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
-                    snapshotTask.getSignature(), taskStatus);
+                        snapshotTask.getSignature(), taskStatus);
             request.setSnapshot_files(snapshotFiles);
             request.setSnapshot_path(snapshotPath);
             Assert.assertTrue(job.finishTabletSnapshotTask(snapshotTask, request));
@@ -284,7 +288,7 @@ public class BackupJobMaterializedViewTest {
             Assert.assertTrue(task instanceof SnapshotTask);
             SnapshotTask snapshotTask = (SnapshotTask) task;
             TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
-                    snapshotTask.getSignature(), taskStatus);
+                        snapshotTask.getSignature(), taskStatus);
             request.setSnapshot_files(snapshotFiles);
             request.setSnapshot_path(snapshotPath);
             Assert.assertTrue(job.finishTabletSnapshotTask(snapshotTask, request));
@@ -307,7 +311,7 @@ public class BackupJobMaterializedViewTest {
         Assert.assertEquals(job.getJobId(), upTask.getJobId());
         Map<String, String> srcToDest = upTask.getSrcToDestPath();
         Assert.assertEquals(1, srcToDest.size());
-        String dest = srcToDest.get(snapshotPath + "/" + tabletId  + "/" + 0);
+        String dest = srcToDest.get(snapshotPath + "/" + tabletId + "/" + 0);
         Assert.assertNotNull(dest);
 
         // 5. uploading
@@ -316,7 +320,7 @@ public class BackupJobMaterializedViewTest {
         Assert.assertEquals(BackupJobState.UPLOADING, job.getState());
         Map<Long, List<String>> tabletFileMap = Maps.newHashMap();
         TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.UPLOAD,
-                upTask.getSignature(), taskStatus);
+                    upTask.getSignature(), taskStatus);
         request.setTablet_files(tabletFileMap);
 
         Assert.assertFalse(job.finishSnapshotUploadTask(upTask, request));
@@ -354,16 +358,18 @@ public class BackupJobMaterializedViewTest {
                 Assert.assertNotNull(olapTable);
                 Assert.assertNotNull(restoreMetaInfo.getTable(UnitTestUtil.TABLE_NAME));
                 List<String> names = Lists.newArrayList(olapTable.getPartitionNames());
-                Assert.assertEquals(((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, names, true),
-                        olapTable.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
+                Assert.assertEquals(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getId(), tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, names, true),
+                            olapTable.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
             }
             {
                 MaterializedView mv = (MaterializedView) restoreMetaInfo.getTable(tblId + 1);
                 Assert.assertNotNull(mv);
                 Assert.assertNotNull(restoreMetaInfo.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME));
                 List<String> names = Lists.newArrayList(mv.getPartitionNames());
-                Assert.assertEquals(((OlapTable) db.getTable(tblId + 1)).getSignature(BackupHandler.SIGNATURE_VERSION, names,
-                                true), mv.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
+                Assert.assertEquals(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tblId + 1)).getSignature(BackupHandler.SIGNATURE_VERSION, names,
+                            true), mv.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
             }
 
             restoreJobInfo = BackupJobInfo.fromFile(job.getLocalJobInfoFilePath());
@@ -387,7 +393,7 @@ public class BackupJobMaterializedViewTest {
             Assert.assertTrue(mv != null);
             Assert.assertTrue(!mv.isActive());
             Assert.assertTrue(mv.getInactiveReason().contains(String.format("Set the materialized view %s inactive in backup",
-                    UnitTestUtil.MATERIALIZED_VIEW_NAME)));
+                        UnitTestUtil.MATERIALIZED_VIEW_NAME)));
         } catch (IOException e) {
             e.printStackTrace();
             Assert.fail();
@@ -417,7 +423,7 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_mv"), null));
 
         job = new BackupJob("mv_label_abnormal", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000,
-                globalStateMgr, repo.getId());
+                    globalStateMgr, repo.getId());
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -171,6 +171,14 @@ public class BackupJobMaterializedViewTest {
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;
+
+                globalStateMgr.getLocalMetastore().getTable("testDb", "unknown_mv");
+                minTimes = 0;
+                result = null;
+
+                globalStateMgr.getLocalMetastore().getTable("testDb", "unknown_tbl");
+                minTimes = 0;
+                result = null;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
@@ -187,6 +187,14 @@ public class BackupJobPrimaryKeyTest {
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;
+
+                globalStateMgr.getLocalMetastore().getTable(testDbName, testTableName);
+                minTimes = 0;
+                result = db.getTable(tblId);
+
+                globalStateMgr.getLocalMetastore().getTable(testDbName, "unknown_tbl");
+                minTimes = 0;
+                result = null;
             }
         };
 
@@ -242,8 +250,7 @@ public class BackupJobPrimaryKeyTest {
         List<String> partNames = Lists.newArrayList(backupTbl.getPartitionNames());
         Assert.assertNotNull(backupTbl);
         Assert.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
-                    ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tblId)).getSignature(
-                                BackupHandler.SIGNATURE_VERSION, partNames, true));
+                ((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum());
         AgentTask task = AgentTaskQueue.getTask(backendId, TTaskType.MAKE_SNAPSHOT, tabletId);
         Assert.assertTrue(task instanceof SnapshotTask);
@@ -329,9 +336,8 @@ public class BackupJobPrimaryKeyTest {
             Assert.assertNotNull(olapTable);
             Assert.assertNotNull(restoreMetaInfo.getTable(testTableName));
             List<String> names = Lists.newArrayList(olapTable.getPartitionNames());
-            Assert.assertEquals(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(db.getId(), tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, names, true),
-                        olapTable.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
+            Assert.assertEquals(((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, names, true),
+                    olapTable.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
 
             restoreJobInfo = BackupJobInfo.fromFile(job.getLocalJobInfoFilePath());
             Assert.assertEquals(testDbName, restoreJobInfo.dbName);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
@@ -172,6 +172,8 @@ public class BackupJobTest {
                 minTimes = 0;
                 result = db;
 
+
+
                 globalStateMgr.getNextId();
                 minTimes = 0;
                 result = id.getAndIncrement();
@@ -179,6 +181,14 @@ public class BackupJobTest {
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;
+
+                globalStateMgr.getLocalMetastore().getTable("testDb", "testTable");
+                minTimes = 0;
+                result = db.getTable(tblId);
+
+                globalStateMgr.getLocalMetastore().getTable("testDb", "unknown_tbl");
+                minTimes = 0;
+                result = null;
             }
         };
 
@@ -233,8 +243,7 @@ public class BackupJobTest {
         List<String> partNames = Lists.newArrayList(backupTbl.getPartitionNames());
         Assert.assertNotNull(backupTbl);
         Assert.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
-                    ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tblId)).getSignature(
-                                BackupHandler.SIGNATURE_VERSION, partNames, true));
+                ((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum());
         AgentTask task = AgentTaskQueue.getTask(backendId, TTaskType.MAKE_SNAPSHOT, tabletId);
         Assert.assertTrue(task instanceof SnapshotTask);
@@ -323,9 +332,8 @@ public class BackupJobTest {
             Assert.assertNotNull(olapTable);
             Assert.assertNotNull(restoreMetaInfo.getTable(UnitTestUtil.TABLE_NAME));
             List<String> names = Lists.newArrayList(olapTable.getPartitionNames());
-            Assert.assertEquals(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(db.getId(), tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, names, true),
-                        olapTable.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
+            Assert.assertEquals(((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, names, true),
+                    olapTable.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
 
             restoreJobInfo = BackupJobInfo.fromFile(job.getLocalJobInfoFilePath());
             Assert.assertEquals(UnitTestUtil.DB_NAME, restoreJobInfo.dbName);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -531,19 +531,19 @@ public class CatalogMocker {
 
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb(TEST_DB_NAME);
+                globalStateMgr.getLocalMetastore().getDb(TEST_DB_NAME);
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb(WRONG_DB);
+                globalStateMgr.getLocalMetastore().getDb(WRONG_DB);
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getDb(TEST_DB_ID);
+                globalStateMgr.getLocalMetastore().getDb(TEST_DB_ID);
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = new Database();
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -85,7 +85,6 @@ import static com.starrocks.common.util.UnitTestUtil.DB_NAME;
 import static com.starrocks.common.util.UnitTestUtil.MATERIALIZED_VIEW_NAME;
 import static com.starrocks.common.util.UnitTestUtil.TABLE_NAME;
 
-
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class RestoreJobMaterializedViewTest {
 
@@ -112,7 +111,6 @@ public class RestoreJobMaterializedViewTest {
     private MockRepositoryMgr repoMgr;
 
     private MvRestoreContext mvRestoreContext;
-
 
     // Thread is not mockable in Jmockit, use subclass instead
     private final class MockBackupHandler extends BackupHandler {
@@ -147,11 +145,12 @@ public class RestoreJobMaterializedViewTest {
 
     @Injectable
     private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
-            new BlobStorage("broker", Maps.newHashMap()));
+                new BlobStorage("broker", Maps.newHashMap()));
 
     private BackupMeta backupMeta;
 
     private Object[] arrayIds;
+
     private void setUpMocker() {
         MetricRepo.init();
 
@@ -164,7 +163,7 @@ public class RestoreJobMaterializedViewTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
 
@@ -176,7 +175,7 @@ public class RestoreJobMaterializedViewTest {
                 minTimes = 0;
                 result = systemInfoService;
 
-                globalStateMgr.mayGetDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = Optional.of(db);
 
@@ -225,24 +224,24 @@ public class RestoreJobMaterializedViewTest {
             }
         };
         new MockUp<MarkedCountDownLatch>() {
-                @Mock
-                boolean await(long timeout, TimeUnit unit) {
-                    return true;
-                }
-            };
+            @Mock
+            boolean await(long timeout, TimeUnit unit) {
+                return true;
+            }
+        };
 
         new MockUp<ConnectContext>() {
-                @Mock
-                GlobalStateMgr getGlobalStateMgr() {
-                    return globalStateMgr;
-                }
-            };
+            @Mock
+            GlobalStateMgr getGlobalStateMgr() {
+                return globalStateMgr;
+            }
+        };
         new MockUp<GlobalStateMgr>() {
-                @Mock
-                BackupHandler getBackupHandler() {
-                    return backupHandler;
-                }
-            };
+            @Mock
+            BackupHandler getBackupHandler() {
+                return backupHandler;
+            }
+        };
 
         new MockUp<HdfsUtil>() {
             @Mock
@@ -259,7 +258,7 @@ public class RestoreJobMaterializedViewTest {
         Deencapsulation.setField(globalStateMgr, "backupHandler", backupHandler);
         systemInfoService = new SystemInfoService();
         db = UnitTestUtil.createDbWithMaterializedView(dbId, tblId, partId, idxId, tabletId,
-                backendId, version, KeysType.DUP_KEYS);
+                    backendId, version, KeysType.DUP_KEYS);
         mvRestoreContext = new MvRestoreContext();
         setUpMocker();
     }
@@ -302,7 +301,8 @@ public class RestoreJobMaterializedViewTest {
 
         List<Table> tbls = Lists.newArrayList();
         for (String tbl : restoreTbls) {
-            OlapTable baseTable = (OlapTable) db.getTable(tbl);
+            OlapTable baseTable =
+                        (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tbl);
             BackupTableInfo baseTblInfo = mockBackupTableInfo(baseTable);
             jobInfo.tables.put(baseTblInfo.name, baseTblInfo);
             tbls.add(baseTable);
@@ -315,8 +315,8 @@ public class RestoreJobMaterializedViewTest {
         }
 
         RestoreJob job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, mvRestoreContext);
+                    jobInfo, false, 3, 100000,
+                    globalStateMgr, repo.getId(), backupMeta, mvRestoreContext);
         job.setRepo(repo);
 
         // add job into mvRestoreContext
@@ -358,7 +358,7 @@ public class RestoreJobMaterializedViewTest {
             TStatus taskStatus = new TStatus(TStatusCode.OK);
             TBackend tBackend = new TBackend("", 0, 1);
             TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
-                    task.getSignature(), taskStatus);
+                        task.getSignature(), taskStatus);
             request.setSnapshot_path(snapshotPath);
             Assert.assertTrue(job.finishTabletSnapshotTask(task, request));
         }
@@ -391,7 +391,7 @@ public class RestoreJobMaterializedViewTest {
             TStatus taskStatus = new TStatus(TStatusCode.OK);
             TBackend tBackend = new TBackend("", 0, 1);
             TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
-                    agentTask.getSignature(), taskStatus);
+                        agentTask.getSignature(), taskStatus);
             request.setDownloaded_tablet_ids(downloadedTabletIds);
             Assert.assertTrue(job.finishTabletDownloadTask((DownloadTask) agentTask, request));
         }
@@ -423,7 +423,7 @@ public class RestoreJobMaterializedViewTest {
             TStatus taskStatus = new TStatus(TStatusCode.OK);
             TBackend tBackend = new TBackend("", 0, 1);
             TFinishTaskRequest request = new TFinishTaskRequest(tBackend, TTaskType.MAKE_SNAPSHOT,
-                    agentTask.getSignature(), taskStatus);
+                        agentTask.getSignature(), taskStatus);
             job.finishDirMoveTask((DirMoveTask) agentTask, request);
         }
 
@@ -489,7 +489,7 @@ public class RestoreJobMaterializedViewTest {
         new MockUp<MetadataMgr>() {
             @Mock
             public Table getTable(String catalogName, String dbName, String tblName) {
-                return db.getTable(tblName);
+                return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tblName);
             }
         };
         // gen BackupJobInfo
@@ -504,7 +504,7 @@ public class RestoreJobMaterializedViewTest {
     }
 
     private void assertMVActiveEquals(String mvName, boolean expect) {
-        Table mvTable = db.getTable(mvName);
+        Table mvTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName);
         Assert.assertTrue(mvTable != null);
         Assert.assertTrue(mvTable.isMaterializedView());
         MaterializedView mv = (MaterializedView) mvTable;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -151,10 +151,6 @@ public class RestoreJobPrimaryKeyTest {
 
         new Expectations() {
             {
-                globalStateMgr.getLocalMetastore().getDb(anyLong);
-                minTimes = 0;
-                result = db;
-
                 globalStateMgr.getNextId();
                 minTimes = 0;
                 result = id.getAndIncrement();
@@ -230,8 +226,7 @@ public class RestoreJobPrimaryKeyTest {
         jobInfo.name = label;
         jobInfo.success = true;
 
-        expectedRestoreTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getId(), CatalogMocker.TEST_TBL3_ID);
+        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL3_ID);
         BackupTableInfo tblInfo = new BackupTableInfo();
         tblInfo.id = CatalogMocker.TEST_TBL3_ID;
         tblInfo.name = CatalogMocker.TEST_TBL3_NAME;
@@ -388,8 +383,7 @@ public class RestoreJobPrimaryKeyTest {
         sig2.update("name1".getBytes());
         System.out.println("sig2: " + Math.abs((int) sig2.getValue()));
 
-        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getFullName(), CatalogMocker.TEST_TBL_NAME);
+        OlapTable tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
         List<String> partNames = Lists.newArrayList(tbl.getPartitionNames());
         System.out.println(partNames);
         System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -152,7 +152,8 @@ public class RestoreJobTest {
     }
 
     public void testResetPartitionForRestore() {
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+        expectedRestoreTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), CatalogMocker.TEST_TBL4_ID);
 
         OlapTable localTbl = new OlapTable(expectedRestoreTbl.getId(), expectedRestoreTbl.getName(),
                     expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
@@ -169,7 +170,7 @@ public class RestoreJobTest {
     public void testRunBackupMultiSubPartitionTable() {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
 
@@ -250,7 +251,8 @@ public class RestoreJobTest {
         jobInfo.name = label;
         jobInfo.success = true;
 
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+        expectedRestoreTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), CatalogMocker.TEST_TBL4_ID);
         BackupTableInfo tblInfo = new BackupTableInfo();
         tblInfo.id = CatalogMocker.TEST_TBL4_ID;
         tblInfo.name = CatalogMocker.TEST_TBL4_NAME;
@@ -344,7 +346,7 @@ public class RestoreJobTest {
     public void testRunBackupRangeTable() {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
 
@@ -424,7 +426,8 @@ public class RestoreJobTest {
         jobInfo.name = label;
         jobInfo.success = true;
 
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
+        expectedRestoreTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), CatalogMocker.TEST_TBL2_ID);
         BackupTableInfo tblInfo = new BackupTableInfo();
         tblInfo.id = CatalogMocker.TEST_TBL2_ID;
         tblInfo.name = CatalogMocker.TEST_TBL2_NAME;
@@ -515,7 +518,8 @@ public class RestoreJobTest {
 
         Locker locker = new Locker();
 
-        OlapTable tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), CatalogMocker.TEST_TBL_NAME);
         List<String> partNames = Lists.newArrayList(tbl.getPartitionNames());
         System.out.println(partNames);
         System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
@@ -528,7 +532,8 @@ public class RestoreJobTest {
     public void testColocateRestore() {
         Config.enable_colocate_restore = true;
 
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+        expectedRestoreTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), CatalogMocker.TEST_TBL4_ID);
 
         expectedRestoreTbl.resetIdsForRestore(globalStateMgr, db, 3, null);
 

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRefreshConcurrencyTest.java
@@ -123,9 +123,9 @@ public class MvRefreshConcurrencyTest extends MvRewriteTestBase {
                     System.out.println(sql);
                     starRocksAssert.withMaterializedView(sql);
 
-                    Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                     String mvName = buildMVName(i);
-                    Table table = db.getTable(mvName);
+                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName);
                     Assert.assertTrue(table != null);
                     mvs.add((MaterializedView) table);
                     starRocksAssert.useDatabase("test");

--- a/fe/fe-core/src/test/java/com/starrocks/binlog/BinlogManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/binlog/BinlogManagerTest.java
@@ -55,8 +55,9 @@ public class BinlogManagerTest {
 
     @Test
     public void testTryEnableBinlog() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("binlog_test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "binlog_test");
         boolean result = binlogManager.tryEnableBinlog(db, table.getId(), 200L, -1L);
         Assert.assertTrue(result);
         Assert.assertEquals(1, table.getBinlogVersion());
@@ -68,16 +69,18 @@ public class BinlogManagerTest {
 
     @Test
     public void testTryDisableBinlog() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("binlog_test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "binlog_test");
         boolean result = binlogManager.tryDisableBinlog(db, table.getId());
         Assert.assertFalse(table.isBinlogEnabled());
     }
 
     @Test
     public void testCheckAndSetBinlogAvailableVersion() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("binlog_test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "binlog_test");
         table.setBinlogTxnId(2);
         long totalNum = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletIdsByBackendId(10001).size();
         binlogManager.checkAndSetBinlogAvailableVersion(db, table, 1, 10002);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/AdminStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/AdminStmtTest.java
@@ -86,9 +86,9 @@ public class AdminStmtTest {
 
     @Test
     public void testAdminSetReplicaStatus() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         Assert.assertNotNull(db);
-        OlapTable tbl = (OlapTable) db.getTable("tbl1");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         Assert.assertNotNull(tbl);
         // tablet id, backend id
         List<Pair<Long, Long>> tabletToBackendList = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -57,8 +57,8 @@ public class CatalogRecycleBinLakeTableTest {
     private static Table createTable(ConnectContext connectContext, String sql) throws Exception {
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb(createTableStmt.getDbName());
-        return db.getTable(createTableStmt.getTableName());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(createTableStmt.getDbName());
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), createTableStmt.getTableName());
     }
 
     private static void dropTable(ConnectContext connectContext, String sql) throws Exception {
@@ -215,7 +215,7 @@ public class CatalogRecycleBinLakeTableTest {
 
         // Recover table2
         Assert.assertTrue(recycleBin.recoverTable(db, "t0"));
-        Assert.assertSame(table2, db.getTable("t0"));
+        Assert.assertSame(table2, GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0"));
         Assert.assertNull(recycleBin.getTable(db.getId(), table2.getId()));
         checkTableTablet(table2, true);
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.starrocks.lake.LakeTable;
@@ -58,13 +57,13 @@ public class ColocateTableIndexTest {
 
     /**
      * [
-     *   [10002.10006, 10002_group1, 10004, 10016, 4, 1, int(11), true],
-     *   [10026.10030, 10026_group2, 10028, 4, 1, int(11), true]
-     *  ]
+     * [10002.10006, 10002_group1, 10004, 10016, 4, 1, int(11), true],
+     * [10026.10030, 10026_group2, 10028, 4, 1, int(11), true]
+     * ]
      * ->
      * {
-     *   'group1': [10002.10006, 10002_group1, 10004, 10016, 4, 1, int(11), true],
-     *   'group2': [10026.10030, 10026_group2, 10028, 4, 1, int(11), true]
+     * 'group1': [10002.10006, 10002_group1, 10004, 10016, 4, 1, int(11), true],
+     * 'group2': [10026.10030, 10026_group2, 10028, 4, 1, int(11), true]
      * }
      */
     private Map<String, List<String>> groupByName(List<List<String>> lists) {
@@ -86,33 +85,33 @@ public class ColocateTableIndexTest {
 
         // create table1_1->group1
         String sql = "CREATE TABLE db1.table1_1 (k1 int, k2 int, k3 varchar(32))\n" +
-                "PRIMARY KEY(k1)\n" +
-                "DISTRIBUTED BY HASH(k1)\n" +
-                "BUCKETS 4\n" +
-                "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
+                    "PRIMARY KEY(k1)\n" +
+                    "DISTRIBUTED BY HASH(k1)\n" +
+                    "BUCKETS 4\n" +
+                    "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         List<List<String>> infos = GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos();
         // group1->table1To1
         Assert.assertEquals(1, infos.size());
         Map<String, List<String>> map = groupByName(infos);
-        Table table1To1 = GlobalStateMgr.getCurrentState().getDb("db1").getTable("table1_1");
+        Table table1To1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1").getTable("table1_1");
         Assert.assertEquals(String.format("%d", table1To1.getId()), map.get("group1").get(2));
         LOG.info("after create db1.table1_1: {}", infos);
 
         // create table1_2->group1
         sql = "CREATE TABLE db1.table1_2 (k1 int, k2 int, k3 varchar(32))\n" +
-                "PRIMARY KEY(k1)\n" +
-                "DISTRIBUTED BY HASH(k1)\n" +
-                "BUCKETS 4\n" +
-                "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
+                    "PRIMARY KEY(k1)\n" +
+                    "DISTRIBUTED BY HASH(k1)\n" +
+                    "BUCKETS 4\n" +
+                    "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
         createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         // group1 -> table1To1, table1To2
         infos = GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos();
         Assert.assertEquals(1, infos.size());
         map = groupByName(infos);
-        Table table1To2 = GlobalStateMgr.getCurrentState().getDb("db1").getTable("table1_2");
+        Table table1To2 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1").getTable("table1_2");
         Assert.assertEquals(String.format("%d, %d", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
         LOG.info("after create db1.table1_2: {}", infos);
 
@@ -122,10 +121,10 @@ public class ColocateTableIndexTest {
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
         // create table2_1 -> group2
         sql = "CREATE TABLE db2.table2_1 (k1 int, k2 int, k3 varchar(32))\n" +
-                "PRIMARY KEY(k1)\n" +
-                "DISTRIBUTED BY HASH(k1)\n" +
-                "BUCKETS 4\n" +
-                "PROPERTIES(\"colocate_with\"=\"group2\", \"replication_num\" = \"1\");\n";
+                    "PRIMARY KEY(k1)\n" +
+                    "DISTRIBUTED BY HASH(k1)\n" +
+                    "BUCKETS 4\n" +
+                    "PROPERTIES(\"colocate_with\"=\"group2\", \"replication_num\" = \"1\");\n";
         createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         // group1 -> table1_1, table1_2
@@ -134,7 +133,7 @@ public class ColocateTableIndexTest {
         Assert.assertEquals(2, infos.size());
         map = groupByName(infos);
         Assert.assertEquals(String.format("%d, %d", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
-        Table table2To1 = GlobalStateMgr.getCurrentState().getDb("db2").getTable("table2_1");
+        Table table2To1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2").getTable("table2_1");
         Assert.assertEquals(String.format("%d", table2To1.getId()), map.get("group2").get(2));
         LOG.info("after create db2.table2_1: {}", infos);
 
@@ -162,11 +161,10 @@ public class ColocateTableIndexTest {
         Assert.assertEquals(2, infos.size());
         Assert.assertEquals(String.format("%d*, %d*", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
         Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
-                map.get("group1").get(3));
+                    map.get("group1").get(3));
 
         Assert.assertEquals(String.format("%d", table2To1.getId()), map.get("group2").get(2));
         Assert.assertEquals(String.format("table2_1", table2To1.getId()), map.get("group2").get(3));
-
 
         LOG.info("after drop db1.table1_2: {}", infos);
 
@@ -189,13 +187,13 @@ public class ColocateTableIndexTest {
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
         // create table2_1 -> group2
         sql = "CREATE TABLE db2.table2_3 (k1 int, k2 int, k3 varchar(32))\n" +
-                "PRIMARY KEY(k1)\n" +
-                "DISTRIBUTED BY HASH(k1)\n" +
-                "BUCKETS 4\n" +
-                "PROPERTIES(\"colocate_with\"=\"group3\", \"replication_num\" = \"1\");\n";
+                    "PRIMARY KEY(k1)\n" +
+                    "DISTRIBUTED BY HASH(k1)\n" +
+                    "BUCKETS 4\n" +
+                    "PROPERTIES(\"colocate_with\"=\"group3\", \"replication_num\" = \"1\");\n";
         createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Table table2To3 = GlobalStateMgr.getCurrentState().getDb("db2").getTable("table2_3");
+        Table table2To3 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2").getTable("table2_3");
         sql = "DROP DATABASE db2;";
         dropDbStmt = (DropDbStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getMetadata().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
@@ -207,10 +205,10 @@ public class ColocateTableIndexTest {
         Assert.assertEquals("[deleted], [deleted]", map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To1.getId()), map.get("group2").get(2));
         Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
-                map.get("group1").get(3));
+                    map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To3.getId()), map.get("group3").get(2));
         Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
-                map.get("group1").get(3));
+                    map.get("group1").get(3));
     }
 
     @Test
@@ -221,31 +219,31 @@ public class ColocateTableIndexTest {
         // create goodDb
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database goodDb;", connectContext);
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
-        Database goodDb = GlobalStateMgr.getCurrentState().getDb("goodDb");
+        Database goodDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("goodDb");
         // create goodtable
         String sql = "CREATE TABLE " +
-                "goodDb.goodTable (k1 int, k2 int, k3 varchar(32))\n" +
-                "PRIMARY KEY(k1)\n" +
-                "DISTRIBUTED BY HASH(k1)\n" +
-                "BUCKETS 4\n" +
-                "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
+                    "goodDb.goodTable (k1 int, k2 int, k3 varchar(32))\n" +
+                    "PRIMARY KEY(k1)\n" +
+                    "DISTRIBUTED BY HASH(k1)\n" +
+                    "BUCKETS 4\n" +
+                    "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        OlapTable table = (OlapTable) goodDb.getTable("goodTable");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(goodDb.getFullName(), "goodTable");
         ColocateTableIndex.GroupId goodGroup = GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId());
-
 
         // create a bad db
         long badDbId = 4000;
         table.id = 4001;
         table.name = "goodTableOfBadDb";
         colocateTableIndex.addTableToGroup(
-                badDbId, table, "badGroupOfBadDb", new ColocateTableIndex.GroupId(badDbId, 4002), false);
+                    badDbId, table, "badGroupOfBadDb", new ColocateTableIndex.GroupId(badDbId, 4002), false);
         // create a bad table in good db
         table.id = 4003;
         table.name = "badTable";
         colocateTableIndex.addTableToGroup(
-                goodDb.getId(), table, "badGroupOfBadTable", new ColocateTableIndex.GroupId(goodDb.getId(), 4004), false);
+                    goodDb.getId(), table, "badGroupOfBadTable", new ColocateTableIndex.GroupId(goodDb.getId(), 4004), false);
 
         Map<String, List<String>> map = groupByName(GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos());
         Assert.assertTrue(map.containsKey("goodGroup"));
@@ -299,10 +297,11 @@ public class ColocateTableIndexTest {
         };
 
         colocateTableIndex.addTableToGroup(
-                dbId, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId, 10000), false /* isReplay */);
+                    dbId, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId, 10000), false /* isReplay */);
         Assert.assertTrue(colocateTableIndex.isLakeColocateTable(tableId));
         colocateTableIndex.addTableToGroup(
-                dbId2, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId2, 10000), false /* isReplay */);
+                    dbId2, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId2, 10000),
+                    false /* isReplay */);
         Assert.assertTrue(colocateTableIndex.isLakeColocateTable(tableId));
 
         Assert.assertTrue(colocateTableIndex.isGroupUnstable(new ColocateTableIndex.GroupId(dbId, 10000)));
@@ -319,19 +318,19 @@ public class ColocateTableIndexTest {
 
         // create goodDb
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils
-                .parseStmtWithNewParser("create database db_image;", connectContext);
+                    .parseStmtWithNewParser("create database db_image;", connectContext);
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
-        Database db = GlobalStateMgr.getCurrentState().getDb("db_image");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_image");
         // create goodtable
         String sql = "CREATE TABLE " +
-                "db_image.tbl1 (k1 int, k2 int, k3 varchar(32))\n" +
-                "PRIMARY KEY(k1)\n" +
-                "DISTRIBUTED BY HASH(k1)\n" +
-                "BUCKETS 4\n" +
-                "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
+                    "db_image.tbl1 (k1 int, k2 int, k3 varchar(32))\n" +
+                    "PRIMARY KEY(k1)\n" +
+                    "DISTRIBUTED BY HASH(k1)\n" +
+                    "BUCKETS 4\n" +
+                    "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        OlapTable table = (OlapTable) db.getTable("tbl1");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
         colocateTableIndex.saveColocateTableIndexV2(image.getImageWriter());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
@@ -110,8 +110,8 @@ public class ColocateTableTest {
                 ");");
 
         ColocateTableIndex index = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        Database db = GlobalStateMgr.getCurrentState().getDb(fullDbName);
-        long tableId = db.getTable(tableName1).getId();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(fullDbName);
+        long tableId = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName1).getId();
 
         Assert.assertEquals(1, Deencapsulation.<Multimap<GroupId, Long>>getField(index, "group2Tables").size());
         Assert.assertEquals(1, index.getAllGroupIds().size());
@@ -168,9 +168,9 @@ public class ColocateTableTest {
                 ");");
 
         ColocateTableIndex index = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        Database db = GlobalStateMgr.getCurrentState().getDb(fullDbName);
-        long firstTblId = db.getTable(tableName1).getId();
-        long secondTblId = db.getTable(tableName2).getId();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(fullDbName);
+        long firstTblId = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName1).getId();
+        long secondTblId = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName2).getId();
 
         Assert.assertEquals(2, Deencapsulation.<Multimap<GroupId, Long>>getField(index, "group2Tables").size());
         Assert.assertEquals(1, index.getAllGroupIds().size());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableLikeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableLikeTest.java
@@ -76,7 +76,7 @@ public class CreateTableLikeTest {
 
     private static void createTableLike(String sql) throws Exception {
         CreateTableLikeStmt createTableLikeStmt =
-                (CreateTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    (CreateTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableLikeStmt.getCreateTableStmt());
     }
 
@@ -86,7 +86,7 @@ public class CreateTableLikeTest {
         List<String> existedTableStmt = Lists.newArrayList();
         AstToStringBuilder.getDdlStmt(existedTable, existedTableStmt, null, null, false, true /* hide password */);
         Assert.assertEquals(newCreateTableStmt.get(0).replace(newTable.getName(), existedTable.getName()),
-                existedTableStmt.get(0));
+                    existedTableStmt.get(0));
     }
 
     private static void checkCreateOlapTableLike(String createTableSql, String createTableLikeSql,
@@ -94,10 +94,12 @@ public class CreateTableLikeTest {
                                                  String newTblName, String existedTblName) throws Exception {
         createTable(createTableSql);
         createTableLike(createTableLikeSql);
-        Database newDb = GlobalStateMgr.getCurrentState().getDb(newDbName);
-        Database existedDb = GlobalStateMgr.getCurrentState().getDb(existedDbName);
-        OlapTable newTbl = (OlapTable) newDb.getTable(newTblName);
-        OlapTable existedTbl = (OlapTable) existedDb.getTable(existedTblName);
+        Database newDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(newDbName);
+        Database existedDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(existedDbName);
+        OlapTable newTbl =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(newDb.getFullName(), newTblName);
+        OlapTable existedTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(existedDb.getFullName(), existedTblName);
         checkTableEqual(newTbl, existedTbl);
     }
 
@@ -107,10 +109,12 @@ public class CreateTableLikeTest {
 
         createTable(createTableSql);
         createTableLike(createTableLikeSql);
-        Database newDb = GlobalStateMgr.getCurrentState().getDb(newDbName);
-        Database existedDb = GlobalStateMgr.getCurrentState().getDb(existedDbName);
-        MysqlTable newTbl = (MysqlTable) newDb.getTable(newTblName);
-        MysqlTable existedTbl = (MysqlTable) existedDb.getTable(existedTblName);
+        Database newDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(newDbName);
+        Database existedDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(existedDbName);
+        MysqlTable newTbl =
+                    (MysqlTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(newDb.getFullName(), newTblName);
+        MysqlTable existedTbl = (MysqlTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(existedDb.getFullName(), existedTblName);
         checkTableEqual(newTbl, existedTbl);
     }
 
@@ -118,7 +122,7 @@ public class CreateTableLikeTest {
     public void testNormal() throws Exception {
         // 1. creat table with single partition
         String createTableSql = "create table test.testTbl1\n" + "(k1 int, k2 int)\n" + "duplicate key(k1)\n"
-                + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
+                    + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
         String createTableLikeSql = "create table test.testTbl1_like like test.testTbl1";
         String newDbName = "test";
         String newTblName = "testTbl1_like";
@@ -126,157 +130,158 @@ public class CreateTableLikeTest {
         checkCreateOlapTableLike(createTableSql, createTableLikeSql, newDbName, newDbName, newTblName, existedTblName);
         // 2. create table with hash partition
         String createTableWithHashPartitionSql = "create table test.testTbl2\n" + "(k1 int, k2 int)\n"
-                + "duplicate key(k1)\n" + "partition by range(k2)\n" + "(partition p1 values less than(\"10\"))\n"
-                + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
+                    + "duplicate key(k1)\n" + "partition by range(k2)\n" + "(partition p1 values less than(\"10\"))\n"
+                    + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
         String createTableLikeSql2 = "create table test.testTbl2_like like test.testTbl2";
         String newDbName2 = "test";
         String newTblName2 = "testTbl2_like";
         String existedTblName2 = "testTbl2";
         checkCreateOlapTableLike(createTableWithHashPartitionSql, createTableLikeSql2, newDbName2, newDbName2,
-                newTblName2, existedTblName2);
+                    newTblName2, existedTblName2);
         // 3. create aggregate table
         String createAggTableSql3 = "create table test.testTbl3\n" + "(k1 varchar(40), k2 int, v1 int sum)\n"
-                + "partition by range(k2)\n" + "(partition p1 values less than(\"10\"))\n"
-                + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1');";
+                    + "partition by range(k2)\n" + "(partition p1 values less than(\"10\"))\n"
+                    + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1');";
         String createTableLikeSql3 = "create table test.testTbl3_like like test.testTbl3";
         String newDbName3 = "test";
         String newTblName3 = "testTbl3_like";
         String existedTblName3 = "testTbl3";
         checkCreateOlapTableLike(createAggTableSql3, createTableLikeSql3, newDbName3, newDbName3, newTblName3,
-                existedTblName3);
+                    existedTblName3);
         // 4. create aggregate table without partition
         String createAggTableWithoutPartitionSql4 =
-                "create table test.testTbl4\n" + "(k1 varchar(40), k2 int, k3 int)\n" + "duplicate key(k1, k2, k3)\n"
-                        + "partition by range(k2)\n" + "()\n"
-                        + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1');";
+                    "create table test.testTbl4\n" + "(k1 varchar(40), k2 int, k3 int)\n" + "duplicate key(k1, k2, k3)\n"
+                                + "partition by range(k2)\n" + "()\n"
+                                + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1');";
         String createTableLikeSql4 = "create table test.testTbl4_like like test.testTbl4";
         String newDbName4 = "test";
         String newTblName4 = "testTbl4_like";
         String existedTblName4 = "testTbl4";
         checkCreateOlapTableLike(createAggTableWithoutPartitionSql4, createTableLikeSql4, newDbName4, newDbName4,
-                newTblName4, existedTblName4);
+                    newTblName4, existedTblName4);
         // 5. create table from different db
         String createTableFromDiffDb5 =
-                "create table test.testTbl5\n" + "(k1 varchar(40), k2 int, k3 int)\n" + "duplicate key(k1, k2, k3)\n"
-                        + "partition by range(k2)\n" + "()\n"
-                        + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1');";
+                    "create table test.testTbl5\n" + "(k1 varchar(40), k2 int, k3 int)\n" + "duplicate key(k1, k2, k3)\n"
+                                + "partition by range(k2)\n" + "()\n"
+                                + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1');";
         String createTableLikeSql5 = "create table test2.testTbl5_like like test.testTbl5";
         String newDbName5 = "test2";
         String existedDbName5 = "test";
         String newTblName5 = "testTbl5_like";
         String existedTblName5 = "testTbl5";
         checkCreateOlapTableLike(createTableFromDiffDb5, createTableLikeSql5, newDbName5, existedDbName5, newTblName5,
-                existedTblName5);
+                    existedTblName5);
         // 6. create table from dynamic partition table
         String createDynamicTblSql = "CREATE TABLE test.`dynamic_partition_normal` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"false\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");";
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"false\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");";
         String createTableLikeSql6 =
-                "create table test.dynamic_partition_normal_like like test.dynamic_partition_normal";
+                    "create table test.dynamic_partition_normal_like like test.dynamic_partition_normal";
         String newDbName6 = "test";
         String newTblName6 = "dynamic_partition_normal_like";
         String existedTblName6 = "dynamic_partition_normal";
         checkCreateOlapTableLike(createDynamicTblSql, createTableLikeSql6, newDbName6, newDbName6, newTblName6,
-                existedTblName6);
+                    existedTblName6);
         // 7. create table from colocate table
         String createColocateTblSql = "create table test.colocateTbl (\n" +
-                " `k1` int NULL COMMENT \"\",\n" +
-                " `k2` varchar(10) NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1\n" +
-                "PROPERTIES (\n" +
-                " \"replication_num\" = \"1\",\n" +
-                " \"colocate_with\" = \"test_group\"\n" +
-                ");";
+                    " `k1` int NULL COMMENT \"\",\n" +
+                    " `k2` varchar(10) NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1\n" +
+                    "PROPERTIES (\n" +
+                    " \"replication_num\" = \"1\",\n" +
+                    " \"colocate_with\" = \"test_group\"\n" +
+                    ");";
         String createTableLikeSql7 = "create table test.colocateTbl_like like test.colocateTbl";
         String newDbName7 = "test";
         String newTblName7 = "colocateTbl_like";
         String existedTblName7 = "colocateTbl";
         checkCreateOlapTableLike(createColocateTblSql, createTableLikeSql7, newDbName7, newDbName7, newTblName7,
-                existedTblName7);
+                    existedTblName7);
         // 8. creat non-OLAP table
         String createNonOlapTableSql = "create table test.testMysqlTbl\n" +
-                "(k1 DATE, k2 INT, k3 SMALLINT, k4 VARCHAR(2048), k5 DATETIME)\n" +
-                "ENGINE=mysql\nPROPERTIES(\n" +
-                "\"host\" = \"127.0.0.1\",\n" +
-                "\"port\" = \"8239\",\n" +
-                "\"user\" = \"mysql_passwd\",\n" +
-                "\"password\" = \"mysql_passwd\",\n" +
-                "\"database\" = \"mysql_db_test\",\n" +
-                "\"table\" = \"mysql_table_test\");";
+                    "(k1 DATE, k2 INT, k3 SMALLINT, k4 VARCHAR(2048), k5 DATETIME)\n" +
+                    "ENGINE=mysql\nPROPERTIES(\n" +
+                    "\"host\" = \"127.0.0.1\",\n" +
+                    "\"port\" = \"8239\",\n" +
+                    "\"user\" = \"mysql_passwd\",\n" +
+                    "\"password\" = \"mysql_passwd\",\n" +
+                    "\"database\" = \"mysql_db_test\",\n" +
+                    "\"table\" = \"mysql_table_test\");";
         String createTableLikeSql8 = "create table test.testMysqlTbl_like like test.testMysqlTbl";
         String newDbName8 = "test";
         String existedDbName8 = "test";
         String newTblName8 = "testMysqlTbl_like";
         String existedTblName8 = "testMysqlTbl";
         checkCreateMysqlTableLike(createNonOlapTableSql, createTableLikeSql8, newDbName8, existedDbName8, newTblName8,
-                existedTblName8);
+                    existedTblName8);
         // 9. create automatic table
         String automaticTableSql = "CREATE TABLE test.`duplicate_table_with_null` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` datetime NULL COMMENT \"\",\n" +
-                "  `k3` char(20) NULL COMMENT \"\",\n" +
-                "  `k4` varchar(20) NULL COMMENT \"\",\n" +
-                "  `k5` boolean NULL COMMENT \"\",\n" +
-                "  `k6` tinyint(4) NULL COMMENT \"\",\n" +
-                "  `k7` smallint(6) NULL COMMENT \"\",\n" +
-                "  `k8` int(11) NULL COMMENT \"\",\n" +
-                "  `k9` bigint(20) NULL COMMENT \"\",\n" +
-                "  `k10` largeint(40) NULL COMMENT \"\",\n" +
-                "  `k11` float NULL COMMENT \"\",\n" +
-                "  `k12` double NULL COMMENT \"\",\n" +
-                "  `k13` decimal128(27, 9) NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP \n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY date_trunc('day', k1)\n" +
-                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 2 \n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"in_memory\" = \"false\",\n" +
-                "\"enable_persistent_index\" = \"false\",\n" +
-                "\"replicated_storage\" = \"true\",\n" +
-                "\"compression\" = \"LZ4\"\n" +
-                ");";
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` datetime NULL COMMENT \"\",\n" +
+                    "  `k3` char(20) NULL COMMENT \"\",\n" +
+                    "  `k4` varchar(20) NULL COMMENT \"\",\n" +
+                    "  `k5` boolean NULL COMMENT \"\",\n" +
+                    "  `k6` tinyint(4) NULL COMMENT \"\",\n" +
+                    "  `k7` smallint(6) NULL COMMENT \"\",\n" +
+                    "  `k8` int(11) NULL COMMENT \"\",\n" +
+                    "  `k9` bigint(20) NULL COMMENT \"\",\n" +
+                    "  `k10` largeint(40) NULL COMMENT \"\",\n" +
+                    "  `k11` float NULL COMMENT \"\",\n" +
+                    "  `k12` double NULL COMMENT \"\",\n" +
+                    "  `k13` decimal128(27, 9) NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP \n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY date_trunc('day', k1)\n" +
+                    "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 2 \n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"in_memory\" = \"false\",\n" +
+                    "\"enable_persistent_index\" = \"false\",\n" +
+                    "\"replicated_storage\" = \"true\",\n" +
+                    "\"compression\" = \"LZ4\"\n" +
+                    ");";
         String createTableLikeSql9 = "create table test.table_like_02 like test.duplicate_table_with_null;";
         String newDbName9 = "test";
         String existedDbName9 = "test";
         String newTblName9 = "duplicate_table_with_null";
         String existedTblName9 = "table_like_02";
         checkCreateOlapTableLike(automaticTableSql, createTableLikeSql9, newDbName9, existedDbName9, newTblName9,
-                existedTblName9);
+                    existedTblName9);
 
         // 10. create table like with properties
         String sql = "create table test.table_like_10 " +
-                "distributed by random buckets 7 " +
-                "properties('replication_num'='1') " +
-                "like test.duplicate_table_with_null";
+                    "distributed by random buckets 7 " +
+                    "properties('replication_num'='1') " +
+                    "like test.duplicate_table_with_null";
         createTableLike(sql);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb(newDbName).getTable("table_like_10");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(newDbName).getTable("table_like_10");
         Assert.assertEquals(new RandomDistributionInfo(7), table.getDefaultDistributionInfo());
         Assert.assertEquals("1", table.getProperties().get("replication_num"));
     }
@@ -285,23 +290,23 @@ public class CreateTableLikeTest {
     public void testAbnormal() {
         // 1. create table with same name
         String createTableSql = "create table test.testAbTbl1\n" + "(k1 int, k2 int)\n" + "duplicate key(k1)\n"
-                + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
+                    + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
         String createTableLikeSql = "create table test.testAbTbl1 like test.testAbTbl1";
         String newDbName = "test";
         String newTblName = "testAbTbl1";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Table 'testAbTbl1' already exists",
-                () -> checkCreateOlapTableLike(createTableSql, createTableLikeSql, newDbName, newDbName, newTblName,
-                        newTblName));
+                    () -> checkCreateOlapTableLike(createTableSql, createTableLikeSql, newDbName, newDbName, newTblName,
+                                newTblName));
         // 2. create table with not existed DB
         String createTableSql2 = "create table test.testAbTbl2\n" + "(k1 int, k2 int)\n" + "duplicate key(k1)\n"
-                + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
+                    + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
         String createTableLikeSql2 = "create table fake_test.testAbTbl2_like like test.testAbTbl1";
         String newDbName2 = "fake_test";
         String existedDbName2 = "test";
         String newTblName2 = "testAbTbl2_like";
         String existedTblName2 = "testAbTbl1";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Unknown database 'fake_test'",
-                () -> checkCreateOlapTableLike(createTableSql2, createTableLikeSql2, newDbName2, existedDbName2,
-                        newTblName2, existedTblName2));
+                    () -> checkCreateOlapTableLike(createTableSql2, createTableLikeSql2, newDbName2, existedDbName2,
+                                newTblName2, existedTblName2));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -297,13 +297,13 @@ public class CreateTableTest {
                         "    \"dynamic_partition.history_partition_num\" = \"0\"\n" +
                         ");"));
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl6 = (OlapTable) db.getTable("tbl6");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl6 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl6");
         Assert.assertTrue(tbl6.getColumn("k1").isKey());
         Assert.assertTrue(tbl6.getColumn("k2").isKey());
         Assert.assertTrue(tbl6.getColumn("k3").isKey());
 
-        OlapTable tbl7 = (OlapTable) db.getTable("tbl7");
+        OlapTable tbl7 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl7");
         Assert.assertTrue(tbl7.getColumn("k1").isKey());
         Assert.assertFalse(tbl7.getColumn("k2").isKey());
         Assert.assertTrue(tbl7.getColumn("k2").getAggregationType() == AggregateType.NONE);
@@ -331,7 +331,7 @@ public class CreateTableTest {
                         "    \"dynamic_partition.buckets\" = \"32\",\n" +
                         "    \"dynamic_partition.history_partition_num\" = \"0\"\n" +
                         ");"));
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         Table str2dateTable = db.getTable("partition_str2date");
         Assert.assertTrue(DynamicPartitionUtil.isDynamicPartitionTable(str2dateTable));
 
@@ -682,7 +682,8 @@ public class CreateTableTest {
         ExceptionChecker.expectThrowsNoException(
                 () -> createTable("create table test.tmp1\n" + "(k1 int, k2 int)\n"));
         ExceptionChecker.expectThrowsNoException(
-                () -> createTable("create table test.tmp2\n" + "(k1 int, k2 float) PROPERTIES(\"replication_num\" = \"1\");\n"));
+                () -> createTable(
+                        "create table test.tmp2\n" + "(k1 int, k2 float) PROPERTIES(\"replication_num\" = \"1\");\n"));
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Data type of first column cannot be HLL",
                 () -> createTable("create table test.tmp3\n" + "(k1 hll, k2 float)\n"));
     }
@@ -700,7 +701,7 @@ public class CreateTableTest {
                 "AGGREGATE KEY(id_int)\n" +
                 "DISTRIBUTED BY HASH(id_int) BUCKETS 10\n" +
                 "PROPERTIES(\"replication_num\" = \"1\");");
-        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb(connectContext.getDatabase())
                 .getTable("aggregate_table_sum");
         String columns = table.getColumns().toString();
         System.out.println("columns = " + columns);
@@ -748,7 +749,7 @@ public class CreateTableTest {
                 "than_64_chars VARCHAR(100)) DISTRIBUTED BY HASH(oh_my_gosh_this_is_a_long_column_name_look_at_it_it_" +
                 "has_more_than_64_chars) BUCKETS 8 PROPERTIES(\"replication_num\" = \"1\");";
         starRocksAssert.withTable(sql);
-        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb(connectContext.getDatabase())
                 .getTable("long_column_table");
         Assert.assertEquals(1, table.getColumns().size());
         Assert.assertNotNull(
@@ -771,7 +772,7 @@ public class CreateTableTest {
                 "    \"in_memory\" = \"false\"\n" +
                 ");";
         starRocksAssert.withTable(sql);
-        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb(connectContext.getDatabase())
                 .getTable("test_create_default_current_timestamp");
         Assert.assertEquals(2, table.getColumns().size());
     }
@@ -792,7 +793,7 @@ public class CreateTableTest {
                 "    \"in_memory\" = \"false\"\n" +
                 ");";
         starRocksAssert.withTable(sql);
-        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb(connectContext.getDatabase())
                 .getTable("test_create_default_uuid");
         Assert.assertEquals(2, table.getColumns().size());
 
@@ -809,7 +810,7 @@ public class CreateTableTest {
                 ");";
         starRocksAssert.withTable(sql2);
 
-        final Table table2 = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+        final Table table2 = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb(connectContext.getDatabase())
                 .getTable("test_create_default_uuid_numeric");
         Assert.assertEquals(2, table2.getColumns().size());
     }
@@ -860,7 +861,7 @@ public class CreateTableTest {
 
     @Test
     public void testCreateTableWithLocation() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         // add label to backend
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
@@ -886,7 +887,8 @@ public class CreateTableTest {
                 "    \"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable table = (OlapTable) testDb.getTable("test_location_no_prop");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "test_location_no_prop");
         Assert.assertNotNull(table.getLocation());
         System.out.println(table.getLocation());
         Assert.assertTrue(table.getLocation().containsKey("*"));
@@ -895,7 +897,7 @@ public class CreateTableTest {
         String showSql = "show create table test.`test_location_no_prop`";
         ShowCreateTableStmt showCreateTableStmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showSql,
                 connectContext);
-        
+
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         System.out.println(showResultSet.getResultRows());
         Assert.assertTrue(showResultSet.getResultRows().get(0).toString().contains("\"" +
@@ -920,7 +922,8 @@ public class CreateTableTest {
                 "    \"replication_num\" = \"1\",\n" +
                 "    \"in_memory\" = \"false\"\n" +
                 ");");
-        table = (OlapTable) testDb.getTable("test_location_no_backend_prop");
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "test_location_no_backend_prop");
         Assert.assertNull(table.getLocation());
 
         // verify the location property in show create table result, shouldn't exist
@@ -985,7 +988,8 @@ public class CreateTableTest {
                 }
             } else {
                 createTable(createTableSql);
-                table = (OlapTable) testDb.getTable("test_location_prop_" + i);
+                table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "test_location_prop_" + i);
                 if (tableLocationProp.isEmpty()) {
                     Assert.assertNull(table.getLocation());
                     continue;
@@ -1339,8 +1343,9 @@ public class CreateTableTest {
                         ");"
         ));
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("binlog_table");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "binlog_table");
         Assert.assertNotNull(table.getCurBinlogConfig());
         Assert.assertTrue(table.isBinlogEnabled());
 
@@ -1375,8 +1380,9 @@ public class CreateTableTest {
                         ");"
         ));
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("not_binlog_table");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "not_binlog_table");
 
         Assert.assertFalse(table.containsBinlogConfig());
         Assert.assertFalse(table.isBinlogEnabled());
@@ -1405,8 +1411,9 @@ public class CreateTableTest {
                         ");"
         ));
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("parent_table1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "parent_table1");
 
         Assert.assertTrue(table.hasUniqueConstraints());
         List<UniqueConstraint> uniqueConstraint = table.getUniqueConstraints();
@@ -1429,7 +1436,8 @@ public class CreateTableTest {
                         ");"
         ));
 
-        OlapTable table2 = (OlapTable) db.getTable("parent_table2");
+        OlapTable table2 =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "parent_table2");
 
         Assert.assertTrue(table2.hasUniqueConstraints());
         List<UniqueConstraint> uniqueConstraint2 = table2.getUniqueConstraints();
@@ -2049,8 +2057,8 @@ public class CreateTableTest {
         String sql1 = "create table tbl_simple_pk(key0 string, __op boolean) primary key(key0)" +
                 " distributed by hash(key0) properties(\"replication_num\"=\"1\");";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Getting analyzing error." +
-                " Detail message: Column name [__op] is a system reserved name." +
-                " If you are sure you want to use it, please set FE configuration allow_system_reserved_names",
+                        " Detail message: Column name [__op] is a system reserved name." +
+                        " If you are sure you want to use it, please set FE configuration allow_system_reserved_names",
                 () -> starRocksAssert.withTable(sql1));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableWithAggStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableWithAggStateTest.java
@@ -65,7 +65,8 @@ public class CreateTableWithAggStateTest {
                         "PARTITION BY (k1) \n" +
                         "DISTRIBUTED BY HASH(k1) BUCKETS 3;",
                 () -> {
-                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                            .getDb(connectContext.getDatabase())
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`k1` varchar(10) NULL COMMENT \"\", " +
@@ -100,7 +101,8 @@ public class CreateTableWithAggStateTest {
                 "PARTITION BY (k1) \n" +
                 "DISTRIBUTED BY HASH(k1) BUCKETS 3;",
                 () -> {
-                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                            .getDb(connectContext.getDatabase())
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`k1` varchar(10) NULL COMMENT \"\", " +
@@ -131,7 +133,8 @@ public class CreateTableWithAggStateTest {
                         "PARTITION BY (dt) \n" +
                         "DISTRIBUTED BY HASH(dt) BUCKETS 4;",
                 () -> {
-                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                            .getDb(connectContext.getDatabase())
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`dt` varchar(10) NULL COMMENT \"\", " +
@@ -162,7 +165,8 @@ public class CreateTableWithAggStateTest {
                         "PARTITION BY (k1) \n" +
                         "DISTRIBUTED BY HASH(k1) BUCKETS 3;",
                 () -> {
-                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                            .getDb(connectContext.getDatabase())
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`k1` varchar(10) NULL COMMENT \"\", " +
@@ -198,7 +202,8 @@ public class CreateTableWithAggStateTest {
                         "PARTITION BY (k1) \n" +
                         "DISTRIBUTED BY HASH(k1) BUCKETS 3;",
                 () -> {
-                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                            .getDb(connectContext.getDatabase())
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`k1` varchar(10) NULL COMMENT \"\", " +
@@ -234,7 +239,8 @@ public class CreateTableWithAggStateTest {
                         "PARTITION BY (k1) \n" +
                         "DISTRIBUTED BY HASH(k1) BUCKETS 3;",
                 () -> {
-                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+                    final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                            .getDb(connectContext.getDatabase())
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`k1` varchar(10) NULL COMMENT \"\", " +
@@ -263,7 +269,8 @@ public class CreateTableWithAggStateTest {
                     "AGGREGATE KEY(k1)\n" +
                     "PARTITION BY (k1) \n" +
                     "DISTRIBUTED BY HASH(k1) BUCKETS 3;");
-            final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+            final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                    .getDb(connectContext.getDatabase())
                     .getTable("test_agg_tbl1");
             Assert.assertEquals(null, table);
         } catch (Exception e) {
@@ -284,7 +291,8 @@ public class CreateTableWithAggStateTest {
                     "AGGREGATE KEY(k1)\n" +
                     "PARTITION BY (k1) \n" +
                     "DISTRIBUTED BY HASH(k1) BUCKETS 3;");
-            final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getDb(connectContext.getDatabase())
+            final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                    .getDb(connectContext.getDatabase())
                     .getTable("test_agg_tbl1");
             Assert.assertEquals(null, table);
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableWithLocationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableWithLocationTest.java
@@ -75,7 +75,7 @@ public class CreateTableWithLocationTest {
         PseudoCluster cluster = PseudoCluster.getInstance();
         for (PseudoBackend backend : cluster.getBackends()) {
             String stmtStr = "alter system modify backend '" + backend.getHostHeartbeatPort() + "' set ('" +
-                    AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = '')";
+                        AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = '')";
             System.out.println(stmtStr);
             cluster.runSql(null, stmtStr);
         }
@@ -86,32 +86,32 @@ public class CreateTableWithLocationTest {
         int i = 0;
         for (PseudoBackend backend : cluster.getBackends()) {
             String stmtStr = "alter system modify backend '" + backend.getHostHeartbeatPort() + "' set ('" +
-                    AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = '" + locations.get(i++) +  "')";
+                        AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = '" + locations.get(i++) + "')";
             System.out.println(stmtStr);
             cluster.runSql(null, stmtStr);
         }
     }
-
 
     @Test
     public void testCreateTableAndBackendNoLocationProp() throws SQLException {
         clearBackendLocationProp();
         PseudoCluster cluster = PseudoCluster.getInstance();
         String sql = "CREATE TABLE test.`test_table_backend_no_loc` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_table_backend_no_loc");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_backend_no_loc");
         Assert.assertNull(table.getLocation());
     }
 
@@ -120,7 +120,7 @@ public class CreateTableWithLocationTest {
         Set<Long> backendIds = Sets.newHashSet();
         for (PseudoBackend pseudoBackend : cluster.getBackends()) {
             Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                    .getClusterInfo().getBackend(pseudoBackend.getId());
+                        .getClusterInfo().getBackend(pseudoBackend.getId());
             if (!backend.getLocation().isEmpty()) {
                 backendIds.add(backend.getId());
             }
@@ -133,7 +133,7 @@ public class CreateTableWithLocationTest {
         Set<Long> backendIds = Sets.newHashSet();
         for (PseudoBackend pseudoBackend : cluster.getBackends()) {
             Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                    .getClusterInfo().getBackend(pseudoBackend.getId());
+                        .getClusterInfo().getBackend(pseudoBackend.getId());
             if (backend.getLocation().containsKey(locationKey)) {
                 backendIds.add(backend.getId());
             }
@@ -146,9 +146,9 @@ public class CreateTableWithLocationTest {
         Set<Long> backendIds = Sets.newHashSet();
         for (PseudoBackend pseudoBackend : cluster.getBackends()) {
             Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                    .getClusterInfo().getBackend(pseudoBackend.getId());
+                        .getClusterInfo().getBackend(pseudoBackend.getId());
             if (backend.getLocation().containsKey(locationKey) &&
-                    Objects.equals(backend.getLocation().get(locationKey), locationVal)) {
+                        Objects.equals(backend.getLocation().get(locationKey), locationVal)) {
                 backendIds.add(backend.getId());
             }
         }
@@ -160,7 +160,7 @@ public class CreateTableWithLocationTest {
         Set<Long> backendIds = Sets.newHashSet();
         for (PseudoBackend pseudoBackend : cluster.getBackends()) {
             Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                    .getClusterInfo().getBackend(pseudoBackend.getId());
+                        .getClusterInfo().getBackend(pseudoBackend.getId());
             if (backend.getLocation().isEmpty()) {
                 backendIds.add(backend.getId());
             }
@@ -172,24 +172,25 @@ public class CreateTableWithLocationTest {
     public void testCreateTableNoLocPropBackendWithLocProp() throws SQLException {
         // last backend doesn't contain location property
         List<String> locations = Lists.newArrayList("rack:r1", "rack:rack2", "rack:rack3",
-                "region:r1", "region:r2", "region:r3", "");
+                    "region:r1", "region:r2", "region:r3", "");
         setBackendLocationProp(locations);
         PseudoCluster cluster = PseudoCluster.getInstance();
         String sql = "CREATE TABLE test.`test_table_no_loc_backend_with_loc` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_table_no_loc_backend_with_loc");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_no_loc_backend_with_loc");
         Assert.assertTrue(table.getLocation().keySet().contains("*"));
 
         List<Partition> partitions = new ArrayList<>(table.getAllPartitions());
@@ -215,27 +216,28 @@ public class CreateTableWithLocationTest {
     public void testCreateTableWithExplicitLocPropBackendWithLocProp() throws SQLException {
         // last backend doesn't contain location property
         List<String> locations = Lists.newArrayList("rack:r1", "rack:rack2", "rack:rack3",
-                "region:r1", "region:r2", "region:r3", "");
+                    "region:r1", "region:r2", "region:r3", "");
         setBackendLocationProp(locations);
         PseudoCluster cluster = PseudoCluster.getInstance();
 
         // Test: rack:*
         String sql = "CREATE TABLE test.`test_table_explicit_loc_backend_with_loc1` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "\" = \"rack:*\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:*\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         System.out.println(sql);
         cluster.runSql("test", sql);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_table_explicit_loc_backend_with_loc1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_explicit_loc_backend_with_loc1");
         Assert.assertTrue(table.getLocation().keySet().contains("rack"));
         List<Partition> partitions = new ArrayList<>(table.getAllPartitions());
         List<Tablet> tablets = partitions.get(0).getBaseIndex().getTablets();
@@ -259,21 +261,22 @@ public class CreateTableWithLocationTest {
 
         // Test: rack:*, region:*
         sql = "CREATE TABLE test.`test_table_explicit_loc_backend_with_loc2` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "\" = \"rack:*, region:*\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:*, region:*\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
         boolean hasReplicaOnRegionBackend = false;
         boolean hasReplicaOnRackBackend = false;
-        table = (OlapTable) db.getTable("test_table_explicit_loc_backend_with_loc2");
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_explicit_loc_backend_with_loc2");
         Assert.assertTrue(table.getLocation().keySet().contains("rack"));
         Assert.assertTrue(table.getLocation().keySet().contains("region"));
         partitions = new ArrayList<>(table.getAllPartitions());
@@ -299,19 +302,20 @@ public class CreateTableWithLocationTest {
 
         // Test: rack:r1, rack:rack2, rack:rack3
         sql = "CREATE TABLE test.`test_table_explicit_loc_backend_with_loc3` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "\" = \"rack:r1, rack:rack2, rack:rack3\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:r1, rack:rack2, rack:rack3\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
-        table = (OlapTable) db.getTable("test_table_explicit_loc_backend_with_loc3");
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_explicit_loc_backend_with_loc3");
         Assert.assertTrue(table.getLocation().keySet().contains("rack"));
         Assert.assertEquals(1, table.getLocation().keySet().size());
         partitions = new ArrayList<>(table.getAllPartitions());
@@ -333,19 +337,20 @@ public class CreateTableWithLocationTest {
 
         // Test: rack:r1, region:*
         sql = "CREATE TABLE test.`test_table_explicit_loc_backend_with_loc4` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "\" = \"rack:r1, region:*\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:r1, region:*\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
-        table = (OlapTable) db.getTable("test_table_explicit_loc_backend_with_loc4");
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_explicit_loc_backend_with_loc4");
         Assert.assertTrue(table.getLocation().keySet().contains("rack"));
         Assert.assertTrue(table.getLocation().keySet().contains("region"));
         partitions = new ArrayList<>(table.getAllPartitions());
@@ -372,19 +377,20 @@ public class CreateTableWithLocationTest {
 
         // Test: rack:r1, rack:rack2, not enough hosts, fallback to ignore location prop
         sql = "CREATE TABLE test.`test_table_explicit_loc_backend_with_loc5` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "\" = \"rack:r1, rack:rack2\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:r1, rack:rack2\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
-        table = (OlapTable) db.getTable("test_table_explicit_loc_backend_with_loc5");
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_explicit_loc_backend_with_loc5");
         Assert.assertTrue(table.getLocation().keySet().contains("rack"));
         partitions = new ArrayList<>(table.getAllPartitions());
         tablets = partitions.get(0).getBaseIndex().getTablets();
@@ -403,27 +409,27 @@ public class CreateTableWithLocationTest {
         backendIdsWithLocProp = getBackendIdsWithLocProp();
         backendIdsWithLocProp.addAll(getBackendIdsWithoutLocProp());
         Assert.assertEquals(backendIdsWithLocProp.size(),
-                Sets.intersection(allReplicasBackendIds, backendIdsWithLocProp).size());
+                    Sets.intersection(allReplicasBackendIds, backendIdsWithLocProp).size());
 
         // Test: rack:r1, rack:rack2, not enough hosts, fallback to ignore location prop
         sql = "CREATE TABLE test.`test_table_explicit_loc_backend_with_loc6` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"10\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "\" = \"rack:r1, rack:rack2\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"10\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:r1, rack:rack2\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
 
         try {
             cluster.runSql("test", sql);
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains(
-                    "Table replication num should be less than of equal to the number of available BE nodes"));
+                        "Table replication num should be less than of equal to the number of available BE nodes"));
         }
 
         // clean up
@@ -434,27 +440,28 @@ public class CreateTableWithLocationTest {
     public void testBestEffortMatchLocationProp() throws SQLException {
         // last backend has the same location prop with the first one
         List<String> locations = Lists.newArrayList("rack:r1", "rack:rack2", "rack:rack3",
-                "region:r1", "region:r2", "region:r3", "rack:r1");
+                    "region:r1", "region:r2", "region:r3", "rack:r1");
         setBackendLocationProp(locations);
         PseudoCluster cluster = PseudoCluster.getInstance();
 
         // Test: rack:r1, rack:rack2, 3 hosts, but only 2 racks
         String sql = "CREATE TABLE test.`test_table_explicit_loc_backend_with_loc_best_effort` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION +  "\" = \"rack:r1, rack:rack2\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:r1, rack:rack2\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         System.out.println(sql);
         cluster.runSql("test", sql);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_table_explicit_loc_backend_with_loc_best_effort");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_explicit_loc_backend_with_loc_best_effort");
         Assert.assertTrue(table.getLocation().keySet().contains("rack"));
         List<Partition> partitions = new ArrayList<>(table.getAllPartitions());
         List<Tablet> tablets = partitions.get(0).getBaseIndex().getTablets();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateViewTest.java
@@ -74,7 +74,7 @@ public class CreateViewTest {
                 .withView("create view test_null_view as select * from site_access;");
 
         Table view = starRocksAssert.getCtx().getGlobalStateMgr()
-                .getDb("test").getTable("test_null_view");
+                .getLocalMetastore().getDb("test").getTable("test_null_view");
         Assert.assertTrue(view instanceof View);
         List<Column> columns = view.getColumns();
         for (Column column : columns) {
@@ -135,7 +135,7 @@ public class CreateViewTest {
                         ", lead(price ignore nulls,1,0) over (partition by username) as leadValue\n" +
                         "from sample_data;");
 
-        Table view = starRocksAssert.getCtx().getGlobalStateMgr()
+        Table view = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
                 .getDb("test").getTable("test_ignore_nulls");
         Assert.assertTrue(view instanceof View);
         String str = ((View) view).getInlineViewDef();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -121,8 +121,9 @@ public class DatabaseTest {
         // duplicate
         Assert.assertFalse(db.registerTableUnlocked(table));
 
-        Assert.assertEquals(table, db.getTable(table.getId()));
-        Assert.assertEquals(table, db.getTable(table.getName()));
+        Assert.assertEquals(table, GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), table.getId()));
+        Assert.assertEquals(table, GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), table.getName()));
 
         Assert.assertEquals(1, db.getTables().size());
         Assert.assertEquals(table, db.getTables().get(0));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -121,9 +121,8 @@ public class DatabaseTest {
         // duplicate
         Assert.assertFalse(db.registerTableUnlocked(table));
 
-        Assert.assertEquals(table, GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), table.getId()));
-        Assert.assertEquals(table, GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getFullName(), table.getName()));
+        Assert.assertEquals(table, db.getTable(table.getId()));
+        Assert.assertEquals(table, db.getTable(table.getName()));
 
         Assert.assertEquals(1, db.getTables().size());
         Assert.assertEquals(table, db.getTables().get(0));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionTest.java
@@ -97,8 +97,8 @@ public class DropPartitionTest {
 
     @Test
     public void testNormalDropPartition() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("tbl1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         Partition partition = table.getPartition("p20210201");
         long tabletId = partition.getBaseIndex().getTablets().get(0).getId();
         String dropPartitionSql = " alter table test.tbl1 drop partition p20210201;";
@@ -119,8 +119,8 @@ public class DropPartitionTest {
 
     @Test
     public void testForceDropPartition() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("tbl1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         Partition partition = table.getPartition("p20210202");
         long tabletId = partition.getBaseIndex().getTablets().get(0).getId();
         String dropPartitionSql = " alter table test.tbl1 drop partition p20210202 force;";
@@ -144,8 +144,8 @@ public class DropPartitionTest {
 
     @Test
     public void testDropPartitionAndReserveTablets() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("tbl1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         Partition partition = table.getPartition("p20210203");
         long tabletId = partition.getBaseIndex().getTablets().get(0).getId();
         table.dropPartitionAndReserveTablet("p20210203");
@@ -249,8 +249,8 @@ public class DropPartitionTest {
     }
 
     private void checkBeforeDrop(String dbName, String tableName, String partitionName, long tabletId) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        OlapTable table = (OlapTable) db.getTable(tableName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         List<Replica> replicaList =
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(tabletId);
         Partition partition = table.getPartition(partitionName);
@@ -273,7 +273,7 @@ public class DropPartitionTest {
     }
 
     private Table getTable(String dbName, String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        return (OlapTable) db.getTable(tableName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
@@ -78,34 +78,35 @@ public class DynamicPartitionTableTest {
     @Test
     public void testNormal() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_normal` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("dynamic_partition_normal");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "dynamic_partition_normal");
         Assert.assertEquals(table.getTableProperty().getDynamicPartitionProperty().getReplicationNum(),
-                DynamicPartitionProperty.NOT_SET_REPLICATION_NUM);
+                    DynamicPartitionProperty.NOT_SET_REPLICATION_NUM);
     }
 
     @Test
@@ -113,57 +114,57 @@ public class DynamicPartitionTableTest {
         expectedException.expect(DdlException.class);
         expectedException.expectMessage("Must assign dynamic_partition.time_unit properties");
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_time_unit` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");");
     }
 
     @Test
     public void testMissStart() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_start` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");");
     }
 
     @Test
@@ -171,59 +172,60 @@ public class DynamicPartitionTableTest {
         expectedException.expect(DdlException.class);
         expectedException.expectMessage("Must assign dynamic_partition.end properties");
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_end` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");");
     }
 
     @Test
     public void testMissBuckets() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_buckets` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\"\n" +
-                ");");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("dynamic_partition_buckets");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\"\n" +
+                    ");");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "dynamic_partition_buckets");
         Assert.assertEquals(table.getTableProperty().getDynamicPartitionProperty().getBuckets(), 0);
     }
 
@@ -232,24 +234,24 @@ public class DynamicPartitionTableTest {
         expectedException.expect(DdlException.class);
         expectedException.expectMessage("Only support dynamic partition properties on range partition table");
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_non_range` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");");
     }
 
     @Test
@@ -257,89 +259,89 @@ public class DynamicPartitionTableTest {
         expectedException.expect(DdlException.class);
         expectedException.expectMessage("Dynamic partition only support single-column range partition");
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_normal` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1, k2)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\", \"100\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\", \"200\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\", \"300\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1, k2)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\", \"100\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\", \"200\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\", \"300\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");");
     }
 
     @Test
     public void testMissTimeZone() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_miss_time_zone` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.buckets\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.buckets\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\"\n" +
+                    ");");
     }
 
     @Test
     public void testNormalTimeZone() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_time_zone` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.buckets\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.buckets\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\"\n" +
+                    ");");
     }
 
     @Test
@@ -347,96 +349,96 @@ public class DynamicPartitionTableTest {
         expectedException.expect(DdlException.class);
         expectedException.expectMessage("Unknown or incorrect time zone: 'invalid'");
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_invalid_time_zone` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.buckets\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.time_zone\" = \"invalid\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\"\n" +
-                ");");
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.buckets\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.time_zone\" = \"invalid\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\"\n" +
+                    ");");
     }
 
     @Test
     public void testSetDynamicPartitionReplicationNum() throws Exception {
         String tableName = "dynamic_partition_replication_num";
         starRocksAssert.withTable("CREATE TABLE test.`" + tableName + "` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE (k1)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\",\n" +
-                "\"dynamic_partition.replication_num\" = \"2\"\n" +
-                ");");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable(tableName);
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE (k1)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"),\n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"true\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\",\n" +
+                    "\"dynamic_partition.replication_num\" = \"2\"\n" +
+                    ");");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         Assert.assertEquals(table.getTableProperty().getDynamicPartitionProperty().getReplicationNum(), 2);
     }
 
     @Test
     public void testEmptyDynamicPartition() throws Exception {
         String createOlapTblStmt = "CREATE TABLE test.`empty_dynamic_partition` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` int NULL COMMENT \"\",\n" +
-                "  `k3` smallint NULL COMMENT \"\",\n" +
-                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
-                "  `v2` datetime NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY RANGE(`k1`)\n" +
-                "()\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"dynamic_partition.enable\" = \"false\",\n" +
-                "\"dynamic_partition.start\" = \"-3\",\n" +
-                "\"dynamic_partition.end\" = \"3\",\n" +
-                "\"dynamic_partition.time_unit\" = \"day\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"1\"\n" +
-                ");";
+                    "  `k1` date NULL COMMENT \"\",\n" +
+                    "  `k2` int NULL COMMENT \"\",\n" +
+                    "  `k3` smallint NULL COMMENT \"\",\n" +
+                    "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                    "  `v2` datetime NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY RANGE(`k1`)\n" +
+                    "()\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 32\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"dynamic_partition.enable\" = \"false\",\n" +
+                    "\"dynamic_partition.start\" = \"-3\",\n" +
+                    "\"dynamic_partition.end\" = \"3\",\n" +
+                    "\"dynamic_partition.time_unit\" = \"day\",\n" +
+                    "\"dynamic_partition.prefix\" = \"p\",\n" +
+                    "\"dynamic_partition.buckets\" = \"1\"\n" +
+                    ");";
         String insertStmt =
-                "insert into test.`empty_dynamic_partition` values ('2020-09-10', 1000, 100, 'test', '2020-09-10 23:59:59');";
+                    "insert into test.`empty_dynamic_partition` values ('2020-09-10', 1000, 100, 'test', '2020-09-10 23:59:59');";
         createTable(createOlapTblStmt);
         expectedException.expect(AnalysisException.class);
         expectedException.expectMessage("data cannot be inserted into table with empty partition." +
-                "Use `SHOW PARTITIONS FROM empty_dynamic_partition` to see the currently partitions of this table. ");
+                    "Use `SHOW PARTITIONS FROM empty_dynamic_partition` to see the currently partitions of this table. ");
         UtFrameUtils.parseStmtWithNewParser("explain " + insertStmt, connectContext);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -58,7 +58,6 @@ public class ExpressionRangePartitionInfoTest {
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
 
-
     @Before
     public void setUp() throws Exception {
         partitionExprs = Lists.newArrayList();
@@ -71,7 +70,7 @@ public class ExpressionRangePartitionInfoTest {
         fnChildren.add(slotRef2);
         functionCallExpr = new FunctionCallExpr("date_trunc", fnChildren);
         functionCallExpr.setFn(Expr.getBuiltinFunction(
-                "date_trunc", new Type[] {Type.VARCHAR, Type.DATETIME}, Function.CompareMode.IS_IDENTICAL));
+                    "date_trunc", new Type[] {Type.VARCHAR, Type.DATETIME}, Function.CompareMode.IS_IDENTICAL));
 
         FeConstants.runningUnitTest = true;
         UtFrameUtils.createMinStarRocksCluster();
@@ -90,9 +89,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
         List<Column> schema = Collections.singletonList(k1);
         ExpressionRangePartitionInfo expressionRangePartitionInfo = new ExpressionRangePartitionInfo(partitionExprs,
-                schema, PartitionType.RANGE);
+                    schema, PartitionType.RANGE);
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns(
-                MetaUtils.buildIdToColumn(schema));
+                    MetaUtils.buildIdToColumn(schema));
         Assert.assertEquals(partitionColumns.size(), 1);
         Assert.assertEquals(partitionColumns.get(0), k1);
     }
@@ -102,9 +101,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(functionCallExpr));
         List<Column> schema = Collections.singletonList(k2);
         ExpressionRangePartitionInfo expressionRangePartitionInfo =
-                new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
+                    new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns(
-                MetaUtils.buildIdToColumn(schema));
+                    MetaUtils.buildIdToColumn(schema));
         Assert.assertEquals(partitionColumns.size(), 1);
         Assert.assertEquals(partitionColumns.get(0), k2);
     }
@@ -117,9 +116,9 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(functionCallExpr));
         List<Column> schema = Arrays.asList(k1, k2);
         ExpressionRangePartitionInfo expressionRangePartitionInfo =
-                new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
+                    new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns(
-                MetaUtils.buildIdToColumn(schema));
+                    MetaUtils.buildIdToColumn(schema));
         Assert.assertEquals(partitionColumns.size(), 2);
         Assert.assertEquals(partitionColumns.get(0), k1);
         Assert.assertEquals(partitionColumns.get(1), k2);
@@ -135,15 +134,15 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1",
-                new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("-128"))),
-                null));
+                    new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("-128"))),
+                    null));
 
         List<Column> schema = Collections.singletonList(k1);
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(1, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema),
-                    singleRangePartitionDesc, 20000L, false);
+                        singleRangePartitionDesc, 20000L, false);
         }
     }
 
@@ -154,15 +153,15 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1",
-                new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("-32768"))),
-                null));
+                    new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("-32768"))),
+                    null));
 
         List<Column> schema = Collections.singletonList(k1);
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(1, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema),
-                    singleRangePartitionDesc, 20000L, false);
+                        singleRangePartitionDesc, 20000L, false);
         }
     }
 
@@ -173,15 +172,15 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1",
-                new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("-2147483648"))),
-                null));
+                    new PartitionKeyDesc(Lists.newArrayList(new PartitionValue("-2147483648"))),
+                    null));
 
         List<Column> schema = Collections.singletonList(k1);
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(1, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -192,13 +191,13 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("-9223372036854775808"))), null));
+                    .newArrayList(new PartitionValue("-9223372036854775808"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p2", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("-9223372036854775806"))), null));
+                    .newArrayList(new PartitionValue("-9223372036854775806"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p3", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("0"))), null));
+                    .newArrayList(new PartitionValue("0"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p4", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("9223372036854775806"))), null));
+                    .newArrayList(new PartitionValue("9223372036854775806"))), null));
 
         List<Column> schema = Collections.singletonList(k1);
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
@@ -206,7 +205,7 @@ public class ExpressionRangePartitionInfoTest {
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(1, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -217,13 +216,13 @@ public class ExpressionRangePartitionInfoTest {
         partitionExprs.add(ColumnIdExpr.create(slotRef));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("-9223372036854775806"))), null));
+                    .newArrayList(new PartitionValue("-9223372036854775806"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p2", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("-9223372036854775805"))), null));
+                    .newArrayList(new PartitionValue("-9223372036854775805"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p3", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("0"))), null));
+                    .newArrayList(new PartitionValue("0"))), null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p4", new PartitionKeyDesc(Lists
-                .newArrayList(new PartitionValue("9223372036854775806"))), null));
+                    .newArrayList(new PartitionValue("9223372036854775806"))), null));
 
         List<Column> schema = Collections.singletonList(k1);
         partitionInfo = new ExpressionRangePartitionInfo(partitionExprs, schema, PartitionType.RANGE);
@@ -231,7 +230,7 @@ public class ExpressionRangePartitionInfoTest {
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(1, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -256,17 +255,17 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
         PartitionKeyDesc p2 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("10")),
-                Lists.newArrayList(new PartitionValue("20190107"), new PartitionValue("10")));
+                    Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("10")),
+                    Lists.newArrayList(new PartitionValue("20190107"), new PartitionValue("10")));
         PartitionKeyDesc p3 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("20181231"), new PartitionValue("10")),
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")));
+                    Lists.newArrayList(new PartitionValue("20181231"), new PartitionValue("10")),
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")));
         PartitionKeyDesc p4 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("100")),
-                Lists.newArrayList(new PartitionValue("20190120"), new PartitionValue("10000000000")));
+                    Lists.newArrayList(new PartitionValue("20190105"), new PartitionValue("100")),
+                    Lists.newArrayList(new PartitionValue("20190120"), new PartitionValue("10000000000")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p2", p2, null));
@@ -279,7 +278,7 @@ public class ExpressionRangePartitionInfoTest {
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -306,14 +305,14 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("2019-02-01"), new PartitionValue("100"),
-                        new PartitionValue("200")));
+                    Lists.newArrayList(new PartitionValue("2019-02-01"), new PartitionValue("100"),
+                                new PartitionValue("200")));
         PartitionKeyDesc p2 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("2020-02-01"), new PartitionValue("100"),
-                        new PartitionValue("200")),
-                Lists.newArrayList(new PartitionValue("10000000000")));
+                    Lists.newArrayList(new PartitionValue("2020-02-01"), new PartitionValue("100"),
+                                new PartitionValue("200")),
+                    Lists.newArrayList(new PartitionValue("10000000000")));
         PartitionKeyDesc p3 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("2021-02-01")));
+                    Lists.newArrayList(new PartitionValue("2021-02-01")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p2", p2, null));
@@ -331,7 +330,7 @@ public class ExpressionRangePartitionInfoTest {
             }
             singleRangePartitionDesc.analyze(partitionExprs.size(), null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -353,7 +352,7 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(new ArrayList<>(),
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
 
@@ -363,7 +362,7 @@ public class ExpressionRangePartitionInfoTest {
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -386,8 +385,8 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")),
-                new ArrayList<>());
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("200")),
+                    new ArrayList<>());
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
 
@@ -397,7 +396,7 @@ public class ExpressionRangePartitionInfoTest {
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -419,8 +418,8 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
-                Lists.newArrayList(new PartitionValue("20190201")));
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
+                    Lists.newArrayList(new PartitionValue("20190201")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
 
@@ -430,7 +429,7 @@ public class ExpressionRangePartitionInfoTest {
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -453,8 +452,8 @@ public class ExpressionRangePartitionInfoTest {
 
         //add RangePartitionDescs
         PartitionKeyDesc p1 = new PartitionKeyDesc(
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
-                Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")));
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")),
+                    Lists.newArrayList(new PartitionValue("20190101"), new PartitionValue("100")));
 
         singleRangePartitionDescs.add(new SingleRangePartitionDesc(false, "p1", p1, null));
 
@@ -464,7 +463,7 @@ public class ExpressionRangePartitionInfoTest {
         for (SingleRangePartitionDesc singleRangePartitionDesc : singleRangePartitionDescs) {
             singleRangePartitionDesc.analyze(columns, null);
             partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(schema), singleRangePartitionDesc,
-                    20000L, false);
+                        20000L, false);
         }
     }
 
@@ -472,35 +471,35 @@ public class ExpressionRangePartitionInfoTest {
     public void testExpressionRangePartitionInfoSerialized_FunctionExpr() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE table_hitcount (\n" +
-                "databaseName varchar(200) NULL COMMENT \"\",\n" +
-                "tableName varchar(200) NULL COMMENT \"\",\n" +
-                "queryTime varchar(50) NULL COMMENT \"\",\n" +
-                "queryId varchar(50) NULL COMMENT \"\",\n" +
-                "partitionHitSum int(11) NULL COMMENT \"\",\n" +
-                "partitionSum int(11) NULL COMMENT \"\",\n" +
-                "tabletHitNum int(11) NULL COMMENT \"\",\n" +
-                "tabletSum int(11) NULL COMMENT \"\",\n" +
-                "startHitPartition varchar(20) NULL COMMENT \"\",\n" +
-                "dt date NULL COMMENT \"\",\n" +
-                "clusterAddress varchar(50) NULL COMMENT \"\",\n" +
-                "costTime int(11) NULL COMMENT \"\",\n" +
-                "tableQueryCount int(11) NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(databaseName, tableName)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "PARTITION BY date_trunc('day', dt)\n" +
-                "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"in_memory\" = \"false\",\n" +
-                "\"enable_persistent_index\" = \"false\",\n" +
-                "\"replicated_storage\" = \"true\",\n" +
-                "\"compression\" = \"LZ4\"\n" +
-                ");";
+                    "databaseName varchar(200) NULL COMMENT \"\",\n" +
+                    "tableName varchar(200) NULL COMMENT \"\",\n" +
+                    "queryTime varchar(50) NULL COMMENT \"\",\n" +
+                    "queryId varchar(50) NULL COMMENT \"\",\n" +
+                    "partitionHitSum int(11) NULL COMMENT \"\",\n" +
+                    "partitionSum int(11) NULL COMMENT \"\",\n" +
+                    "tabletHitNum int(11) NULL COMMENT \"\",\n" +
+                    "tabletSum int(11) NULL COMMENT \"\",\n" +
+                    "startHitPartition varchar(20) NULL COMMENT \"\",\n" +
+                    "dt date NULL COMMENT \"\",\n" +
+                    "clusterAddress varchar(50) NULL COMMENT \"\",\n" +
+                    "costTime int(11) NULL COMMENT \"\",\n" +
+                    "tableQueryCount int(11) NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(databaseName, tableName)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "PARTITION BY date_trunc('day', dt)\n" +
+                    "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"in_memory\" = \"false\",\n" +
+                    "\"enable_persistent_index\" = \"false\",\n" +
+                    "\"replicated_storage\" = \"true\",\n" +
+                    "\"compression\" = \"LZ4\"\n" +
+                    ");";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("table_hitcount");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "table_hitcount");
         // serialize
         String json = GsonUtils.GSON.toJson(table);
         // deserialize
@@ -516,34 +515,34 @@ public class ExpressionRangePartitionInfoTest {
     public void testExpressionRangePartitionInfoSerialized_SlotRef() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test_table (\n" +
-                "databaseName varchar(200) NULL COMMENT \"\",\n" +
-                "tableName varchar(200) NULL COMMENT \"\",\n" +
-                "queryTime varchar(50) NULL COMMENT \"\",\n" +
-                "queryId varchar(50) NULL COMMENT \"\",\n" +
-                "dt date NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(databaseName, tableName)\n" +
-                "PARTITION BY RANGE (`dt`)\n" +
-                "(\n" +
-                "    PARTITION p1 values less than('2021-02-01'),\n" +
-                "    PARTITION p2 values less than('2021-03-01')\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");";
+                    "databaseName varchar(200) NULL COMMENT \"\",\n" +
+                    "tableName varchar(200) NULL COMMENT \"\",\n" +
+                    "queryTime varchar(50) NULL COMMENT \"\",\n" +
+                    "queryId varchar(50) NULL COMMENT \"\",\n" +
+                    "dt date NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(databaseName, tableName)\n" +
+                    "PARTITION BY RANGE (`dt`)\n" +
+                    "(\n" +
+                    "    PARTITION p1 values less than('2021-02-01'),\n" +
+                    "    PARTITION p2 values less than('2021-03-01')\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ");";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
 
         starRocksAssert.withMaterializedView("create materialized view test_mv1 " +
-                " DISTRIBUTED BY HASH(dt, queryId) BUCKETS 4\n" +
-                " PARTITION BY dt\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") as select dt, queryId, count(1) from test_table group by dt, queryId"
+                    " DISTRIBUTED BY HASH(dt, queryId) BUCKETS 4\n" +
+                    " PARTITION BY dt\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") as select dt, queryId, count(1) from test_table group by dt, queryId"
         );
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("test_mv1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_mv1");
         // serialize
         String json = GsonUtils.GSON.toJson(table);
         // deserialize
@@ -551,7 +550,7 @@ public class ExpressionRangePartitionInfoTest {
         ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) readTable.getPartitionInfo();
         List<Expr> readPartitionExprs = expressionRangePartitionInfo.getPartitionExprs(readTable.getIdToColumn());
         Assert.assertTrue(readPartitionExprs.get(0) instanceof SlotRef);
-        SlotRef slotRef = (SlotRef)  readPartitionExprs.get(0);
+        SlotRef slotRef = (SlotRef) readPartitionExprs.get(0);
         Assert.assertTrue(!slotRef.getType().isInvalid());
         Assert.assertTrue(slotRef.getType().isDateType());
         starRocksAssert.dropMaterializedView("test_mv1");
@@ -562,30 +561,31 @@ public class ExpressionRangePartitionInfoTest {
     public void testExpressionRangePartitionInfoV2SerializedWrongNotFailed() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE `game_log2` (\n" +
-                "  `cloud_id` varchar(65533) NULL COMMENT \"\",\n" +
-                "  `user_id` varchar(65533) NULL COMMENT \"\",\n" +
-                "  `day` date NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP \n" +
-                "DUPLICATE KEY(`cloud_id`, `user_id`)\n" +
-                "PARTITION BY RANGE(cast(substr(cloud_id, 3, 11) as bigint))()\n" +
-                "DISTRIBUTED BY HASH(`cloud_id`, `user_id`) BUCKETS 1 \n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"in_memory\" = \"false\",\n" +
-                "\"enable_persistent_index\" = \"false\",\n" +
-                "\"replicated_storage\" = \"true\",\n" +
-                "\"compression\" = \"ZSTD\"\n" +
-                ");";
+                    "  `cloud_id` varchar(65533) NULL COMMENT \"\",\n" +
+                    "  `user_id` varchar(65533) NULL COMMENT \"\",\n" +
+                    "  `day` date NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP \n" +
+                    "DUPLICATE KEY(`cloud_id`, `user_id`)\n" +
+                    "PARTITION BY RANGE(cast(substr(cloud_id, 3, 11) as bigint))()\n" +
+                    "DISTRIBUTED BY HASH(`cloud_id`, `user_id`) BUCKETS 1 \n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"in_memory\" = \"false\",\n" +
+                    "\"enable_persistent_index\" = \"false\",\n" +
+                    "\"replicated_storage\" = \"true\",\n" +
+                    "\"compression\" = \"ZSTD\"\n" +
+                    ");";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable olapTable = (OlapTable) db.getTable("game_log2");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "game_log2");
         ExpressionRangePartitionInfoV2 expressionRangePartitionInfo =
-                (ExpressionRangePartitionInfoV2) olapTable.getPartitionInfo();
+                    (ExpressionRangePartitionInfoV2) olapTable.getPartitionInfo();
         expressionRangePartitionInfo.setPartitionExprs(Lists.newArrayList(
-                ColumnIdExpr.create(new FunctionCallExpr("abc", Lists.newArrayList(new SlotRef(
-                        new TableName("test", "game_log2"), "cloud_id"))))));
+                    ColumnIdExpr.create(new FunctionCallExpr("abc", Lists.newArrayList(new SlotRef(
+                                new TableName("test", "game_log2"), "cloud_id"))))));
         // serialize
         String json = GsonUtils.GSON.toJson(olapTable);
         // deserialize

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
@@ -44,7 +44,7 @@ public class ForeignKeyConstraintTest {
                 minTimes = 0;
                 result = globalStateMgr;
 
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
@@ -37,6 +37,10 @@ public class ForeignKeyConstraintTest {
         db.registerTableUnlocked(table1);
         db.registerTableUnlocked(table2);
         db.registerTableUnlocked(table3);
+    }
+
+    @Test
+    public void testParseInternal() {
 
         new Expectations(globalStateMgr) {
             {
@@ -47,12 +51,21 @@ public class ForeignKeyConstraintTest {
                 globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
+
+                globalStateMgr.getLocalMetastore().getTable(anyLong, 1000L);
+                minTimes = 0;
+                result = db.getTable(1000L);
+
+                globalStateMgr.getLocalMetastore().getTable(anyLong, 1001L);
+                minTimes = 0;
+                result = db.getTable(1001L);
+
+                globalStateMgr.getLocalMetastore().getTable(anyLong, 1002L);
+                minTimes = 0;
+                result = db.getTable(1002L);
             }
         };
-    }
 
-    @Test
-    public void testParseInternal() {
         // internal catalog
         String constraintDescs = "(column1)  REFERENCES  default_catalog.100.1000(newColumn1)";
         List<ForeignKeyConstraint> foreignKeyConstraints1 = ForeignKeyConstraint.parse(constraintDescs);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -115,11 +115,11 @@ public class GlobalStateMgrTestUtil {
     }
 
     public static boolean compareState(GlobalStateMgr masterGlobalStateMgr, GlobalStateMgr slaveGlobalStateMgr) {
-        Database masterDb = masterGlobalStateMgr.getDb(testDb1);
-        Database slaveDb = slaveGlobalStateMgr.getDb(testDb1);
+        Database masterDb = masterGlobalStateMgr.getLocalMetastore().getDb(testDb1);
+        Database slaveDb = slaveGlobalStateMgr.getLocalMetastore().getDb(testDb1);
         List<Table> tables = masterDb.getTables();
         for (Table table : tables) {
-            Table slaveTable = slaveDb.getTable(table.getId());
+            Table slaveTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(slaveDb.getId(), table.getId());
             if (slaveTable == null) {
                 return false;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -107,7 +107,7 @@ public class InfoSchemaDbTest {
         Assert.assertFalse(db.registerTableUnlocked(null));
         db.dropTable("authors");
         db.write(null);
-        Assert.assertNull(db.getTable("authors"));
+        Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "authors"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.google.common.base.Strings;
@@ -91,7 +90,7 @@ public class MaterializedViewTest {
         Assert.assertEquals(null, mv.getTableProperty());
 
         MaterializedView mv2 = new MaterializedView(1000, 100, "mv2", columns, KeysType.AGG_KEYS,
-                null, null, null);
+                    null, null, null);
         Assert.assertEquals(100, mv2.getDbId());
         Assert.assertEquals(Table.TableType.MATERIALIZED_VIEW, mv2.getType());
         Assert.assertEquals(null, mv2.getTableProperty());
@@ -131,16 +130,16 @@ public class MaterializedViewTest {
     @Test
     public void testSchema() {
         MaterializedView mv = new MaterializedView(1000, 100, "mv2", columns, KeysType.AGG_KEYS,
-                null, null, null);
+                    null, null, null);
         mv.setBaseIndexId(1L);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         Assert.assertEquals(1, mv.getBaseIndexId());
         mv.rebuildFullSchema();
         Assert.assertEquals("mv_name", mv.getIndexNameById(1L));
         List<Column> indexColumns = Lists.newArrayList(columns.get(0), columns.get(2));
         mv.setIndexMeta(2L, "index_name", indexColumns, 0,
-                222, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                    222, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         mv.rebuildFullSchema();
         Assert.assertEquals("index_name", mv.getIndexNameById(2L));
     }
@@ -157,9 +156,9 @@ public class MaterializedViewTest {
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
 
         MaterializedView mv = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                partitionInfo, distributionInfo, refreshScheme);
+                    partitionInfo, distributionInfo, refreshScheme);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         Assert.assertEquals("mv_name", mv.getName());
         mv.setName("new_name");
         Assert.assertEquals("new_name", mv.getName());
@@ -184,9 +183,9 @@ public class MaterializedViewTest {
         rangePartitionInfo.setTabletType(1, TTabletType.TABLET_TYPE_DISK);
 
         MaterializedView mv2 = new MaterializedView(1000, 100, "mv_name_2", columns, KeysType.AGG_KEYS,
-                rangePartitionInfo, distributionInfo, refreshScheme);
+                    rangePartitionInfo, distributionInfo, refreshScheme);
         mv2.setIndexMeta(1L, "mv_name_2", columns, 0,
-                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         Assert.assertEquals("mv_name_2", mv2.getName());
         mv2.setName("new_name_2");
         Assert.assertEquals("new_name_2", mv2.getName());
@@ -214,16 +213,16 @@ public class MaterializedViewTest {
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
 
         MaterializedView mv = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                partitionInfo, distributionInfo, refreshScheme);
+                    partitionInfo, distributionInfo, refreshScheme);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         DistributionInfo distributionInfo1 = mv.getDefaultDistributionInfo();
         Assert.assertTrue(distributionInfo1 instanceof RandomDistributionInfo);
         Assert.assertEquals(0, mv.getDistributionColumnNames().size());
 
         HashDistributionInfo hashDistributionInfo = new HashDistributionInfo(10, Lists.newArrayList(columns.get(0)));
         MaterializedView mv2 = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                partitionInfo, hashDistributionInfo, refreshScheme);
+                    partitionInfo, hashDistributionInfo, refreshScheme);
         DistributionInfo distributionInfo2 = mv2.getDefaultDistributionInfo();
         Assert.assertTrue(distributionInfo2 instanceof HashDistributionInfo);
         Assert.assertEquals(1, mv2.getDistributionColumnNames().size());
@@ -240,9 +239,9 @@ public class MaterializedViewTest {
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
 
         MaterializedView mv = new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
-                partitionInfo, distributionInfo, refreshScheme);
+                    partitionInfo, distributionInfo, refreshScheme);
         mv.setIndexMeta(1L, "mv_name", columns, 0,
-                111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
+                    111, (short) 2, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
         TTableDescriptor tableDescriptor = mv.toThrift(null);
         Assert.assertEquals(TTableType.MATERIALIZED_VIEW, tableDescriptor.getTableType());
         Assert.assertEquals(1000, tableDescriptor.getId());
@@ -252,40 +251,40 @@ public class MaterializedViewTest {
     @Test
     public void testRenameMaterializedView() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("create materialized view mv_to_rename\n" +
-                        "PARTITION BY k1\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;")
-                .withMaterializedView("create materialized view mv_to_rename2\n" +
-                        "PARTITION BY date_trunc('month', k1)\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
+                    .withTable("CREATE TABLE test.tbl1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withMaterializedView("create materialized view mv_to_rename\n" +
+                                "PARTITION BY k1\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "refresh async\n" +
+                                "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;")
+                    .withMaterializedView("create materialized view mv_to_rename2\n" +
+                                "PARTITION BY date_trunc('month', k1)\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "refresh async\n" +
+                                "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
 
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
         Assert.assertNotNull(db);
-        Table table = db.getTable("mv_to_rename");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv_to_rename");
         Assert.assertNotNull(table);
         // test partition related info
         MaterializedView oldMv = (MaterializedView) table;
         Assert.assertTrue(oldMv.getRefreshScheme().isAsync());
         Assert.assertTrue(oldMv.getRefreshScheme().toString().contains("MvRefreshScheme"));
         Map<Table, Column> partitionMap = oldMv.getRefBaseTablePartitionColumns();
-        Table table1 = db.getTable("tbl1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         Assert.assertTrue(partitionMap.containsKey(table1));
         List<Table.TableType> baseTableType = oldMv.getBaseTableTypes();
         Assert.assertEquals(1, baseTableType.size());
@@ -301,8 +300,9 @@ public class MaterializedViewTest {
 
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
         stmtExecutor.execute();
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView mv = ((MaterializedView) testDb.getTable("mv_new_name"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "mv_new_name"));
         Assert.assertNotNull(mv);
         Assert.assertEquals("mv_new_name", mv.getName());
         ExpressionRangePartitionInfo partitionInfo = (ExpressionRangePartitionInfo) mv.getPartitionInfo();
@@ -317,7 +317,8 @@ public class MaterializedViewTest {
         statement = SqlParser.parseSingleStatement(alterSql2, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, statement);
         stmtExecutor2.execute();
-        MaterializedView mv2 = ((MaterializedView) testDb.getTable("mv_new_name2"));
+        MaterializedView mv2 = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "mv_new_name2"));
         Assert.assertNotNull(mv2);
         Assert.assertEquals("mv_new_name2", mv2.getName());
         ExpressionRangePartitionInfo partitionInfo2 = (ExpressionRangePartitionInfo) mv2.getPartitionInfo();
@@ -334,34 +335,34 @@ public class MaterializedViewTest {
     @Test
     public void testReplay() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("create materialized view mv_replay\n" +
-                        "PARTITION BY k1\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
+                    .withTable("CREATE TABLE test.tbl1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withMaterializedView("create materialized view mv_replay\n" +
+                                "PARTITION BY k1\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "refresh async\n" +
+                                "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
         connectContext.executeSql("insert into test.tbl1 values('2022-02-01', 2, 3)");
         connectContext.executeSql("insert into test.tbl1 values('2022-02-16', 3, 5)");
         connectContext.executeSql("refresh materialized view mv_replay with sync mode");
 
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
         Assert.assertNotNull(db);
-        Table table = db.getTable("mv_replay");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv_replay");
         MaterializedView mv = (MaterializedView) table;
         AlterMaterializedViewBaseTableInfosLog log = new AlterMaterializedViewBaseTableInfosLog(db.getId(), mv.getId(), null,
-                mv.getBaseTableInfos(), mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap());
+                    mv.getBaseTableInfos(), mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap());
         mv.replayAlterMaterializedViewBaseTableInfos(log);
 
         starRocksAssert.dropMaterializedView("mv_replay");
@@ -370,25 +371,26 @@ public class MaterializedViewTest {
     @Test
     public void testMvAfterDropBaseTable() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl_drop\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("create materialized view mv_to_check\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k2, sum(v1) as total from tbl_drop group by k2;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView mv = ((MaterializedView) testDb.getTable("mv_to_check"));
+                    .withTable("CREATE TABLE test.tbl_drop\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withMaterializedView("create materialized view mv_to_check\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "refresh async\n" +
+                                "as select k2, sum(v1) as total from tbl_drop group by k2;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "mv_to_check"));
         String dropSql = "drop table tbl_drop;";
         StatementBase statement = SqlParser.parseSingleStatement(dropSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
@@ -400,29 +402,30 @@ public class MaterializedViewTest {
     @Test
     public void testMvAfterBaseTableRename() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl_to_rename\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("create materialized view mv_to_check\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k2, sum(v1) as total from tbl_to_rename group by k2;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    .withTable("CREATE TABLE test.tbl_to_rename\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withMaterializedView("create materialized view mv_to_check\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "refresh async\n" +
+                                "as select k2, sum(v1) as total from tbl_to_rename group by k2;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         String alterSql = "alter table tbl_to_rename rename new_tbl_name;";
         StatementBase statement = SqlParser.parseSingleStatement(alterSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
         stmtExecutor.execute();
-        MaterializedView mv = ((MaterializedView) testDb.getTable("mv_to_check"));
+        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "mv_to_check"));
         Assert.assertNotNull(mv);
         Assert.assertFalse(mv.isActive());
     }
@@ -430,26 +433,28 @@ public class MaterializedViewTest {
     @Test
     public void testMaterializedViewWithHint() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("create materialized view mv_with_hint\n" +
-                        "PARTITION BY k1\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select /*+ SET_VAR(query_timeout = 500) */ k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView mv = ((MaterializedView) testDb.getTable("mv_with_hint"));
+                    .withTable("CREATE TABLE test.tbl1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withMaterializedView("create materialized view mv_with_hint\n" +
+                                "PARTITION BY k1\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "refresh async\n" +
+                                "as select /*+ SET_VAR(query_timeout = 500) */ k1, k2, sum(v1) " +
+                                "as total from tbl1 group by k1, k2;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "mv_with_hint"));
         String mvTaskName = "mv-" + mv.getId();
         Task task = connectContext.getGlobalStateMgr().getTaskManager().getTask(mvTaskName);
         Assert.assertNotNull(task);
@@ -463,24 +468,24 @@ public class MaterializedViewTest {
     @Test
     public void testRollupMaterializedViewWithScalarFunction() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE `part_with_mv` (\n" +
-                        "  `p_partkey` int(11) NOT NULL COMMENT \"\",\n" +
-                        "  `p_name` varchar(55) NOT NULL COMMENT \"\",\n" +
-                        "  `p_mfgr` varchar(25) NOT NULL COMMENT \"\",\n" +
-                        "  `p_brand` varchar(10) NOT NULL COMMENT \"\",\n" +
-                        "  `p_type` varchar(25) NOT NULL COMMENT \"\",\n" +
-                        "  `p_size` int(11) NOT NULL COMMENT \"\",\n" +
-                        "  `p_container` varchar(10) NOT NULL COMMENT \"\",\n" +
-                        "  `p_retailprice` decimal64(15, 2) NOT NULL COMMENT \"\",\n" +
-                        "  `p_comment` varchar(23) NOT NULL COMMENT \"\"\n" +
-                        ") ENGINE=OLAP\n" +
-                        "DUPLICATE KEY(`p_partkey`)\n" +
-                        "COMMENT \"OLAP\"\n" +
-                        "DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\");");
+                    .withTable("CREATE TABLE `part_with_mv` (\n" +
+                                "  `p_partkey` int(11) NOT NULL COMMENT \"\",\n" +
+                                "  `p_name` varchar(55) NOT NULL COMMENT \"\",\n" +
+                                "  `p_mfgr` varchar(25) NOT NULL COMMENT \"\",\n" +
+                                "  `p_brand` varchar(10) NOT NULL COMMENT \"\",\n" +
+                                "  `p_type` varchar(25) NOT NULL COMMENT \"\",\n" +
+                                "  `p_size` int(11) NOT NULL COMMENT \"\",\n" +
+                                "  `p_container` varchar(10) NOT NULL COMMENT \"\",\n" +
+                                "  `p_retailprice` decimal64(15, 2) NOT NULL COMMENT \"\",\n" +
+                                "  `p_comment` varchar(23) NOT NULL COMMENT \"\"\n" +
+                                ") ENGINE=OLAP\n" +
+                                "DUPLICATE KEY(`p_partkey`)\n" +
+                                "COMMENT \"OLAP\"\n" +
+                                "DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\");");
         String createMvSql = "create materialized view mv1 as select p_partkey, p_name, length(p_brand) as v1 " +
-                "from part_with_mv;";
+                    "from part_with_mv;";
         StatementBase statement = SqlParser.parseSingleStatement(createMvSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
         stmtExecutor.execute();
@@ -490,56 +495,57 @@ public class MaterializedViewTest {
     @Test(expected = SemanticException.class)
     public void testNonPartitionMvSupportedProperties() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE goods(\n" +
-                        "item_id1 INT,\n" +
-                        "item_name STRING,\n" +
-                        "price FLOAT\n" +
-                        ") DISTRIBUTED BY HASH(item_id1)\n" +
-                        "PROPERTIES(\"replication_num\" = \"1\");");
+                    .withTable("CREATE TABLE goods(\n" +
+                                "item_id1 INT,\n" +
+                                "item_name STRING,\n" +
+                                "price FLOAT\n" +
+                                ") DISTRIBUTED BY HASH(item_id1)\n" +
+                                "PROPERTIES(\"replication_num\" = \"1\");");
 
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW order_mv\n" +
-                "DISTRIBUTED BY HASH(item_id1) BUCKETS 12\n" +
-                "PROPERTIES (\n" +
-                "\"partition_refresh_number\" = \"10\"\n" +
-                ")\n" +
-                "REFRESH ASYNC\n" +
-                "AS SELECT\n" +
-                "item_id1,\n" +
-                "sum(price) as total\n" +
-                "FROM goods\n" +
-                "GROUP BY item_id1;");
+                    "DISTRIBUTED BY HASH(item_id1) BUCKETS 12\n" +
+                    "PROPERTIES (\n" +
+                    "\"partition_refresh_number\" = \"10\"\n" +
+                    ")\n" +
+                    "REFRESH ASYNC\n" +
+                    "AS SELECT\n" +
+                    "item_id1,\n" +
+                    "sum(price) as total\n" +
+                    "FROM goods\n" +
+                    "GROUP BY item_id1;");
     }
 
     @Test
     public void testCreateMaterializedViewWithInactiveMaterializedView() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE base_table\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("CREATE MATERIALIZED VIEW base_mv\n" +
-                        "PARTITION BY k1\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "REFRESH manual\n" +
-                        "as select k1,k2,v1 from base_table;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView baseMv = ((MaterializedView) testDb.getTable("base_mv"));
+                    .withTable("CREATE TABLE base_table\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW base_mv\n" +
+                                "PARTITION BY k1\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "REFRESH manual\n" +
+                                "as select k1,k2,v1 from base_table;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView baseMv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "base_mv"));
         baseMv.setInactiveAndReason("");
 
         SinglePartitionInfo singlePartitionInfo = new SinglePartitionInfo();
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
         HashDistributionInfo hashDistributionInfo = new HashDistributionInfo(3, Lists.newArrayList(columns.get(0)));
         MaterializedView mv = new MaterializedView(1000, testDb.getId(), "mv", columns, KeysType.AGG_KEYS,
-                singlePartitionInfo, hashDistributionInfo, refreshScheme);
+                    singlePartitionInfo, hashDistributionInfo, refreshScheme);
         List<BaseTableInfo> baseTableInfos = Lists.newArrayList();
         BaseTableInfo baseTableInfo = new BaseTableInfo(testDb.getId(), testDb.getFullName(), baseMv.getName(), baseMv.getId());
         baseTableInfos.add(baseTableInfo);
@@ -572,22 +578,22 @@ public class MaterializedViewTest {
     @Test
     public void testShowSyncMV() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl_sync_mv\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("create materialized view sync_mv_to_check\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "as select k2, sum(v1) as total from tbl_sync_mv group by k2;");
+                    .withTable("CREATE TABLE test.tbl_sync_mv\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withMaterializedView("create materialized view sync_mv_to_check\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "as select k2, sum(v1) as total from tbl_sync_mv group by k2;");
         String showSql = "show create materialized view sync_mv_to_check;";
         StatementBase statement = SqlParser.parseSingleStatement(showSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
@@ -615,7 +621,7 @@ public class MaterializedViewTest {
                         "distributed by hash(k2) buckets 3\n" +
                         "as select k2, sum(v1) as total from table1 group by k2;");
 
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
         Assert.assertNotNull(db);
         Table table = db.getTable("index_mv_to_check");
         Assert.assertNotNull(table);
@@ -641,7 +647,7 @@ public class MaterializedViewTest {
         testAlterMVWithIndex();
         String showCreateSql = "show create materialized view test.index_mv_to_check;";
         ShowCreateTableStmt showCreateTableStmt =
-                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
+                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         System.out.println(showResultSet.getMetaData().toString());
         System.out.println(showResultSet.getResultRows());
@@ -650,47 +656,47 @@ public class MaterializedViewTest {
     @Test
     public void testAlterViewWithIndex() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.table1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withView("create view index_view_to_check\n" +
-                        "as select k2, sum(v1) as total from table1 group by k2;");
+                    .withTable("CREATE TABLE test.table1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');")
+                    .withView("create view index_view_to_check\n" +
+                                "as select k2, sum(v1) as total from table1 group by k2;");
         String bitmapSql = "create index index1 ON test.index_view_to_check (k2) USING BITMAP COMMENT 'balabala'";
         AlterTableStmt alterViewStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(bitmapSql, connectContext);
         Assert.assertThrows("Do not support alter non-native table/materialized-view[index_view_to_check]",
-                SemanticException.class,
-                () -> DDLStmtExecutor.execute(alterViewStmt, connectContext));
+                    SemanticException.class,
+                    () -> DDLStmtExecutor.execute(alterViewStmt, connectContext));
     }
 
     public void testCreateMV(String mvSql) throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.table1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.table1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         starRocksAssert.withMaterializedView(mvSql);
         String showCreateSql = "show create materialized view test.index_mv_to_check;";
         ShowCreateTableStmt showCreateTableStmt =
-                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
+                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showCreateSql, connectContext);
         ShowResultSet showResultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         System.out.println(showResultSet.getResultRows());
     }
@@ -698,109 +704,108 @@ public class MaterializedViewTest {
     @Test
     public void testCreateMVWithIndex() throws Exception {
         String mvSqlWithBitMapAndBloomfilter = "create materialized view index_mv_to_check " +
-                "(k2 ," +
-                " total ," +
-                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
-                ")" +
-                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                "REFRESH MANUAL\n" +
-                "PROPERTIES " +
-                "("
-                + "\"replicated_storage\" = \"true\","
-                + "\"replication_num\" = \"1\","
-                + "\"storage_medium\" = \"HDD\","
-                + "\"bloom_filter_columns\" = \"k2\""
-                + ")" +
-                "as select k2, sum(v1) as total from table1 group by k2;";
+                    "(k2 ," +
+                    " total ," +
+                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
+                    ")" +
+                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                    "REFRESH MANUAL\n" +
+                    "PROPERTIES " +
+                    "("
+                    + "\"replicated_storage\" = \"true\","
+                    + "\"replication_num\" = \"1\","
+                    + "\"storage_medium\" = \"HDD\","
+                    + "\"bloom_filter_columns\" = \"k2\""
+                    + ")" +
+                    "as select k2, sum(v1) as total from table1 group by k2;";
         String mvSqlWithBitMap = "create materialized view index_mv_to_check " +
-                "(k2 ," +
-                " total ," +
-                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
-                ")" +
-                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                "REFRESH MANUAL\n" +
-                "PROPERTIES " +
-                "("
-                + "\"replicated_storage\" = \"true\","
-                + "\"replication_num\" = \"1\","
-                + "\"storage_medium\" = \"HDD\""
-                + ")" +
-                "as select k2, sum(v1) as total from table1 group by k2;";
+                    "(k2 ," +
+                    " total ," +
+                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala' " +
+                    ")" +
+                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                    "REFRESH MANUAL\n" +
+                    "PROPERTIES " +
+                    "("
+                    + "\"replicated_storage\" = \"true\","
+                    + "\"replication_num\" = \"1\","
+                    + "\"storage_medium\" = \"HDD\""
+                    + ")" +
+                    "as select k2, sum(v1) as total from table1 group by k2;";
         String mvSqlWithBloomFilter = "create materialized view index_mv_to_check " +
-                "(k2 ," +
-                " total" +
-                ")" +
-                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                "REFRESH MANUAL\n" +
-                "PROPERTIES " +
-                "("
-                + "\"replicated_storage\" = \"true\","
-                + "\"replication_num\" = \"1\","
-                + "\"storage_medium\" = \"HDD\","
-                + "\"bloom_filter_columns\" = \"k2\""
-                + ")" +
-                "as select k2, sum(v1) as total from table1 group by k2;";
+                    "(k2 ," +
+                    " total" +
+                    ")" +
+                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                    "REFRESH MANUAL\n" +
+                    "PROPERTIES " +
+                    "("
+                    + "\"replicated_storage\" = \"true\","
+                    + "\"replication_num\" = \"1\","
+                    + "\"storage_medium\" = \"HDD\","
+                    + "\"bloom_filter_columns\" = \"k2\""
+                    + ")" +
+                    "as select k2, sum(v1) as total from table1 group by k2;";
         testCreateMV(mvSqlWithBitMapAndBloomfilter);
         testCreateMV(mvSqlWithBitMap);
         testCreateMV(mvSqlWithBloomFilter);
     }
 
-
     @Test
     public void testCreateMVWithDuplicateIndexOrDuplicateColumn() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.table1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.table1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String mvSql = "create materialized view index_mv_to_check " +
-                "(k2 ," +
-                " total ," +
-                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
-                "INDEX index1 (`total`) USING BITMAP COMMENT 'balabala' " +
-                ")" +
-                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                "REFRESH MANUAL\n" +
-                "PROPERTIES " +
-                "("
-                + "\"replicated_storage\" = \"true\","
-                + "\"replication_num\" = \"1\","
-                + "\"storage_medium\" = \"HDD\","
-                + "\"bloom_filter_columns\" = \"k2\""
-                + ")" +
-                "as select k2, sum(v1) as total from table1 group by k2;";
+                    "(k2 ," +
+                    " total ," +
+                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
+                    "INDEX index1 (`total`) USING BITMAP COMMENT 'balabala' " +
+                    ")" +
+                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                    "REFRESH MANUAL\n" +
+                    "PROPERTIES " +
+                    "("
+                    + "\"replicated_storage\" = \"true\","
+                    + "\"replication_num\" = \"1\","
+                    + "\"storage_medium\" = \"HDD\","
+                    + "\"bloom_filter_columns\" = \"k2\""
+                    + ")" +
+                    "as select k2, sum(v1) as total from table1 group by k2;";
         Assert.assertThrows("Duplicate index name 'index1'",
-                UserException.class,
-                () -> starRocksAssert.withMaterializedView(mvSql));
+                    UserException.class,
+                    () -> starRocksAssert.withMaterializedView(mvSql));
 
         String mvSql2 = "create materialized view index_mv_to_check " +
-                "(k2 ," +
-                " total ," +
-                "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
-                "INDEX index2 (`k2`) USING BITMAP COMMENT 'balabala' " +
-                ")" +
-                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
-                "REFRESH MANUAL\n" +
-                "PROPERTIES " +
-                "("
-                + "\"replicated_storage\" = \"true\","
-                + "\"replication_num\" = \"1\","
-                + "\"storage_medium\" = \"HDD\","
-                + "\"bloom_filter_columns\" = \"k2\""
-                + ")" +
-                "as select k2, sum(v1) as total from table1 group by k2;";
+                    "(k2 ," +
+                    " total ," +
+                    "INDEX index1 (`k2`) USING BITMAP COMMENT 'balabala', " +
+                    "INDEX index2 (`k2`) USING BITMAP COMMENT 'balabala' " +
+                    ")" +
+                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                    "REFRESH MANUAL\n" +
+                    "PROPERTIES " +
+                    "("
+                    + "\"replicated_storage\" = \"true\","
+                    + "\"replication_num\" = \"1\","
+                    + "\"storage_medium\" = \"HDD\","
+                    + "\"bloom_filter_columns\" = \"k2\""
+                    + ")" +
+                    "as select k2, sum(v1) as total from table1 group by k2;";
         Assert.assertThrows("Duplicate column name 'k2' in index",
-                UserException.class,
-                () -> starRocksAssert.withMaterializedView(mvSql2));
+                    UserException.class,
+                    () -> starRocksAssert.withMaterializedView(mvSql2));
     }
 
     @Test
@@ -813,6 +818,6 @@ public class MaterializedViewTest {
         Assert.assertEquals(100, basePartitionInfo.getExtLastFileModifiedTime());
         Assert.assertEquals(10, basePartitionInfo.getFileNumber());
         Assert.assertTrue(basePartitionInfo.toString().contains(
-                "BasePartitionInfo{id=-1, version=-1, lastRefreshTime=123456, lastFileModifiedTime=100, fileNumber=10}"));
+                    "BasePartitionInfo{id=-1, version=-1, lastRefreshTime=123456, lastFileModifiedTime=100, fileNumber=10}"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
@@ -99,6 +99,10 @@ public class MetadataViewerTest {
                 globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = db;
+
+                globalStateMgr.getLocalMetastore().getTable(anyString, anyString);
+                minTimes = 0;
+                result = db.getTable(CatalogMocker.TEST_TBL_NAME);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MetadataViewerTest.java
@@ -96,7 +96,7 @@ public class MetadataViewerTest {
                 minTimes = 0;
                 result = globalStateMgr;
 
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = db;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StorageCoolDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StorageCoolDownTest.java
@@ -142,7 +142,7 @@ public class StorageCoolDownTest {
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
                 .getTable("site_access_datetime_with_1_day_ttl_less_than");
 
         RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
@@ -200,7 +200,7 @@ public class StorageCoolDownTest {
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
                 .getTable("site_access_date_upper_lower_ttl");
 
         RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
@@ -250,7 +250,7 @@ public class StorageCoolDownTest {
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
                 .getTable("site_access_date_with_1_day_ttl_start_end");
 
         RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
@@ -303,7 +303,7 @@ public class StorageCoolDownTest {
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
                 .getTable("site_access_date_with_1_day_ttl_less_than");
 
         RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
@@ -356,7 +356,7 @@ public class StorageCoolDownTest {
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
                 .getTable("site_access_with_max_partition");
 
         RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StorageMediumInferTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StorageMediumInferTest.java
@@ -85,14 +85,14 @@ public class StorageMediumInferTest {
 
     @Test
     public void testCreateTable() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
 
         be1.setStorageMediumForAllDisks(TStorageMedium.HDD);
         be2.setStorageMediumForAllDisks(TStorageMedium.HDD);
         createTable("create table test.tbl1(key1 int, key2 varchar(10)) \n" +
                 "distributed by hash(key1) buckets 10 properties('replication_num' = '1');");
-        OlapTable tbl1 = (OlapTable) db.getTable("tbl1");
+        OlapTable tbl1 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         List<Partition> partitionList1 = Lists.newArrayList(tbl1.getPartitions());
         DataProperty dataProperty1 =
                 globalStateMgr.getLocalMetastore().getDataPropertyIncludeRecycleBin(tbl1.getPartitionInfo(),
@@ -105,7 +105,7 @@ public class StorageMediumInferTest {
                 + "duplicate key(k1)\n" + "partition by range(k2)\n" + "(partition p1 values less than(\"10\"))\n"
                 + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
         createTable(sql);
-        OlapTable tbl2 = (OlapTable) db.getTable("tbl2");
+        OlapTable tbl2 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl2");
         List<Partition> partitionList2 = Lists.newArrayList(tbl2.getPartitions());
         DataProperty dataProperty2 =
                 globalStateMgr.getLocalMetastore().getDataPropertyIncludeRecycleBin(tbl2.getPartitionInfo(),
@@ -117,7 +117,7 @@ public class StorageMediumInferTest {
         Config.tablet_sched_storage_cooldown_second = 123123213L;
         createTable("create table test.tbl3(key1 int, key2 varchar(10)) \n" +
                 "distributed by hash(key1) buckets 10 properties('replication_num' = '1');");
-        OlapTable tbl3 = (OlapTable) db.getTable("tbl3");
+        OlapTable tbl3 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl3");
         List<Partition> partitionList3 = Lists.newArrayList(tbl3.getPartitions());
         DataProperty dataProperty3 =
                 globalStateMgr.getLocalMetastore().getDataPropertyIncludeRecycleBin(tbl3.getPartitionInfo(),
@@ -127,7 +127,7 @@ public class StorageMediumInferTest {
         Config.tablet_sched_storage_cooldown_second = -1L; // default value, no storage cool down
         createTable("create table test.tbl4(key1 int, key2 varchar(10)) \n" +
                 "distributed by hash(key1) buckets 10 properties('replication_num' = '1');");
-        OlapTable tbl4 = (OlapTable) db.getTable("tbl4");
+        OlapTable tbl4 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl4");
         List<Partition> partitionList4 = Lists.newArrayList(tbl4.getPartitions());
         DataProperty dataProperty4 =
                 globalStateMgr.getLocalMetastore().getDataPropertyIncludeRecycleBin(tbl4.getPartitionInfo(),
@@ -137,7 +137,7 @@ public class StorageMediumInferTest {
 
     @Test
     public void testAlterTableAddPartition() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         be1.setStorageMediumForAllDisks(TStorageMedium.SSD);
         be2.setStorageMediumForAllDisks(TStorageMedium.SSD);
@@ -146,7 +146,7 @@ public class StorageMediumInferTest {
                 + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
         createTable(sql);
         alterTableWithNewParser("ALTER TABLE test.tblp2 ADD PARTITION IF NOT EXISTS p2 VALUES LESS THAN (\"20\")");
-        OlapTable tbl2 = (OlapTable) db.getTable("tblp2");
+        OlapTable tbl2 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tblp2");
         List<Partition> partitionList2 = Lists.newArrayList(tbl2.getPartitions());
         Assert.assertEquals(2, partitionList2.size());
         for (Partition partition : partitionList2) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
@@ -379,7 +379,7 @@ public class TempPartitionTest {
                         "distributed by hash(k2) buckets 1\n" +
                         "properties('replication_num' = '1');");
 
-        Database db2 = GlobalStateMgr.getCurrentState().getDb("db2");
+        Database db2 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2");
         OlapTable tbl2 = (OlapTable) db2.getTable("tbl2");
 
         Map<String, Long> originPartitionTabletIds = Maps.newHashMap();
@@ -608,7 +608,7 @@ public class TempPartitionTest {
         }
 
         OlapTable olapTable =
-                (OlapTable) GlobalStateMgr.getCurrentState().getDb("db2").getTable("tbl2");
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2").getTable("tbl2");
 
         // waiting table state to normal
         int retryTimes = 5;
@@ -675,7 +675,7 @@ public class TempPartitionTest {
                 "distributed by hash(k2) buckets 1\n" +
                 "properties('replication_num' = '1');");
 
-        Database db3 = GlobalStateMgr.getCurrentState().getDb("db3");
+        Database db3 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db3");
         OlapTable tbl3 = (OlapTable) db3.getTable("tbl3");
 
         // base range is [min, 10), [10, 20), [20, 30)

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -143,24 +143,25 @@ public class ColocateTableBalancerTest {
     }
 
     private void addTabletsToScheduler(String dbName, String tableName, boolean setGroupId) {
-        Database database = GlobalStateMgr.getCurrentState().getDb(dbName);
-        OlapTable table = (OlapTable) database.getTable(tableName);
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableName);
         // add its tablet to TabletScheduler
         TabletScheduler tabletScheduler = GlobalStateMgr.getCurrentState().getTabletScheduler();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex materializedIndex = partition.getBaseIndex();
             for (Tablet tablet : materializedIndex.getTablets()) {
                 TabletSchedCtx ctx = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR,
-                        database.getId(),
-                        table.getId(),
-                        partition.getId(),
-                        materializedIndex.getId(),
-                        tablet.getId(),
-                        System.currentTimeMillis());
+                            database.getId(),
+                            table.getId(),
+                            partition.getId(),
+                            materializedIndex.getId(),
+                            tablet.getId(),
+                            System.currentTimeMillis());
                 ctx.setOrigPriority(TabletSchedCtx.Priority.LOW);
                 if (setGroupId) {
                     ctx.setColocateGroupId(
-                            GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId()));
+                                GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId()));
                 }
                 tabletScheduler.addTablet(ctx, false);
             }
@@ -170,12 +171,13 @@ public class ColocateTableBalancerTest {
     @Test
     public void test1MatchGroup() throws Exception {
         starRocksAssert.withDatabase("db1").useDatabase("db1")
-                .withTable("CREATE TABLE db1.tbl(id INT NOT NULL) " +
-                        "distributed by hash(`id`) buckets 3 " +
-                        "properties('replication_num' = '1', 'colocate_with' = 'group1');");
+                    .withTable("CREATE TABLE db1.tbl(id INT NOT NULL) " +
+                                "distributed by hash(`id`) buckets 3 " +
+                                "properties('replication_num' = '1', 'colocate_with' = 'group1');");
 
-        Database database = GlobalStateMgr.getCurrentState().getDb("db1");
-        OlapTable table = (OlapTable) database.getTable("tbl");
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "tbl");
         addTabletsToScheduler("db1", "tbl", false);
 
         ColocateTableIndex colocateIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
@@ -203,12 +205,13 @@ public class ColocateTableBalancerTest {
         UtFrameUtils.addMockBackend(10003);
         UtFrameUtils.addMockBackend(10004);
         starRocksAssert.withDatabase("db3").useDatabase("db3")
-                .withTable("CREATE TABLE db3.tbl3(id INT NOT NULL) " +
-                        "distributed by hash(`id`) buckets 1 " +
-                        "properties('replication_num' = '1', 'colocate_with' = 'group3');");
+                    .withTable("CREATE TABLE db3.tbl3(id INT NOT NULL) " +
+                                "distributed by hash(`id`) buckets 1 " +
+                                "properties('replication_num' = '1', 'colocate_with' = 'group3');");
 
-        Database database = GlobalStateMgr.getCurrentState().getDb("db3");
-        OlapTable table = (OlapTable) database.getTable("tbl3");
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db3");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "tbl3");
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
 
         List<Partition> partitions = Lists.newArrayList(table.getPartitions());
@@ -309,7 +312,7 @@ public class ColocateTableBalancerTest {
         GroupId groupId = new GroupId(10005, 10006);
         short replicationNUm = 3;
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 4L, 1L, 2L, 5L), replicationNUm);
+                    Lists.newArrayList(1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 4L, 1L, 2L, 5L), replicationNUm);
         setGroup2Schema(groupId, colocateTableIndex, 4, replicationNUm);
 
         Set<Long> unavailableBeIds = Sets.newHashSet(5L);
@@ -318,23 +321,23 @@ public class ColocateTableBalancerTest {
         boolean changed = false;
         ColocateTableBalancer.disableRepairPrecedence = true;
         changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         Assert.assertTrue(changed);
         System.out.println(balancedBackendsPerBucketSeq);
         List<List<Long>> expected = Lists.partition(
-                Lists.newArrayList(4L, 2L, 3L, 1L, 2L, 3L, 1L, 3L, 4L, 1L, 2L, 4L), 3);
+                    Lists.newArrayList(4L, 2L, 3L, 1L, 2L, 3L, 1L, 3L, 4L, 1L, 2L, 4L), 3);
         Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
 
         ColocateTableBalancer.disableRepairPrecedence = false;
         balancedBackendsPerBucketSeq.clear();
         changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         Assert.assertTrue(changed);
         System.out.println(balancedBackendsPerBucketSeq);
         expected = Lists.partition(
-                Lists.newArrayList(1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 4L, 1L, 2L, 4L), 3);
+                    Lists.newArrayList(1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 4L, 1L, 2L, 4L), 3);
         Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
     }
 
@@ -389,7 +392,6 @@ public class ColocateTableBalancerTest {
             }
         };
 
-
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", Type.INT));
@@ -401,27 +403,27 @@ public class ColocateTableBalancerTest {
         // [[1, 2, 3], [4, 1, 2], [3, 4, 1], [2, 3, 4], [1, 2, 3]]
         FeConstants.runningUnitTest = true;
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
+                    Lists.newArrayList(1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
 
         List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
         List<Long> allAvailBackendIds = Lists.newArrayList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
         boolean changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, new HashSet<Long>(), allAvailBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, new HashSet<Long>(), allAvailBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         List<List<Long>> expected = Lists.partition(
-                Lists.newArrayList(9L, 5L, 3L, 4L, 6L, 8L, 7L, 6L, 1L, 2L, 9L, 4L, 1L, 2L, 3L), 3);
+                    Lists.newArrayList(9L, 5L, 3L, 4L, 6L, 8L, 7L, 6L, 1L, 2L, 9L, 4L, 1L, 2L, 3L), 3);
         Assert.assertTrue(changed);
         Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
 
         // 2. balance an already balanced group
         colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
+                    Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
         balancedBackendsPerBucketSeq.clear();
         changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, new HashSet<Long>(), allAvailBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, new HashSet<Long>(), allAvailBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         System.out.println(balancedBackendsPerBucketSeq);
         Assert.assertFalse(changed);
         Assert.assertTrue(balancedBackendsPerBucketSeq.isEmpty());
@@ -516,10 +518,10 @@ public class ColocateTableBalancerTest {
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         // For group 1, bucket: 3, replication_num: 1, backend list per bucket seq: [[1], [2], [3]]
         colocateTableIndex.addBackendsPerBucketSeq(groupId1,
-                Lists.partition(Lists.newArrayList(1L, 2L, 3L), 1));
+                    Lists.partition(Lists.newArrayList(1L, 2L, 3L), 1));
         // For group 2, bucket: 3, replication_num: 1, backend list per bucket seq: [[1], [2], [3]]
         colocateTableIndex.addBackendsPerBucketSeq(groupId2,
-                Lists.partition(Lists.newArrayList(1L, 2L, 3L), 1));
+                    Lists.partition(Lists.newArrayList(1L, 2L, 3L), 1));
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
         Multimap<GroupId, Long> group2Tables = ArrayListMultimap.create();
         group2Tables.put(groupId1, 20001L);
@@ -546,7 +548,7 @@ public class ColocateTableBalancerTest {
             // totally 6 replicas, after adding 2 backends and overall balance,
             // every backend should have 1 replica, except one
             Assert.assertEquals(Lists.newArrayList(1, 1, 1, 1, 2),
-                    result.values().stream().sorted().collect(Collectors.toList()));
+                        result.values().stream().sorted().collect(Collectors.toList()));
         }
     }
 
@@ -555,7 +557,7 @@ public class ColocateTableBalancerTest {
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", Type.INT));
         ColocateGroupSchema groupSchema =
-                new ColocateGroupSchema(groupId, distributionCols, bucketNum, replicationNum);
+                    new ColocateGroupSchema(groupId, distributionCols, bucketNum, replicationNum);
         Map<GroupId, ColocateGroupSchema> group2Schema = Maps.newHashMap();
         group2Schema.put(groupId, groupSchema);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
@@ -611,7 +613,7 @@ public class ColocateTableBalancerTest {
         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
         GroupId groupId = new GroupId(10000, 10001);
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(4L, 2L, 3L, 4L, 2L, 3L, 4L, 2L, 3L), 3);
+                    Lists.newArrayList(4L, 2L, 3L, 4L, 2L, 3L, 4L, 2L, 3L), 3);
         setGroup2Schema(groupId, colocateTableIndex, 3, (short) 3);
 
         Set<Long> unavailableBeIds = Sets.newHashSet(3L, 4L);
@@ -619,8 +621,8 @@ public class ColocateTableBalancerTest {
         List<Long> availBackendIds = Lists.newArrayList(2L);
 
         boolean changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         // in this case, there is only on available backend, no need to make balancing decision.
         Assert.assertFalse(changed);
     }
@@ -677,7 +679,7 @@ public class ColocateTableBalancerTest {
         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
         GroupId groupId = new GroupId(10000, 10001);
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(4L, 2L, 3L, 4L, 2L, 3L, 4L, 2L, 3L), 1);
+                    Lists.newArrayList(4L, 2L, 3L, 4L, 2L, 3L, 4L, 2L, 3L), 1);
         setGroup2Schema(groupId, colocateTableIndex, 9, (short) 1);
 
         Set<Long> unavailableBeIds = Sets.newHashSet(4L);
@@ -686,22 +688,22 @@ public class ColocateTableBalancerTest {
         boolean changed = false;
 
         changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         // there is unavailable backend, but the replication number is 1 and replicas on available backends are
         // already balanced, so the bucket sequence will remain unchanged.
         Assert.assertFalse(changed);
 
         colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(2L, 2L, 4L, 2L, 2L, 4L, 3L, 2L, 4L), 1);
+                    Lists.newArrayList(2L, 2L, 4L, 2L, 2L, 4L, 3L, 2L, 4L), 1);
         setGroup2Schema(groupId, colocateTableIndex, 9, (short) 1);
         changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         Assert.assertTrue(changed);
         System.out.println(balancedBackendsPerBucketSeq);
         List<List<Long>> expected = Lists.partition(
-                Lists.newArrayList(3L, 3L, 4L, 2L, 2L, 4L, 3L, 2L, 4L), 1);
+                    Lists.newArrayList(3L, 3L, 4L, 2L, 2L, 4L, 3L, 2L, 4L), 1);
         // there is unavailable backend, but the replication number is 1 and replicas on available backends are
         // not balanced, check the balancer actually working.
         Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
@@ -715,15 +717,15 @@ public class ColocateTableBalancerTest {
         };
         balancedBackendsPerBucketSeq = Lists.newArrayList();
         colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(2L, 2L, 4L, 2L, 2L, 4L, 3L, 2L, 4L), 1);
+                    Lists.newArrayList(2L, 2L, 4L, 2L, 2L, 4L, 3L, 2L, 4L), 1);
         setGroup2Schema(groupId, colocateTableIndex, 9, (short) 1);
         changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, availBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         Assert.assertTrue(changed);
         System.out.println(balancedBackendsPerBucketSeq);
         List<List<Long>> expected3 = Lists.partition(
-                Lists.newArrayList(2L, 2L, 3L, 2L, 2L, 3L, 3L, 2L, 3L), 1);
+                    Lists.newArrayList(2L, 2L, 3L, 2L, 2L, 3L, 3L, 2L, 3L), 1);
         // there is unavailable backend, but the replication number is 1 and there is decommissioned backend,
         // so we need to do relocation first.
         Assert.assertEquals(expected3, balancedBackendsPerBucketSeq);
@@ -777,42 +779,42 @@ public class ColocateTableBalancerTest {
         // 1. only one available backend
         // [[7], [7], [7], [7], [7]]
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
+                    Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
 
         List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
         List<Long> allAvailBackendIds = Lists.newArrayList(7L);
         boolean changed =
-                Deencapsulation.invoke(balancer, "doRelocateAndBalance",
-                        groupId, new HashSet<Long>(), allAvailBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    Deencapsulation.invoke(balancer, "doRelocateAndBalance",
+                                groupId, new HashSet<Long>(), allAvailBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         Assert.assertFalse(changed);
 
         // 2. all backends are checked but this round is not changed
         // [[7], [7], [7], [7], [7]]
         // and add new backends 8, 9 that are on the same host with 7
         colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
+                    Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
 
         balancedBackendsPerBucketSeq = Lists.newArrayList();
         allAvailBackendIds = Lists.newArrayList(7L, 8L, 9L);
         changed =
-                Deencapsulation.invoke(balancer, "doRelocateAndBalance",
-                        groupId, new HashSet<Long>(), allAvailBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    Deencapsulation.invoke(balancer, "doRelocateAndBalance",
+                                groupId, new HashSet<Long>(), allAvailBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         Assert.assertFalse(changed);
 
         // 3. all backends are not available
         colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
+                    Lists.newArrayList(7L, 7L, 7L, 7L, 7L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
         balancedBackendsPerBucketSeq = Lists.newArrayList();
         allAvailBackendIds = Lists.newArrayList();
         Set<Long> unAvailableBackendIds = Sets.newHashSet(7L);
         changed = Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unAvailableBackendIds, allAvailBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unAvailableBackendIds, allAvailBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         Assert.assertFalse(changed);
     }
 
@@ -836,15 +838,15 @@ public class ColocateTableBalancerTest {
         Set<Long> unavailBackendIds = Sets.newHashSet(9L);
         List<Long> flatBackendsPerBucketSeq = Lists.newArrayList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
         List<Map.Entry<Long, Long>> backends = Deencapsulation.invoke(balancer, "getSortedBackendReplicaNumPairs",
-                allAvailBackendIds, unavailBackendIds, statistic, flatBackendsPerBucketSeq);
+                    allAvailBackendIds, unavailBackendIds, statistic, flatBackendsPerBucketSeq);
         long[] backendIds = backends.stream().mapToLong(Map.Entry::getKey).toArray();
         Assert.assertArrayEquals(new long[] {7L, 8L, 6L, 2L, 3L, 5L, 4L, 1L}, backendIds);
 
         // 0,1 bucket on same be and 5, 6 on same be
         flatBackendsPerBucketSeq = Lists.newArrayList(1L, 1L, 3L, 4L, 5L, 6L, 7L, 7L, 9L);
         backends = Deencapsulation
-                .invoke(balancer, "getSortedBackendReplicaNumPairs", allAvailBackendIds, unavailBackendIds,
-                        statistic, flatBackendsPerBucketSeq);
+                    .invoke(balancer, "getSortedBackendReplicaNumPairs", allAvailBackendIds, unavailBackendIds,
+                                statistic, flatBackendsPerBucketSeq);
         backendIds = backends.stream().mapToLong(Map.Entry::getKey).toArray();
         Assert.assertArrayEquals(new long[] {7L, 1L, 6L, 3L, 5L, 4L, 8L, 2L}, backendIds);
     }
@@ -865,7 +867,7 @@ public class ColocateTableBalancerTest {
     public void testGetBeSeqIndexes() {
         List<Long> flatBackendsPerBucketSeq = Lists.newArrayList(1L, 2L, 2L, 3L, 4L, 2L);
         List<Integer> indexes = Deencapsulation.invoke(balancer,
-                "getBeSeqIndexes", flatBackendsPerBucketSeq, 2L);
+                    "getBeSeqIndexes", flatBackendsPerBucketSeq, 2L);
         Assert.assertArrayEquals(new int[] {1, 2, 5}, indexes.stream().mapToInt(i -> i).toArray());
         System.out.println("backend1 id is " + backend1.getId());
     }
@@ -901,9 +903,9 @@ public class ColocateTableBalancerTest {
         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
 
         Set<Long> unavailableBeIds = Deencapsulation
-                .invoke(balancer, "getUnavailableBeIdsInGroup", infoService, colocateTableIndex, groupId);
+                    .invoke(balancer, "getUnavailableBeIdsInGroup", infoService, colocateTableIndex, groupId);
         Assert.assertArrayEquals(new long[] {1L, 3L, 5L},
-                unavailableBeIds.stream().mapToLong(i -> i).sorted().toArray());
+                    unavailableBeIds.stream().mapToLong(i -> i).sorted().toArray());
     }
 
     @Test
@@ -1032,18 +1034,18 @@ public class ColocateTableBalancerTest {
 
         // group is balanced before backend 9 is dropped
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
-                Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
+                    Lists.newArrayList(9L, 8L, 7L, 8L, 6L, 5L, 9L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
         List<List<Long>> balancedBackendsPerBucketSeq = Lists.newArrayList();
         Set<Long> unavailableBeIds = Sets.newHashSet(9L);
         List<Long> allAvailBackendIds = Lists.newArrayList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L);
         boolean changed = (Boolean) Deencapsulation
-                .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, allAvailBackendIds,
-                        colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
+                    .invoke(balancer, "doRelocateAndBalance", groupId, unavailableBeIds, allAvailBackendIds,
+                                colocateTableIndex, infoService, statistic, balancedBackendsPerBucketSeq);
         System.out.println(balancedBackendsPerBucketSeq);
         Assert.assertTrue(changed);
         List<List<Long>> expected = Lists.partition(
-                Lists.newArrayList(5L, 8L, 7L, 8L, 6L, 5L, 6L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
+                    Lists.newArrayList(5L, 8L, 7L, 8L, 6L, 5L, 6L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Assert.assertEquals(expected, balancedBackendsPerBucketSeq);
     }
 
@@ -1063,10 +1065,10 @@ public class ColocateTableBalancerTest {
         // set stable last time to 1s, and sleep 1s, the system becomes to stable
         Config.tablet_sched_colocate_balance_wait_system_stable_time_s = 1;
         System.out.println("before sleep, time: " + System.currentTimeMillis()
-                + "alive backend is: " + infoService.getBackendIds(true));
+                    + "alive backend is: " + infoService.getBackendIds(true));
         Thread.sleep(2000L);
         System.out.println("after sleep, time: " + System.currentTimeMillis()
-                + "alive backend is: " + infoService.getBackendIds(true));
+                    + "alive backend is: " + infoService.getBackendIds(true));
         Assert.assertTrue(balancer.isSystemStable(infoService));
         Assert.assertTrue(balancer.isSystemStable(infoService));
 
@@ -1075,10 +1077,10 @@ public class ColocateTableBalancerTest {
         Assert.assertFalse(balancer.isSystemStable(infoService));
         Assert.assertFalse(balancer.isSystemStable(infoService));
         System.out.println("before sleep, time: " + System.currentTimeMillis()
-                + "alive backend is: " + infoService.getBackendIds(true));
+                    + "alive backend is: " + infoService.getBackendIds(true));
         Thread.sleep(2000L);
         System.out.println("after sleep, time: " + System.currentTimeMillis()
-                + "alive backend is: " + infoService.getBackendIds(true));
+                    + "alive backend is: " + infoService.getBackendIds(true));
         Assert.assertTrue(balancer.isSystemStable(infoService));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
@@ -58,28 +58,28 @@ public class DynamicPartitionSchedulerTest {
     @Test
     public void testPartitionTTLProperties() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    v1 int \n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01'),\n" +
-                        "    PARTITION p3 values less than('2020-04-01'),\n" +
-                        "    PARTITION p4 values less than('2020-05-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
-                        "PROPERTIES" +
-                        "(" +
-                        "    'replication_num' = '1'\n" +
-                        ");");
+                    .withTable("CREATE TABLE test.tbl1\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    v1 int \n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01'),\n" +
+                                "    PARTITION p3 values less than('2020-04-01'),\n" +
+                                "    PARTITION p4 values less than('2020-05-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
+                                "PROPERTIES" +
+                                "(" +
+                                "    'replication_num' = '1'\n" +
+                                ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                .getDynamicPartitionScheduler();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("tbl1");
+                    .getDynamicPartitionScheduler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         // Now the table does not actually support partition ttl,
         // so in order to simplify the test, it is directly set like this
         tbl.getTableProperty().getProperties().put("partition_ttl_number", "3");
@@ -88,37 +88,36 @@ public class DynamicPartitionSchedulerTest {
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
         dynamicPartitionScheduler.runAfterCatalogReady();
 
-
         Assert.assertEquals(3, tbl.getPartitions().size());
     }
 
     @Test
     public void testPartitionTTLPropertiesZero() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.base\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values less than('2020-02-01'),\n" +
-                        "    PARTITION p2 values less than('2020-03-01')\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');");
+                    .withTable("CREATE TABLE test.base\n" +
+                                "(\n" +
+                                "    k1 date,\n" +
+                                "    k2 int,\n" +
+                                "    v1 int sum\n" +
+                                ")\n" +
+                                "PARTITION BY RANGE(k1)\n" +
+                                "(\n" +
+                                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                                "    PARTITION p2 values less than('2020-03-01')\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                                "PROPERTIES('replication_num' = '1');");
         String sql = "create materialized view mv1 " +
-                "partition by k1 " +
-                "distributed by hash(k2) " +
-                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"partition_ttl_number\" = \"0\"\n" +
-                ") " +
-                "as select k1, k2 from test.base;";
+                    "partition by k1 " +
+                    "distributed by hash(k2) " +
+                    "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"partition_ttl_number\" = \"0\"\n" +
+                    ") " +
+                    "as select k1, k2 from test.base;";
         CreateMaterializedViewStatement createMaterializedViewStatement =
-                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                    (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMaterializedViewStatement);
             Assert.fail();
@@ -132,33 +131,34 @@ public class DynamicPartitionSchedulerTest {
         new MockUp<LocalDateTime>() {
             @Mock
             public LocalDateTime now() {
-                return  LocalDateTime.of(2023, 3, 30, 1, 1, 1);
+                return LocalDateTime.of(2023, 3, 30, 1, 1, 1);
             }
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE site_access(\n" +
-                        "    event_day datetime,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('day', event_day)(\n" +
-                        " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
-                        " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\n" +
-                        "    \"partition_live_number\" = \"3\",\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE site_access(\n" +
+                                "    event_day datetime,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day)(\n" +
+                                " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
+                                " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\n" +
+                                "    \"partition_live_number\" = \"3\",\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                .getDynamicPartitionScheduler();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("site_access");
+                    .getDynamicPartitionScheduler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access");
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
         dynamicPartitionScheduler.runOnceForTest();
 
@@ -176,33 +176,34 @@ public class DynamicPartitionSchedulerTest {
         new MockUp<LocalDateTime>() {
             @Mock
             public LocalDateTime now() {
-                return  LocalDateTime.of(2023, 3, 30, 1, 1, 1);
+                return LocalDateTime.of(2023, 3, 30, 1, 1, 1);
             }
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE site_access(\n" +
-                        "    event_day datetime,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('day', event_day)(\n" +
-                        " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
-                        " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY RANDOM BUCKETS 32\n" +
-                        "PROPERTIES(\n" +
-                        "    \"partition_live_number\" = \"3\",\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE site_access(\n" +
+                                "    event_day datetime,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day)(\n" +
+                                " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
+                                " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                                "PROPERTIES(\n" +
+                                "    \"partition_live_number\" = \"3\",\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                .getDynamicPartitionScheduler();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("site_access");
+                    .getDynamicPartitionScheduler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access");
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
         dynamicPartitionScheduler.runOnceForTest();
 
@@ -220,34 +221,35 @@ public class DynamicPartitionSchedulerTest {
         new MockUp<LocalDateTime>() {
             @Mock
             public LocalDateTime now() {
-                return  LocalDateTime.of(2023, 3, 30, 1, 1, 1);
+                return LocalDateTime.of(2023, 3, 30, 1, 1, 1);
             }
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test_random_bucket (\n" +
-                        "    uid String,\n" +
-                        "    tdbank_imp_date Date\n" +
-                        ") ENGINE=OLAP \n" +
-                        "DUPLICATE KEY(`uid`) \n" +
-                        "PARTITION BY RANGE(`tdbank_imp_date`) ()\n" +
-                        "DISTRIBUTED BY RANDOM BUCKETS 1\n" +
-                        "PROPERTIES (\n" +
-                        "     \"replication_num\" = \"1\", \n" +
-                        "     \"dynamic_partition.enable\" = \"true\", \n" +
-                        "     \"dynamic_partition.time_unit\" = \"DAY\", \n" +
-                        "     \"dynamic_partition.time_zone\" = \"Asia/Shanghai\", \n" +
-                        "     \"dynamic_partition.start\" = \"-180\", \n" +
-                        "     \"dynamic_partition.end\" = \"3\", \n" +
-                        "     \"dynamic_partition.prefix\" = \"p\", \n" +
-                        "     \"dynamic_partition.buckets\" = \"4\", \n" +
-                        "     \"dynamic_partition.history_partition_num\" = \"0\",\n" +
-                        "     \"compression\" = \"LZ4\" );");
+                    .withTable("CREATE TABLE test_random_bucket (\n" +
+                                "    uid String,\n" +
+                                "    tdbank_imp_date Date\n" +
+                                ") ENGINE=OLAP \n" +
+                                "DUPLICATE KEY(`uid`) \n" +
+                                "PARTITION BY RANGE(`tdbank_imp_date`) ()\n" +
+                                "DISTRIBUTED BY RANDOM BUCKETS 1\n" +
+                                "PROPERTIES (\n" +
+                                "     \"replication_num\" = \"1\", \n" +
+                                "     \"dynamic_partition.enable\" = \"true\", \n" +
+                                "     \"dynamic_partition.time_unit\" = \"DAY\", \n" +
+                                "     \"dynamic_partition.time_zone\" = \"Asia/Shanghai\", \n" +
+                                "     \"dynamic_partition.start\" = \"-180\", \n" +
+                                "     \"dynamic_partition.end\" = \"3\", \n" +
+                                "     \"dynamic_partition.prefix\" = \"p\", \n" +
+                                "     \"dynamic_partition.buckets\" = \"4\", \n" +
+                                "     \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                                "     \"compression\" = \"LZ4\" );");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                .getDynamicPartitionScheduler();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("test_random_bucket");
+                    .getDynamicPartitionScheduler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_random_bucket");
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
         dynamicPartitionScheduler.runOnceForTest();
 
@@ -263,42 +265,43 @@ public class DynamicPartitionSchedulerTest {
         new MockUp<LocalDateTime>() {
             @Mock
             public LocalDateTime now() {
-                return  LocalDateTime.of(2023, 3, 30, 1, 1, 1);
+                return LocalDateTime.of(2023, 3, 30, 1, 1, 1);
             }
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE `test_hour_partition2` (\n" +
-                        "  `event_day` date NULL COMMENT \"\",\n" +
-                        "  `site_id` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
-                        "  `city_code` varchar(100) NULL COMMENT \"\",\n" +
-                        "  `user_name` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
-                        "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
-                        ") ENGINE=OLAP \n" +
-                        "DUPLICATE KEY(`event_day`, `site_id`, `city_code`, `user_name`)\n" +
-                        "PARTITION BY RANGE(`event_day`)\n" +
-                        "()\n" +
-                        "DISTRIBUTED BY HASH(`event_day`, `site_id`) BUCKETS 32 \n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"dynamic_partition.enable\" = \"true\",\n" +
-                        "\"dynamic_partition.time_unit\" = \"DAY\",\n" +
-                        "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
-                        "\"dynamic_partition.start\" = \"-1\",\n" +
-                        "\"dynamic_partition.end\" = \"10\",\n" +
-                        "\"dynamic_partition.prefix\" = \"p\",\n" +
-                        "\"dynamic_partition.buckets\" = \"3\",\n" +
-                        "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
-                        "\"in_memory\" = \"false\",\n" +
-                        "\"storage_format\" = \"DEFAULT\",\n" +
-                        "\"enable_persistent_index\" = \"false\",\n" +
-                        "\"compression\" = \"LZ4\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE `test_hour_partition2` (\n" +
+                                "  `event_day` date NULL COMMENT \"\",\n" +
+                                "  `site_id` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
+                                "  `city_code` varchar(100) NULL COMMENT \"\",\n" +
+                                "  `user_name` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                                "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
+                                ") ENGINE=OLAP \n" +
+                                "DUPLICATE KEY(`event_day`, `site_id`, `city_code`, `user_name`)\n" +
+                                "PARTITION BY RANGE(`event_day`)\n" +
+                                "()\n" +
+                                "DISTRIBUTED BY HASH(`event_day`, `site_id`) BUCKETS 32 \n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"dynamic_partition.enable\" = \"true\",\n" +
+                                "\"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                                "\"dynamic_partition.start\" = \"-1\",\n" +
+                                "\"dynamic_partition.end\" = \"10\",\n" +
+                                "\"dynamic_partition.prefix\" = \"p\",\n" +
+                                "\"dynamic_partition.buckets\" = \"3\",\n" +
+                                "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                                "\"in_memory\" = \"false\",\n" +
+                                "\"storage_format\" = \"DEFAULT\",\n" +
+                                "\"enable_persistent_index\" = \"false\",\n" +
+                                "\"compression\" = \"LZ4\"\n" +
+                                ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                .getDynamicPartitionScheduler();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("test_hour_partition2");
+                    .getDynamicPartitionScheduler();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_hour_partition2");
         DynamicPartitionProperty dynamicPartitionProperty = tbl.getTableProperty().getDynamicPartitionProperty();
         dynamicPartitionProperty.setTimeUnit("HOUR");
         boolean result = dynamicPartitionScheduler.executeDynamicPartitionForTable(db.getId(), tbl.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -128,7 +128,7 @@ public class TabletSchedCtxTest {
         olapTable.setIndexMeta(INDEX_ID, TB_NAME, TB_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
         olapTable.addPartition(partition);
-        Database db = new Database();
+        Database db = new Database(DB_ID, "");
         db.registerTableUnlocked(olapTable);
         GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().put(DB_ID, db);
 

--- a/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
@@ -140,6 +140,14 @@ public class SystemInfoServiceTest {
             }
         };
 
+        new Expectations(localMetastore) {
+            {
+                localMetastore.getDb(anyLong);
+                minTimes = 0;
+                result = db;
+            }
+        };
+
         new Expectations(nodeMgr) {
             {
                 systemInfoService = new SystemInfoService();

--- a/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
@@ -112,7 +112,7 @@ public class SystemInfoServiceTest {
                 minTimes = 0;
                 result = editLog;
 
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/DbsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/DbsProcDirTest.java
@@ -83,27 +83,27 @@ public class DbsProcDirTest {
     public void testLookupNormal() throws AnalysisException {
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb("db1");
+                globalStateMgr.getLocalMetastore().getDb("db1");
                 minTimes = 0;
                 result = db1;
 
-                globalStateMgr.getDb("db2");
+                globalStateMgr.getLocalMetastore().getDb("db2");
                 minTimes = 0;
                 result = db2;
 
-                globalStateMgr.getDb("db3");
+                globalStateMgr.getLocalMetastore().getDb("db3");
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getDb(db1.getId());
+                globalStateMgr.getLocalMetastore().getDb(db1.getId());
                 minTimes = 0;
                 result = db1;
 
-                globalStateMgr.getDb(db2.getId());
+                globalStateMgr.getLocalMetastore().getDb(db2.getId());
                 minTimes = 0;
                 result = db2;
 
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = null;
             }
@@ -164,27 +164,27 @@ public class DbsProcDirTest {
                 minTimes = 0;
                 result = Lists.newArrayList("db1", "db2");
 
-                globalStateMgr.getDb("db1");
+                globalStateMgr.getLocalMetastore().getDb("db1");
                 minTimes = 0;
                 result = db1;
 
-                globalStateMgr.getDb("db2");
+                globalStateMgr.getLocalMetastore().getDb("db2");
                 minTimes = 0;
                 result = db2;
 
-                globalStateMgr.getDb("db3");
+                globalStateMgr.getLocalMetastore().getDb("db3");
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getDb(db1.getId());
+                globalStateMgr.getLocalMetastore().getDb(db1.getId());
                 minTimes = 0;
                 result = db1;
 
-                globalStateMgr.getDb(db2.getId());
+                globalStateMgr.getLocalMetastore().getDb(db2.getId());
                 minTimes = 0;
                 result = db2;
 
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/TablesProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/TablesProcDirTest.java
@@ -26,11 +26,15 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.server.LocalMetastore;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -105,6 +109,28 @@ public class TablesProcDirTest {
         db.registerTableUnlocked(tb1);
         db.registerTableUnlocked(tb2);
         db.registerTableUnlocked(tb3);
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return db;
+            }
+
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                return db.getTable(tblName);
+            }
+
+            @Mock
+            public Table getTable(Long dbId, Long tableId) {
+                return db.getTable(tableId);
+            }
+
+            @Mock
+            public List<Table> getTables(Long dbId) {
+                return db.getTables();
+            }
+        };
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SmallFileMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SmallFileMgrTest.java
@@ -81,7 +81,7 @@ public class SmallFileMgrTest {
                 db.getId();
                 minTimes = 0;
                 result = 1L;
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = db;
                 stmt1.getDbName();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsShardPartitionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsShardPartitionsTest.java
@@ -47,8 +47,8 @@ public class EsShardPartitionsTest extends EsTestCase {
     @Test
     public void testPartition() throws Exception {
         EsTable esTable = (EsTable) GlobalStateMgr.getCurrentState()
-                .getDb(GlobalStateMgrTestUtil.testDb1)
-                .getTable(GlobalStateMgrTestUtil.testEsTableId1);
+                .getLocalMetastore()
+                .getTable(GlobalStateMgrTestUtil.testDb1, GlobalStateMgrTestUtil.testEsTable1);
         EsShardPartitions esShardPartitions = EsShardPartitions.findShardPartitions("doe",
                 loadJsonFromFile("data/es/test_search_shards.json"));
         EsTablePartitions esTablePartitions = EsTablePartitions.fromShardPartitions(esTable, esShardPartitions);

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -77,7 +77,7 @@ public class ConsistencyCheckerTest {
                 result = Lists.newArrayList(dbId);
                 minTimes = 0;
 
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = database;
                 minTimes = 0;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -80,6 +80,10 @@ public class ConsistencyCheckerTest {
                 globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = database;
                 minTimes = 0;
+
+                globalStateMgr.getLocalMetastore().getTables(dbId);
+                result = database.getTables();
+                minTimes = 0;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
@@ -53,16 +53,16 @@ public class MetaRecoveryDaemonTest {
     public void testRecover() throws Exception {
         PseudoCluster cluster = PseudoCluster.getInstance();
         String sql = "CREATE TABLE test.`tbl_recover` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 8\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 8\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
         cluster.runSql("test", "insert into test.tbl_recover values (1, 'a'), (2, 'b')");
 
@@ -70,7 +70,8 @@ public class MetaRecoveryDaemonTest {
         Thread.sleep(2000L);
 
         Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-        OlapTable table = (OlapTable) database.getTable("tbl_recover");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(database.getFullName(), "tbl_recover");
         Partition partition = table.getPartition("tbl_recover");
         MaterializedIndex index = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).get(0);
         for (Tablet tablet : index.getTablets()) {
@@ -88,19 +89,19 @@ public class MetaRecoveryDaemonTest {
 
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
             backend.getBackendStatus().lastSuccessReportTabletsTime = TimeUtils
-                    .longToTimeString(System.currentTimeMillis());
+                        .longToTimeString(System.currentTimeMillis());
         }
 
         // add a committed txn
         TransactionState transactionState = new TransactionState(database.getId(), Lists.newArrayList(table.getId()),
-                11111, "xxxx", null, TransactionState.LoadJobSourceType.FRONTEND, null, 2222, 100000);
+                    11111, "xxxx", null, TransactionState.LoadJobSourceType.FRONTEND, null, 2222, 100000);
         TableCommitInfo tableCommitInfo = new TableCommitInfo(table.getId());
         PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(partition.getId(), 4, -1L);
         tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
         transactionState.putIdToTableCommitInfo(table.getId(), tableCommitInfo);
         transactionState.setTransactionStatus(TransactionStatus.COMMITTED);
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                .getDatabaseTransactionMgr(database.getId()).replayUpsertTransactionState(transactionState);
+                    .getDatabaseTransactionMgr(database.getId()).replayUpsertTransactionState(transactionState);
 
         // recover will fail, because there is a committed txn on that partition
         MetaRecoveryDaemon recovery = new MetaRecoveryDaemon();
@@ -121,13 +122,13 @@ public class MetaRecoveryDaemonTest {
 
         // change replica version
         LocalTablet localTablet = (LocalTablet) partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)
-                .get(0).getTablets().get(0);
+                    .get(0).getTablets().get(0);
         long version = 3;
         for (Replica replica : localTablet.getAllReplicas()) {
             replica.updateForRestore(++version, 10, 10);
         }
         LocalTablet localTablet2 = (LocalTablet) partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)
-                .get(0).getTablets().get(0);
+                    .get(0).getTablets().get(0);
         for (Replica replica : localTablet2.getAllReplicas()) {
             replica.updateForRestore(4, 10, 10);
         }
@@ -172,7 +173,7 @@ public class MetaRecoveryDaemonTest {
         MetaRecoveryDaemon metaRecoveryDaemon = new MetaRecoveryDaemon();
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
             backend.getBackendStatus().lastSuccessReportTabletsTime = TimeUtils
-                    .longToTimeString(timeMs);
+                        .longToTimeString(timeMs);
         }
         Assert.assertFalse(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs + 1000L));
         Assert.assertTrue(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs - 1000L));

--- a/fe/fe-core/src/test/java/com/starrocks/external/starrocks/TableMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/starrocks/TableMetaSyncerTest.java
@@ -127,7 +127,7 @@ public class TableMetaSyncerTest {
         LeaderImpl leader = new LeaderImpl();
         TGetTableMetaResponse response = leader.getTableMeta(request);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test_db").getTable("test_ext_table");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test_db").getTable("test_ext_table");
         ExternalOlapTable extTable = (ExternalOlapTable) table;
         // remove the thread local meta context
         MetaContext.remove();

--- a/fe/fe-core/src/test/java/com/starrocks/http/ShowDataActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ShowDataActionTest.java
@@ -45,10 +45,14 @@ public class ShowDataActionTest extends StarRocksHttpTestCase {
         ConcurrentHashMap<String, Database> fullNameToDb = GlobalStateMgr.getCurrentState()
                 .getLocalMetastore().getFullNameToDb();
         fullNameToDb.put(SHOW_DATA_DB_NAME, db);
+
+        ConcurrentHashMap<Long, Database> idToDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb();
+        idToDb.put(1000 + testDbId, db);
     }
 
     @Test
     public void testGetShowData() throws IOException {
+
         Config.http_slow_request_threshold_ms = 0;
         Request request = new Request.Builder()
                 .get()

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -284,14 +284,6 @@ public abstract class StarRocksHttpTestCase {
 
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getLocalMetastore().getDb(db.getId());
-                minTimes = 0;
-                result = db;
-
-                globalStateMgr.getLocalMetastore().getDb(DB_NAME);
-                minTimes = 0;
-                result = db;
-
                 globalStateMgr.isLeader();
                 minTimes = 0;
                 result = true;
@@ -320,13 +312,13 @@ public abstract class StarRocksHttpTestCase {
 
         new Expectations(localMetastore) {
             {
-                localMetastore.listDbNames();
+                localMetastore.getDb("testDb");
                 minTimes = 0;
-                result = Lists.newArrayList("testDb");
+                result = db;
 
-                localMetastore.getFullNameToDb();
+                localMetastore.getDb(testDbId);
                 minTimes = 0;
-                result = nameToDb;
+                result = db;
             }
         };
 
@@ -352,25 +344,9 @@ public abstract class StarRocksHttpTestCase {
 
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getLocalMetastore().getDb(db.getId());
-                minTimes = 0;
-                result = db;
-
-                globalStateMgr.getLocalMetastore().getDb(DB_NAME);
-                minTimes = 0;
-                result = db;
-
                 globalStateMgr.isLeader();
                 minTimes = 0;
                 result = true;
-
-                globalStateMgr.getLocalMetastore().getDb("emptyDb");
-                minTimes = 0;
-                result = null;
-
-                globalStateMgr.getLocalMetastore().getDb(anyString);
-                minTimes = 0;
-                result = new Database();
 
                 globalStateMgr.getLoadInstance();
                 minTimes = 0;
@@ -383,6 +359,10 @@ public abstract class StarRocksHttpTestCase {
                 globalStateMgr.getMetadataMgr();
                 minTimes = 0;
                 result = metadataMgr;
+
+                globalStateMgr.getLocalMetastore();
+                minTimes = 0;
+                result = localMetastore;
             }
         };
 
@@ -401,7 +381,18 @@ public abstract class StarRocksHttpTestCase {
                 result = newEmptyTable;
             }
         };
-        ;
+
+        new Expectations(localMetastore) {
+            {
+                localMetastore.getDb("testDb");
+                minTimes = 0;
+                result = db;
+
+                localMetastore.getDb(testDbId);
+                minTimes = 0;
+                result = db;
+            }
+        };
 
         return globalStateMgr;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -284,11 +284,11 @@ public abstract class StarRocksHttpTestCase {
 
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb(db.getId());
+                globalStateMgr.getLocalMetastore().getDb(db.getId());
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb(DB_NAME);
+                globalStateMgr.getLocalMetastore().getDb(DB_NAME);
                 minTimes = 0;
                 result = db;
 
@@ -296,11 +296,11 @@ public abstract class StarRocksHttpTestCase {
                 minTimes = 0;
                 result = true;
 
-                globalStateMgr.getDb("emptyDb");
+                globalStateMgr.getLocalMetastore().getDb("emptyDb");
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = new Database();
 
@@ -352,11 +352,11 @@ public abstract class StarRocksHttpTestCase {
 
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb(db.getId());
+                globalStateMgr.getLocalMetastore().getDb(db.getId());
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb(DB_NAME);
+                globalStateMgr.getLocalMetastore().getDb(DB_NAME);
                 minTimes = 0;
                 result = db;
 
@@ -364,11 +364,11 @@ public abstract class StarRocksHttpTestCase {
                 minTimes = 0;
                 result = true;
 
-                globalStateMgr.getDb("emptyDb");
+                globalStateMgr.getLocalMetastore().getDb("emptyDb");
                 minTimes = 0;
                 result = null;
 
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = new Database();
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -106,7 +106,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testOlapTable() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(testDbId);
         db.registerTableUnlocked(newOlapTable(
                 TB_OLAP_TABLE_ID, TB_OLAP_TABLE_NAME, PARTITION_SIZE));
 
@@ -153,7 +153,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testLakeTable() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(testDbId);
         db.registerTableUnlocked(newLakeTable(
                 TB_LAKE_TABLE_ID, TB_LAKE_TABLE_NAME, PARTITION_SIZE));
 
@@ -200,7 +200,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testPages() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(testDbId);
         db.registerTableUnlocked(newOlapTable(
                 TB_OLAP_TABLE_ID, TB_OLAP_TABLE_NAME, PARTITION_SIZE));
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
@@ -75,7 +75,7 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
 
     @Override
     protected void doSetUp() {
-        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(testDbId);
         db.registerTableUnlocked(newOlapTable(TB_GET_TABLE_SCHEMA_ID, TB_GET_TABLE_SCHEMA_NAME));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/AlterTest.java
@@ -63,35 +63,35 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.test_lake_partition (\n" +
-                "      k1 DATE,\n" +
-                "      k2 INT,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "DUPLICATE KEY(k1, k2, k3)\n" +
-                "PARTITION BY RANGE (k1, k2, k3) (\n" +
-                "    PARTITION p1 VALUES [(\"2014-01-01\", \"10\", \"200\"), (\"2014-01-01\", \"20\", \"300\")),\n" +
-                "    PARTITION p2 VALUES [(\"2014-06-01\", \"100\", \"200\"), (\"2014-07-01\", \"100\", \"300\"))\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "   \"datacache.enable\" = \"true\"\n" +
-                ")";
+                    "      k1 DATE,\n" +
+                    "      k2 INT,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(k1, k2, k3)\n" +
+                    "PARTITION BY RANGE (k1, k2, k3) (\n" +
+                    "    PARTITION p1 VALUES [(\"2014-01-01\", \"10\", \"200\"), (\"2014-01-01\", \"20\", \"300\")),\n" +
+                    "    PARTITION p2 VALUES [(\"2014-06-01\", \"100\", \"200\"), (\"2014-07-01\", \"100\", \"300\"))\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "   \"datacache.enable\" = \"true\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE test_lake_partition ADD\n" +
-                "    PARTITION p3 VALUES LESS THAN (\"2014-01-01\")";
+                    "    PARTITION p3 VALUES LESS THAN (\"2014-01-01\")";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "test_lake_partition", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "test_lake_partition", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("test_lake_partition");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("test_lake_partition");
 
         Assert.assertNotNull(table.getPartition("p1"));
         Assert.assertNotNull(table.getPartition("p2"));
@@ -109,35 +109,35 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE site_access (\n" +
-                "    datekey INT,\n" +
-                "    site_id INT,\n" +
-                "    city_code SMALLINT,\n" +
-                "    user_name VARCHAR(32),\n" +
-                "    pv BIGINT DEFAULT '0'\n" +
-                ")\n" +
-                "DUPLICATE KEY(datekey, site_id, city_code, user_name)\n" +
-                "PARTITION BY RANGE (datekey) (\n" +
-                "    START (\"1\") END (\"5\") EVERY (1)\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(site_id) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"1\"\n" +
-                ")";
+                    "    datekey INT,\n" +
+                    "    site_id INT,\n" +
+                    "    city_code SMALLINT,\n" +
+                    "    user_name VARCHAR(32),\n" +
+                    "    pv BIGINT DEFAULT '0'\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(datekey, site_id, city_code, user_name)\n" +
+                    "PARTITION BY RANGE (datekey) (\n" +
+                    "    START (\"1\") END (\"5\") EVERY (1)\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(site_id) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"1\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String alterSQL = "ALTER TABLE site_access \n" +
-                "   ADD PARTITIONS START (\"7\") END (\"9\") EVERY (1)";
+                    "   ADD PARTITIONS START (\"7\") END (\"9\") EVERY (1)";
 
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSQL, ctx);
         AddPartitionClause addPartitionClause = (AddPartitionClause) alterTableStmt.getAlterClauseList().get(0);
         GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .addPartitions(Util.getOrCreateConnectContext(), db, "site_access", addPartitionClause);
+                    .addPartitions(Util.getOrCreateConnectContext(), db, "site_access", addPartitionClause);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test")
-                .getTable("site_access");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test")
+                    .getTable("site_access");
 
         Assert.assertNotNull(table.getPartition("p1"));
         Assert.assertNotNull(table.getPartition("p2"));
@@ -155,26 +155,27 @@ public class AlterTest {
     public void testSingleRangePartitionPersistInfo() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.new_table (\n" +
-                "      k1 DATE,\n" +
-                "      k2 INT,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "DUPLICATE KEY(k1, k2, k3)\n" +
-                "PARTITION BY RANGE (k1, k2, k3) (\n" +
-                "    PARTITION p1 VALUES [(\"2014-01-01\", \"10\", \"200\"), (\"2014-01-01\", \"20\", \"300\")),\n" +
-                "    PARTITION p2 VALUES [(\"2014-06-01\", \"100\", \"200\"), (\"2014-07-01\", \"100\", \"300\"))\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "   \"datacache.enable\" = \"true\"\n" +
-                ")";
+                    "      k1 DATE,\n" +
+                    "      k2 INT,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(k1, k2, k3)\n" +
+                    "PARTITION BY RANGE (k1, k2, k3) (\n" +
+                    "    PARTITION p1 VALUES [(\"2014-01-01\", \"10\", \"200\"), (\"2014-01-01\", \"20\", \"300\")),\n" +
+                    "    PARTITION p2 VALUES [(\"2014-06-01\", \"100\", \"200\"), (\"2014-07-01\", \"100\", \"300\"))\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "   \"datacache.enable\" = \"true\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("new_table");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "new_table");
         RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
 
         long dbId = db.getId();
@@ -188,7 +189,7 @@ public class AlterTest {
         Range<PartitionKey> range = partitionInfo.getRange(partitionId);
         DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
         RangePartitionPersistInfo partitionPersistInfoOut = new RangePartitionPersistInfo(dbId, tableId, partition,
-                dataProperty, replicationNum, isInMemory, isTempPartition, range, dataCacheInfo);
+                    dataProperty, replicationNum, isInMemory, isTempPartition, range, dataCacheInfo);
 
         // write log
         File file = new File("./test_serial.log");
@@ -229,21 +230,21 @@ public class AlterTest {
         DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         String createSQL = "CREATE TABLE test.t1 (\n" +
-                "      k1 DATE,\n" +
-                "      k2 INT,\n" +
-                "      k3 SMALLINT,\n" +
-                "      v1 VARCHAR(2048),\n" +
-                "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
-                ")\n" +
-                "DUPLICATE KEY(k1, k2, k3)\n" +
-                "PARTITION BY RANGE (k1, k2, k3) (\n" +
-                "    PARTITION p1 VALUES [(\"2014-01-01\", \"10\", \"200\"), (\"2014-01-01\", \"20\", \"300\")),\n" +
-                "    PARTITION p2 VALUES [(\"2014-06-01\", \"100\", \"200\"), (\"2014-07-01\", \"100\", \"300\"))\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "   \"datacache.enable\" = \"true\"\n" +
-                ")";
+                    "      k1 DATE,\n" +
+                    "      k2 INT,\n" +
+                    "      k3 SMALLINT,\n" +
+                    "      v1 VARCHAR(2048),\n" +
+                    "      v2 DATETIME DEFAULT \"2014-02-04 15:36:00\"\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(k1, k2, k3)\n" +
+                    "PARTITION BY RANGE (k1, k2, k3) (\n" +
+                    "    PARTITION p1 VALUES [(\"2014-01-01\", \"10\", \"200\"), (\"2014-01-01\", \"20\", \"300\")),\n" +
+                    "    PARTITION p2 VALUES [(\"2014-06-01\", \"100\", \"200\"), (\"2014-07-01\", \"100\", \"300\"))\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "   \"datacache.enable\" = \"true\"\n" +
+                    ")";
 
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -67,14 +67,14 @@ public class CreateLakeTableTest {
     }
 
     private void checkLakeTable(String dbName, String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(tableName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         Assert.assertTrue(table.isCloudNativeTable());
     }
 
     private LakeTable getLakeTable(String dbName, String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(tableName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         Assert.assertTrue(table.isCloudNativeTable());
         return (LakeTable) table;
     }
@@ -120,7 +120,7 @@ public class CreateLakeTableTest {
                         "properties('replication_num' = '1');"));
         checkLakeTable("lake_test", "multi_partition_unique_key");
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("lake_test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("lake_test");
         LakeTable table = getLakeTable("lake_test", "multi_partition_unique_key");
         String defaultFullPath = getDefaultStorageVolumeFullPath();
         String defaultTableFullPath = String.format("%s/db%d/%d", defaultFullPath, db.getId(), table.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -94,17 +94,17 @@ public class LakeMaterializedViewTest {
         starRocksAssert.withDatabase(DB).useDatabase(DB);
 
         starRocksAssert.withTable("CREATE TABLE base_table\n" +
-                "(\n" +
-                "    k1 date,\n" +
-                "    k2 int,\n" +
-                "    k3 int\n" +
-                ")\n" +
-                "PARTITION BY RANGE(k1)\n" +
-                "(\n" +
-                "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 3");
+                    "(\n" +
+                    "    k1 date,\n" +
+                    "    k2 int,\n" +
+                    "    k3 int\n" +
+                    ")\n" +
+                    "PARTITION BY RANGE(k1)\n" +
+                    "(\n" +
+                    "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                    "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 3");
     }
 
     @AfterClass
@@ -157,7 +157,7 @@ public class LakeMaterializedViewTest {
 
         // Lake mv
         LakeMaterializedView mv = new LakeMaterializedView(mvId, dbId, "mv1", columns, KeysType.AGG_KEYS,
-                partitionInfo, distributionInfo, mvRefreshScheme);
+                    partitionInfo, distributionInfo, mvRefreshScheme);
         Deencapsulation.setField(mv, "baseIndexId", indexId);
         mv.addPartition(partition);
         mv.setIndexMeta(indexId, "mv1", columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
@@ -202,17 +202,18 @@ public class LakeMaterializedViewTest {
     @Test
     public void testCreateMaterializedView() throws Exception {
         starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "PROPERTIES(\n" +
-                        "   'datacache.enable' = 'true',\n" +
-                        "   'enable_async_write_back' = 'false',\n" +
-                        "   'datacache.partition_duration' = '6 day'\n" +
-                        ")\n" +
-                        "refresh async\n" +
-                        "as select k2, sum(k3) as total from base_table group by k2;");
+                    "distributed by hash(k2) buckets 3\n" +
+                    "PROPERTIES(\n" +
+                    "   'datacache.enable' = 'true',\n" +
+                    "   'enable_async_write_back' = 'false',\n" +
+                    "   'datacache.partition_duration' = '6 day'\n" +
+                    ")\n" +
+                    "refresh async\n" +
+                    "as select k2, sum(k3) as total from base_table group by k2;");
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        MaterializedView mv = (MaterializedView) db.getTable("mv1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        MaterializedView mv =
+                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1");
         Assert.assertTrue(mv.isCloudNativeMaterializedView());
         Assert.assertTrue(mv.isActive());
 
@@ -243,46 +244,48 @@ public class LakeMaterializedViewTest {
         Assert.assertNotNull(task);
 
         starRocksAssert.dropMaterializedView("mv1");
-        Assert.assertNull(db.getTable("mv1"));
+        Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv1"));
     }
 
     @Test
     public void testInactiveMaterializedView() throws Exception {
         starRocksAssert.withTable("create table base_table2\n" +
-                "(\n" +
-                "    k4 date,\n" +
-                "    k5 int\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k4) BUCKETS 3");
+                    "(\n" +
+                    "    k4 date,\n" +
+                    "    k5 int\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k4) BUCKETS 3");
         starRocksAssert.withMaterializedView("create materialized view mv2\n" +
-                "distributed by hash(k2) buckets 3\n" +
-                "refresh async\n" +
-                "as select k1, k2, sum(k3) as total from base_table, base_table2 where k1 = k4 group by k1, k2;");
+                    "distributed by hash(k2) buckets 3\n" +
+                    "refresh async\n" +
+                    "as select k1, k2, sum(k3) as total from base_table, base_table2 where k1 = k4 group by k1, k2;");
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        MaterializedView mv = (MaterializedView) db.getTable("mv2");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        MaterializedView mv =
+                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv2");
         Assert.assertTrue(mv.isCloudNativeMaterializedView());
         Assert.assertTrue(mv.isActive());
 
         // drop base table and inactive mv
         starRocksAssert.dropTable("base_table2");
-        Assert.assertNull(db.getTable("base_table2"));
+        Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "base_table2"));
         Assert.assertFalse(mv.isActive());
 
         starRocksAssert.dropMaterializedView("mv2");
-        Assert.assertNull(db.getTable("mv2"));
+        Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv2"));
     }
 
     @Test
     public void testAlterAsyncMaterializedViewInterval() throws Exception {
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv3\n" +
-                        "PARTITION BY k1\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "REFRESH async START('2122-12-31 20:45:11') EVERY(INTERVAL 1 DAY)\n" +
-                        "as select k1,k2 from base_table;");
+                    "PARTITION BY k1\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                    "REFRESH async START('2122-12-31 20:45:11') EVERY(INTERVAL 1 DAY)\n" +
+                    "as select k1,k2 from base_table;");
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        MaterializedView mv = (MaterializedView) db.getTable("mv3");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        MaterializedView mv =
+                    (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv3");
         Assert.assertTrue(mv.isCloudNativeMaterializedView());
 
         MaterializedView.AsyncRefreshContext asyncRefreshContext = mv.getRefreshScheme().getAsyncRefreshContext();
@@ -299,25 +302,26 @@ public class LakeMaterializedViewTest {
         Assert.assertEquals(2, asyncRefreshContext.getStep());
 
         starRocksAssert.dropMaterializedView("mv3");
-        Assert.assertNull(db.getTable("mv3"));
+        Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv3"));
     }
 
     @Test
     public void testModifyRelatedColumnWithMaterializedView() {
         try {
             starRocksAssert.withTable("create table base_table4\n" +
-                    "(\n" +
-                    "    k4 date,\n" +
-                    "    k5 int\n" +
-                    ")\n" +
-                    "duplicate key(k4) distributed by hash(k4) buckets 3;");
+                        "(\n" +
+                        "    k4 date,\n" +
+                        "    k5 int\n" +
+                        ")\n" +
+                        "duplicate key(k4) distributed by hash(k4) buckets 3;");
             starRocksAssert.withMaterializedView("create materialized view mv4\n" +
-                    "distributed by hash(k1) buckets 3\n" +
-                    "refresh async\n" +
-                    "as select k1, k5, sum(k3) as total from base_table, base_table4 where k1 = k4 group by k1, k5;");
+                        "distributed by hash(k1) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k1, k5, sum(k3) as total from base_table, base_table4 where k1 = k4 group by k1, k5;");
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-            MaterializedView mv = (MaterializedView) db.getTable("mv4");
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+            MaterializedView mv =
+                        (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv4");
             Assert.assertTrue(mv.isCloudNativeMaterializedView());
             Assert.assertTrue(mv.isActive());
 
@@ -332,9 +336,9 @@ public class LakeMaterializedViewTest {
             Assert.assertFalse(mv.isActive());
 
             starRocksAssert.dropMaterializedView("mv4");
-            Assert.assertNull(db.getTable("mv4"));
+            Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv4"));
             starRocksAssert.dropTable("base_table4");
-            Assert.assertNull(db.getTable("base_table4"));
+            Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "base_table4"));
         } catch (Exception e) {
             System.out.println(e);
             Assert.fail();
@@ -345,27 +349,28 @@ public class LakeMaterializedViewTest {
     public void testNonPartitionMvEnableFillDataCache() {
         try {
             starRocksAssert.withTable("create table base_table5\n" +
-                    "(\n" +
-                    "    k4 date,\n" +
-                    "    k5 int\n" +
-                    ")\n" +
-                    "duplicate key(k4) distributed by hash(k4) buckets 3;");
+                        "(\n" +
+                        "    k4 date,\n" +
+                        "    k5 int\n" +
+                        ")\n" +
+                        "duplicate key(k4) distributed by hash(k4) buckets 3;");
             starRocksAssert.withMaterializedView("create materialized view mv5\n" +
-                    "distributed by hash(k1) buckets 3\n" +
-                    "refresh async\n" +
-                    "as select k1, k5, sum(k3) as total from base_table, base_table5 where k1 = k4 group by k1, k5;");
+                        "distributed by hash(k1) buckets 3\n" +
+                        "refresh async\n" +
+                        "as select k1, k5, sum(k3) as total from base_table, base_table5 where k1 = k4 group by k1, k5;");
 
-            Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-            MaterializedView mv = (MaterializedView) db.getTable("mv5");
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+            MaterializedView mv =
+                        (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv5");
             Assert.assertTrue(mv.isCloudNativeMaterializedView());
 
             Partition p = mv.getPartition("mv5");
             Assert.assertTrue(mv.isEnableFillDataCache(p));
 
             starRocksAssert.dropMaterializedView("mv5");
-            Assert.assertNull(db.getTable("mv5"));
+            Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv5"));
             starRocksAssert.dropTable("base_table5");
-            Assert.assertNull(db.getTable("base_table5"));
+            Assert.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "base_table5"));
         } catch (Exception e) {
             System.out.println(e);
             Assert.fail();
@@ -418,7 +423,7 @@ public class LakeMaterializedViewTest {
         LocalDate lower1 = upper1.minus(duration);
         Range<PartitionKey> range1 = Range.closedOpen(PartitionKey.ofDate(lower1), PartitionKey.ofDate(upper1));
         partitionInfo.addPartition(partition1Id, false, range1, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, false,
-                                   new DataCacheInfo(true, false));
+                    new DataCacheInfo(true, false));
 
         // partition2
         MaterializedIndex index2 = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
@@ -431,7 +436,7 @@ public class LakeMaterializedViewTest {
         LocalDate lower2 = upper2.minus(duration);
         Range<PartitionKey> range2 = Range.closedOpen(PartitionKey.ofDate(lower2), PartitionKey.ofDate(upper2));
         partitionInfo.addPartition(partition2Id, false, range2, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, false,
-                                   new DataCacheInfo(true, false));
+                    new DataCacheInfo(true, false));
 
         // refresh scheme
         MvRefreshScheme mvRefreshScheme = new MvRefreshScheme();
@@ -439,7 +444,7 @@ public class LakeMaterializedViewTest {
 
         // Lake mv
         LakeMaterializedView mv = new LakeMaterializedView(mvId, dbId, "mv1", columns, KeysType.AGG_KEYS,
-                                                           partitionInfo, distributionInfo, mvRefreshScheme);
+                    partitionInfo, distributionInfo, mvRefreshScheme);
         Deencapsulation.setField(mv, "baseIndexId", indexId);
         mv.addPartition(partition1);
         mv.addPartition(partition2);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -152,6 +152,9 @@ public class DeleteTest {
                 globalStateMgr.getLocalMetastore().getDb(anyString);
                 result = db;
 
+                globalStateMgr.getLocalMetastore().getTable(anyString, anyString);
+                result = db.getTable(tableId);
+
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
                 result = globalTransactionMgr;
 
@@ -326,6 +329,9 @@ public class DeleteTest {
 
                 globalStateMgr.getLocalMetastore().getDb(anyString);
                 result = db;
+
+                globalStateMgr.getLocalMetastore().getTable(anyString, anyString);
+                result = db.getTable(tableId);
 
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
                 result = globalTransactionMgr;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -149,7 +149,7 @@ public class DeleteTest {
                 GlobalStateMgr.getCurrentState();
                 result = globalStateMgr;
 
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 result = db;
 
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
@@ -324,7 +324,7 @@ public class DeleteTest {
                 GlobalStateMgr.getCurrentState();
                 result = globalStateMgr;
 
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 result = db;
 
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/ShowExecutorTest.java
@@ -81,11 +81,11 @@ public class ShowExecutorTest {
         globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb("testDb");
+                globalStateMgr.getLocalMetastore().getDb("testDb");
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb("testDb1");
+                globalStateMgr.getLocalMetastore().getDb("testDb1");
                 minTimes = 0;
                 result = db1;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/BrokerFileGroupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/BrokerFileGroupTest.java
@@ -31,11 +31,14 @@ import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.CsvFormat;
 import com.starrocks.common.UserException;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -151,6 +154,13 @@ public class BrokerFileGroupTest {
                 result = Lists.newArrayList(k1, k2, k4);
                 hiveTable.getId();
                 result = 10;
+            }
+        };
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return db;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -136,11 +136,11 @@ public class DeleteHandlerTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = db;
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeletePruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeletePruneTest.java
@@ -17,6 +17,7 @@ package com.starrocks.load;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -41,55 +42,56 @@ public class DeletePruneTest {
         deleteHandler = new DeleteMgr();
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE `test_delete` (\n" +
-                        "  `k1` date NULL COMMENT \"\",\n" +
-                        "  `k2` datetime NULL COMMENT \"\",\n" +
-                        "  `k3` char(20) NULL COMMENT \"\",\n" +
-                        "  `k4` varchar(20) NULL COMMENT \"\",\n" +
-                        "  `k5` boolean NULL COMMENT \"\",\n" +
-                        "  `k6` tinyint(4) NULL COMMENT \"\",\n" +
-                        "  `k7` smallint(6) NULL COMMENT \"\",\n" +
-                        "  `k8` int(11) NULL COMMENT \"\",\n" +
-                        "  `k9` bigint(20) NULL COMMENT \"\",\n" +
-                        "  `k10` largeint(40) NULL COMMENT \"\",\n" +
-                        "  `k11` float NULL COMMENT \"\",\n" +
-                        "  `k12` double NULL COMMENT \"\",\n" +
-                        "  `k13` decimal128(27, 9) NULL COMMENT \"\"\n" +
-                        ") ENGINE=OLAP \n" +
-                        "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)\n" +
-                        "COMMENT \"OLAP\"\n" +
-                        "PARTITION BY RANGE(`k1`) (\n" +
-                        "    START (\"2020-01-01\") END (\"2021-01-01\") EVERY (INTERVAL 1 day)\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 \n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"in_memory\" = \"false\"\n" +
-                        ");")
-                .withTable("CREATE TABLE `test_delete2` (\n" +
-                        "  `date` date NULL COMMENT \"\",\n" +
-                        "  `id` int(11) NULL COMMENT \"\",\n" +
-                        "  `value` char(20) NULL COMMENT \"\"\n" +
-                        ") ENGINE=OLAP \n" +
-                        "DUPLICATE KEY(`date`, `id`)\n" +
-                        "COMMENT \"OLAP\"\n" +
-                        "PARTITION BY RANGE(`date`, `id`)\n" +
-                        "(\n" +
-                        "    PARTITION `p202001_1000` VALUES LESS THAN (\"2020-02-01\", \"1000\"),\n" +
-                        "    PARTITION `p202002_2000` VALUES LESS THAN (\"2020-03-01\", \"2000\"),\n" +
-                        "    PARTITION `p202003_all`  VALUES LESS THAN (\"2020-04-01\")\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(`date`, `id`) BUCKETS 3 \n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE `test_delete` (\n" +
+                                "  `k1` date NULL COMMENT \"\",\n" +
+                                "  `k2` datetime NULL COMMENT \"\",\n" +
+                                "  `k3` char(20) NULL COMMENT \"\",\n" +
+                                "  `k4` varchar(20) NULL COMMENT \"\",\n" +
+                                "  `k5` boolean NULL COMMENT \"\",\n" +
+                                "  `k6` tinyint(4) NULL COMMENT \"\",\n" +
+                                "  `k7` smallint(6) NULL COMMENT \"\",\n" +
+                                "  `k8` int(11) NULL COMMENT \"\",\n" +
+                                "  `k9` bigint(20) NULL COMMENT \"\",\n" +
+                                "  `k10` largeint(40) NULL COMMENT \"\",\n" +
+                                "  `k11` float NULL COMMENT \"\",\n" +
+                                "  `k12` double NULL COMMENT \"\",\n" +
+                                "  `k13` decimal128(27, 9) NULL COMMENT \"\"\n" +
+                                ") ENGINE=OLAP \n" +
+                                "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)\n" +
+                                "COMMENT \"OLAP\"\n" +
+                                "PARTITION BY RANGE(`k1`) (\n" +
+                                "    START (\"2020-01-01\") END (\"2021-01-01\") EVERY (INTERVAL 1 day)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 \n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"in_memory\" = \"false\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE `test_delete2` (\n" +
+                                "  `date` date NULL COMMENT \"\",\n" +
+                                "  `id` int(11) NULL COMMENT \"\",\n" +
+                                "  `value` char(20) NULL COMMENT \"\"\n" +
+                                ") ENGINE=OLAP \n" +
+                                "DUPLICATE KEY(`date`, `id`)\n" +
+                                "COMMENT \"OLAP\"\n" +
+                                "PARTITION BY RANGE(`date`, `id`)\n" +
+                                "(\n" +
+                                "    PARTITION `p202001_1000` VALUES LESS THAN (\"2020-02-01\", \"1000\"),\n" +
+                                "    PARTITION `p202002_2000` VALUES LESS THAN (\"2020-03-01\", \"2000\"),\n" +
+                                "    PARTITION `p202003_all`  VALUES LESS THAN (\"2020-04-01\")\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(`date`, `id`) BUCKETS 3 \n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");");
     }
 
     @Test
     public void testDeletePrune() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
-        Database db = ctx.getGlobalStateMgr().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("test_delete");
+        Database db = ctx.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable tbl =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_delete");
 
         String deleteSQL = "delete from test_delete where k1 = '2020-01-01'";
         DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
@@ -153,8 +155,9 @@ public class DeletePruneTest {
     @Test
     public void testDeletePruneMultiPartition() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
-        Database db = ctx.getGlobalStateMgr().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("test_delete2");
+        Database db = ctx.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable tbl =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_delete2");
 
         String deleteSQL = "delete from test_delete2 where date in ('2020-02-02') and id = 1000";
         DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -83,8 +83,8 @@ public class InsertOverwriteJobRunnerTest {
 
     @Test
     public void testReplayInsertOverwrite() {
-        Database database = GlobalStateMgr.getCurrentState().getDb("insert_overwrite_test");
-        Table table = database.getTable("t1");
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("insert_overwrite_test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t1");
         Assert.assertTrue(table instanceof OlapTable);
         OlapTable olapTable = (OlapTable) table;
         InsertOverwriteJob insertOverwriteJob = new InsertOverwriteJob(100L, database.getId(), olapTable.getId(),
@@ -123,8 +123,8 @@ public class InsertOverwriteJobRunnerTest {
         String sql = "insert overwrite t1 select * from t2";
         InsertStmt insertStmt = (InsertStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StmtExecutor executor = new StmtExecutor(connectContext, insertStmt);
-        Database database = GlobalStateMgr.getCurrentState().getDb("insert_overwrite_test");
-        Table table = database.getTable("t1");
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("insert_overwrite_test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t1");
         Assert.assertTrue(table instanceof OlapTable);
         OlapTable olapTable = (OlapTable) table;
         InsertOverwriteJob insertOverwriteJob = new InsertOverwriteJob(100L, insertStmt, database.getId(), olapTable.getId(),

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -111,7 +111,7 @@ public class BrokerLoadJobTest {
                 labelName.getDbName();
                 minTimes = 0;
                 result = databaseName;
-                globalStateMgr.getDb(databaseName);
+                globalStateMgr.getLocalMetastore().getDb(databaseName);
                 minTimes = 0;
                 result = database;
                 loadStmt.getDataDescriptions();
@@ -120,7 +120,7 @@ public class BrokerLoadJobTest {
                 dataDescription.getTableName();
                 minTimes = 0;
                 result = tableName;
-                database.getTable(tableName);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableName);
                 minTimes = 0;
                 result = null;
             }
@@ -162,7 +162,7 @@ public class BrokerLoadJobTest {
                 labelName.getLabelName();
                 minTimes = 0;
                 result = label;
-                globalStateMgr.getDb(databaseName);
+                globalStateMgr.getLocalMetastore().getDb(databaseName);
                 minTimes = 0;
                 result = database;
                 loadStmt.getDataDescriptions();
@@ -171,7 +171,7 @@ public class BrokerLoadJobTest {
                 dataDescription.getTableName();
                 minTimes = 0;
                 result = tableName;
-                database.getTable(tableName);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableName);
                 minTimes = 0;
                 result = olapTable;
                 dataDescription.getPartitionNames();
@@ -231,7 +231,7 @@ public class BrokerLoadJobTest {
                 labelName.getLabelName();
                 minTimes = 0;
                 result = label;
-                globalStateMgr.getDb(databaseName);
+                globalStateMgr.getLocalMetastore().getDb(databaseName);
                 minTimes = 0;
                 result = database;
                 loadStmt.getDataDescriptions();
@@ -240,7 +240,7 @@ public class BrokerLoadJobTest {
                 dataDescription.getTableName();
                 minTimes = 0;
                 result = tableName;
-                database.getTable(tableName);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableName);
                 minTimes = 0;
                 result = olapTable;
                 dataDescription.getPartitionNames();
@@ -296,10 +296,10 @@ public class BrokerLoadJobTest {
                 fileGroupAggInfo.getAllTableIds();
                 minTimes = 0;
                 result = Sets.newHashSet(1L);
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
-                database.getTable(1L);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), 1L);
                 minTimes = 0;
                 result = table;
                 table.getName();
@@ -567,7 +567,7 @@ public class BrokerLoadJobTest {
                 attachment1.getTaskId();
                 minTimes = 0;
                 result = 1L;
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
             }
@@ -719,7 +719,7 @@ public class BrokerLoadJobTest {
                 attachment1.getTaskId();
                 minTimes = 0;
                 result = 1L;
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
                 globalStateMgr.getCurrentState().getGlobalTransactionMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -108,21 +108,17 @@ public class BrokerLoadJobTest {
                 loadStmt.getLabel();
                 minTimes = 0;
                 result = labelName;
+
                 labelName.getDbName();
                 minTimes = 0;
                 result = databaseName;
-                globalStateMgr.getLocalMetastore().getDb(databaseName);
-                minTimes = 0;
-                result = database;
+
                 loadStmt.getDataDescriptions();
                 minTimes = 0;
                 result = dataDescriptionList;
                 dataDescription.getTableName();
                 minTimes = 0;
                 result = tableName;
-                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableName);
-                minTimes = 0;
-                result = null;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/InsertLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/InsertLoadJobTest.java
@@ -62,9 +62,9 @@ public class InsertLoadJobTest {
         String tableName = "table1";
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 result = database;
-                database.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), anyLong);
                 result = table;
                 table.getName();
                 result = tableName;
@@ -84,9 +84,9 @@ public class InsertLoadJobTest {
                                    @Injectable Table table) throws MetaNotFoundException {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 result = database;
-                database.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), anyLong);
                 result = table;
                 table.getName();
                 result = "some_table";

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
@@ -80,7 +80,7 @@ public class LoadJobTest {
         Deencapsulation.setField(loadJob, "dbId", 1L);
         new Expectations() {
             {
-                globalStateMgr.getDb(1L);
+                globalStateMgr.getLocalMetastore().getDb(1L);
                 minTimes = 0;
                 result = null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
@@ -83,10 +83,10 @@ public class LoadMgrTest {
                                         @Injectable Table table) throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
-                database.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), anyLong);
                 minTimes = 0;
                 result = table;
                 table.getName();
@@ -115,10 +115,10 @@ public class LoadMgrTest {
                                                 @Injectable Table table) throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
-                database.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), anyLong);
                 minTimes = 0;
                 result = table;
                 table.getName();
@@ -150,10 +150,10 @@ public class LoadMgrTest {
                                                 @Injectable Table table) throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
-                database.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), anyLong);
                 minTimes = 0;
                 result = table;
                 table.getName();
@@ -206,7 +206,7 @@ public class LoadMgrTest {
                                      @Injectable Database db) throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 result = db;
             }
         };
@@ -320,7 +320,7 @@ public class LoadMgrTest {
                                   @Injectable Database db) throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 result = db;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
@@ -157,11 +157,11 @@ public class SparkLoadJobTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(dbName);
+                globalStateMgr.getLocalMetastore().getDb(dbName);
                 result = db;
                 globalStateMgr.getResourceMgr();
                 result = resourceMgr;
-                db.getTable(tableName);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
                 result = olapTable;
                 db.getId();
                 result = dbId;
@@ -372,9 +372,9 @@ public class SparkLoadJobTest {
                 result = status;
                 handler.getEtlFilePaths(etlOutputPath, (BrokerDesc) any);
                 result = filePathToSize;
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = db;
-                db.getTable(tableId);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                 result = table;
                 table.getPartition(partitionId);
                 result = partition;
@@ -470,9 +470,9 @@ public class SparkLoadJobTest {
                 result = status;
                 handler.getEtlFilePaths(etlOutputPath, (BrokerDesc) any);
                 result = filePathToSize;
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = db;
-                db.getTable(tableId);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
                 result = table;
                 table.getPartition(partitionId);
                 result = partition;
@@ -528,7 +528,7 @@ public class SparkLoadJobTest {
                                                  @Injectable Database db) throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = db;
             }
         };
@@ -619,7 +619,7 @@ public class SparkLoadJobTest {
                                              @Injectable Database db) throws Exception {
         new Expectations() {
             {
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = db;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
@@ -125,11 +125,11 @@ public class SparkLoadPendingTaskTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = database;
                 sparkLoadJob.getHandle();
                 result = handle;
-                database.getTable(tableId);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
                 result = table;
                 table.getPartitions();
                 result = partitions;
@@ -181,7 +181,7 @@ public class SparkLoadPendingTaskTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = null;
             }
         };
@@ -210,9 +210,9 @@ public class SparkLoadPendingTaskTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = database;
-                database.getTable(tableId);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
                 result = null;
             }
         };
@@ -286,9 +286,9 @@ public class SparkLoadPendingTaskTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(dbId);
+                globalStateMgr.getLocalMetastore().getDb(dbId);
                 result = database;
-                database.getTable(tableId);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
                 result = table;
                 table.getPartitions();
                 result = partitions;

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -132,7 +132,7 @@ public class PipeManagerTest {
 
     @After
     public void after() {
-        long dbId = ctx.getGlobalStateMgr().getDb(PIPE_TEST_DB).getId();
+        long dbId = ctx.getGlobalStateMgr().getLocalMetastore().getDb(PIPE_TEST_DB).getId();
         PipeManager pm = ctx.getGlobalStateMgr().getPipeManager();
         pm.dropPipesOfDb(PIPE_TEST_DB, dbId);
     }
@@ -229,7 +229,7 @@ public class PipeManagerTest {
 
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        long dbId = ctx.getGlobalStateMgr().getDb(PIPE_TEST_DB).getId();
+        long dbId = ctx.getGlobalStateMgr().getLocalMetastore().getDb(PIPE_TEST_DB).getId();
         pm.dropPipesOfDb(PIPE_TEST_DB, dbId);
 
         // create pipe 1
@@ -835,7 +835,7 @@ public class PipeManagerTest {
         sql = "create pipe p_crud1 as insert into tbl1 select * from files('path'='fake://pipe', 'format'='parquet')";
         createStmt = (CreatePipeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         pm.createPipe(createStmt);
-        long dbId = ctx.getGlobalStateMgr().getDb(PIPE_TEST_DB).getId();
+        long dbId = ctx.getGlobalStateMgr().getLocalMetastore().getDb(PIPE_TEST_DB).getId();
         pm.dropPipesOfDb(PIPE_TEST_DB, dbId);
         Assert.assertEquals(0, pm.getPipesUnlock().size());
     }
@@ -1030,7 +1030,7 @@ public class PipeManagerTest {
 
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
         UtFrameUtils.PseudoImage emptyImage = new UtFrameUtils.PseudoImage();
-        long dbId = ctx.getGlobalStateMgr().getDb(PIPE_TEST_DB).getId();
+        long dbId = ctx.getGlobalStateMgr().getLocalMetastore().getDb(PIPE_TEST_DB).getId();
         pm.dropPipesOfDb(PIPE_TEST_DB, dbId);
 
         // create pipe 1

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -279,7 +279,7 @@ public class KafkaRoutineLoadJobTest {
 
         new Expectations() {
             {
-                database.getTable(tableNameString);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableNameString);
                 minTimes = 0;
                 result = null;
             }
@@ -312,7 +312,7 @@ public class KafkaRoutineLoadJobTest {
 
         new Expectations() {
             {
-                database.getTable(tableNameString);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableNameString);
                 minTimes = 0;
                 result = table;
                 database.getId();
@@ -392,7 +392,7 @@ public class KafkaRoutineLoadJobTest {
 
         new Expectations() {
             {
-                database.getTable(tableNameString);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableNameString);
                 minTimes = 0;
                 result = table;
                 database.getId();
@@ -460,7 +460,7 @@ public class KafkaRoutineLoadJobTest {
 
         new Expectations() {
             {
-                database.getTable(tableNameString);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), tableNameString);
                 minTimes = 0;
                 result = table;
                 database.getId();

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobMetaTest.java
@@ -63,7 +63,7 @@ public class RoutineLoadJobMetaTest {
     @Test
     public void testMetaNotFound() throws UserException {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getDb("test");
+        Database db = globalStateMgr.getLocalMetastore().getDb("test");
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "rj", db.getId(), 2L, "", "");
 
         Exception e = Assert.assertThrows(MetaNotFoundException.class,
@@ -73,8 +73,8 @@ public class RoutineLoadJobMetaTest {
     @Test
     public void testTxnNotFound() throws UserException {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getDb("test");
-        Table table = db.getTable("site_access_auto");
+        Database db = globalStateMgr.getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_auto");
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "rj", db.getId(), table.getId(), "", "");
 
         Exception e = Assert.assertThrows(MetaNotFoundException.class,

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -350,7 +350,7 @@ public class RoutineLoadJobTest {
     public void testUpdateWhileDbDeleted(@Mocked GlobalStateMgr globalStateMgr) throws UserException {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = null;
             }
@@ -367,10 +367,10 @@ public class RoutineLoadJobTest {
                                             @Injectable Database database) throws UserException {
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
-                database.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), anyLong);
                 minTimes = 0;
                 result = null;
             }
@@ -389,10 +389,10 @@ public class RoutineLoadJobTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
-                database.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), anyLong);
                 minTimes = 0;
                 result = table;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
@@ -574,7 +574,7 @@ public class RoutineLoadManagerTest {
                 routineLoadJob3.getName();
                 minTimes = 0;
                 result = "bbb";
-                globalStateMgr.getDb("db1");
+                globalStateMgr.getLocalMetastore().getDb("db1");
                 minTimes = 0;
                 result = database;
                 database.getId();
@@ -624,7 +624,7 @@ public class RoutineLoadManagerTest {
                 routineLoadJob3.getName();
                 minTimes = 0;
                 result = "bbb";
-                globalStateMgr.getDb("db1");
+                globalStateMgr.getLocalMetastore().getDb("db1");
                 minTimes = 0;
                 result = database;
                 database.getId();
@@ -664,7 +664,7 @@ public class RoutineLoadManagerTest {
                 routineLoadJob3.isFinal();
                 minTimes = 0;
                 result = true;
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = database;
                 database.getId();
@@ -718,7 +718,7 @@ public class RoutineLoadManagerTest {
                 pauseRoutineLoadStmt.getName();
                 minTimes = 0;
                 result = "";
-                globalStateMgr.getDb("");
+                globalStateMgr.getLocalMetastore().getDb("");
                 minTimes = 0;
                 result = database;
                 database.getId();
@@ -769,7 +769,7 @@ public class RoutineLoadManagerTest {
                 resumeRoutineLoadStmt.getName();
                 minTimes = 0;
                 result = "";
-                globalStateMgr.getDb("");
+                globalStateMgr.getLocalMetastore().getDb("");
                 minTimes = 0;
                 result = database;
                 database.getId();
@@ -806,7 +806,7 @@ public class RoutineLoadManagerTest {
                 stopRoutineLoadStmt.getName();
                 minTimes = 0;
                 result = "";
-                globalStateMgr.getDb("");
+                globalStateMgr.getLocalMetastore().getDb("");
                 minTimes = 0;
                 result = database;
                 database.getId();
@@ -946,7 +946,7 @@ public class RoutineLoadManagerTest {
                 stopRoutineLoadStmt.getName();
                 minTimes = 0;
                 result = "";
-                globalStateMgr.getDb("");
+                globalStateMgr.getLocalMetastore().getDb("");
                 minTimes = 0;
                 result = database;
                 database.getId();

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
@@ -104,10 +104,10 @@ public class RoutineLoadSchedulerTest {
                 routineLoadManager.getRoutineLoadJobByState(Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE));
                 minTimes = 0;
                 result = routineLoadJobList;
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
-                database.getTable(1L);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), 1L);
                 minTimes = 0;
                 result = olapTable;
                 systemInfoService.getBackendIds(true);
@@ -172,7 +172,7 @@ public class RoutineLoadSchedulerTest {
                 globalStateMgr.getRoutineLoadMgr();
                 minTimes = 0;
                 result = routineLoadManager;
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 minTimes = 0;
                 result = database;
                 systemInfoService.getBackendIds(true);

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
@@ -104,12 +104,6 @@ public class RoutineLoadSchedulerTest {
                 routineLoadManager.getRoutineLoadJobByState(Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE));
                 minTimes = 0;
                 result = routineLoadJobList;
-                globalStateMgr.getLocalMetastore().getDb(anyLong);
-                minTimes = 0;
-                result = database;
-                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), 1L);
-                minTimes = 0;
-                result = olapTable;
                 systemInfoService.getBackendIds(true);
                 minTimes = 0;
                 result = beIds;

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -87,6 +87,10 @@ public class StreamLoadManagerTest {
                 minTimes = 0;
                 result = db;
 
+                globalStateMgr.getLocalMetastore().getTable(anyString, anyString);
+                minTimes = 0;
+                result = db.getTable(CatalogMocker.TEST_TBL_ID);
+
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -83,7 +83,7 @@ public class StreamLoadManagerTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(anyString);
+                globalStateMgr.getLocalMetastore().getDb(anyString);
                 minTimes = 0;
                 result = db;
 

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ColumnRenameTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ColumnRenameTest.java
@@ -84,24 +84,24 @@ public class ColumnRenameTest {
 
     @Test
     public void testReplayRenameColumn() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = testDb.getTable("tbl1");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "tbl1");
         ColumnRenameInfo columnRenameInfo = new ColumnRenameInfo(testDb.getId(), table.getId(), "k1", "k3");
         GlobalStateMgr.getCurrentState().getLocalMetastore().replayRenameColumn(columnRenameInfo);
         Assert.assertEquals("k3", table.getColumn("k3").getName());
 
 
-        table = testDb.getTable("tbl2");
+        table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "tbl2");
         columnRenameInfo = new ColumnRenameInfo(testDb.getId(), table.getId(), "k1", "k3");
         GlobalStateMgr.getCurrentState().getLocalMetastore().replayRenameColumn(columnRenameInfo);
         Assert.assertEquals("k3", table.getColumn("k3").getName());
 
-        table = testDb.getTable("tbl3");
+        table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "tbl3");
         columnRenameInfo = new ColumnRenameInfo(testDb.getId(), table.getId(), "k1", "k3");
         GlobalStateMgr.getCurrentState().getLocalMetastore().replayRenameColumn(columnRenameInfo);
         Assert.assertEquals("k3", table.getColumn("k3").getName());
 
-        table = testDb.getTable("tbl4");
+        table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "tbl4");
         columnRenameInfo = new ColumnRenameInfo(testDb.getId(), table.getId(), "k1", "k3");
         GlobalStateMgr.getCurrentState().getLocalMetastore().replayRenameColumn(columnRenameInfo);
         Assert.assertEquals("k3", table.getColumn("k3").getName());

--- a/fe/fe-core/src/test/java/com/starrocks/persist/RenameMaterializedViewLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/RenameMaterializedViewLogTest.java
@@ -65,10 +65,10 @@ public class RenameMaterializedViewLogTest {
         in.close();
         new Expectations() {
             {
-                globalStateMgr.getDb(anyLong);
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
                 result = db;
 
-                db.getTable(anyLong);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), anyLong);
                 result = table;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
@@ -39,9 +39,9 @@ public class MaterializedViewLowCardTPCHTest extends MaterializedViewTestBase {
         int scale = 1;
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         connectContext.getGlobalStateMgr().setStatisticStorage(new MockTpchStatisticStorage(connectContext, scale));
-        OlapTable t4 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("customer");
+        OlapTable t4 = (OlapTable) globalStateMgr.getLocalMetastore().getDb(MATERIALIZED_DB_NAME).getTable("customer");
         setTableStatistics(t4, 150000 * scale);
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
 
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -48,9 +48,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
         int scale = 1;
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         connectContext.getGlobalStateMgr().setStatisticStorage(new MockTpchStatisticStorage(connectContext, scale));
-        OlapTable t4 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("customer");
+        OlapTable t4 = (OlapTable) globalStateMgr.getLocalMetastore().getDb(MATERIALIZED_DB_NAME).getTable("customer");
         setTableStatistics(t4, 150000 * scale);
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
 
         // When force rule based rewrite is enabled, query will be transformed into scan in Rule Rewrite Phase.

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -415,7 +415,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ");");
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("emps");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb(MATERIALIZED_DB_NAME).getTable("emps");
         setTableStatistics(t7, 6000000);
     }
 
@@ -4563,7 +4563,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     ");";
             starRocksAssert.withTable(table2);
 
-            OlapTable t4 = (OlapTable) GlobalStateMgr.getCurrentState().getDb(MATERIALIZED_DB_NAME)
+            OlapTable t4 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(MATERIALIZED_DB_NAME)
                     .getTable("test_sr_table_join");
             setTableStatistics(t4, 150000);
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -288,8 +288,8 @@ public class MaterializedViewTestBase extends PlanTestBase {
     }
 
     protected static Table getTable(String dbName, String mvName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(mvName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName);
         Assert.assertNotNull(table);
         return table;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTPCHTest.java
@@ -44,9 +44,9 @@ public class MaterializedViewTextBasedRewriteTPCHTest extends MaterializedViewTe
         int scale = 1;
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         connectContext.getGlobalStateMgr().setStatisticStorage(new MockTpchStatisticStorage(connectContext, scale));
-        OlapTable t4 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("customer");
+        OlapTable t4 = (OlapTable) globalStateMgr.getLocalMetastore().getDb(MATERIALIZED_DB_NAME).getTable("customer");
         setTableStatistics(t4, 150000 * scale);
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
@@ -58,8 +58,8 @@ public class OlapTableSinkTest2 {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("db2");
-        OlapTable olapTable = (OlapTable) db.getTable("tbl1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
 
         List<Long> partitionIds = olapTable.getAllPartitionIds();
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
@@ -102,7 +102,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
                                 toPartitionInfo(curPartition, 100L, currentTs);
 
-                        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
                         MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
 
@@ -156,7 +156,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
                                 toPartitionInfo(curPartition, 100L, currentTs);
 
-                        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
                         MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
 
@@ -215,7 +215,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
                                 toPartitionInfo(p2, 100L, currentTs);
 
-                        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
                         MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
 
@@ -282,7 +282,7 @@ public class MVMetaVersionRepairerTest extends MvRewriteTestBase {
                         MVRepairHandler.PartitionRepairInfo partitionRepairInfo =
                                 toPartitionInfo(p1, 100L, currentTs);
 
-                        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
                         MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
 

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/AuthorizationMgrTest.java
@@ -22,6 +22,7 @@ import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -45,6 +46,7 @@ import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.CreateCatalogStmt;
@@ -1663,6 +1665,18 @@ public class AuthorizationMgrTest {
 
     @Test
     public void testPartialRevoke() throws Exception {
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new TableName("db", "tbl1")).get();
+            }
+
+            @Mock
+            public Table getTable(Long dbId, Long tableId) {
+                return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new TableName("db", "tbl1")).get();
+            }
+        };
+
         String sql = "grant select on table db.tbl0 to test_user";
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
 

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/RBACMockedMetadataMgr.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/RBACMockedMetadataMgr.java
@@ -118,17 +118,6 @@ public class RBACMockedMetadataMgr extends MetadataMgr {
     }
 
     @Override
-    public Table getTable(Long databaseId, Long tableId) {
-        for (Table table : tableMap.values()) {
-            if (table.getId() == tableId) {
-                return table;
-            }
-        }
-
-        return null;
-    }
-
-    @Override
     public List<String> listTableNames(String catalogName, String dbName) {
         return new ArrayList<>(tableMap.keySet());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BeRestartTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BeRestartTest.java
@@ -64,7 +64,7 @@ public class BeRestartTest {
             createTableSqls[i] = PseudoCluster.newCreateTableSqlBuilder().setTableName(name).build();
             insertSqls[i] = PseudoCluster.buildInsertSql("test", name);
             cluster.runSqls("test", createTableSqls[i], insertSqls[i], insertSqls[i], insertSqls[i]);
-            tableIds[i] = GlobalStateMgr.getCurrentState().getDb("test").getTable(name).getId();
+            tableIds[i] = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable(name).getId();
             // insert 3 times -> version: 4
             tableVersions[i] = 4;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/LocationLabeledTableBalanceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/LocationLabeledTableBalanceTest.java
@@ -105,7 +105,7 @@ public class LocationLabeledTableBalanceTest {
                 ");";
         cluster.runSql("test", sql);
 
-        Database test = GlobalStateMgr.getCurrentState().getDb("test");
+        Database test = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable olapTable = (OlapTable) test.getTable("test_table_best_effort_balance");
 
         // Add another backend without location property, with best-effort balance strategy,
@@ -177,7 +177,7 @@ public class LocationLabeledTableBalanceTest {
     @Test
     @Ignore
     public void test2LocationMatchedBalance() throws InterruptedException, SQLException {
-        Database test = GlobalStateMgr.getCurrentState().getDb("test");
+        Database test = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable olapTable = (OlapTable) test.getTable("test_table_best_effort_balance");
 
         long start = System.currentTimeMillis();

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/LocationMismatchRepairTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/LocationMismatchRepairTest.java
@@ -81,7 +81,7 @@ public class LocationMismatchRepairTest {
         int j = 0;
         for (PseudoBackend backend : cluster.getBackends()) {
             String stmtStr = "alter system modify backend '" + backend.getHostHeartbeatPort() + "' set ('" +
-                    AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:r" + i + "')";
+                        AlterSystemStmtAnalyzer.PROP_KEY_LOCATION + "' = 'rack:r" + i + "')";
             if (j % 2 == 1) {
                 i++;
             }
@@ -96,9 +96,9 @@ public class LocationMismatchRepairTest {
         Set<Long> backendIds = Sets.newHashSet();
         for (PseudoBackend pseudoBackend : cluster.getBackends()) {
             Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                    .getClusterInfo().getBackend(pseudoBackend.getId());
+                        .getClusterInfo().getBackend(pseudoBackend.getId());
             if (backend.getLocation().containsKey(locationKey) &&
-                    Objects.equals(backend.getLocation().get(locationKey), locationVal)) {
+                        Objects.equals(backend.getLocation().get(locationKey), locationVal)) {
                 backendIds.add(backend.getId());
             }
         }
@@ -112,9 +112,9 @@ public class LocationMismatchRepairTest {
                 stringBuffer.append("tablet ").append(tablet.getId()).append(": ");
                 for (Replica replica : tablet.getAllReplicas()) {
                     stringBuffer.append(replica.getBackendId()).append(" ")
-                            .append(GlobalStateMgr.getCurrentState().getNodeMgr()
-                                    .getClusterInfo().getBackend(
-                            replica.getBackendId()).getLocation()).append(", ");
+                                .append(GlobalStateMgr.getCurrentState().getNodeMgr()
+                                            .getClusterInfo().getBackend(
+                                                        replica.getBackendId()).getLocation()).append(", ");
                 }
                 System.out.println(stringBuffer);
             });
@@ -136,20 +136,21 @@ public class LocationMismatchRepairTest {
 
         PseudoCluster cluster = PseudoCluster.getInstance();
         String sql = "CREATE TABLE test.`test_table_backend_no_loc` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_table_backend_no_loc");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_backend_no_loc");
         Assert.assertNotNull(table.getLocation());
         Assert.assertTrue(table.getLocation().keySet().contains("*"));
 
@@ -173,22 +174,22 @@ public class LocationMismatchRepairTest {
         long oldCloneFinishedCnt = stat.counterCloneTaskSucceeded.get();
         long oldLocationMismatchErr = stat.counterReplicaLocMismatchErr.get();
         System.out.println("old clone finished: " + oldCloneFinishedCnt + ", old location mismatch: " +
-                oldLocationMismatchErr);
+                    oldLocationMismatchErr);
         sql = "ALTER TABLE test.`test_table_backend_no_loc` SET ('" +
-                PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:r1,rack:r2,rack:r3');";
+                    PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:r1,rack:r2,rack:r3');";
         cluster.runSql("test", sql);
         System.out.println("=========================");
         long start = System.currentTimeMillis();
         while (true) {
             if (stat.counterCloneTaskSucceeded.get() - oldCloneFinishedCnt >= locationMismatchFullCloneNeeded
-                    && stat.counterReplicaLocMismatchErr.get() - oldLocationMismatchErr >=
-                    locationMismatchFullCloneNeeded) {
+                        && stat.counterReplicaLocMismatchErr.get() - oldLocationMismatchErr >=
+                        locationMismatchFullCloneNeeded) {
                 break;
             }
             System.out.println("wait for enough clone tasks for LOCATION_MISMATCH finished, " +
-                    "current clone finished: " + stat.counterCloneTaskSucceeded.get() +
-                    ", current location mismatch: " + stat.counterReplicaLocMismatchErr.get() +
-                    ", expected clone finished: " + locationMismatchFullCloneNeeded);
+                        "current clone finished: " + stat.counterCloneTaskSucceeded.get() +
+                        ", current location mismatch: " + stat.counterReplicaLocMismatchErr.get() +
+                        ", expected clone finished: " + locationMismatchFullCloneNeeded);
             Thread.sleep(1000);
             if (System.currentTimeMillis() - start > 180000) {
                 Assert.fail("wait for enough clone tasks for LOCATION_MISMATCH finished timeout");
@@ -208,7 +209,7 @@ public class LocationMismatchRepairTest {
             Set<Pair<String, String>> racks = new HashSet<>();
             for (long backendId : intersection) {
                 Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                        .getClusterInfo().getBackend(backendId);
+                            .getClusterInfo().getBackend(backendId);
                 racks.add(backend.getSingleLevelLocationKV());
             }
             Assert.assertEquals(3, racks.size());
@@ -221,17 +222,17 @@ public class LocationMismatchRepairTest {
 
         PseudoCluster cluster = PseudoCluster.getInstance();
         String sql = "CREATE TABLE test.`test_table_backend_no_loc` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:r0,rack:r1,rack:r2,rack:r4\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:r0,rack:r1,rack:r2,rack:r4\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
 
         // decommission backends with 'rack:r4' location
@@ -251,7 +252,7 @@ public class LocationMismatchRepairTest {
             while (true) {
                 int curTabletNum = decommissionBE.getTabletManager().getNumTablet();
                 System.out.printf("#tablets: %d/%d: fullClone: %d wait...\n", curTabletNum, pair.second,
-                        Tablet.getTotalFullClone());
+                            Tablet.getTotalFullClone());
                 if (curTabletNum == 0) {
                     break;
                 }
@@ -261,8 +262,9 @@ public class LocationMismatchRepairTest {
 
         // sleep to wait for redundant replicas cleaned
         Thread.sleep(5000);
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_table_backend_no_loc");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_table_backend_no_loc");
         printTabletReplicaInfo(table);
         Set<Long> stayedBackendIds = getBackendIdsWithLocProp("rack", "r0");
         stayedBackendIds.addAll(getBackendIdsWithLocProp("rack", "r1"));
@@ -277,13 +279,12 @@ public class LocationMismatchRepairTest {
             Set<Pair<String, String>> racks = new HashSet<>();
             for (long backendId : intersection) {
                 Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                        .getClusterInfo().getBackend(backendId);
+                            .getClusterInfo().getBackend(backendId);
                 racks.add(backend.getSingleLevelLocationKV());
             }
             Assert.assertEquals(3, racks.size());
         }
     }
-
 
     @Test
     public void testMVRepairAfterChangeTableLocation() throws Exception {
@@ -292,32 +293,33 @@ public class LocationMismatchRepairTest {
         PseudoCluster cluster = PseudoCluster.getInstance();
         // create base table
         String sql = "CREATE TABLE test.`test_base_table` (\n" +
-                "    k1 int,\n" +
-                "    k2 VARCHAR NOT NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "COMMENT \"OLAP\"\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
-                "PROPERTIES (\n" +
-                "    \"replication_num\" = \"3\",\n" +
-                "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:*\",\n" +
-                "    \"in_memory\" = \"false\"\n" +
-                ");";
+                    "    k1 int,\n" +
+                    "    k2 VARCHAR NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`k1`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n" +
+                    "PROPERTIES (\n" +
+                    "    \"replication_num\" = \"3\",\n" +
+                    "    \"" + PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "\" = \"rack:*\",\n" +
+                    "    \"in_memory\" = \"false\"\n" +
+                    ");";
         cluster.runSql("test", sql);
 
         // create mv
         sql = "CREATE MATERIALIZED VIEW test_mv01\n" +
-                "DISTRIBUTED BY HASH(`k1`)\n" +
-                "buckets 15\n" +
-                "REFRESH MANUAL\n" +
-                "properties(\n" +
-                "    \"replication_num\" = \"3\"" +
-                ")\n" +
-                "AS SELECT test_base_table.k1 FROM test_base_table;";
+                    "DISTRIBUTED BY HASH(`k1`)\n" +
+                    "buckets 15\n" +
+                    "REFRESH MANUAL\n" +
+                    "properties(\n" +
+                    "    \"replication_num\" = \"3\"" +
+                    ")\n" +
+                    "AS SELECT test_base_table.k1 FROM test_base_table;";
         cluster.runSql("test", sql);
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("test_mv01");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table =
+                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_mv01");
         Assert.assertNotNull(table.getLocation());
         Assert.assertTrue(table.getLocation().keySet().contains("*"));
 
@@ -341,22 +343,22 @@ public class LocationMismatchRepairTest {
         long oldCloneFinishedCnt = stat.counterCloneTaskSucceeded.get();
         long oldLocationMismatchErr = stat.counterReplicaLocMismatchErr.get();
         System.out.println("old clone finished: " + oldCloneFinishedCnt + ", old location mismatch: " +
-                oldLocationMismatchErr);
+                    oldLocationMismatchErr);
         sql = "ALTER MATERIALIZED VIEW test.`test_mv01` SET ('" +
-                PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:r1,rack:r2,rack:r3');";
+                    PropertyAnalyzer.PROPERTIES_LABELS_LOCATION + "' = 'rack:r1,rack:r2,rack:r3');";
         cluster.runSql("test", sql);
         System.out.println("=========================");
         long start = System.currentTimeMillis();
         while (true) {
             if (stat.counterCloneTaskSucceeded.get() - oldCloneFinishedCnt >= locationMismatchFullCloneNeeded
-                    && stat.counterReplicaLocMismatchErr.get() - oldLocationMismatchErr >=
-                    locationMismatchFullCloneNeeded) {
+                        && stat.counterReplicaLocMismatchErr.get() - oldLocationMismatchErr >=
+                        locationMismatchFullCloneNeeded) {
                 break;
             }
             System.out.println("wait for enough clone tasks for LOCATION_MISMATCH finished, " +
-                    "current clone finished: " + stat.counterCloneTaskSucceeded.get() +
-                    ", current location mismatch: " + stat.counterReplicaLocMismatchErr.get() +
-                    ", expected clone finished: " + locationMismatchFullCloneNeeded);
+                        "current clone finished: " + stat.counterCloneTaskSucceeded.get() +
+                        ", current location mismatch: " + stat.counterReplicaLocMismatchErr.get() +
+                        ", expected clone finished: " + locationMismatchFullCloneNeeded);
             Thread.sleep(1000);
             if (System.currentTimeMillis() - start > 180000) {
                 Assert.fail("wait for enough clone tasks for LOCATION_MISMATCH finished timeout");
@@ -376,7 +378,7 @@ public class LocationMismatchRepairTest {
             Set<Pair<String, String>> racks = new HashSet<>();
             for (long backendId : intersection) {
                 Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr()
-                        .getClusterInfo().getBackend(backendId);
+                            .getClusterInfo().getBackend(backendId);
                 racks.add(backend.getSingleLevelLocationKV());
             }
             Assert.assertEquals(3, racks.size());

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -284,14 +284,14 @@ public class PseudoCluster {
     }
 
     public List<Long> listTablets(String dbName, String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
         if (db == null) {
             return null;
         }
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table table = db.getTable(tableName);
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
             if (table == null) {
                 return null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/ReplicaMinReadableVersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/ReplicaMinReadableVersionTest.java
@@ -50,7 +50,7 @@ public class ReplicaMinReadableVersionTest {
 
     @Test
     public void testReplicaMinReadableVersionReported() throws Exception {
-        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test").getTable(tableName);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable(tableName);
         long tableId = olapTable.getId();
         PseudoBackend be = cluster.getBackend(10001);
         Tablet tablet = be.getTabletsByTable(tableId).get(0);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -253,7 +253,7 @@ public class ShowExecutorTest {
         };
 
         BaseTableInfo baseTableInfo = new BaseTableInfo(
-                "default_catalog", "testDb", "testTbl", null);
+                    "default_catalog", "testDb", "testTbl", null);
 
         // mock materialized view
         MaterializedView mv = new MaterializedView();
@@ -302,10 +302,10 @@ public class ShowExecutorTest {
                 mv.getPartitionInfo();
                 minTimes = 0;
                 result = new ExpressionRangePartitionInfo(
-                        Collections.singletonList(
-                                ColumnIdExpr.create(new SlotRef(
-                                        new TableName("test", "testMv"), column1.getName()))),
-                        Collections.singletonList(column1), PartitionType.RANGE);
+                            Collections.singletonList(
+                                        ColumnIdExpr.create(new SlotRef(
+                                                    new TableName("test", "testMv"), column1.getName()))),
+                            Collections.singletonList(column1), PartitionType.RANGE);
 
                 mv.getDefaultDistributionInfo();
                 minTimes = 0;
@@ -326,7 +326,7 @@ public class ShowExecutorTest {
                 mv.getTableProperty();
                 minTimes = 0;
                 result = new TableProperty(
-                        Collections.singletonMap(PROPERTIES_STORAGE_COOLDOWN_TIME, "100"));
+                            Collections.singletonMap(PROPERTIES_STORAGE_COOLDOWN_TIME, "100"));
 
                 mv.getIdToColumn();
                 minTimes = 0;
@@ -338,15 +338,15 @@ public class ShowExecutorTest {
         Database db = new Database();
         new Expectations(db) {
             {
-                db.getTable("testMv");
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "testMv");
                 minTimes = 0;
                 result = mv;
 
-                db.getTable("testTbl");
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "testTbl");
                 minTimes = 0;
                 result = table;
 
-                db.getTable("emptyTable");
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "emptyTable");
                 minTimes = 0;
                 result = table;
 
@@ -368,11 +368,11 @@ public class ShowExecutorTest {
         globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getDb("testDb");
+                globalStateMgr.getLocalMetastore().getDb("testDb");
                 minTimes = 0;
                 result = db;
 
-                globalStateMgr.getDb("emptyDb");
+                globalStateMgr.getLocalMetastore().getDb("emptyDb");
                 minTimes = 0;
                 result = null;
 
@@ -397,7 +397,7 @@ public class ShowExecutorTest {
                 result = null;
 
                 metadataMgr.getTable("default_catalog", "testDb",
-                        "testTbl");
+                            "testTbl");
                 minTimes = 0;
                 result = table;
             }
@@ -494,7 +494,7 @@ public class ShowExecutorTest {
 
         new Expectations() {
             {
-                globalStateMgr.getDb(0);
+                globalStateMgr.getLocalMetastore().getDb(0);
                 minTimes = 0;
                 result = db;
             }
@@ -502,7 +502,7 @@ public class ShowExecutorTest {
 
         // Ok to test
         ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName("testDb", "testTbl"),
-                null, null, null, false);
+                    null, null, null, false);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
@@ -549,7 +549,7 @@ public class ShowExecutorTest {
         ctx.setQualifiedUser("testUser");
 
         DescribeStmt stmt = (DescribeStmt) com.starrocks.sql.parser.SqlParser.parse("desc testTbl",
-                ctx.getSessionVariable().getSqlMode()).get(0);
+                    ctx.getSessionVariable().getSqlMode()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         ShowResultSet resultSet;
@@ -655,7 +655,7 @@ public class ShowExecutorTest {
     @Test(expected = SemanticException.class)
     public void testShowCreateTableEmptyDb() throws SemanticException, DdlException {
         ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("emptyDb", "testTable"),
-                ShowCreateTableStmt.CreateTableType.TABLE);
+                    ShowCreateTableStmt.CreateTableType.TABLE);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
 
@@ -668,7 +668,7 @@ public class ShowExecutorTest {
         ctx.setQualifiedUser("testUser");
 
         ShowColumnStmt stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show columns from testTbl in testDb",
-                ctx.getSessionVariable()).get(0);
+                    ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
@@ -682,7 +682,7 @@ public class ShowExecutorTest {
 
         // verbose
         stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show full columns from testTbl in testDb",
-                ctx.getSessionVariable()).get(0);
+                    ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         resultSet = ShowExecutor.execute(stmt, ctx);
@@ -697,7 +697,7 @@ public class ShowExecutorTest {
 
         // show full fields
         stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show full fields from testTbl in testDb",
-                ctx.getSessionVariable()).get(0);
+                    ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         resultSet = ShowExecutor.execute(stmt, ctx);
@@ -712,7 +712,7 @@ public class ShowExecutorTest {
 
         // pattern
         stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show full columns from testTbl in testDb like \"%1\"",
-                ctx.getSessionVariable().getSqlMode()).get(0);
+                    ctx.getSessionVariable().getSqlMode()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         resultSet = ShowExecutor.execute(stmt, ctx);
@@ -895,10 +895,10 @@ public class ShowExecutorTest {
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
 
         Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.size(),
-                resultSet.getMetaData().getColumnCount());
+                    resultSet.getMetaData().getColumnCount());
         for (int i = 0; i < ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.size(); ++i) {
             Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.get(i),
-                    resultSet.getMetaData().getColumn(i).getName());
+                        resultSet.getMetaData().getColumn(i).getName());
         }
 
         Assert.assertTrue(resultSet.next());
@@ -1003,15 +1003,15 @@ public class ShowExecutorTest {
 
     private void verifyShowMaterializedViewResult(ShowResultSet resultSet) throws AnalysisException, DdlException {
         String expectedSqlText = "CREATE MATERIALIZED VIEW `testMv` (`col1`, `col2`)\n" +
-                "COMMENT \"TEST MATERIALIZED VIEW\"\n" +
-                "PARTITION BY (`col1`)\n" +
-                "DISTRIBUTED BY HASH(`col1`) BUCKETS 10 \n" +
-                "REFRESH ASYNC\n" +
-                "PROPERTIES (\n" +
-                "\"storage_cooldown_time\" = \"1970-01-01 08:00:00\",\n" +
-                "\"storage_medium\" = \"SSD\"\n" +
-                ")\n" +
-                "AS select col1, col2 from table1;";
+                    "COMMENT \"TEST MATERIALIZED VIEW\"\n" +
+                    "PARTITION BY (`col1`)\n" +
+                    "DISTRIBUTED BY HASH(`col1`) BUCKETS 10 \n" +
+                    "REFRESH ASYNC\n" +
+                    "PROPERTIES (\n" +
+                    "\"storage_cooldown_time\" = \"1970-01-01 08:00:00\",\n" +
+                    "\"storage_medium\" = \"SSD\"\n" +
+                    ")\n" +
+                    "AS select col1, col2 from table1;";
 
         Assert.assertTrue(resultSet.next());
         List<Column> mvSchemaTable = MaterializedViewsSystemTable.create().getFullSchema();
@@ -1053,7 +1053,8 @@ public class ShowExecutorTest {
     @Test
     public void testShowAlterTable() throws AnalysisException, DdlException {
         ShowAlterStmt stmt = new ShowAlterStmt(ShowAlterStmt.AlterType.OPTIMIZE, "testDb", null, null, null);
-        stmt.setNode(new OptimizeProcDir(globalStateMgr.getSchemaChangeHandler(), globalStateMgr.getDb("testDb")));
+        stmt.setNode(new OptimizeProcDir(globalStateMgr.getSchemaChangeHandler(),
+                    globalStateMgr.getLocalMetastore().getDb("testDb")));
 
         ShowExecutor.execute(stmt, ctx);
     }
@@ -1082,34 +1083,34 @@ public class ShowExecutorTest {
                 partitions.add("year");
                 partitions.add("dt");
                 HiveTable.Builder tableBuilder = HiveTable.builder()
-                        .setId(1)
-                        .setTableName("test_table")
-                        .setCatalogName("hive_catalog")
-                        .setResourceName(toResourceName("hive_catalog", "hive"))
-                        .setHiveDbName("hive_db")
-                        .setHiveTableName("test_table")
-                        .setPartitionColumnNames(partitions)
-                        .setFullSchema(fullSchema)
-                        .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
-                        .setCreateTime(10000);
+                            .setId(1)
+                            .setTableName("test_table")
+                            .setCatalogName("hive_catalog")
+                            .setResourceName(toResourceName("hive_catalog", "hive"))
+                            .setHiveDbName("hive_db")
+                            .setHiveTableName("test_table")
+                            .setPartitionColumnNames(partitions)
+                            .setFullSchema(fullSchema)
+                            .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
+                            .setCreateTime(10000);
                 return tableBuilder.build();
             }
         };
 
         ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("hive_catalog", "hive_db", "test_table"),
-                ShowCreateTableStmt.CreateTableType.TABLE);
+                    ShowCreateTableStmt.CreateTableType.TABLE);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assert.assertEquals("test_table", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE TABLE `test_table` (\n" +
-                        "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
-                        "  `name` varchar DEFAULT NULL,\n" +
-                        "  `year` int(11) DEFAULT NULL,\n" +
-                        "  `dt` int(11) DEFAULT NULL\n" +
-                        ")\n" +
-                        "PARTITION BY (year, dt)\n" +
-                        "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
-                resultSet.getResultRows().get(0).get(1));
+                                "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
+                                "  `name` varchar DEFAULT NULL,\n" +
+                                "  `year` int(11) DEFAULT NULL,\n" +
+                                "  `dt` int(11) DEFAULT NULL\n" +
+                                ")\n" +
+                                "PARTITION BY (year, dt)\n" +
+                                "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
+                    resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
@@ -1136,35 +1137,35 @@ public class ShowExecutorTest {
                 partitions.add("year");
                 partitions.add("dt");
                 HiveTable.Builder tableBuilder = HiveTable.builder()
-                        .setId(1)
-                        .setTableName("test_table")
-                        .setCatalogName("hive_catalog")
-                        .setResourceName(toResourceName("hive_catalog", "hive"))
-                        .setHiveDbName("hive_db")
-                        .setHiveTableName("test_table")
-                        .setPartitionColumnNames(partitions)
-                        .setFullSchema(fullSchema)
-                        .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
-                        .setCreateTime(10000)
-                        .setHiveTableType(HiveTable.HiveTableType.EXTERNAL_TABLE);
+                            .setId(1)
+                            .setTableName("test_table")
+                            .setCatalogName("hive_catalog")
+                            .setResourceName(toResourceName("hive_catalog", "hive"))
+                            .setHiveDbName("hive_db")
+                            .setHiveTableName("test_table")
+                            .setPartitionColumnNames(partitions)
+                            .setFullSchema(fullSchema)
+                            .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
+                            .setCreateTime(10000)
+                            .setHiveTableType(HiveTable.HiveTableType.EXTERNAL_TABLE);
                 return tableBuilder.build();
             }
         };
 
         ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("hive_catalog", "hive_db", "test_table"),
-                ShowCreateTableStmt.CreateTableType.TABLE);
+                    ShowCreateTableStmt.CreateTableType.TABLE);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assert.assertEquals("test_table", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE EXTERNAL TABLE `test_table` (\n" +
-                        "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
-                        "  `name` varchar DEFAULT NULL,\n" +
-                        "  `year` int(11) DEFAULT NULL,\n" +
-                        "  `dt` int(11) DEFAULT NULL\n" +
-                        ")\n" +
-                        "PARTITION BY (year, dt)\n" +
-                        "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
-                resultSet.getResultRows().get(0).get(1));
+                                "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
+                                "  `name` varchar DEFAULT NULL,\n" +
+                                "  `year` int(11) DEFAULT NULL,\n" +
+                                "  `dt` int(11) DEFAULT NULL\n" +
+                                ")\n" +
+                                "PARTITION BY (year, dt)\n" +
+                                "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
+                    resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
@@ -1185,10 +1186,10 @@ public class ShowExecutorTest {
 
         Assert.assertEquals("test_hive", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE EXTERNAL CATALOG `test_hive`\n" +
-                "comment \"hive_test\"\n" +
-                "PROPERTIES (\"type\"  =  \"hive\",\n" +
-                "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\"\n" +
-                ")", resultSet.getResultRows().get(0).get(1));
+                    "comment \"hive_test\"\n" +
+                    "PROPERTIES (\"type\"  =  \"hive\",\n" +
+                    "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\"\n" +
+                    ")", resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
@@ -1203,7 +1204,7 @@ public class ShowExecutorTest {
         ShowCreateExternalCatalogStmt stmt = new ShowCreateExternalCatalogStmt("catalog_not_exist");
 
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "Unknown catalog 'catalog_not_exist'",
-                () -> ShowExecutor.execute(stmt, ctx));
+                    () -> ShowExecutor.execute(stmt, ctx));
     }
 
     @Test
@@ -1213,8 +1214,8 @@ public class ShowExecutorTest {
             public Map<AnalyzeMgr.StatsMetaKey, ExternalBasicStatsMeta> getExternalBasicStatsMetaMap() {
                 Map<AnalyzeMgr.StatsMetaKey, ExternalBasicStatsMeta> map = new HashMap<>();
                 map.put(new AnalyzeMgr.StatsMetaKey("hive0", "testDb", "testTable"),
-                        new ExternalBasicStatsMeta("hive0", "testDb", "testTable", null,
-                                StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), Maps.newHashMap()));
+                            new ExternalBasicStatsMeta("hive0", "testDb", "testTable", null,
+                                        StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), Maps.newHashMap()));
                 return map;
             }
         };
@@ -1235,13 +1236,13 @@ public class ShowExecutorTest {
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         resultSet.getResultRows().forEach(System.out::println);
         String expectString1 = "root, null, GRANT CREATE TABLE, DROP, ALTER, CREATE VIEW, CREATE FUNCTION, " +
-                "CREATE MATERIALIZED VIEW, CREATE PIPE ON ALL DATABASES TO ROLE 'root'";
+                    "CREATE MATERIALIZED VIEW, CREATE PIPE ON ALL DATABASES TO ROLE 'root'";
         Assert.assertTrue(resultSet.getResultRows().stream().anyMatch(l ->
-                l.toString().contains(expectString1)));
+                    l.toString().contains(expectString1)));
         String expectString2 = "root, null, GRANT DELETE, DROP, INSERT, SELECT, ALTER, EXPORT, " +
-                "UPDATE ON ALL TABLES IN ALL DATABASES TO ROLE 'root'";
+                    "UPDATE ON ALL TABLES IN ALL DATABASES TO ROLE 'root'";
         Assert.assertTrue(resultSet.getResultRows().stream().anyMatch(l ->
-                l.toString().contains(expectString2)));
+                    l.toString().contains(expectString2)));
     }
 
     @Test
@@ -1264,12 +1265,12 @@ public class ShowExecutorTest {
 
         Assert.assertEquals("test_hive", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE EXTERNAL CATALOG `test_hive`\n" +
-                "comment \"hive_test\"\n" +
-                "PROPERTIES (\"aws.s3.access_key\"  =  \"ia******ey\",\n" +
-                "\"aws.s3.secret_key\"  =  \"ia******ey\",\n" +
-                "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\",\n" +
-                "\"type\"  =  \"hive\"\n" +
-                ")", resultSet.getResultRows().get(0).get(1));
+                    "comment \"hive_test\"\n" +
+                    "PROPERTIES (\"aws.s3.access_key\"  =  \"ia******ey\",\n" +
+                    "\"aws.s3.secret_key\"  =  \"ia******ey\",\n" +
+                    "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\",\n" +
+                    "\"type\"  =  \"hive\"\n" +
+                    ")", resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
@@ -1282,7 +1283,7 @@ public class ShowExecutorTest {
         properties.put("ni", "hao");
         StringLiteral stringLiteral = new StringLiteral("hello");
         dataCacheMgr.createCacheRule(QualifiedName.of(ImmutableList.of("test2", "test2", "test2")),
-                stringLiteral, -1, properties);
+                    stringLiteral, -1, properties);
 
         ShowDataCacheRulesStmt stmt = new ShowDataCacheRulesStmt(NodePosition.ZERO);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowTableMockMeta.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowTableMockMeta.java
@@ -131,17 +131,6 @@ public class ShowTableMockMeta extends MetadataMgr {
     }
 
     @Override
-    public Table getTable(Long databaseId, Long tableId) {
-        for (Table table : tableMap.values()) {
-            if (table.getId() == tableId) {
-                return table;
-            }
-        }
-
-        return null;
-    }
-
-    @Override
     public List<String> listTableNames(String catalogName, String dbName) {
         if (catalogName.equals("hive_catalog")) {
             return new ArrayList<>(externalTbSet.keySet());

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -74,7 +74,7 @@ public class ReplicationMgrTest {
         starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
         starRocksAssert.withDatabase("test").useDatabase("test");
 
-        db = GlobalStateMgr.getCurrentState().getDb("test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
                 "distributed by hash(key1) buckets 1\n" +
@@ -83,7 +83,8 @@ public class ReplicationMgrTest {
                 AnalyzeTestUtil.getConnectContext());
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
 
-        table = (OlapTable) db.getTable("single_partition_duplicate_key");
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "single_partition_duplicate_key");
         srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
 
         partition = table.getPartitions().iterator().next();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
@@ -97,8 +97,8 @@ public class MVRefreshTestBase {
     }
 
     protected MaterializedView getMv(String dbName, String mvName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(mvName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName);
         Assert.assertNotNull(table);
         Assert.assertTrue(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;
@@ -106,8 +106,8 @@ public class MVRefreshTestBase {
     }
 
     protected Table getTable(String dbName, String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(tableName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         Assert.assertNotNull(table);
         return table;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -53,75 +53,75 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
         MVRefreshTestBase.beforeClass();
         // table whose partitions have multiple values
         T1 = "CREATE TABLE t1 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (province) (\n" +
-                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
-                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
-                ")\n" +
-                "DISTRIBUTED BY RANDOM\n";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (province) (\n" +
+                    "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                    "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY RANDOM\n";
         // table whose partitions have only single values
         T2 = "CREATE TABLE t2 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (province) (\n" +
-                "     PARTITION p1 VALUES IN (\"beijing\") ,\n" +
-                "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
-                ")\n" +
-                "DISTRIBUTED BY RANDOM\n";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (province) (\n" +
+                    "     PARTITION p1 VALUES IN (\"beijing\") ,\n" +
+                    "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY RANDOM\n";
         // table whose partitions have multi columns
         T3 = "CREATE TABLE t3 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10) not null,\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY LIST (province, dt) (\n" +
-                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\"))  ,\n" +
-                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\")), \n" +
-                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\"))  ,\n" +
-                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\")) \n" +
-                ")\n" +
-                "DISTRIBUTED BY RANDOM\n";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10) not null,\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY LIST (province, dt) (\n" +
+                    "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\"))  ,\n" +
+                    "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\")), \n" +
+                    "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\"))  ,\n" +
+                    "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\")) \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY RANDOM\n";
         // table with partition expression whose partitions have multiple values
         T4 = "CREATE TABLE t4 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY (province) \n" +
-                "DISTRIBUTED BY RANDOM\n";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY (province) \n" +
+                    "DISTRIBUTED BY RANDOM\n";
         // table with partition expression whose partitions have multi columns
         T5 = "CREATE TABLE t5 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10) not null,\n" +
-                "      province VARCHAR(64) not null\n" +
-                ")\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY (province, dt) \n" +
-                "DISTRIBUTED BY RANDOM\n";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10) not null,\n" +
+                    "      province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY (province, dt) \n" +
+                    "DISTRIBUTED BY RANDOM\n";
         // table with partition expression whose partitions have multi columns(nullable partition columns)
         T6 = "CREATE TABLE t6 (\n" +
-                "      id BIGINT,\n" +
-                "      age SMALLINT,\n" +
-                "      dt VARCHAR(10),\n" +
-                "      province VARCHAR(64)\n" +
-                ")\n" +
-                "DUPLICATE KEY(id)\n" +
-                "PARTITION BY (province, dt) \n" +
-                "DISTRIBUTED BY RANDOM\n";
+                    "      id BIGINT,\n" +
+                    "      age SMALLINT,\n" +
+                    "      dt VARCHAR(10),\n" +
+                    "      province VARCHAR(64)\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(id)\n" +
+                    "PARTITION BY (province, dt) \n" +
+                    "DISTRIBUTED BY RANDOM\n";
     }
 
     @AfterClass
@@ -144,7 +144,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
             initAndExecuteTaskRun(taskRun);
 
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                    taskRun.getProcessor();
+                        taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             return execPlan;
@@ -178,12 +178,12 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
     }
 
     private String toPartitionVal(String val) {
-        return val == null ?  "NULL" : String.format("'%s'", val);
+        return val == null ? "NULL" : String.format("'%s'", val);
     }
 
     private void addListPartition(String tbl, String pName, String pVal1, String pVal2) {
         String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION %s VALUES IN ((%s, %s))", tbl, pName,
-                toPartitionVal(pVal1), toPartitionVal(pVal2));
+                    toPartitionVal(pVal1), toPartitionVal(pVal2));
         StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
         try {
             new StmtExecutor(connectContext, stmt).execute();
@@ -194,772 +194,794 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
 
     @Test
     public void testRefreshNonPartitionedMV() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T2, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "as select dt, province, sum(age) from t2 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "as select dt, province, sum(age) from t2 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=2/2");
+                            {
+                                String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=2/2");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(1, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(1, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t2", "p3", "hangzhou");
+                            {
+                                // add a new partition
+                                addListPartition("t2", "p3", "hangzhou");
 
-                            String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=3/3");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(1, partitions.size());
-                        }
-                    });
+                                String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=3/3");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(1, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshSingleColumnMVWithSingleValues() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T2, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as select dt, province, sum(age) from t2 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as select dt, province, sum(age) from t2 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
+                            {
+                                String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t2", "p3", "hangzhou");
+                            {
+                                // add a new partition
+                                addListPartition("t2", "p3", "hangzhou");
 
-                            String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/3");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
-                    });
+                                String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/3");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshSingleColumnWithMultiValues() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T1, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as select dt, province, sum(age) from t1 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as select dt, province, sum(age) from t1 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
+                            {
+                                String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t1", "p3", "hangzhou");
+                            {
+                                // add a new partition
+                                addListPartition("t1", "p3", "hangzhou");
 
-                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/3");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
-                    });
+                                String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/3");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshMultiColumnsMV1() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T3, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as select dt, province, sum(age) from t3 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as select dt, province, sum(age) from t3 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            {
+                                String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
 
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
-                                    "     TABLE: t3\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=2/4");
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                                            "     TABLE: t3\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=2/4");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
-                            insertSql = "insert into t3 partition(p3) values(1, 1, '2024-01-02', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
+                            {
+                                String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
+                                insertSql = "insert into t3 partition(p3) values(1, 1, '2024-01-02', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
 
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=2/4");
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=2/4");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t3", "p5", "hangzhou", "2022-01-01");
-                            String insertSql = "INSERT INTO t3 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/5");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
-                    });
+                            {
+                                // add a new partition
+                                addListPartition("t3", "p5", "hangzhou", "2022-01-01");
+                                String insertSql = "INSERT INTO t3 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/5");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshMultiColumnsMV2() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T3, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by dt \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as select dt, province, sum(age) from t3 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by dt \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as select dt, province, sum(age) from t3 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t3 values (1, 1, '2024-01-01', 'beijing')," +
-                                    "(2, 20, '2024-01-01', 'guangdong'), (3, 30, '2024-01-02', 'guangdong');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            {
+                                String insertSql = "insert into t3 values (1, 1, '2024-01-01', 'beijing')," +
+                                            "(2, 20, '2024-01-01', 'guangdong'), (3, 30, '2024-01-02', 'guangdong');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
 
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=4/4");
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=4/4");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
-                            insertSql = "insert into t3 partition(p3) values(1, 1, '2024-01-02', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
+                            {
+                                String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
+                                insertSql = "insert into t3 partition(p3) values(1, 1, '2024-01-02', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
 
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=4/4");
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=4/4");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t3", "p5", "hangzhou", "2024-01-01");
-                            String insertSql = "INSERT INTO t3 partition(p5) values(1, 1, '2024-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=3/5");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                        }
-                    });
+                            {
+                                // add a new partition
+                                addListPartition("t3", "p5", "hangzhou", "2024-01-01");
+                                String insertSql = "INSERT INTO t3 partition(p5) values(1, 1, '2024-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t3\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=3/5");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshSingleColumnMVWithPartitionExpr() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T4, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as select dt, province, sum(age) from t4 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as select dt, province, sum(age) from t4 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            addListPartition("t4", "p1", "beijing");
-                            String insertSql = "insert into t4 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
+                            {
+                                addListPartition("t4", "p1", "beijing");
+                                String insertSql = "insert into t4 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(1, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(1, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t4", "p3", "hangzhou");
+                            {
+                                // add a new partition
+                                addListPartition("t4", "p3", "hangzhou");
 
-                            String insertSql = "INSERT INTO t4 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/3");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                        }
-                    });
+                                String insertSql = "INSERT INTO t4 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/3");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshMultiColumnsMVWithPartitionExpr() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T5, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as select dt, province, sum(age) from t5 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as select dt, province, sum(age) from t5 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t5", "p1", "beijing", "2022-01-01");
-                            String insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            {
+                                // add a new partition
+                                addListPartition("t5", "p1", "beijing", "2022-01-01");
+                                String insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
 
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(1, partitions.size());
-                            Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(1, partitions.size());
+                                Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
-                            addListPartition("t5", "p2", "beijing", "2022-01-02");
-                            insertSql = "insert into t5 partition(p2) values(1, 1, '2021-12-02', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
+                            {
+                                String insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
+                                addListPartition("t5", "p2", "beijing", "2022-01-02");
+                                insertSql = "insert into t5 partition(p2) values(1, 1, '2021-12-02', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
 
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=2/3");
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=2/3");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(1, partitions.size());
-                            Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(1, partitions.size());
+                                Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t5", "p5", "hangzhou", "2022-01-01");
-                            String insertSql = "INSERT INTO t5 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/4");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                        }
-                    });
+                            {
+                                // add a new partition
+                                addListPartition("t5", "p5", "hangzhou", "2022-01-01");
+                                String insertSql = "INSERT INTO t5 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/4");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshMultiBaseTablesWithSingleColumn() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTables(ImmutableList.of(T2, T4), () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as " +
-                            "   select dt, province, sum(age) from t2 group by dt, province " +
-                            " union all " +
-                            "   select dt, province, sum(age) from t4 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as " +
+                                    "   select dt, province, sum(age) from t2 group by dt, province " +
+                                    " union all " +
+                                    "   select dt, province, sum(age) from t4 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // only one table has updated
-                            String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "  1:OlapScanNode\n" +
-                                    "     TABLE: t2\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2\n" +
-                                    "     rollup: t2");
-                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/1\n" +
-                                    "     rollup: t4");
+                            {
+                                // only one table has updated
+                                String insertSql = "insert into t2 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "  1:OlapScanNode\n" +
+                                            "     TABLE: t2\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2\n" +
+                                            "     rollup: t2");
+                                PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/1\n" +
+                                            "     rollup: t4");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // t2 add a new partition
-                            addListPartition("t2", "p3", "hangzhou");
-                            String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            executeInsertSql(connectContext, insertSql);
+                            {
+                                // t2 add a new partition
+                                addListPartition("t2", "p3", "hangzhou");
+                                String insertSql = "INSERT INTO t2 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                executeInsertSql(connectContext, insertSql);
 
-                            // t4 add a new partition
-                            addListPartition("t4", "p3", "hangzhou");
-                            insertSql = "INSERT INTO t4 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            executeInsertSql(connectContext, insertSql);
+                                // t4 add a new partition
+                                addListPartition("t4", "p3", "hangzhou");
+                                insertSql = "INSERT INTO t4 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                executeInsertSql(connectContext, insertSql);
 
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/3");
-                            PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
-                    });
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/3");
+                                PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshMultiBaseTablesWithMultiColumns() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTables(ImmutableList.of(T1, T5), () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1') \n" +
-                            "as select dt, province, sum(age) from t1 group by dt, province \n" +
-                            " union all\n" +
-                            " select dt, province, sum(age) from t5 group by dt, province",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1') \n" +
+                                    "as select dt, province, sum(age) from t1 group by dt, province \n" +
+                                    " union all\n" +
+                                    " select dt, province, sum(age) from t5 group by dt, province",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // only t1 has updated
-                            String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2\n" +
-                                    "     rollup: t1");
+                            {
+                                // only t1 has updated
+                                String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2\n" +
+                                            "     rollup: t1");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t1", "p3", "hangzhou");
+                            {
+                                // add a new partition
+                                addListPartition("t1", "p3", "hangzhou");
 
-                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/3");
-                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/1\n" +
-                                    "     rollup: t5");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
+                                String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/3");
+                                PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/1\n" +
+                                            "     rollup: t5");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
 
-                        {
-                            // t1 add a new partition
-                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            executeInsertSql(connectContext, insertSql);
-                            // t5 add a new partition
-                            addListPartition("t5", "p1", "beijing", "2022-01-01");
-                            insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
+                            {
+                                // t1 add a new partition
+                                String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                executeInsertSql(connectContext, insertSql);
+                                // t5 add a new partition
+                                addListPartition("t5", "p1", "beijing", "2022-01-01");
+                                insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
 
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=2/3\n" +
-                                    "     rollup: t1");
-                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
-                    });
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=2/3\n" +
+                                            "     rollup: t1");
+                                PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshJoinWithMultiColumns1() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTables(ImmutableList.of(T1, T5), () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1') \n" +
-                            "as select t1.dt, t5.province, sum(t5.age) from t1 join t5 on t1.province=t5.province " +
-                            "group by t1.dt, t5.province \n",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1') \n" +
+                                    "as select t1.dt, t5.province, sum(t5.age) from t1 join t5 on t1.province=t5.province " +
+                                    "group by t1.dt, t5.province \n",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // only t1 has updated
-                            String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2\n" +
-                                    "     rollup: t1");
+                            {
+                                // only t1 has updated
+                                String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2\n" +
+                                            "     rollup: t1");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t1", "p3", "hangzhou");
+                            {
+                                // add a new partition
+                                addListPartition("t1", "p3", "hangzhou");
 
-                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/3");
-                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/1\n" +
-                                    "     rollup: t5");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
+                                String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/3");
+                                PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/1\n" +
+                                            "     rollup: t5");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
 
-                        {
-                            // t1 add a new partition
-                            String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
-                            executeInsertSql(connectContext, insertSql);
-                            // t5 add a new partition
-                            addListPartition("t5", "p1", "beijing", "2022-01-01");
-                            insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
+                            {
+                                // t1 add a new partition
+                                String insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                                executeInsertSql(connectContext, insertSql);
+                                // t5 add a new partition
+                                addListPartition("t5", "p1", "beijing", "2022-01-01");
+                                insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
 
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=2/3");
-                            PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
-                    });
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=2/3");
+                                PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
+                        });
         });
     }
 
     @Test
     public void testRefreshMVWithMultiNulllalbeColumns() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(T6, () -> {
             starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_refresh_number' = '-1')" +
-                            "as select dt, province, sum(age) from t6 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                    "partition by province \n" +
+                                    "distributed by random \n" +
+                                    "REFRESH DEFERRED MANUAL \n" +
+                                    "properties ('partition_refresh_number' = '-1')" +
+                                    "as select dt, province, sum(age) from t6 group by dt, province;",
+                        (obj) -> {
+                            String mvName = (String) obj;
+                            MaterializedView materializedView =
+                                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                    .getTable(testDb.getFullName(), mvName));
+                            Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                        {
-                            // no partition has changed, no need to refresh
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                            {
+                                // no partition has changed, no need to refresh
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t6", "p1", "beijing", "2022-01-01");
-                            String insertSql = "insert into t6 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                            {
+                                // add a new partition
+                                addListPartition("t6", "p1", "beijing", "2022-01-01");
+                                String insertSql = "insert into t6 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
 
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/2");
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/2");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(1, partitions.size());
-                            Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(1, partitions.size());
+                                Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            String insertSql = "insert into t6 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
-                            addListPartition("t6", "p2", "beijing", "2022-01-02");
-                            insertSql = "insert into t6 partition(p2) values(1, 1, '2021-12-02', 'beijing');";
-                            executeInsertSql(connectContext, insertSql);
+                            {
+                                String insertSql = "insert into t6 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
+                                addListPartition("t6", "p2", "beijing", "2022-01-02");
+                                insertSql = "insert into t6 partition(p2) values(1, 1, '2021-12-02', 'beijing');";
+                                executeInsertSql(connectContext, insertSql);
 
-                            ExecPlan execPlan = getExecPlan(taskRun);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=2/3");
+                                ExecPlan execPlan = getExecPlan(taskRun);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=2/3");
 
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(1, partitions.size());
-                            Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
-                            // refresh again, refreshed partitions should not be refreshed again.
-                            execPlan = getExecPlan(taskRun);
-                            Assert.assertTrue(execPlan == null);
-                        }
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(1, partitions.size());
+                                Assert.assertTrue(partitions.iterator().next().getName().equals("p1"));
+                                // refresh again, refreshed partitions should not be refreshed again.
+                                execPlan = getExecPlan(taskRun);
+                                Assert.assertTrue(execPlan == null);
+                            }
 
-                        {
-                            // add a new partition
-                            addListPartition("t6", "p5", "hangzhou", "2022-01-01");
-                            String insertSql = "INSERT INTO t6 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/4");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(2, partitions.size());
-                        }
+                            {
+                                // add a new partition
+                                addListPartition("t6", "p5", "hangzhou", "2022-01-01");
+                                String insertSql = "INSERT INTO t6 partition(p5) values(1, 1, '2022-01-01', 'hangzhou')";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/4");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(2, partitions.size());
+                            }
 
-                        {
-                            // add a null partition
-                            addListPartition("t6", "p6", null, null);
-                            String insertSql = "INSERT INTO t6 partition(p6) values(1, 1, NULL, NULL)";
-                            ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
-                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                            PlanTestBase.assertContains(plan, "    TABLE: t6\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/5");
-                            Collection<Partition> partitions = materializedView.getPartitions();
-                            Assert.assertEquals(3, partitions.size());
-                        }
-                    });
+                            {
+                                // add a null partition
+                                addListPartition("t6", "p6", null, null);
+                                String insertSql = "INSERT INTO t6 partition(p6) values(1, 1, NULL, NULL)";
+                                ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
+                                String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                                PlanTestBase.assertContains(plan, "    TABLE: t6\n" +
+                                            "     PREAGGREGATION: ON\n" +
+                                            "     partitions=1/5");
+                                Collection<Partition> partitions = materializedView.getPartitions();
+                                Assert.assertEquals(3, partitions.size());
+                            }
+                        });
         });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -149,8 +149,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv1"));
         materializedView.getTableProperty().setAutoRefreshPartitionsLimit(2);
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
@@ -194,8 +195,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
     @Test
     public void testRefreshWithHiveTableJoin() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_join_mv"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_join_mv"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -229,8 +231,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
                         "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -274,8 +277,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 "AS SELECT t1.c1, t1.c2, t1_par.par_col, t1_par.par_date FROM `hive0`.`partitioned_db`.`t1` join " +
                 "`hive0`.`partitioned_db`.`t1_par` using (par_col)");
 
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_join_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_join_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -323,8 +327,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`,`o_custkey` FROM `hive0`.`partitioned_db`.`lineitem_par` " +
                 "as a join `hive0`.`tpch`.`orders` on l_orderkey = o_orderkey");
 
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_join_mv2"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_join_mv2"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -371,8 +376,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 ")\n" +
                 "AS SELECT `n_nationkey`, `n_name`, `n_comment`  FROM `hive0`.`tpch`.`nation`;");
 
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_tbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_tbl_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -414,8 +420,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -464,8 +471,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_tbl_mv2"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_tbl_mv2"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -509,8 +517,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                         ")\n" +
                         "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a" +
                         " join test.tbl1 b on a.l_suppkey=b.k2;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_join_internal_mv"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_join_internal_mv"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -554,8 +563,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 ")\n" +
                 "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`LINEITEM_PAR` as " +
                 "`LINEITEM_PAR_ALIAS`;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -604,8 +614,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 ")\n" +
                 "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_DB`.`LINEITEM_PAR` as " +
                 "`LINEITEM_PAR_ALIAS`;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -655,8 +666,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
                         "AS SELECT c1, c2, par_col FROM `hive0`.`partitioned_db2`.`t2`;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -691,8 +703,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
     @Test
     public void testRangePartitionRefreshWithHiveTable() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv"));
         HashMap<String, String> taskRunProperties = new HashMap<>();
         taskRunProperties.put(PARTITION_START, "1998-01-01");
         taskRunProperties.put(TaskRun.PARTITION_END, "1998-01-03");
@@ -718,8 +731,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
     @Test
     public void testRefreshPartitionWithMulParColumnsHiveTable1() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_mul_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_mul_parttbl_mv1"));
         Map<String, String> mvProperties = Maps.newHashMap();
         mvProperties.put(PARTITION_START, "1998-01-01");
         mvProperties.put(PARTITION_END, "1998-01-03");
@@ -740,8 +754,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
     @Test
     public void testRefreshPartitionWithMulParColumnsHiveTable2() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_mul_parttbl_mv2"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_mul_parttbl_mv2"));
         Map<String, String> mvProperties = Maps.newHashMap();
         mvProperties.put(PARTITION_START, "2020-01-01");
         mvProperties.put(PARTITION_END, "2020-01-03");
@@ -762,7 +777,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
     @Test
     public void testHivePartitionPruneNonRefBaseTable1() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withMaterializedView(
                 "CREATE MATERIALIZED VIEW `test`.`hive_partition_prune_non_ref_tables2`\n" +
                         "COMMENT \"MATERIALIZED_VIEW\"\n" +
@@ -778,7 +793,8 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                         "`hive0`.`partitioned_db`.`part_tbl2` using (par_date)");
 
         MaterializedView materializedView =
-                ((MaterializedView) testDb.getTable("hive_partition_prune_non_ref_tables2"));
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "hive_partition_prune_non_ref_tables2"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
@@ -891,7 +907,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
     @Test
     public void testHivePartitionPruneNonRefBaseTable2() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withMaterializedView(
                 "CREATE MATERIALIZED VIEW `test`.`hive_partition_prune_non_ref_tables1`\n" +
                         "COMMENT \"MATERIALIZED_VIEW\"\n" +
@@ -907,7 +923,8 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                         "`hive0`.`partitioned_db`.`t1_par` using (par_col)");
 
         MaterializedView materializedView =
-                ((MaterializedView) testDb.getTable("hive_partition_prune_non_ref_tables1"));
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "hive_partition_prune_non_ref_tables1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -1000,7 +1017,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
     @Test
     public void testHivePartitionPruneNonRefBaseTable3() throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable("CREATE TABLE `test_partition_prune_tbl1` (\n" +
                 "`k1` date,\n" +
                 "`k2` int,\n" +
@@ -1034,7 +1051,8 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 "      FROM test_partition_prune_tbl1 join test_partition_prune_tbl2 on " +
                 " test_partition_prune_tbl1.k1=test_partition_prune_tbl2.k1;");
 
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("partition_prune_mv1"));
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "partition_prune_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
 
@@ -1118,8 +1136,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
                         "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "hive_parttbl_mv1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -1143,8 +1162,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                 "refresh async every (interval 1 day)\n" +
                 "as SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
 
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView mv = ((MaterializedView) testDb.getTable("test_drop_partition_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "test_drop_partition_mv1"));
         Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> versionMap =
                 mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap();
         Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -68,7 +68,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
     }
 
     private static void triggerRefreshMv(Database testDb, MaterializedView partitionedMaterializedView)
-            throws Exception {
+                throws Exception {
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
@@ -77,31 +77,32 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
     @Test
     public void testCreateNonPartitionedMVForIceberg() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv1` " +
-                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                        "REFRESH DEFERRED MANUAL\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"storage_medium\" = \"HDD\"\n" +
-                        ")\n" +
-                        "AS SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;")
-                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv2` " +
-                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                        "REFRESH DEFERRED MANUAL\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"storage_medium\" = \"HDD\"\n" +
-                        ")\n" +
-                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv1` " +
+                                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                "REFRESH DEFERRED MANUAL\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"storage_medium\" = \"HDD\"\n" +
+                                ")\n" +
+                                "AS SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv2` " +
+                                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                "REFRESH DEFERRED MANUAL\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"storage_medium\" = \"HDD\"\n" +
+                                ")\n" +
+                                "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
 
         // Partitioned base table
         {
             String mvName = "iceberg_mv2";
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), mvName));
             refreshMVRange(mvName, true);
             List<String> partitionNames = mv.getPartitions().stream().map(Partition::getName)
-                    .sorted().collect(Collectors.toList());
+                        .sorted().collect(Collectors.toList());
             Assert.assertEquals(ImmutableList.of(mvName), partitionNames);
             String querySql = "SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1`";
             starRocksAssert.query(querySql).explainContains(mvName);
@@ -111,11 +112,12 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
         // Non-Partitioned base table
         {
             String mvName = "iceberg_mv1";
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), mvName));
             refreshMVRange(mvName, true);
             List<String> partitionNames = mv.getPartitions().stream().map(Partition::getName)
-                    .sorted().collect(Collectors.toList());
+                        .sorted().collect(Collectors.toList());
             Assert.assertEquals(ImmutableList.of(mvName), partitionNames);
 
             // test rewrite
@@ -129,55 +131,56 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
     public void testCreatePartitionedMVForIceberg() throws Exception {
         String mvName = "iceberg_parttbl_mv1";
         starRocksAssert.useDatabase("test")
-                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv1`\n" +
-                        "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
-                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                        "REFRESH DEFERRED MANUAL\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"storage_medium\" = \"HDD\"\n" +
-                        ")\n" +
-                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv1`\n" +
+                                "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
+                                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                "REFRESH DEFERRED MANUAL\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"storage_medium\" = \"HDD\"\n" +
+                                ")\n" +
+                                "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
 
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_parttbl_mv1"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "iceberg_parttbl_mv1"));
         triggerRefreshMv(testDb, partitionedMaterializedView);
 
         Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
         Assert.assertEquals(4, partitions.size());
 
         MockIcebergMetadata mockIcebergMetadata =
-                (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
-                        getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+                    (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                                getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
         mockIcebergMetadata.updatePartitions("partitioned_db", "t1",
-                ImmutableList.of("date=2020-01-02"));
+                    ImmutableList.of("date=2020-01-02"));
         // refresh only one partition
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                taskRun.getProcessor();
+                    taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "3: date >= '2020-01-02', 3: date < '2020-01-03'");
 
         Map<String, Long> partitionVersionMap = partitionedMaterializedView.getPartitions().stream()
-                .collect(Collectors.toMap(Partition::getName, Partition::getVisibleVersion));
+                    .collect(Collectors.toMap(Partition::getName, Partition::getVisibleVersion));
         Assert.assertEquals(
-                ImmutableMap.of("p20200104_20200105", 2L,
-                        "p20200101_20200102", 2L,
-                        "p20200103_20200104", 2L,
-                        "p20200102_20200103", 3L),
-                ImmutableMap.copyOf(partitionVersionMap));
+                    ImmutableMap.of("p20200104_20200105", 2L,
+                                "p20200101_20200102", 2L,
+                                "p20200103_20200104", 2L,
+                                "p20200102_20200103", 3L),
+                    ImmutableMap.copyOf(partitionVersionMap));
 
         // add new row and refresh again
         mockIcebergMetadata.updatePartitions("partitioned_db", "t1",
-                ImmutableList.of("date=2020-01-01"));
+                    ImmutableList.of("date=2020-01-01"));
         taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor)
-                taskRun.getProcessor();
+                    taskRun.getProcessor();
 
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -185,9 +188,9 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
 
         // test rewrite
         starRocksAssert.query("SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1`")
-                .explainContains(mvName);
+                    .explainContains(mvName);
         starRocksAssert.query("SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` where date = '2020-01-01'")
-                .explainContains(mvName);
+                    .explainContains(mvName);
         starRocksAssert.dropMaterializedView(mvName);
     }
 
@@ -197,37 +200,39 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
         {
             String mvName = "iceberg_year_mv1";
             starRocksAssert.useDatabase("test")
-                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_year_mv1`\n" +
-                            "PARTITION BY ts\n" +
-                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                            "REFRESH DEFERRED MANUAL\n" +
-                            "PROPERTIES (\n" +
-                            "\"replication_num\" = \"1\",\n" +
-                            "\"storage_medium\" = \"HDD\"\n" +
-                            ")\n" +
-                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year` as a;");
+                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_year_mv1`\n" +
+                                    "PARTITION BY ts\n" +
+                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                    "REFRESH DEFERRED MANUAL\n" +
+                                    "PROPERTIES (\n" +
+                                    "\"replication_num\" = \"1\",\n" +
+                                    "\"storage_medium\" = \"HDD\"\n" +
+                                    ")\n" +
+                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_year_mv1"));
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView partitionedMaterializedView =
+                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "iceberg_year_mv1"));
             triggerRefreshMv(testDb, partitionedMaterializedView);
 
             Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
             List<String> partitionNames = ImmutableList.of("p20190101000000", "p20200101000000", "p20210101000000",
-                    "p20220101000000", "p20230101000000");
+                        "p20220101000000", "p20230101000000");
             Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
 
             MockIcebergMetadata mockIcebergMetadata =
-                    (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
-                            getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+                        (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                                    getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
             mockIcebergMetadata.updatePartitions("partitioned_transforms_db", "t0_year",
-                    ImmutableList.of("ts_year=2020"));
+                        ImmutableList.of("ts_year=2020"));
             // refresh only one partition
             Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
             TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
             initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                    taskRun.getProcessor();
+                        taskRun.getProcessor();
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -235,91 +240,97 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
 
             // test rewrite
             starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year`")
-                    .explainContains(mvName);
+                        .explainContains(mvName);
             starRocksAssert.dropMaterializedView(mvName);
         }
         // test partition by month(ts)
         {
             String mvName = "iceberg_month_mv1";
             starRocksAssert.useDatabase("test")
-                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_month_mv1`\n" +
-                            "PARTITION BY ts\n" +
-                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                            "REFRESH DEFERRED MANUAL\n" +
-                            "PROPERTIES (\n" +
-                            "\"replication_num\" = \"1\",\n" +
-                            "\"storage_medium\" = \"HDD\"\n" +
-                            ")\n" +
-                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
+                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_month_mv1`\n" +
+                                    "PARTITION BY ts\n" +
+                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                    "REFRESH DEFERRED MANUAL\n" +
+                                    "PROPERTIES (\n" +
+                                    "\"replication_num\" = \"1\",\n" +
+                                    "\"storage_medium\" = \"HDD\"\n" +
+                                    ")\n" +
+                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_month_mv1"));
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView partitionedMaterializedView =
+                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "iceberg_month_mv1"));
             triggerRefreshMv(testDb, partitionedMaterializedView);
 
             Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
             List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220201000000", "p20220301000000",
-                    "p20220401000000", "p20220501000000");
+                        "p20220401000000", "p20220501000000");
             Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
             // test rewrite
             starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month`")
-                    .explainContains(mvName);
+                        .explainContains(mvName);
             starRocksAssert.dropMaterializedView(mvName);
         }
         // test partition by day(ts)
         {
             String mvName = "iceberg_day_mv1";
             starRocksAssert.useDatabase("test")
-                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
-                            "PARTITION BY ts\n" +
-                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                            "REFRESH DEFERRED MANUAL\n" +
-                            "PROPERTIES (\n" +
-                            "\"replication_num\" = \"1\",\n" +
-                            "\"storage_medium\" = \"HDD\"\n" +
-                            ")\n" +
-                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day` as a;");
+                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
+                                    "PARTITION BY ts\n" +
+                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                    "REFRESH DEFERRED MANUAL\n" +
+                                    "PROPERTIES (\n" +
+                                    "\"replication_num\" = \"1\",\n" +
+                                    "\"storage_medium\" = \"HDD\"\n" +
+                                    ")\n" +
+                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_day_mv1"));
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView partitionedMaterializedView =
+                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "iceberg_day_mv1"));
             triggerRefreshMv(testDb, partitionedMaterializedView);
 
             Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
             List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220102000000", "p20220103000000",
-                    "p20220104000000", "p20220105000000");
+                        "p20220104000000", "p20220105000000");
             Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
             // test rewrite
             starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day`")
-                    .explainContains(mvName);
+                        .explainContains(mvName);
             starRocksAssert.dropMaterializedView(mvName);
         }
         // test partition by hour(ts)
         {
             String mvName = "iceberg_hour_mv1";
             starRocksAssert.useDatabase("test")
-                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_hour_mv1`\n" +
-                            "PARTITION BY ts\n" +
-                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                            "REFRESH DEFERRED MANUAL\n" +
-                            "PROPERTIES (\n" +
-                            "\"replication_num\" = \"1\",\n" +
-                            "\"storage_medium\" = \"HDD\"\n" +
-                            ")\n" +
-                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour` as a;");
+                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_hour_mv1`\n" +
+                                    "PARTITION BY ts\n" +
+                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                    "REFRESH DEFERRED MANUAL\n" +
+                                    "PROPERTIES (\n" +
+                                    "\"replication_num\" = \"1\",\n" +
+                                    "\"storage_medium\" = \"HDD\"\n" +
+                                    ")\n" +
+                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_hour_mv1"));
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView partitionedMaterializedView =
+                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "iceberg_hour_mv1"));
             triggerRefreshMv(testDb, partitionedMaterializedView);
 
             Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
             List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220101010000", "p20220101020000",
-                    "p20220101030000", "p20220101040000");
+                        "p20220101030000", "p20220101040000");
             Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
             // test rewrite
             starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour`")
-                    .explainContains(mvName);
+                        .explainContains(mvName);
             starRocksAssert.dropMaterializedView(mvName);
         }
     }
@@ -327,27 +338,27 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
     @Test
     public void testRefreshWithCachePartitionTraits() {
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_mv1`\n" +
-                        "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
-                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                        "REFRESH DEFERRED MANUAL\n" +
-                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;",
-                () -> {
-                    MaterializedView mv = getMv("test", "test_mv1");
-                    PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
-                    RuntimeProfile runtimeProfile = processor.getRuntimeProfile();
-                    QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
-                    Assert.assertTrue(queryCacheStats != null);
-                    queryCacheStats.getCounter().forEach((key, value) -> {
-                        if (key.contains("cache_partitionNames")) {
-                            Assert.assertEquals(1L, value.longValue());
-                        } else if (key.contains("cache_getPartitionKeyRange")) {
-                            Assert.assertEquals(3L, value.longValue());
-                        } else {
-                            Assert.assertEquals(1L, value.longValue());
-                        }
+                                "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
+                                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                                "REFRESH DEFERRED MANUAL\n" +
+                                "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;",
+                    () -> {
+                        MaterializedView mv = getMv("test", "test_mv1");
+                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                        RuntimeProfile runtimeProfile = processor.getRuntimeProfile();
+                        QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
+                        Assert.assertTrue(queryCacheStats != null);
+                        queryCacheStats.getCounter().forEach((key, value) -> {
+                            if (key.contains("cache_partitionNames")) {
+                                Assert.assertEquals(1L, value.longValue());
+                            } else if (key.contains("cache_getPartitionKeyRange")) {
+                                Assert.assertEquals(3L, value.longValue());
+                            } else {
+                                Assert.assertEquals(1L, value.longValue());
+                            }
+                        });
+                        Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);
+                        Assert.assertTrue(partitionsToRefresh1.isEmpty());
                     });
-                    Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);
-                    Assert.assertTrue(partitionsToRefresh1.isEmpty());
-                });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -54,57 +54,57 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
         MVRefreshTestBase.beforeClass();
         ConnectorPlanTestBase.mockCatalog(connectContext, MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME);
         starRocksAssert
-                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`jdbc_parttbl_mv0`\n" +
-                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
-                        "PARTITION BY (`d`)\n" +
-                        "DISTRIBUTED BY HASH(`a`) BUCKETS 10\n" +
-                        "REFRESH DEFERRED MANUAL\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"storage_medium\" = \"HDD\"\n" +
-                        ")\n" +
-                        "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc0`.`partitioned_db0`.`tbl0`;")
-                .withMaterializedView("create materialized view jdbc_parttbl_mv1 " +
-                        "partition by ss " +
-                        "distributed by hash(a) buckets 10 " +
-                        "REFRESH DEFERRED MANUAL " +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ") " +
-                        "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;")
-                .withMaterializedView("create materialized view jdbc_parttbl_mv2 " +
-                        "partition by ss " +
-                        "distributed by hash(a) buckets 10 " +
-                        "REFRESH DEFERRED MANUAL " +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ") " +
-                        "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl2;")
-                .withMaterializedView("create materialized view jdbc_parttbl_mv3 " +
-                        "partition by str2date(d,'%Y%m%d') " +
-                        "distributed by hash(a) buckets 10 " +
-                        "REFRESH DEFERRED MANUAL " +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ") " +
-                        "as select a, b, c, d from jdbc0.partitioned_db0.tbl1;")
-                .withMaterializedView("create materialized view jdbc_parttbl_mv5 " +
-                        "partition by str2date(d,'%Y%m%d') " +
-                        "distributed by hash(a) buckets 10 " +
-                        "REFRESH DEFERRED MANUAL " +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ") " +
-                        "as select a, b, c, d from jdbc0.partitioned_db0.tbl3;")
-                .withMaterializedView("create materialized view jdbc_parttbl_mv6 " +
-                        "partition by ss " +
-                        "distributed by hash(a) buckets 10 " +
-                        "REFRESH DEFERRED MANUAL " +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"partition_refresh_number\" = \"1\"" +
-                        ") " +
-                        "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`jdbc_parttbl_mv0`\n" +
+                                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                                "PARTITION BY (`d`)\n" +
+                                "DISTRIBUTED BY HASH(`a`) BUCKETS 10\n" +
+                                "REFRESH DEFERRED MANUAL\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"storage_medium\" = \"HDD\"\n" +
+                                ")\n" +
+                                "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc0`.`partitioned_db0`.`tbl0`;")
+                    .withMaterializedView("create materialized view jdbc_parttbl_mv1 " +
+                                "partition by ss " +
+                                "distributed by hash(a) buckets 10 " +
+                                "REFRESH DEFERRED MANUAL " +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ") " +
+                                "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;")
+                    .withMaterializedView("create materialized view jdbc_parttbl_mv2 " +
+                                "partition by ss " +
+                                "distributed by hash(a) buckets 10 " +
+                                "REFRESH DEFERRED MANUAL " +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ") " +
+                                "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl2;")
+                    .withMaterializedView("create materialized view jdbc_parttbl_mv3 " +
+                                "partition by str2date(d,'%Y%m%d') " +
+                                "distributed by hash(a) buckets 10 " +
+                                "REFRESH DEFERRED MANUAL " +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ") " +
+                                "as select a, b, c, d from jdbc0.partitioned_db0.tbl1;")
+                    .withMaterializedView("create materialized view jdbc_parttbl_mv5 " +
+                                "partition by str2date(d,'%Y%m%d') " +
+                                "distributed by hash(a) buckets 10 " +
+                                "REFRESH DEFERRED MANUAL " +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ") " +
+                                "as select a, b, c, d from jdbc0.partitioned_db0.tbl3;")
+                    .withMaterializedView("create materialized view jdbc_parttbl_mv6 " +
+                                "partition by ss " +
+                                "distributed by hash(a) buckets 10 " +
+                                "REFRESH DEFERRED MANUAL " +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"partition_refresh_number\" = \"1\"" +
+                                ") " +
+                                "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
     }
 
     @AfterClass
@@ -137,24 +137,24 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
     public void testPartitionJDBCSupported() throws Exception {
         // not supported
         Assert.assertThrows(AnalysisException.class, () ->
-                starRocksAssert.withMaterializedView("create materialized view mv_jdbc_postgres " +
-                        "partition by d " +
-                        "refresh deferred manual " +
-                        "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc_postgres`.`partitioned_db0`.`tbl0`;")
+                    starRocksAssert.withMaterializedView("create materialized view mv_jdbc_postgres " +
+                                "partition by d " +
+                                "refresh deferred manual " +
+                                "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc_postgres`.`partitioned_db0`.`tbl0`;")
         );
 
         // supported
         starRocksAssert.withMaterializedView("create materialized view mv_jdbc_mysql " +
-                "partition by d " +
-                "refresh deferred manual " +
-                "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc0`.`partitioned_db0`.`tbl0`;");
+                    "partition by d " +
+                    "refresh deferred manual " +
+                    "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc0`.`partitioned_db0`.`tbl0`;");
     }
 
     @Test
     public void testRangePartitionChangeWithJDBCTable() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         MaterializedView materializedView = refreshMaterializedView("jdbc_parttbl_mv0", "20230801", "20230805");
@@ -169,8 +169,9 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
 
     @NotNull
     private MaterializedView refreshMaterializedView(String materializedViewName, String start, String end) throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(materializedViewName));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), materializedViewName));
         refreshMVRange(materializedView.getName(), start, end, false);
         return materializedView;
     }
@@ -179,15 +180,15 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
     public void testRangePartitionWithJDBCTableUseStr2Date() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         MaterializedView materializedView = refreshMaterializedView("jdbc_parttbl_mv1", "20230731", "20230805");
         List<String> partitions = materializedView.getPartitions().stream()
-                .map(Partition::getName).sorted().collect(Collectors.toList());
+                    .map(Partition::getName).sorted().collect(Collectors.toList());
         Assert.assertEquals(ImmutableList.of("p00010101_20230801", "p20230801_20230802",
-                        "p20230802_20230803", "p20230803_99991231"),
-                partitions);
+                                "p20230802_20230803", "p20230803_99991231"),
+                    partitions);
     }
 
     @Test
@@ -203,74 +204,75 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
     public void testRangePartitionWithJDBCTableUseStr2Date2() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         MaterializedView materializedView = refreshMaterializedView("jdbc_parttbl_mv3", "20230731", "20230805");
         List<String> partitions = materializedView.getPartitions().stream()
-                .map(Partition::getName).sorted().collect(Collectors.toList());
+                    .map(Partition::getName).sorted().collect(Collectors.toList());
         Assert.assertEquals(ImmutableList.of("p00010101_20230801", "p20230801_20230802",
-                        "p20230802_20230803", "p20230803_99991231"),
-                partitions);
+                                "p20230802_20230803", "p20230803_99991231"),
+                    partitions);
     }
 
     @Test
     public void testStr2Date_DateTrunc() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         String mvName = "jdbc_parttbl_str2date";
         starRocksAssert.withMaterializedView("create materialized view jdbc_parttbl_str2date " +
-                "partition by date_trunc('month', ss) " +
-                "distributed by hash(a) buckets 10 " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"partition_refresh_number\" = \"1\"" +
-                ") " +
-                "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl5;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by date_trunc('month', ss) " +
+                    "distributed by hash(a) buckets 10 " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"partition_refresh_number\" = \"1\"" +
+                    ") " +
+                    "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl5;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // full refresh
         {
             starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
             List<String> partitions =
-                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                            .collect(Collectors.toList());
+                        materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                    .collect(Collectors.toList());
             Assert.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
         }
 
         // partial range refresh 1
         {
             Map<String, Long> partitionVersionMap = materializedView.getPartitions().stream().collect(
-                    Collectors.toMap(Partition::getName, Partition::getVisibleVersion));
+                        Collectors.toMap(Partition::getName, Partition::getVisibleVersion));
             starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName +
-                    " partition start('2023-08-02') end('2023-09-01')" +
-                    "force with sync mode");
+                        " partition start('2023-08-02') end('2023-09-01')" +
+                        "force with sync mode");
             List<String> partitions =
-                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                            .collect(Collectors.toList());
+                        materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                    .collect(Collectors.toList());
             Assert.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
             Assert.assertEquals(partitionVersionMap.get("p202308_202309").longValue(),
-                    materializedView.getPartition("p202308_202309").getVisibleVersion());
+                        materializedView.getPartition("p202308_202309").getVisibleVersion());
         }
 
         // partial range refresh 2
         {
             Map<String, Long> partitionVersionMap = materializedView.getPartitions().stream().collect(
-                    Collectors.toMap(Partition::getName, Partition::getVisibleVersion));
+                        Collectors.toMap(Partition::getName, Partition::getVisibleVersion));
             starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName +
-                    " partition start('2023-07-01') end('2023-08-01')" +
-                    "force with sync mode");
+                        " partition start('2023-07-01') end('2023-08-01')" +
+                        "force with sync mode");
             List<String> partitions =
-                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                            .collect(Collectors.toList());
+                        materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                    .collect(Collectors.toList());
             Assert.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
             Assert.assertEquals(partitionVersionMap.get("p202308_202309").longValue(),
-                    materializedView.getPartition("p202308_202309").getVisibleVersion());
+                        materializedView.getPartition("p202308_202309").getVisibleVersion());
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -280,40 +282,41 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
     public void testStr2Date_TTL() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         String mvName = "jdbc_parttbl_str2date";
         starRocksAssert.withMaterializedView("create materialized view jdbc_parttbl_str2date " +
-                "partition by ss " +
-                "distributed by hash(a) buckets 10 " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"partition_refresh_number\" = \"1\"," +
-                "'partition_ttl_number'='2'" +
-                ") " +
-                "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by ss " +
+                    "distributed by hash(a) buckets 10 " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"partition_refresh_number\" = \"1\"," +
+                    "'partition_ttl_number'='2'" +
+                    ") " +
+                    "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230802_20230803", "p20230803_99991231"), partitions);
 
         // modify TTL
         {
             starRocksAssert.getCtx().executeSql(
-                    String.format("alter materialized view %s set ('partition_ttl_number'='1')", mvName));
+                        String.format("alter materialized view %s set ('partition_ttl_number'='1')", mvName));
             starRocksAssert.getCtx().executeSql(String.format("refresh materialized view %s with sync mode", mvName));
             GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
 
             partitions =
-                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                            .collect(Collectors.toList());
+                        materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                    .collect(Collectors.toList());
             Assert.assertEquals(Arrays.asList("p20230803_99991231"), partitions);
         }
         starRocksAssert.dropMaterializedView(mvName);
@@ -323,36 +326,37 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
     public void testRangePartitionWithJDBCTableUseStr2Date3() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         MaterializedView materializedView = refreshMaterializedView("jdbc_parttbl_mv5", "20230731", "20230805");
         List<String> partitions = materializedView.getPartitions().stream()
-                .map(Partition::getName).sorted().collect(Collectors.toList());
+                    .map(Partition::getName).sorted().collect(Collectors.toList());
         Assert.assertEquals(ImmutableList.of("p00010101_20230801", "p20230801_20230802",
-                        "p20230802_20230803", "p20230803_20230804"),
-                partitions);
+                                "p20230802_20230803", "p20230803_20230804"),
+                    partitions);
     }
 
     @Test
     public void testRefreshByParCreateOnlyNecessaryPar() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         // get base table partitions
         List<String> baseParNames = mockedJDBCMetadata.listPartitionNames("partitioned_db0", "tbl1", TableVersionRange.empty());
         Assert.assertEquals(4, baseParNames.size());
 
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("jdbc_parttbl_mv6"));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "jdbc_parttbl_mv6"));
         HashMap<String, String> taskRunProperties = new HashMap<>();
         // check corner case: the first partition of base table is 0000 to 20230801
         // p20230801 of mv should not be created
         refreshMVRange(materializedView.getName(), "20230801", "20230802", false);
         List<String> partitions = materializedView.getPartitions().stream()
-                .map(Partition::getName).sorted().collect(Collectors.toList());
+                    .map(Partition::getName).sorted().collect(Collectors.toList());
         Assert.assertEquals(ImmutableList.of("p20230801_20230802"), partitions);
     }
 
@@ -360,31 +364,32 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
     public void testStr2DateMVRefresh_Rewrite() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
 
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y%m%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y%m%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p00010101_20230801", "p20230801_20230802", "p20230802_20230803",
-                "p20230803_99991231"), partitions);
+                    "p20230803_99991231"), partitions);
 
         starRocksAssert.dropMaterializedView(mvName);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -108,13 +108,15 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                             String mvName = (String) obj;
                             assertPlanWithoutPushdownBelowScan(mvName);
                         });
-                    };
+                    }
+                    ;
                 });
     }
 
     private void assertPlanWithoutPushdownBelowScan(String mvName) throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), mvName));
         Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         Map<String, String> testProperties = task.getProperties();
@@ -188,13 +190,15 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                             String mvName = (String) obj;
                             assertPlanWithPushdownBelowScan(mvName);
                         });
-                    };
+                    }
+                    ;
                 });
     }
 
     private void assertPlanWithPushdownBelowScan(String mvName) throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), mvName));
         Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         Map<String, String> testProperties = task.getProperties();
@@ -268,7 +272,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
 
                     executeInsertSql(connectContext, "insert into tbl1 values(\"2022-02-20\", 2, 10)");
                     Partition p2 = table.getPartition("p2");
-                    while (p2.getVisibleVersion()  != 3) {
+                    while (p2.getVisibleVersion() != 3) {
                         System.out.println("waiting for partition p2 to be visible:" + p2.getVisibleVersion());
                         Thread.sleep(1000);
                     }
@@ -318,7 +322,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                                     "properties('replication_num' = '1', 'partition_refresh_number'='1')\n" +
                                     "as select k1, k2 from tbl6;");
                     String mvName = "mv_refresh_priority";
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb(TEST_DB_NAME);
+                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(TEST_DB_NAME);
                     MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
                     TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
 
@@ -384,7 +388,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                             "refresh deferred manual\n" +
                             "properties('replication_num' = '1', 'partition_refresh_number'='1')\n" +
                             "as select k1, k2 from tbl6;");
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                     MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
                     TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
                     long taskId = tm.getTask(TaskBuilder.getMvTaskName(mv.getId())).getId();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -444,7 +444,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                             ")\n" +
                             "as select k1, k2 from tbl6;",
                             () -> {
-                                Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                                Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                                 MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
                                 executeInsertSql(connectContext,
                                         "insert into tbl6 partition(p1) values('2022-01-02',2,10);");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorPaimonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorPaimonTest.java
@@ -74,10 +74,11 @@ public class PartitionBasedMvRefreshProcessorPaimonTest extends MVRefreshTestBas
                         ")\n" +
                         "AS SELECT pk, d  FROM `paimon0`.`pmn_db1`.`unpartitioned_table` as a;",
                 () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
                     MaterializedView unpartitionedMaterializedView =
-                            ((MaterializedView) testDb.getTable("paimon_parttbl_mv2"));
+                            ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "paimon_parttbl_mv2"));
                     triggerRefreshMv(testDb, unpartitionedMaterializedView);
 
                     Collection<Partition> partitions = unpartitionedMaterializedView.getPartitions();
@@ -104,9 +105,10 @@ public class PartitionBasedMvRefreshProcessorPaimonTest extends MVRefreshTestBas
                         ")\n" +
                         "AS SELECT pk, pt,d  FROM `paimon0`.`pmn_db1`.`partitioned_table` as a;",
                 () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                     MaterializedView partitionedMaterializedView =
-                            ((MaterializedView) testDb.getTable("paimon_parttbl_mv1"));
+                            ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "paimon_parttbl_mv1"));
                     triggerRefreshMv(testDb, partitionedMaterializedView);
 
                     Collection<Partition> partitions = partitionedMaterializedView.getPartitions();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -49,62 +49,62 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
         MVRefreshTestBase.beforeClass();
         ConnectorPlanTestBase.mockAllCatalogs(connectContext, temp.newFolder().toURI().toString());
         starRocksAssert
-                .withTable("CREATE TABLE `t1` (\n" +
-                        "    `k1`  date not null, \n" +
-                        "    `k2`  datetime not null, \n" +
-                        "    `k3`  char(20), \n" +
-                        "    `k4`  varchar(20), \n" +
-                        "    `k5`  boolean, \n" +
-                        "    `k6`  tinyint, \n" +
-                        "    `k7`  smallint, \n" +
-                        "    `k8`  int, \n" +
-                        "    `k9`  bigint, \n" +
-                        "    `k10` largeint, \n" +
-                        "    `k11` float, \n" +
-                        "    `k12` double, \n" +
-                        "    `k13` decimal(27,9) ) \n" +
-                        "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) \n" +
-                        "PARTITION BY RANGE(`k1`) \n" +
-                        "(\n" +
-                        "PARTITION p20201022 VALUES [(\"2020-10-22\"), (\"2020-10-23\")), \n" +
-                        "PARTITION p20201023 VALUES [(\"2020-10-23\"), (\"2020-10-24\")), \n" +
-                        "PARTITION p20201024 VALUES [(\"2020-10-24\"), (\"2020-10-25\"))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;")
-                .withTable("CREATE TABLE `t2` (\n" +
-                        "    `k1`  date not null, \n" +
-                        "    `k2`  datetime not null, \n" +
-                        "    `k3`  char(20), \n" +
-                        "    `k4`  varchar(20), \n" +
-                        "    `k5`  boolean, \n" +
-                        "    `k6`  tinyint, \n" +
-                        "    `k7`  smallint, \n" +
-                        "    `k8`  int, \n" +
-                        "    `k9`  bigint, \n" +
-                        "    `k10` largeint, \n" +
-                        "    `k11` float, \n" +
-                        "    `k12` double, \n" +
-                        "    `k13` decimal(27,9) ) \n" +
-                        "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) \n" +
-                        "PARTITION BY RANGE(`k1`) \n" +
-                        "(\n" +
-                        "PARTITION p20201010 VALUES [(\"2020-10-10\"), (\"2020-10-11\")), \n" +
-                        "PARTITION p20201011 VALUES [(\"2020-10-11\"), (\"2020-10-12\")), \n" +
-                        "PARTITION p20201012 VALUES [(\"2020-10-12\"), (\"2020-10-13\")), \n" +
-                        "PARTITION p20201021 VALUES [(\"2020-10-21\"), (\"2020-10-22\")), \n" +
-                        "PARTITION p20201022 VALUES [(\"2020-10-22\"), (\"2020-10-23\"))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;");
+                    .withTable("CREATE TABLE `t1` (\n" +
+                                "    `k1`  date not null, \n" +
+                                "    `k2`  datetime not null, \n" +
+                                "    `k3`  char(20), \n" +
+                                "    `k4`  varchar(20), \n" +
+                                "    `k5`  boolean, \n" +
+                                "    `k6`  tinyint, \n" +
+                                "    `k7`  smallint, \n" +
+                                "    `k8`  int, \n" +
+                                "    `k9`  bigint, \n" +
+                                "    `k10` largeint, \n" +
+                                "    `k11` float, \n" +
+                                "    `k12` double, \n" +
+                                "    `k13` decimal(27,9) ) \n" +
+                                "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) \n" +
+                                "PARTITION BY RANGE(`k1`) \n" +
+                                "(\n" +
+                                "PARTITION p20201022 VALUES [(\"2020-10-22\"), (\"2020-10-23\")), \n" +
+                                "PARTITION p20201023 VALUES [(\"2020-10-23\"), (\"2020-10-24\")), \n" +
+                                "PARTITION p20201024 VALUES [(\"2020-10-24\"), (\"2020-10-25\"))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;")
+                    .withTable("CREATE TABLE `t2` (\n" +
+                                "    `k1`  date not null, \n" +
+                                "    `k2`  datetime not null, \n" +
+                                "    `k3`  char(20), \n" +
+                                "    `k4`  varchar(20), \n" +
+                                "    `k5`  boolean, \n" +
+                                "    `k6`  tinyint, \n" +
+                                "    `k7`  smallint, \n" +
+                                "    `k8`  int, \n" +
+                                "    `k9`  bigint, \n" +
+                                "    `k10` largeint, \n" +
+                                "    `k11` float, \n" +
+                                "    `k12` double, \n" +
+                                "    `k13` decimal(27,9) ) \n" +
+                                "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) \n" +
+                                "PARTITION BY RANGE(`k1`) \n" +
+                                "(\n" +
+                                "PARTITION p20201010 VALUES [(\"2020-10-10\"), (\"2020-10-11\")), \n" +
+                                "PARTITION p20201011 VALUES [(\"2020-10-11\"), (\"2020-10-12\")), \n" +
+                                "PARTITION p20201012 VALUES [(\"2020-10-12\"), (\"2020-10-13\")), \n" +
+                                "PARTITION p20201021 VALUES [(\"2020-10-21\"), (\"2020-10-22\")), \n" +
+                                "PARTITION p20201022 VALUES [(\"2020-10-22\"), (\"2020-10-23\"))\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;");
         executeInsertSql(connectContext, "INSERT INTO t1 VALUES\n" +
-                "    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
-                "    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
-                "    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);");
+                    "    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
+                    "    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
+                    "    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);");
         executeInsertSql(connectContext, "INSERT INTO t2 VALUES\n" +
-                "    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
-                "    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
-                "    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
-                "    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
-                "    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)");
+                    "    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
+                    "    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
+                    "    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
+                    "    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
+                    "    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)");
     }
 
     @AfterClass
@@ -127,7 +127,7 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
 
         for (String expected : explain) {
             Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
-                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
+                        StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
         }
     }
 
@@ -156,49 +156,51 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
         Assert.assertTrue(t1PartitionNums.size() == t2PartitionNums.size());
         int mvRefreshTimes = t1PartitionNums.size();
         starRocksAssert.withMaterializedView(mvSql,
-                () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    MaterializedView mv = ((MaterializedView) testDb.getTable("test_mv0"));
-                    Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+                    () -> {
+                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "test_mv0"));
+                        Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
 
-                    TaskRun taskRun = null;
-                    for (int i = 0; i < mvRefreshTimes; i++) {
-                        if (i == 0) {
-                            taskRun = TaskRunBuilder.newBuilder(task).build();
+                        TaskRun taskRun = null;
+                        for (int i = 0; i < mvRefreshTimes; i++) {
+                            if (i == 0) {
+                                taskRun = TaskRunBuilder.newBuilder(task).build();
+                            }
+                            System.out.println("start to execute task run:" + i);
+                            Assert.assertTrue(taskRun != null);
+                            initAndExecuteTaskRun(taskRun);
+                            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                                        taskRun.getProcessor();
+                            MvTaskRunContext mvContext = processor.getMvContext();
+                            ExecPlan execPlan = mvContext.getExecPlan();
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            Assert.assertTrue(plan != null);
+                            taskRun = processor.getNextTaskRun();
+                            PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     partitions=%s/3", t1PartitionNums.get(i)));
+                            PlanTestBase.assertContains(plan, String.format("     TABLE: t2\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     partitions=%s/5", t2PartitionNums.get(i)));
+                            if (i == mvRefreshTimes - 1) {
+                                Assert.assertTrue(taskRun == null);
+                            }
                         }
-                        System.out.println("start to execute task run:" + i);
-                        Assert.assertTrue(taskRun != null);
-                        initAndExecuteTaskRun(taskRun);
-                        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                                taskRun.getProcessor();
-                        MvTaskRunContext mvContext = processor.getMvContext();
-                        ExecPlan execPlan = mvContext.getExecPlan();
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        Assert.assertTrue(plan != null);
-                        taskRun = processor.getNextTaskRun();
-                        PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
-                                "     PREAGGREGATION: ON\n" +
-                                "     partitions=%s/3", t1PartitionNums.get(i)));
-                        PlanTestBase.assertContains(plan, String.format("     TABLE: t2\n" +
-                                "     PREAGGREGATION: ON\n" +
-                                "     partitions=%s/5", t2PartitionNums.get(i)));
-                        if (i == mvRefreshTimes - 1) {
-                            Assert.assertTrue(taskRun == null);
-                        }
-                    }
-                });
+                    });
     }
+
     @Test
     public void testUnionAllMvWithPartition1() {
         String sql = "create materialized view test_mv0 \n" +
-                "partition by k1 \n" +
-                "distributed by random \n" +
-                "refresh async \n" +
-                "properties(" +
-                "\"partition_refresh_number\" = \"1\"" +
-                ")" +
-                "as " +
-                " select * from t1 union all select * from t2;";
+                    "partition by k1 \n" +
+                    "distributed by random \n" +
+                    "refresh async \n" +
+                    "properties(" +
+                    "\"partition_refresh_number\" = \"1\"" +
+                    ")" +
+                    "as " +
+                    " select * from t1 union all select * from t2;";
         List<Integer> t1PartitionNums = ImmutableList.of(0, 0, 0, 0, 1, 1, 1);
         List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1, 1, 1, 0, 0);
         testRefreshUnionAllWithDefaultRefreshNumber(sql, t1PartitionNums, t2PartitionNums);
@@ -207,14 +209,14 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
     @Test
     public void testUnionAllMvWithPartition2() {
         String sql = "create materialized view test_mv0 \n" +
-                "partition by k1 \n" +
-                "distributed by random \n" +
-                "refresh async \n" +
-                "properties(" +
-                "\"partition_refresh_number\" = \"1\"" +
-                ")" +
-                "as " +
-                " select * from t2 union all select * from t1;";
+                    "partition by k1 \n" +
+                    "distributed by random \n" +
+                    "refresh async \n" +
+                    "properties(" +
+                    "\"partition_refresh_number\" = \"1\"" +
+                    ")" +
+                    "as " +
+                    " select * from t2 union all select * from t1;";
         List<Integer> t1PartitionNums = ImmutableList.of(0, 0, 0, 0, 1, 1, 1);
         List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1, 1, 1, 0, 0);
         testRefreshUnionAllWithDefaultRefreshNumber(sql, t1PartitionNums, t2PartitionNums);
@@ -223,121 +225,123 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
     @Test
     public void testUnionAllMvWithPartitionForceMode() {
         String sql = "create materialized view test_mv0 \n" +
-                "partition by k1 \n" +
-                "distributed by random \n" +
-                "refresh async \n" +
-                "as " +
-                " select * from t1 union all select * from t2;";
+                    "partition by k1 \n" +
+                    "distributed by random \n" +
+                    "refresh async \n" +
+                    "as " +
+                    " select * from t1 union all select * from t2;";
         starRocksAssert.withMaterializedView(sql,
-                () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    MaterializedView mv = ((MaterializedView) testDb.getTable("test_mv0"));
-                    Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+                    () -> {
+                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "test_mv0"));
+                        Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
 
-                    TaskRun taskRun = null;
-                    int refreshTimes = 1;
-                    for (int i = 0; i < refreshTimes; i++) {
-                        if (i == 0) {
-                            taskRun = TaskRunBuilder.newBuilder(task).build();
-                        }
-                        System.out.println("start to execute task run:" + i);
-                        Assert.assertTrue(taskRun != null);
-                        initAndExecuteTaskRun(taskRun);
-                        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                                taskRun.getProcessor();
-                        MvTaskRunContext mvContext = processor.getMvContext();
-                        ExecPlan execPlan = mvContext.getExecPlan();
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        taskRun = processor.getNextTaskRun();
+                        TaskRun taskRun = null;
+                        int refreshTimes = 1;
+                        for (int i = 0; i < refreshTimes; i++) {
+                            if (i == 0) {
+                                taskRun = TaskRunBuilder.newBuilder(task).build();
+                            }
+                            System.out.println("start to execute task run:" + i);
+                            Assert.assertTrue(taskRun != null);
+                            initAndExecuteTaskRun(taskRun);
+                            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                                        taskRun.getProcessor();
+                            MvTaskRunContext mvContext = processor.getMvContext();
+                            ExecPlan execPlan = mvContext.getExecPlan();
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            taskRun = processor.getNextTaskRun();
 
-                        PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                                "     PREAGGREGATION: ON\n" +
-                                "     partitions=3/3");
-                        PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
-                                "     PREAGGREGATION: ON\n" +
-                                "     partitions=5/5");
-                        if (i == refreshTimes - 1) {
-                            Assert.assertTrue(taskRun == null);
+                            PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     partitions=3/3");
+                            PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     partitions=5/5");
+                            if (i == refreshTimes - 1) {
+                                Assert.assertTrue(taskRun == null);
+                            }
                         }
-                    }
-                });
+                    });
     }
 
     @Test
     public void testUnionAllMvWithPartitionWithPartitionStartAndEnd() {
         String sql = "create materialized view test_mv0 \n" +
-                "partition by k1 \n" +
-                "distributed by random \n" +
-                "refresh async \n" +
-                "properties(" +
-                "\"partition_refresh_number\" = \"1\"" +
-                ")" +
-                "as " +
-                " select * from t2 union all select * from t1;";
+                    "partition by k1 \n" +
+                    "distributed by random \n" +
+                    "refresh async \n" +
+                    "properties(" +
+                    "\"partition_refresh_number\" = \"1\"" +
+                    ")" +
+                    "as " +
+                    " select * from t2 union all select * from t1;";
         starRocksAssert.withMaterializedView(sql,
-                () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    MaterializedView mv = ((MaterializedView) testDb.getTable("test_mv0"));
+                    () -> {
+                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), "test_mv0"));
 
-                    Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
-                    int mvRefreshTimes = 3;
-                    List<Integer> t1PartitionNums = ImmutableList.of(0, 0, 1);
-                    List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1);
-                    TaskRun taskRun = null;
-                    for (int i = 0; i < mvRefreshTimes; i++) {
-                        System.out.println("start to execute task run:" + i);
-                        if (i == 0) {
-                            taskRun = TaskRunBuilder.newBuilder(task).build();
-                            initAndExecuteTaskRun(taskRun, "2020-10-12", "2020-10-23");
-                        } else {
-                            ExecuteOption executeOption = taskRun.getExecuteOption();
-                            String partitionStart = executeOption.getTaskRunProperties().get(TaskRun.PARTITION_START);
-                            String partitionEnd = executeOption.getTaskRunProperties().get(TaskRun.PARTITION_END);
-                            initAndExecuteTaskRun(taskRun, partitionStart, partitionEnd);
+                        Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+                        int mvRefreshTimes = 3;
+                        List<Integer> t1PartitionNums = ImmutableList.of(0, 0, 1);
+                        List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1);
+                        TaskRun taskRun = null;
+                        for (int i = 0; i < mvRefreshTimes; i++) {
+                            System.out.println("start to execute task run:" + i);
+                            if (i == 0) {
+                                taskRun = TaskRunBuilder.newBuilder(task).build();
+                                initAndExecuteTaskRun(taskRun, "2020-10-12", "2020-10-23");
+                            } else {
+                                ExecuteOption executeOption = taskRun.getExecuteOption();
+                                String partitionStart = executeOption.getTaskRunProperties().get(TaskRun.PARTITION_START);
+                                String partitionEnd = executeOption.getTaskRunProperties().get(TaskRun.PARTITION_END);
+                                initAndExecuteTaskRun(taskRun, partitionStart, partitionEnd);
+                            }
+                            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                                        taskRun.getProcessor();
+                            MvTaskRunContext mvContext = processor.getMvContext();
+                            ExecPlan execPlan = mvContext.getExecPlan();
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            Assert.assertTrue(plan != null);
+                            taskRun = processor.getNextTaskRun();
+                            PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     partitions=%s/3", t1PartitionNums.get(i)));
+                            PlanTestBase.assertContains(plan, String.format("     TABLE: t2\n" +
+                                        "     PREAGGREGATION: ON\n" +
+                                        "     partitions=%s/5", t2PartitionNums.get(i)));
+                            if (i == mvRefreshTimes - 1) {
+                                Assert.assertTrue(taskRun == null);
+                            }
                         }
-                        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                                taskRun.getProcessor();
-                        MvTaskRunContext mvContext = processor.getMvContext();
-                        ExecPlan execPlan = mvContext.getExecPlan();
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        Assert.assertTrue(plan != null);
-                        taskRun = processor.getNextTaskRun();
-                        PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
-                                "     PREAGGREGATION: ON\n" +
-                                "     partitions=%s/3", t1PartitionNums.get(i)));
-                        PlanTestBase.assertContains(plan, String.format("     TABLE: t2\n" +
-                                "     PREAGGREGATION: ON\n" +
-                                "     partitions=%s/5", t2PartitionNums.get(i)));
-                        if (i == mvRefreshTimes - 1) {
-                            Assert.assertTrue(taskRun == null);
-                        }
-                    }
-                });
+                    });
     }
 
     @Test
     public void testJoinMV_SlotRef() throws Exception {
         starRocksAssert.withTable("CREATE TABLE join_base_t1 (dt1 date, int1 int)\n" +
-                "                    PARTITION BY RANGE(dt1)\n" +
-                "                    (\n" +
-                "                    PARTITION p1 VALUES LESS THAN (\"2020-07-01\"),\n" +
-                "                    PARTITION p2 VALUES LESS THAN (\"2020-08-01\"),\n" +
-                "                    PARTITION p3 VALUES LESS THAN (\"2020-09-01\")\n" +
-                "                    );");
+                    "                    PARTITION BY RANGE(dt1)\n" +
+                    "                    (\n" +
+                    "                    PARTITION p1 VALUES LESS THAN (\"2020-07-01\"),\n" +
+                    "                    PARTITION p2 VALUES LESS THAN (\"2020-08-01\"),\n" +
+                    "                    PARTITION p3 VALUES LESS THAN (\"2020-09-01\")\n" +
+                    "                    );");
         starRocksAssert.withTable("CREATE TABLE join_base_t2 (dt2 date, int2 int)\n" +
-                "                    PARTITION BY RANGE(dt2)\n" +
-                "                    (\n" +
-                "                    PARTITION p4 VALUES LESS THAN (\"2020-07-01\"),\n" +
-                "                    PARTITION p5 VALUES LESS THAN (\"2020-08-01\"),\n" +
-                "                    PARTITION p6 VALUES LESS THAN (\"2020-09-01\")\n" +
-                "                    );");
+                    "                    PARTITION BY RANGE(dt2)\n" +
+                    "                    (\n" +
+                    "                    PARTITION p4 VALUES LESS THAN (\"2020-07-01\"),\n" +
+                    "                    PARTITION p5 VALUES LESS THAN (\"2020-08-01\"),\n" +
+                    "                    PARTITION p6 VALUES LESS THAN (\"2020-09-01\")\n" +
+                    "                    );");
         starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW join_mv1 " +
-                "PARTITION BY dt1 " +
-                "REFRESH MANUAL " +
-                "PROPERTIES (\"partition_refresh_number\"=\"3\") AS " +
-                "SELECT dt1,dt2,sum(int1) " +
-                "FROM join_base_t1 t1 " +
-                "JOIN join_base_t2 t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2;");
+                    "PARTITION BY dt1 " +
+                    "REFRESH MANUAL " +
+                    "PROPERTIES (\"partition_refresh_number\"=\"3\") AS " +
+                    "SELECT dt1,dt2,sum(int1) " +
+                    "FROM join_base_t1 t1 " +
+                    "JOIN join_base_t2 t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2;");
 
         MaterializedView mv = starRocksAssert.getMv("test", "join_mv1");
         Assert.assertEquals(Sets.newHashSet("p1", "p2", "p3"), mv.getPartitionNames());
@@ -349,25 +353,25 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
     @Test
     public void testJoinMV_ListPartition() throws Exception {
         starRocksAssert.withTable("CREATE TABLE join_base_t1 (dt1 date, int1 int)\n" +
-                "PARTITION BY RANGE(dt1)\n" +
-                "(\n" +
-                "    PARTITION p202006 VALUES LESS THAN (\"2020-07-01\"),\n" +
-                "    PARTITION p202007 VALUES LESS THAN (\"2020-08-01\"),\n" +
-                "    PARTITION p202008 VALUES LESS THAN (\"2020-09-01\")\n" +
-                ")");
+                    "PARTITION BY RANGE(dt1)\n" +
+                    "(\n" +
+                    "    PARTITION p202006 VALUES LESS THAN (\"2020-07-01\"),\n" +
+                    "    PARTITION p202007 VALUES LESS THAN (\"2020-08-01\"),\n" +
+                    "    PARTITION p202008 VALUES LESS THAN (\"2020-09-01\")\n" +
+                    ")");
         starRocksAssert.withTable("CREATE TABLE join_base_t2 (dt2 date not null, int2 int)\n" +
-                "PARTITION BY LIST(dt2)\n" +
-                "(\n" +
-                "    PARTITION p202006 VALUES in (\"2020-06-23\"),\n" +
-                "    PARTITION p202007 VALUES in (\"2020-07-23\"),\n" +
-                "    PARTITION p202008 VALUES in (\"2020-08-23\")\n" +
-                ");");
+                    "PARTITION BY LIST(dt2)\n" +
+                    "(\n" +
+                    "    PARTITION p202006 VALUES in (\"2020-06-23\"),\n" +
+                    "    PARTITION p202007 VALUES in (\"2020-07-23\"),\n" +
+                    "    PARTITION p202008 VALUES in (\"2020-08-23\")\n" +
+                    ");");
         Exception e = Assert.assertThrows(DmlException.class, () ->
-                starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW join_mv1 " +
-                        "PARTITION BY dt1 REFRESH MANUAL PROPERTIES (\"partition_refresh_number\"=\"3\") AS \n" +
-                        "SELECT dt1,dt2,sum(int1) " +
-                        "FROM join_base_t1 t1 " +
-                        "JOIN join_base_t2 t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2")
+                    starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW join_mv1 " +
+                                "PARTITION BY dt1 REFRESH MANUAL PROPERTIES (\"partition_refresh_number\"=\"3\") AS \n" +
+                                "SELECT dt1,dt2,sum(int1) " +
+                                "FROM join_base_t1 t1 " +
+                                "JOIN join_base_t2 t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2")
         );
         // TODO(fix me): throw a better stack
         System.out.println(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVMaintenanceJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVMaintenanceJobTest.java
@@ -126,7 +126,7 @@ public class MVMaintenanceJobTest extends PlanTestBase {
                 pair.first);
 
         String currentDb = connectContext.getDatabase();
-        long dbId = GlobalStateMgr.getCurrentState().getDb(currentDb).getId();
+        long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(currentDb).getId();
         MaterializedView view = new MaterializedView();
         view.setDbId(dbId);
         view.setId(1024);

--- a/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
@@ -90,9 +90,9 @@ public class ConcurrentDDLTest {
                 try {
                     System.out.println("start to create table");
                     starRocksAssert.withTable("create table test.test_tbl_" + Thread.currentThread().getId() +
-                            " (id int) duplicate key (id)" +
-                            " distributed by hash(id) buckets 5183 " +
-                            "properties(\"replication_num\"=\"1\", \"colocate_with\"=\"test_cg_001\");");
+                                " (id int) duplicate key (id)" +
+                                " distributed by hash(id) buckets 5183 " +
+                                "properties(\"replication_num\"=\"1\", \"colocate_with\"=\"test_cg_001\");");
                     System.out.println("end to create table");
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -111,19 +111,20 @@ public class ConcurrentDDLTest {
             thread.join();
         }
 
-        Database db = GlobalStateMgr.getServingState().getDb("test");
-        Table table = db.getTable("test_tbl_" + threadIds.get(0));
+        Database db = GlobalStateMgr.getServingState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_tbl_" + threadIds.get(0));
 
         List<List<Long>> bucketSeq = GlobalStateMgr.getCurrentState().getColocateTableIndex().getBackendsPerBucketSeq(
-                GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId()));
+                    GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId()));
         // check all created colocate tables has same tablet distribution as the bucket seq in colocate group
         for (long threadId : threadIds) {
-            table = db.getTable("test_tbl_" + threadId);
+            table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_tbl_" + threadId);
             List<Long> tablets = table.getPartitions().stream().findFirst().get().getBaseIndex().getTabletIdsInOrder();
             List<Long> backendIdList = tablets.stream()
-                    .map(id -> GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(id))
-                    .map(replicaList -> replicaList.get(0).getBackendId())
-                    .collect(Collectors.toList());
+                        .map(id -> GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(id))
+                        .map(replicaList -> replicaList.get(0).getBackendId())
+                        .collect(Collectors.toList());
             Assert.assertEquals(bucketSeq, backendIdList.stream().map(Arrays::asList).collect(Collectors.toList()));
         }
     }
@@ -131,13 +132,13 @@ public class ConcurrentDDLTest {
     @Test
     public void testConcurrentlyDropDbAndCreateTable() throws Exception {
         final String createTableSqlFormat =
-                "CREATE TABLE IF NOT EXISTS concurrent_test_db.test_tbl_RRR(k1 int, k2 int, k3 int)" +
-                        " distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
+                    "CREATE TABLE IF NOT EXISTS concurrent_test_db.test_tbl_RRR(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
         final String createViewSqlFormat = "CREATE VIEW IF NOT EXISTS concurrent_test_db.test_view_RRR" +
-                " as select k1,k2 from concurrent_test_db.base_t1;";
+                    " as select k1,k2 from concurrent_test_db.base_t1;";
         final String createMVSqlFormat = "CREATE MATERIALIZED VIEW IF NOT EXISTS" +
-                " concurrent_test_db.test_mv_RRR DISTRIBUTED BY HASH(`k2`) REFRESH MANUAL" +
-                " as select k2,k3 from concurrent_test_db.base_t1;";
+                    " concurrent_test_db.test_mv_RRR DISTRIBUTED BY HASH(`k2`) REFRESH MANUAL" +
+                    " as select k2,k3 from concurrent_test_db.base_t1;";
 
         final int NUM_ROUND = 1;
 
@@ -155,16 +156,16 @@ public class ConcurrentDDLTest {
                         System.out.println("creating table and db time: " + times);
                         starRocksAssert.withDatabase("concurrent_test_db");
                         starRocksAssert.withTable(
-                                "CREATE TABLE IF NOT EXISTS concurrent_test_db.base_t1(k1 int, k2 int, k3 int)" +
-                                        " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+                                    "CREATE TABLE IF NOT EXISTS concurrent_test_db.base_t1(k1 int, k2 int, k3 int)" +
+                                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
                         int time = 300 + random.nextInt(100);
                         // sleep random time before dropping database
                         Thread.sleep(time);
                         System.out.println("dropping table and db");
-                        Database db = GlobalStateMgr.getCurrentState().getDb("concurrent_test_db");
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("concurrent_test_db");
                         ShowTableStmt showTableStmt =
-                                (ShowTableStmt) UtFrameUtils.parseStmtWithNewParser(
-                                        "show tables from concurrent_test_db", connectContext);
+                                    (ShowTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                                                "show tables from concurrent_test_db", connectContext);
                         starRocksAssert.dropDatabase("concurrent_test_db");
                         System.out.println("concurrent_test_db dropped");
                     } catch (Exception e) {
@@ -251,9 +252,9 @@ public class ConcurrentDDLTest {
                     System.out.println("start to create table same_tbl");
                     try {
                         starRocksAssert.withTable("create table test.same_tbl " +
-                                " (id int) duplicate key (id)" +
-                                " distributed by hash(id) buckets 5183 " +
-                                "properties(\"replication_num\"=\"1\", \"colocate_with\"=\"test_cg_001\");");
+                                    " (id int) duplicate key (id)" +
+                                    " distributed by hash(id) buckets 5183 " +
+                                    "properties(\"replication_num\"=\"1\", \"colocate_with\"=\"test_cg_001\");");
                     } catch (Exception e) {
                         errorCount.incrementAndGet();
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -80,17 +80,17 @@ public class LocalMetaStoreTest {
         starRocksAssert = new StarRocksAssert(connectContext);
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable(
-                        "CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
-                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+                    .withTable(
+                                "CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
+                                            " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
 
         UtFrameUtils.PseudoImage.setUpImageVersion();
     }
 
     @Test
     public void testGetNewPartitionsFromPartitions() throws DdlException {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        Table table = db.getTable("t1");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
         Assert.assertTrue(table instanceof OlapTable);
         OlapTable olapTable = (OlapTable) table;
         Partition sourcePartition = olapTable.getPartition("t1");
@@ -102,8 +102,8 @@ public class LocalMetaStoreTest {
         Assert.assertEquals(olapTable.getName(), copiedTable.getName());
         Set<Long> tabletIdSet = Sets.newHashSet();
         List<Partition> newPartitions = localMetastore.getNewPartitionsFromPartitions(db,
-                olapTable, sourcePartitionIds, origPartitions, copiedTable, "_100", tabletIdSet, tmpPartitionIds,
-                null, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                    olapTable, sourcePartitionIds, origPartitions, copiedTable, "_100", tabletIdSet, tmpPartitionIds,
+                    null, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(sourcePartitionIds.size(), newPartitions.size());
         Assert.assertEquals(1, newPartitions.size());
         Partition newPartition = newPartitions.get(0);
@@ -112,8 +112,8 @@ public class LocalMetaStoreTest {
 
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         partitionInfo.addPartition(newPartition.getId(), partitionInfo.getDataProperty(sourcePartition.getId()),
-                partitionInfo.getReplicationNum(sourcePartition.getId()),
-                partitionInfo.getIsInMemory(sourcePartition.getId()));
+                    partitionInfo.getReplicationNum(sourcePartition.getId()),
+                    partitionInfo.getIsInMemory(sourcePartition.getId()));
         olapTable.replacePartition("t1", "t1_100");
 
         Assert.assertEquals(newPartition.getId(), olapTable.getPartition("t1").getId());
@@ -122,15 +122,15 @@ public class LocalMetaStoreTest {
     @Test
     public void testGetPartitionIdToStorageMediumMap() throws Exception {
         starRocksAssert.withMaterializedView(
-                "CREATE MATERIALIZED VIEW test.mv1\n" +
-                        "distributed by hash(k1) buckets 3\n" +
-                        "refresh async\n" +
-                        "properties(\n" +
-                        "'replication_num' = '1'\n" +
-                        ")\n" +
-                        "as\n" +
-                        "select k1,k2 from test.t1;");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+                    "CREATE MATERIALIZED VIEW test.mv1\n" +
+                                "distributed by hash(k1) buckets 3\n" +
+                                "refresh async\n" +
+                                "properties(\n" +
+                                "'replication_num' = '1'\n" +
+                                ")\n" +
+                                "as\n" +
+                                "select k1,k2 from test.t1;");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         new MockUp<PartitionInfo>() {
             @Mock
             public DataProperty getDataProperty(long partitionId) {
@@ -141,7 +141,8 @@ public class LocalMetaStoreTest {
             @Mock
             public void logModifyPartition(ModifyPartitionInfo info) {
                 Assert.assertNotNull(info);
-                Assert.assertTrue(db.getTable(info.getTableId()).isOlapTableOrMaterializedView());
+                Assert.assertTrue(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), info.getTableId())
+                            .isOlapTableOrMaterializedView());
                 Assert.assertEquals(TStorageMedium.HDD, info.getDataProperty().getStorageMedium());
                 Assert.assertEquals(DataProperty.MAX_COOLDOWN_TIME_MS, info.getDataProperty().getCooldownTimeMs());
             }
@@ -156,8 +157,8 @@ public class LocalMetaStoreTest {
     @Test
     public void testLoadClusterV2() throws Exception {
         LocalMetastore localMetaStore = new LocalMetastore(GlobalStateMgr.getCurrentState(),
-                GlobalStateMgr.getCurrentState().getRecycleBin(),
-                GlobalStateMgr.getCurrentState().getColocateTableIndex());
+                    GlobalStateMgr.getCurrentState().getRecycleBin(),
+                    GlobalStateMgr.getCurrentState().getColocateTableIndex());
 
         UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
         localMetaStore.save(image.getImageWriter());
@@ -174,16 +175,16 @@ public class LocalMetaStoreTest {
 
     @Test
     public void testReplayAddSubPartition() throws DdlException {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t1");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
         Partition p = table.getPartitions().stream().findFirst().get();
         int schemaHash = table.getSchemaHashByIndexId(p.getBaseIndex().getId());
         MaterializedIndex index = new MaterializedIndex();
         TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), p.getId(),
-                index.getId(), schemaHash, table.getPartitionInfo().getDataProperty(p.getId()).getStorageMedium());
+                    index.getId(), schemaHash, table.getPartitionInfo().getDataProperty(p.getId()).getStorageMedium());
         index.addTablet(new LocalTablet(0), tabletMeta);
         PhysicalPartitionPersistInfoV2 info = new PhysicalPartitionPersistInfoV2(
-                db.getId(), table.getId(), p.getId(), new PhysicalPartitionImpl(123, "", p.getId(), 0, index));
+                    db.getId(), table.getId(), p.getId(), new PhysicalPartitionImpl(123, "", p.getId(), 0, index));
 
         LocalMetastore localMetastore = connectContext.getGlobalStateMgr().getLocalMetastore();
         localMetastore.replayAddSubPartition(info);
@@ -191,8 +192,8 @@ public class LocalMetaStoreTest {
 
     @Test
     public void testReplayTruncateTable() throws DdlException {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t1");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
         Partition p = table.getPartitions().stream().findFirst().get();
         TruncateTableInfo info = new TruncateTableInfo(db.getId(), table.getId(), Lists.newArrayList(p), false);
 
@@ -202,8 +203,8 @@ public class LocalMetaStoreTest {
 
     @Test
     public void testModifyAutomaticBucketSize() throws DdlException {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t1");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
 
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.WRITE);
@@ -221,8 +222,8 @@ public class LocalMetaStoreTest {
     @Test
     public void testCreateTableIfNotExists() throws Exception {
         // create table if not exists, if the table already exists, do nothing
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        Table table = db.getTable("t1");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
         Assert.assertTrue(table instanceof OlapTable);
         LocalMetastore localMetastore = connectContext.getGlobalStateMgr().getLocalMetastore();
 
@@ -239,20 +240,20 @@ public class LocalMetaStoreTest {
         starRocksAssert = new StarRocksAssert(connectContext);
         // with IF NOT EXIST
         starRocksAssert.useDatabase("test").withTable(
-                "CREATE TABLE IF NOT EXISTS test.t1(k1 int, k2 int, k3 int)" +
-                        " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+                    "CREATE TABLE IF NOT EXISTS test.t1(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
 
         // w/o IF NOT EXIST
         Assert.assertThrows(AnalysisException.class, () ->
-                starRocksAssert.useDatabase("test").withTable(
-                        "CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
-                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');"));
+                    starRocksAssert.useDatabase("test").withTable(
+                                "CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
+                                            " distributed by hash(k1) buckets 3 properties('replication_num' = '1');"));
     }
 
     @Test
     public void testAlterTableProperties() throws Exception {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t1");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION, "abcd");
@@ -277,7 +278,7 @@ public class LocalMetaStoreTest {
         }
 
         Database db = localMetastore.getDb("test");
-        Table table = db.getTable("t1");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
         try {
             localMetastore.renameColumn(new Database(1, "_statistics_"), table, null);
             Assert.fail("should not happen");

--- a/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MVRepairHandlerTest.java
@@ -53,7 +53,7 @@ public class MVRepairHandlerTest {
                         "distributed by hash(k1) buckets 3 refresh async as select k1 from test.t1");
 
         database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-        table = database.getTable("t1");
+        table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t1");
         Assert.assertTrue(table instanceof OlapTable);
         OlapTable olapTable = (OlapTable) table;
         partition = olapTable.getPartition("t1");

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -110,7 +110,7 @@ public class FrontendServiceImplTest {
     ExecuteEnv exeEnv;
 
     private TUpdateResourceUsageRequest genUpdateResourceUsageRequest(
-            long backendId, int numRunningQueries, long memLimitBytes, long memUsedBytes, int cpuUsedPermille) {
+                long backendId, int numRunningQueries, long memLimitBytes, long memUsedBytes, int cpuUsedPermille) {
         TResourceUsage usage = new TResourceUsage();
         usage.setNum_running_queries(numRunningQueries);
         usage.setMem_limit_bytes(memLimitBytes);
@@ -129,7 +129,7 @@ public class FrontendServiceImplTest {
         new MockUp<FrontendServiceImpl>() {
             @Mock
             public synchronized TImmutablePartitionResult updateImmutablePartitionInternal(
-                    TImmutablePartitionRequest request) {
+                        TImmutablePartitionRequest request) {
                 throw new RuntimeException("test");
             }
         };
@@ -157,132 +157,132 @@ public class FrontendServiceImplTest {
         starRocksAssert = new StarRocksAssert(connectContext);
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE site_access_auto (\n" +
-                        "    event_day DATETIME NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "DISTRIBUTED BY RANDOM\n" +
-                        "PROPERTIES(\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_exception (\n" +
-                        "    event_day DATETIME NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "DISTRIBUTED BY RANDOM\n" +
-                        "PROPERTIES(\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_empty (\n" +
-                        "    event_day DATETIME NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('day', event_day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                        "PROPERTIES(\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_border (\n" +
-                        "    event_day DATETIME NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('day', event_day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                        "PROPERTIES(\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_hour (\n" +
-                        "    event_day DATETIME,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('hour', event_day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_day (\n" +
-                        "    event_day DATE,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('day', event_day) (\n" +
-                        "START (\"2020-06-01\") END (\"2022-06-05\") EVERY (INTERVAL 1 day)\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_month (\n" +
-                        "    event_day DATE,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('month', event_day) (\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ");")
-                .withTable("CREATE TABLE site_access_slice (\n" +
-                        "    event_day datetime,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY time_slice(event_day, interval 5 day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\"replication_num\" = \"1\");")
-                .withTable("CREATE TABLE site_access_list (\n" +
-                        "    event_day DATE not null,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY (event_day) (\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ");")
-                .withView("create view v as select * from site_access_empty")
-                .withView("create view v1 as select current_role()")
-                .withView("create view v2 as select current_user()")
-                .withView("create view v3 as select database()")
-                .withView("create view v4 as select user()")
-                .withView("create view v5 as select CONNECTION_ID()")
-                .withView("create view v6 as select CATALOG()")
+                    .withTable("CREATE TABLE site_access_auto (\n" +
+                                "    event_day DATETIME NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "DISTRIBUTED BY RANDOM\n" +
+                                "PROPERTIES(\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_exception (\n" +
+                                "    event_day DATETIME NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "DISTRIBUTED BY RANDOM\n" +
+                                "PROPERTIES(\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_empty (\n" +
+                                "    event_day DATETIME NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                                "PROPERTIES(\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_border (\n" +
+                                "    event_day DATETIME NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                                "PROPERTIES(\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_hour (\n" +
+                                "    event_day DATETIME,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('hour', event_day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_day (\n" +
+                                "    event_day DATE,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day) (\n" +
+                                "START (\"2020-06-01\") END (\"2022-06-05\") EVERY (INTERVAL 1 day)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_month (\n" +
+                                "    event_day DATE,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('month', event_day) (\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withTable("CREATE TABLE site_access_slice (\n" +
+                                "    event_day datetime,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY time_slice(event_day, interval 5 day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\"replication_num\" = \"1\");")
+                    .withTable("CREATE TABLE site_access_list (\n" +
+                                "    event_day DATE not null,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY (event_day) (\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");")
+                    .withView("create view v as select * from site_access_empty")
+                    .withView("create view v1 as select current_role()")
+                    .withView("create view v2 as select current_user()")
+                    .withView("create view v3 as select database()")
+                    .withView("create view v4 as select user()")
+                    .withView("create view v5 as select CONNECTION_ID()")
+                    .withView("create view v6 as select CATALOG()")
 
-                .withMaterializedView("create materialized view mv refresh async as select * from site_access_empty");
+                    .withMaterializedView("create materialized view mv refresh async as select * from site_access_empty");
     }
 
     @AfterClass
@@ -302,13 +302,14 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testImmutablePartitionException() throws TException {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("site_access_exception");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "site_access_exception");
         List<Long> partitionIds = Lists.newArrayList();
         FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
         TImmutablePartitionRequest request = new TImmutablePartitionRequest();
         TImmutablePartitionResult partition = impl.updateImmutablePartition(request);
-        Table t = db.getTable("v");
+        Table t = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "v");
 
         Assert.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
 
@@ -334,7 +335,7 @@ public class FrontendServiceImplTest {
         Assert.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
 
         partitionIds = table.getPhysicalPartitions().stream()
-                .map(PhysicalPartition::getId).collect(Collectors.toList());
+                    .map(PhysicalPartition::getId).collect(Collectors.toList());
         request.setPartition_ids(partitionIds);
         partition = impl.updateImmutablePartition(request);
         Assert.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
@@ -342,10 +343,11 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testImmutablePartitionApi() throws TException {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("site_access_auto");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "site_access_auto");
         List<Long> partitionIds = table.getPhysicalPartitions().stream()
-                .map(PhysicalPartition::getId).collect(Collectors.toList());
+                    .map(PhysicalPartition::getId).collect(Collectors.toList());
         FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
         TImmutablePartitionRequest request = new TImmutablePartitionRequest();
         request.setDb_id(db.getId());
@@ -361,7 +363,7 @@ public class FrontendServiceImplTest {
         Assert.assertEquals(2, table.getPhysicalPartitions().size());
 
         partitionIds = table.getPhysicalPartitions().stream()
-                .map(PhysicalPartition::getId).collect(Collectors.toList());
+                    .map(PhysicalPartition::getId).collect(Collectors.toList());
         request.setPartition_ids(partitionIds);
         partition = impl.updateImmutablePartition(request);
         Assert.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
@@ -377,8 +379,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_day");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_day");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1990-04-24");
@@ -408,8 +410,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_day");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_day");
         ((OlapTable) table).setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
 
         List<List<String>> partitionValues = Lists.newArrayList();
@@ -437,8 +439,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_day");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_day");
         ((OlapTable) table).setState(OlapTable.OlapTableState.ROLLUP);
 
         List<List<String>> partitionValues = Lists.newArrayList();
@@ -457,12 +459,10 @@ public class FrontendServiceImplTest {
         ((OlapTable) table).setState(OlapTable.OlapTableState.NORMAL);
     }
 
-
-
     @Test
     public void testCreatePartitionExceedLimit() throws TException {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_day");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_day");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1990-04-24");
@@ -511,8 +511,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_slice");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_slice");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1990-04-24");
@@ -542,8 +542,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_day");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_day");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1990-04-24");
@@ -579,8 +579,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_month");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_month");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1990-04-24");
@@ -622,8 +622,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_border");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_border");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("NULL");
@@ -654,8 +654,8 @@ public class FrontendServiceImplTest {
     @Test
     public void testAutomaticPartitionLimitExceed() throws TException {
         Config.max_partition_number_per_table = 1;
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_slice");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_slice");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1991-04-24");
@@ -685,8 +685,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_month");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_month");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1999-04-29");
@@ -750,19 +750,19 @@ public class FrontendServiceImplTest {
     @Test
     public void testListViewStatusWithBaseTableDropped() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withTable("CREATE TABLE site_access_empty_for_view (\n" +
-                        "    event_day DATETIME NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('day', event_day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id)\n" +
-                        "PROPERTIES(\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE site_access_empty_for_view (\n" +
+                                "    event_day DATETIME NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('day', event_day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                                "PROPERTIES(\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");");
         starRocksAssert.withView("create view test.view11 as select * from test.site_access_empty_for_view");
         // drop the base table referenced by test.view11
         starRocksAssert.dropTable("test.site_access_empty_for_view");
@@ -782,8 +782,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_hour");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_hour");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1990-04-24 12:34:56");
@@ -806,8 +806,8 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testCreateEmptyPartition() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_empty");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_empty");
         Collection<Partition> partitions = table.getPartitions();
         Assert.assertEquals(1, partitions.size());
         String name = partitions.iterator().next().getName();
@@ -818,125 +818,125 @@ public class FrontendServiceImplTest {
     @Test(expected = AnalysisException.class)
     public void testCreateCeilForbidAutomaticTable() throws Exception {
         starRocksAssert.withDatabase("test2").useDatabase("test2")
-                .withTable("CREATE TABLE site_access_ceil (\n" +
-                        "    event_day datetime,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY time_slice(event_day, interval 1 day, CEIL) \n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\"replication_num\" = \"1\");");
+                    .withTable("CREATE TABLE site_access_ceil (\n" +
+                                "    event_day datetime,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY time_slice(event_day, interval 1 day, CEIL) \n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\"replication_num\" = \"1\");");
     }
 
     @Test(expected = AnalysisException.class)
     public void testCreateTimeSliceForbidAutomaticTable() throws Exception {
         starRocksAssert.withDatabase("test2").useDatabase("test2")
-                .withTable("CREATE TABLE site_access_time_slice_hour_date (\n" +
-                        "    event_day date,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY time_slice(event_day, interval 1 hour) \n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\"replication_num\" = \"1\");");
+                    .withTable("CREATE TABLE site_access_time_slice_hour_date (\n" +
+                                "    event_day date,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY time_slice(event_day, interval 1 hour) \n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\"replication_num\" = \"1\");");
     }
 
     @Test(expected = AnalysisException.class)
     public void testCreateDateTruncForbidAutomaticTable() throws Exception {
         starRocksAssert.withDatabase("test2").useDatabase("test2")
-                .withTable("CREATE TABLE site_access_date_trunc_hour_date (\n" +
-                        "    event_day DATE,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ")\n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('hour', event_day)\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\"replication_num\" = \"1\");");
+                    .withTable("CREATE TABLE site_access_date_trunc_hour_date (\n" +
+                                "    event_day DATE,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('hour', event_day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\"replication_num\" = \"1\");");
     }
 
     @Test(expected = AnalysisException.class)
     public void testUnsupportedAutomaticTableGranularityDoesNotMatch() throws Exception {
         starRocksAssert.withDatabase("test2").useDatabase("test2")
-                .withTable("CREATE TABLE site_access_granularity_does_not_match(\n" +
-                        "    event_day DATE NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ") \n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('month', event_day)(\n" +
-                        "    START (\"2023-05-01\") END (\"2023-05-03\") EVERY (INTERVAL 1 day)\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\n" +
-                        "    \"partition_live_number\" = \"3\",\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE site_access_granularity_does_not_match(\n" +
+                                "    event_day DATE NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ") \n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('month', event_day)(\n" +
+                                "    START (\"2023-05-01\") END (\"2023-05-03\") EVERY (INTERVAL 1 day)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\n" +
+                                "    \"partition_live_number\" = \"3\",\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");");
     }
 
     @Test(expected = AnalysisException.class)
     public void testUnsupportedAutomaticTableGranularityDoesNotMatch2() throws Exception {
         starRocksAssert.withDatabase("test2").useDatabase("test2")
-                .withTable("CREATE TABLE site_access_granularity_does_not_match2(\n" +
-                        "    event_day DATE NOT NULL,\n" +
-                        "    site_id INT DEFAULT '10',\n" +
-                        "    city_code VARCHAR(100),\n" +
-                        "    user_name VARCHAR(32) DEFAULT '',\n" +
-                        "    pv BIGINT DEFAULT '0'\n" +
-                        ") \n" +
-                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                        "PARTITION BY date_trunc('month', event_day)(\n" +
-                        "   START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 1 day),\n" +
-                        "    START (\"2023-05-01\") END (\"2023-05-03\") EVERY (INTERVAL 1 day)\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                        "PROPERTIES(\n" +
-                        "    \"partition_live_number\" = \"3\",\n" +
-                        "    \"replication_num\" = \"1\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE site_access_granularity_does_not_match2(\n" +
+                                "    event_day DATE NOT NULL,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    user_name VARCHAR(32) DEFAULT '',\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ") \n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY date_trunc('month', event_day)(\n" +
+                                "   START (\"2022-05-01\") END (\"2022-05-03\") EVERY (INTERVAL 1 day),\n" +
+                                "    START (\"2023-05-01\") END (\"2023-05-03\") EVERY (INTERVAL 1 day)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                                "PROPERTIES(\n" +
+                                "    \"partition_live_number\" = \"3\",\n" +
+                                "    \"replication_num\" = \"1\"\n" +
+                                ");");
     }
 
     @Test
     public void testGetTablesInfo() throws Exception {
         starRocksAssert.withDatabase("test_table").useDatabase("test_table")
-                .withTable("CREATE TABLE `t1` (\n" +
-                        "  `k1` date NULL COMMENT \"\",\n" +
-                        "  `v1` int(11) NULL COMMENT \"\",\n" +
-                        "  `v2` int(11) NULL COMMENT \"\"\n" +
-                        ") ENGINE=OLAP \n" +
-                        "DUPLICATE KEY(`k1`)\n" +
-                        "COMMENT \"OLAP\"\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"in_memory\" = \"false\",\n" +
-                        "\"enable_persistent_index\" = \"false\",\n" +
-                        "\"replicated_storage\" = \"true\",\n" +
-                        "\"compression\" = \"LZ4\"\n" +
-                        ")")
-                .withTable("CREATE TABLE `t2` (\n" +
-                        "  `k1` date NULL COMMENT \"\",\n" +
-                        "  `v1` int(11) NULL COMMENT \"\",\n" +
-                        "  `v2` int(11) NULL COMMENT \"\"\n" +
-                        ") ENGINE=OLAP \n" +
-                        "DUPLICATE KEY(`k1`)\n" +
-                        "COMMENT \"OLAP\"\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"in_memory\" = \"false\",\n" +
-                        "\"enable_persistent_index\" = \"false\",\n" +
-                        "\"replicated_storage\" = \"true\",\n" +
-                        "\"compression\" = \"LZ4\"\n" +
-                        ")");
+                    .withTable("CREATE TABLE `t1` (\n" +
+                                "  `k1` date NULL COMMENT \"\",\n" +
+                                "  `v1` int(11) NULL COMMENT \"\",\n" +
+                                "  `v2` int(11) NULL COMMENT \"\"\n" +
+                                ") ENGINE=OLAP \n" +
+                                "DUPLICATE KEY(`k1`)\n" +
+                                "COMMENT \"OLAP\"\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"in_memory\" = \"false\",\n" +
+                                "\"enable_persistent_index\" = \"false\",\n" +
+                                "\"replicated_storage\" = \"true\",\n" +
+                                "\"compression\" = \"LZ4\"\n" +
+                                ")")
+                    .withTable("CREATE TABLE `t2` (\n" +
+                                "  `k1` date NULL COMMENT \"\",\n" +
+                                "  `v1` int(11) NULL COMMENT \"\",\n" +
+                                "  `v2` int(11) NULL COMMENT \"\"\n" +
+                                ") ENGINE=OLAP \n" +
+                                "DUPLICATE KEY(`k1`)\n" +
+                                "COMMENT \"OLAP\"\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"in_memory\" = \"false\",\n" +
+                                "\"enable_persistent_index\" = \"false\",\n" +
+                                "\"replicated_storage\" = \"true\",\n" +
+                                "\"compression\" = \"LZ4\"\n" +
+                                ")");
 
         ConnectContext ctx = starRocksAssert.getCtx();
         String createUserSql = "create user test1";
@@ -963,19 +963,19 @@ public class FrontendServiceImplTest {
     @Test
     public void testDefaultValueMeta() throws Exception {
         starRocksAssert.withDatabase("test_table").useDatabase("test_table")
-                .withTable("CREATE TABLE `test_default_value` (\n" +
-                        "  `id` datetime NULL DEFAULT CURRENT_TIMESTAMP COMMENT \"\",\n" +
-                        "  `value` int(11) NULL DEFAULT \"2\" COMMENT \"\"\n" +
-                        ") ENGINE=OLAP \n" +
-                        "DUPLICATE KEY(`id`, `value`)\n" +
-                        "DISTRIBUTED BY RANDOM\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"in_memory\" = \"false\",\n" +
-                        "\"enable_persistent_index\" = \"false\",\n" +
-                        "\"replicated_storage\" = \"true\",\n" +
-                        "\"compression\" = \"LZ4\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE `test_default_value` (\n" +
+                                "  `id` datetime NULL DEFAULT CURRENT_TIMESTAMP COMMENT \"\",\n" +
+                                "  `value` int(11) NULL DEFAULT \"2\" COMMENT \"\"\n" +
+                                ") ENGINE=OLAP \n" +
+                                "DUPLICATE KEY(`id`, `value`)\n" +
+                                "DISTRIBUTED BY RANDOM\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"in_memory\" = \"false\",\n" +
+                                "\"enable_persistent_index\" = \"false\",\n" +
+                                "\"replicated_storage\" = \"true\",\n" +
+                                "\"compression\" = \"LZ4\"\n" +
+                                ");");
 
         ConnectContext ctx = starRocksAssert.getCtx();
         String createUserSql = "create user test2";
@@ -993,8 +993,8 @@ public class FrontendServiceImplTest {
         TDescribeTableResult response = impl.describeTable(request);
         List<TColumnDef> columnDefList = response.getColumns();
         List<TColumnDef> testDefaultValue = columnDefList.stream()
-                .filter(u -> u.getColumnDesc().getTableName().equalsIgnoreCase("test_default_value"))
-                .collect(Collectors.toList());
+                    .filter(u -> u.getColumnDesc().getTableName().equalsIgnoreCase("test_default_value"))
+                    .collect(Collectors.toList());
         Assert.assertEquals(2, testDefaultValue.size());
         Assert.assertEquals("CURRENT_TIMESTAMP", testDefaultValue.get(0).getColumnDesc().getColumnDefault());
         Assert.assertEquals("2", testDefaultValue.get(1).getColumnDesc().getColumnDefault());
@@ -1003,18 +1003,18 @@ public class FrontendServiceImplTest {
     @Test
     public void testGetSpecialColumn() throws Exception {
         starRocksAssert.withDatabase("test_table").useDatabase("test_table")
-                .withTable("CREATE TABLE `ye$test` (\n" +
-                        "event_day DATE,\n" +
-                        "department_id int(11) NOT NULL COMMENT \"\"\n" +
-                        ") ENGINE=OLAP\n" +
-                        "PRIMARY KEY(event_day, department_id)\n" +
-                        "DISTRIBUTED BY HASH(department_id) BUCKETS 1\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"in_memory\" = \"false\",\n" +
-                        "\"storage_format\" = \"DEFAULT\",\n" +
-                        "\"enable_persistent_index\" = \"false\"\n" +
-                        ");");
+                    .withTable("CREATE TABLE `ye$test` (\n" +
+                                "event_day DATE,\n" +
+                                "department_id int(11) NOT NULL COMMENT \"\"\n" +
+                                ") ENGINE=OLAP\n" +
+                                "PRIMARY KEY(event_day, department_id)\n" +
+                                "DISTRIBUTED BY HASH(department_id) BUCKETS 1\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"in_memory\" = \"false\",\n" +
+                                "\"storage_format\" = \"DEFAULT\",\n" +
+                                "\"enable_persistent_index\" = \"false\"\n" +
+                                ");");
 
         ConnectContext ctx = starRocksAssert.getCtx();
         String createUserSql = "create user test3";
@@ -1038,19 +1038,19 @@ public class FrontendServiceImplTest {
     @Test
     public void testGetSpecialColumnForSyncMv() throws Exception {
         starRocksAssert.withDatabase("test_table").useDatabase("test_table")
-                .withTable("CREATE TABLE `base1` (\n" +
-                        "event_day DATE,\n" +
-                        "department_id int(11) NOT NULL COMMENT \"\"\n" +
-                        ") ENGINE=OLAP\n" +
-                        "DUPLICATE KEY(event_day, department_id)\n" +
-                        "DISTRIBUTED BY HASH(department_id) BUCKETS 1\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"in_memory\" = \"false\",\n" +
-                        "\"storage_format\" = \"DEFAULT\",\n" +
-                        "\"enable_persistent_index\" = \"false\"\n" +
-                        ");")
-                .withMaterializedView("create materialized view test_table.mv$test as select event_day from base1");
+                    .withTable("CREATE TABLE `base1` (\n" +
+                                "event_day DATE,\n" +
+                                "department_id int(11) NOT NULL COMMENT \"\"\n" +
+                                ") ENGINE=OLAP\n" +
+                                "DUPLICATE KEY(event_day, department_id)\n" +
+                                "DISTRIBUTED BY HASH(department_id) BUCKETS 1\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\",\n" +
+                                "\"in_memory\" = \"false\",\n" +
+                                "\"storage_format\" = \"DEFAULT\",\n" +
+                                "\"enable_persistent_index\" = \"false\"\n" +
+                                ");")
+                    .withMaterializedView("create materialized view test_table.mv$test as select event_day from base1");
 
         ConnectContext ctx = starRocksAssert.getCtx();
         String createUserSql = "create user test4";
@@ -1074,14 +1074,14 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testGetLoadTxnStatus() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_day");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_day");
         UUID uuid = UUID.randomUUID();
         TUniqueId requestId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
         long transactionId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(db.getId(),
-                Lists.newArrayList(table.getId()), "1jdc689-xd232", requestId,
-                new TxnCoordinator(TxnSourceType.BE, "1.1.1.1"),
-                TransactionState.LoadJobSourceType.BACKEND_STREAMING, -1, 600);
+                    Lists.newArrayList(table.getId()), "1jdc689-xd232", requestId,
+                    new TxnCoordinator(TxnSourceType.BE, "1.1.1.1"),
+                    TransactionState.LoadJobSourceType.BACKEND_STREAMING, -1, 600);
         FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
         TGetLoadTxnStatusRequest request = new TGetLoadTxnStatusRequest();
         request.setDb("non-exist-db");
@@ -1123,9 +1123,9 @@ public class FrontendServiceImplTest {
         List<String> errMsg = status.getError_msgs();
         Assert.assertEquals(1, errMsg.size());
         Assert.assertEquals(
-                "Expr 'str_to_date(`col1`)' analyze error: No matching function with signature: str_to_date(varchar), " +
-                        "derived column is 'event_day'",
-                errMsg.get(0));
+                    "Expr 'str_to_date(`col1`)' analyze error: No matching function with signature: str_to_date(varchar), " +
+                                "derived column is 'event_day'",
+                    errMsg.get(0));
     }
 
     @Test
@@ -1227,8 +1227,8 @@ public class FrontendServiceImplTest {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_list");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_list");
         List<List<String>> partitionValues = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         values.add("1990-04-24");
@@ -1244,25 +1244,26 @@ public class FrontendServiceImplTest {
         TCreatePartitionResult partition = impl.createPartition(request);
 
         GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
-        Database testDb = currentState.getDb("test");
-        OlapTable olapTable = (OlapTable) testDb.getTable("site_access_list");
+        Database testDb = currentState.getLocalMetastore().getDb("test");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "site_access_list");
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         DistributionInfo defaultDistributionInfo = olapTable.getDefaultDistributionInfo();
         List<PartitionDesc> partitionDescs = Lists.newArrayList();
         Partition p19910425 = olapTable.getPartition("p19900425");
 
         partitionDescs.add(new ListPartitionDesc(Lists.newArrayList("p19900425"),
-                Lists.newArrayList(new SingleItemListPartitionDesc(true, "p19900425",
-                        Lists.newArrayList("1990-04-25"), Maps.newHashMap()))));
+                    Lists.newArrayList(new SingleItemListPartitionDesc(true, "p19900425",
+                                Lists.newArrayList("1990-04-25"), Maps.newHashMap()))));
 
         AddPartitionClause addPartitionClause = new AddPartitionClause(partitionDescs.get(0),
-                defaultDistributionInfo.toDistributionDesc(table.getIdToColumn()), Maps.newHashMap(), false);
+                    defaultDistributionInfo.toDistributionDesc(table.getIdToColumn()), Maps.newHashMap(), false);
 
         List<Partition> partitionList = Lists.newArrayList();
         partitionList.add(p19910425);
 
         currentState.getLocalMetastore().addListPartitionLog(testDb, olapTable, partitionDescs,
-                addPartitionClause.isTempPartition(), partitionInfo, partitionList, Sets.newSet("p19900425"));
+                    addPartitionClause.isTempPartition(), partitionInfo, partitionList, Sets.newSet("p19900425"));
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.analyzer;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateAnalyzeJobStmt;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.statistic.StatsConstants;
@@ -65,7 +66,7 @@ public class AnalyzeCreateAnalyzeJobTest {
         String sql = "create analyze full database db";
         CreateAnalyzeJobStmt analyzeStmt = (CreateAnalyzeJobStmt) analyzeSuccess(sql);
 
-        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getDb("db");
+        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb("db");
         Assert.assertEquals(db.getId(), analyzeStmt.getDbId());
         Assert.assertEquals(StatsConstants.DEFAULT_ALL_ID, analyzeStmt.getTableId());
         Assert.assertTrue(analyzeStmt.getColumnNames().isEmpty());
@@ -76,9 +77,9 @@ public class AnalyzeCreateAnalyzeJobTest {
         String sql = "create analyze table db.tbl(kk1, kk2)";
         CreateAnalyzeJobStmt analyzeStmt = (CreateAnalyzeJobStmt) analyzeSuccess(sql);
 
-        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getDb("db");
+        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb("db");
         Assert.assertEquals(db.getId(), analyzeStmt.getDbId());
-        Table table = db.getTable("tbl");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl");
         Assert.assertEquals(table.getId(), analyzeStmt.getTableId());
         Assert.assertEquals(2, analyzeStmt.getColumnNames().size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -101,7 +101,7 @@ public class AnalyzeInsertTest {
     @Test
     public void testInsertOverwriteWhenSchemaChange() throws Exception {
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
-                .getDb("test").getTable("t0");
+                .getLocalMetastore().getDb("test").getTable("t0");
         table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
         analyzeFail("insert overwrite t0 select * from t0;",
                 "table state is SCHEMA_CHANGE, please wait to insert overwrite until table state is normal");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -114,11 +114,15 @@ public class AnalyzeInsertTest {
                 "Unknown catalog 'err_catalog'");
 
         MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
-        new MockUp<MetaUtils>() {
+
+        new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDatabase(String catalogName, String tableName) {
+            public Database getDb(String catalogName, String dbName) {
                 return new Database();
             }
+        };
+
+        new MockUp<MetaUtils>() {
             @Mock
             public Table getSessionAwareTable(ConnectContext context, Database database, TableName tableName) {
                 return null;
@@ -135,6 +139,10 @@ public class AnalyzeInsertTest {
         };
         new Expectations(metadata) {
             {
+                metadata.getDb(anyString, anyString);
+                minTimes = 0;
+                result = new Database();
+
                 icebergTable.supportInsert();
                 result = true;
                 minTimes = 0;
@@ -145,6 +153,10 @@ public class AnalyzeInsertTest {
 
         new Expectations(metadata) {
             {
+                metadata.getDb(anyString, anyString);
+                minTimes = 0;
+                result = new Database();
+
                 icebergTable.getBaseSchema();
                 result = ImmutableList.of(new Column("c1", Type.INT));
                 minTimes = 0;
@@ -157,12 +169,14 @@ public class AnalyzeInsertTest {
     public void testPartitionedIcebergTable(@Mocked IcebergTable icebergTable) {
         MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
 
-        new MockUp<MetaUtils>() {
+        new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDatabase(String catalogName, String databaseName) {
+            public Database getDb(String catalogName, String dbName) {
                 return new Database();
             }
+        };
 
+        new MockUp<MetaUtils>() {
             @Mock
             public Table getSessionAwareTable(ConnectContext context, Database database, TableName tableName) {
                 return icebergTable;
@@ -171,6 +185,10 @@ public class AnalyzeInsertTest {
 
         new Expectations(metadata) {
             {
+                metadata.getDb(anyString, anyString);
+                minTimes = 0;
+                result = new Database();
+
                 icebergTable.supportInsert();
                 result = true;
                 minTimes = 0;
@@ -241,11 +259,14 @@ public class AnalyzeInsertTest {
 
     @Test
     public void testInsertHiveNonManagedTable(@Mocked HiveTable hiveTable) {
-        new MockUp<MetaUtils>() {
+        new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDatabase(String catalogName, String databaseName) {
-                return null;
+            public Database getDb(String catalogName, String dbName) {
+                return new Database();
             }
+        };
+
+        new MockUp<MetaUtils>() {
             @Mock
             public Table getSessionAwareTable(ConnectContext conntext, Database database, TableName tableName) {
                 return hiveTable;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -215,7 +215,7 @@ public class CTASAnalyzerTest {
         String sql = "create table t2 as select k1 as a,k2 as b from duplicate_table_with_null t2;";
 
         StatisticStorage storage = new CachedStatisticStorage();
-        Table table = ctx.getGlobalStateMgr().getDb("ctas")
+        Table table = ctx.getGlobalStateMgr().getLocalMetastore().getDb("ctas")
                 .getTable("duplicate_table_with_null");
         ColumnStatistic k1cs = new ColumnStatistic(1.5928416E9, 1.5982848E9,
                 1.5256461111280627E-4, 4.0, 64.0);
@@ -367,7 +367,7 @@ public class CTASAnalyzerTest {
     @Test
     public void testCTASReplicaNum() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
-        Table table = ctx.getGlobalStateMgr().getDb("ctas")
+        Table table = ctx.getGlobalStateMgr().getLocalMetastore().getDb("ctas")
                 .getTable("duplicate_table_with_null");
         OlapTable olapTable = (OlapTable) table;
         olapTable.setReplicationNum((short) 3);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -30,6 +30,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
@@ -240,8 +241,8 @@ public class MaterializedViewAnalyzerTest {
     @Test
     public void testRefreshMaterializedView() throws Exception {
         analyzeSuccess("refresh materialized view mv");
-        Database testDb = starRocksAssert.getCtx().getGlobalStateMgr().getDb("test");
-        Table table = testDb.getTable("mv");
+        Database testDb = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "mv");
         Assert.assertNotNull(table);
         Assert.assertTrue(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -787,7 +787,7 @@ public class PrivilegeCheckerTest {
         grantRevokeSqlAsRoot("revoke SELECT,INSERT on db3.tbl1 from test");
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db1 = globalStateMgr.getDb("db1");
+        Database db1 = globalStateMgr.getLocalMetastore().getDb("db1");
         nativeAnalyzeJob = new NativeAnalyzeJob(db1.getId(), -1, Lists.newArrayList(), Lists.newArrayList(),
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
@@ -832,7 +832,7 @@ public class PrivilegeCheckerTest {
         new StmtExecutor(ctx, new KillAnalyzeStmt(0L)).checkPrivilegeForKillAnalyzeStmt(ctx, nativeAnalyzeJob.getId());
         grantRevokeSqlAsRoot("revoke SELECT,INSERT on db1.tbl1 from test");
 
-        Database db2 = globalStateMgr.getDb("db2");
+        Database db2 = globalStateMgr.getLocalMetastore().getDb("db2");
         tbl1 = db2.getTable("tbl1");
         nativeAnalyzeJob = new NativeAnalyzeJob(db2.getId(), tbl1.getId(), Lists.newArrayList(), Lists.newArrayList(),
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
@@ -854,7 +854,7 @@ public class PrivilegeCheckerTest {
         AnalyzeMgr analyzeManager = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db1 = globalStateMgr.getDb("db1");
+        Database db1 = globalStateMgr.getLocalMetastore().getDb("db1");
         Table tbl1 = db1.getTable("tbl1");
 
         AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(1, db1.getId(), tbl1.getId(),
@@ -898,7 +898,7 @@ public class PrivilegeCheckerTest {
         // can show result for stats on table that user has any privilege on
         Assert.assertNotNull(showResult);
 
-        Database db2 = globalStateMgr.getDb("db2");
+        Database db2 = globalStateMgr.getLocalMetastore().getDb("db2");
         tbl1 = db2.getTable("tbl1");
         analyzeStatus = new NativeAnalyzeStatus(1, db2.getId(), tbl1.getId(),
                 Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
@@ -1674,7 +1674,7 @@ public class PrivilegeCheckerTest {
                 "Access denied");
 
         // Test `use database` : check any privilege on any function in db
-        Database db1 = GlobalStateMgr.getCurrentState().getDb("db1");
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
         FunctionName fn = FunctionName.createFnName("db1.my_udf_json_get");
         Function function = new Function(fn, Arrays.asList(Type.STRING, Type.STRING), Type.STRING, false);
         try {
@@ -1861,7 +1861,7 @@ public class PrivilegeCheckerTest {
         List<Replica> replicas =
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(tabletId);
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
-        Table table = db.getTable("tbl1");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         ReplicasProcNode replicasProcNode = new ReplicasProcNode(db, (OlapTable) table, tabletId, replicas);
         try {
             replicasProcNode.fetchResult();
@@ -1892,7 +1892,7 @@ public class PrivilegeCheckerTest {
 
         // test user has `OPERATE` privilege
         grantRevokeSqlAsRoot("grant OPERATE on SYSTEM to test");
-        Table table = db.getTable("tbl1");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         tabletSchedCtx = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR,
                 db.getId(), table.getId(), 3, 4, 1000, System.currentTimeMillis());
         result = tabletSchedCtx.checkPrivForCurrUser(testUser);
@@ -2787,7 +2787,7 @@ public class PrivilegeCheckerTest {
 
     @Test
     public void testFunc() throws Exception {
-        Database db1 = GlobalStateMgr.getCurrentState().getDb("db1");
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
         FunctionName fn = FunctionName.createFnName("db1.my_udf_json_get");
         Function function = new Function(fn, Arrays.asList(Type.STRING, Type.STRING), Type.STRING, false);
         try {
@@ -2900,7 +2900,7 @@ public class PrivilegeCheckerTest {
     @Test
     public void testShowFunc() throws Exception {
 
-        Database db1 = GlobalStateMgr.getCurrentState().getDb("db1");
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
         FunctionName fn = FunctionName.createFnName("db1.my_udf_json_get");
         Function function = new Function(fn, Arrays.asList(Type.STRING, Type.STRING), Type.STRING, false);
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/MetaUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/MetaUtilTest.java
@@ -72,8 +72,8 @@ public class MetaUtilTest {
 
     @Test
     public void testIsPartitionExist() {
-        Database database = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = database.getTable("t0");
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t0");
         List<Partition> partitionList = new ArrayList<>(table.getPartitions());
         Assert.assertFalse(MetaUtils.isPartitionExist(GlobalStateMgr.getCurrentState(),
                 -1, -1, -1));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlWithIdUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlWithIdUtilsTest.java
@@ -75,7 +75,7 @@ public class SqlWithIdUtilsTest {
 
     @Test
     public void testDecodeAndEncode() {
-        Database test = GlobalStateMgr.getCurrentState().getDb("test");
+        Database test = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         Table tbl1 = test.getTable("tbl1");
         Table tbl2 = test.getTable("tbl2");
         System.out.println(test.getId() + " " + tbl1.getId() + " " + tbl2.getId());
@@ -128,7 +128,7 @@ public class SqlWithIdUtilsTest {
     @Test
     public void testDecodeAndEncodeNoDataBase() throws Exception {
         String sql = "select tbl1.k1, tbl2.k2 from test.tbl1 join test.tbl2 on tbl1.k1 = tbl2.k1";
-        Database test = GlobalStateMgr.getCurrentState().getDb("test");
+        Database test = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         try {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             String encode = SqlWithIdUtils.encode(statementBase, connectContext);
@@ -171,7 +171,7 @@ public class SqlWithIdUtilsTest {
     @Test
     public void testDecodeAndEncodeNoTable() throws Exception {
         String sql = "select tbl1.k1, tbl2.k2 from test.tbl1 join test.tbl2 on tbl1.k1 = tbl2.k1";
-        Database test = GlobalStateMgr.getCurrentState().getDb("test");
+        Database test = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         Table tbl1 = test.getTable("tbl1");
         Table tbl2 = test.getTable("tbl2");
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/UtilsTest.java
@@ -261,7 +261,7 @@ public class UtilsTest {
     public void unknownStats1() {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 10);
         GlobalStateMgr.getCurrentState().getStatisticStorage().addColumnStatistic(t0, "v1",
                 new ColumnStatistic(1, 1, 0, 1, 1));
@@ -289,7 +289,7 @@ public class UtilsTest {
     @Test
     public void unknownStats2() {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         OptExpression opt =
                 new OptExpression(
                         new LogicalOlapScanOperator(t1, Maps.newHashMap(), Maps.newHashMap(), null, -1, null));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverterTest.java
@@ -264,7 +264,7 @@ public class ColumnFilterConverterTest {
         argument.add(constantOperator);
         ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, argument);
 
-        Table table = GlobalStateMgr.getCurrentState().getDb("test").getTable("bill_detail");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("bill_detail");
         ExpressionRangePartitionInfoV2 partitionInfo = (ExpressionRangePartitionInfoV2) ((OlapTable) table).getPartitionInfo();
         ScalarOperator afterConvert = ColumnFilterConverter.convertPredicate(predicate, partitionInfo, table.getIdToColumn());
         Assert.assertEquals(2921712368984L, ((ConstantOperator) afterConvert.getChild(1)).getValue());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/PredicateReorderRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/PredicateReorderRuleTest.java
@@ -139,8 +139,8 @@ public class PredicateReorderRuleTest {
 
         GlobalStateMgr catalog = GlobalStateMgr.getCurrentState();
         CachedStatisticStorage cachedStatisticStorage = new CachedStatisticStorage();
-        OlapTable t0 = (OlapTable) catalog.getDb("test").getTable("t0");
-        OlapTable t1 = (OlapTable) catalog.getDb("test").getTable("t1");
+        OlapTable t0 = (OlapTable) catalog.getLocalMetastore().getDb("test").getTable("t0");
+        OlapTable t1 = (OlapTable) catalog.getLocalMetastore().getDb("test").getTable("t1");
         cachedStatisticStorage.addColumnStatistic(t0, v1.getName(), statistics.getColumnStatistic(v1));
         cachedStatisticStorage.addColumnStatistic(t0, v2.getName(), statistics.getColumnStatistic(v2));
         cachedStatisticStorage.addColumnStatistic(t1, v1.getName(), statistics.getColumnStatistic(v1));
@@ -156,7 +156,7 @@ public class PredicateReorderRuleTest {
 
         sessionVariable.enablePredicateReorder();
 
-        OlapTable t0 = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("t0");
 
         PredicateReorderRule predicateReorderRule = new PredicateReorderRule(sessionVariable);
 
@@ -230,8 +230,8 @@ public class PredicateReorderRuleTest {
     public void testHashJoinPredicateReorder() {
         sessionVariable.enablePredicateReorder();
 
-        OlapTable t0 = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test").getTable("t0");
-        OlapTable t1 = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test").getTable("t1");
+        OlapTable t0 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("t0");
+        OlapTable t1 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("t1");
 
         PredicateReorderRule predicateReorderRule = new PredicateReorderRule(sessionVariable);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
@@ -47,10 +47,10 @@ public class MaterializedViewRuleTest extends PlanTestBase {
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW lo_count_mv as " +
-                "select LO_ORDERDATE,count(LO_LINENUMBER) from lineorder_flat_for_mv group by LO_ORDERDATE;");
+                    "select LO_ORDERDATE,count(LO_LINENUMBER) from lineorder_flat_for_mv group by LO_ORDERDATE;");
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW lo_count_key_mv as " +
-                "select LO_ORDERDATE, LO_ORDERKEY, count(LO_LINENUMBER) from lineorder_flat_for_mv" +
-                " group by LO_ORDERDATE, LO_ORDERKEY;");
+                    "select LO_ORDERDATE, LO_ORDERKEY, count(LO_LINENUMBER) from lineorder_flat_for_mv" +
+                    " group by LO_ORDERDATE, LO_ORDERKEY;");
     }
 
     @Test
@@ -63,8 +63,9 @@ public class MaterializedViewRuleTest extends PlanTestBase {
         OlapScanNode olapScanNode = (OlapScanNode) plan.getScanNodes().get(0);
         Long selectedIndexid = olapScanNode.getSelectedIndexId();
         GlobalStateMgr globalStateMgr = starRocksAssert.getCtx().getGlobalStateMgr();
-        Database database = globalStateMgr.getDb("test");
-        Table table = database.getTable("lineorder_flat_for_mv");
+        Database database = globalStateMgr.getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(database.getFullName(), "lineorder_flat_for_mv");
         Assert.assertTrue(table instanceof OlapTable);
         OlapTable baseTable = (OlapTable) table;
         Assert.assertEquals(baseTable.getIndexIdByName("lo_count_mv"), selectedIndexid);
@@ -73,13 +74,14 @@ public class MaterializedViewRuleTest extends PlanTestBase {
     @Test
     public void testKeyColumnsMatch() throws Exception {
         GlobalStateMgr globalStateMgr = starRocksAssert.getCtx().getGlobalStateMgr();
-        Database database = globalStateMgr.getDb("test");
-        Table table = database.getTable("lineorder_flat_for_mv");
+        Database database = globalStateMgr.getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(database.getFullName(), "lineorder_flat_for_mv");
         OlapTable baseTable = (OlapTable) table;
 
         String sql = "select LO_ORDERDATE, sum(case when LO_ORDERKEY=0 then 0 else 1 end) as test, " +
-                "sum(case when LO_ORDERKEY=1 then 1 else 0 end) as nontest " +
-                " from lineorder_flat_for_mv group by LO_ORDERDATE;";
+                    "sum(case when LO_ORDERKEY=1 then 1 else 0 end) as nontest " +
+                    " from lineorder_flat_for_mv group by LO_ORDERDATE;";
         ExecPlan plan = getExecPlan(sql);
         OlapScanNode olapScanNode = (OlapScanNode) plan.getScanNodes().get(0);
         Long selectedIndexid = olapScanNode.getSelectedIndexId();
@@ -96,7 +98,7 @@ public class MaterializedViewRuleTest extends PlanTestBase {
         arguments.add(queryColumnRef);
         CallOperator aggCall = new CallOperator(FunctionSet.COUNT, Type.BIGINT, arguments);
         MaterializedViewRule.RewriteContext rewriteContext =
-                new MaterializedViewRule.RewriteContext(aggCall, queryColumnRef, mvColumnRef, mvColumn);
+                    new MaterializedViewRule.RewriteContext(aggCall, queryColumnRef, mvColumnRef, mvColumn);
         ColumnRefOperator dsColumnRef = tmpRefFactory.create("ds", Type.INT, false);
         List<ColumnRefOperator> groupKeys = Lists.newArrayList();
         groupKeys.add(dsColumnRef);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
@@ -70,7 +70,6 @@ public class MVRewriteWithSchemaChangeTest extends MvRewriteTestBase {
         PlanTestBase.assertContains(plan, "sync_mv1");
     }
 
-
     @Test
     public void testMVCacheInvalidAndReValid() throws Exception {
         starRocksAssert.withTable("\n" +
@@ -125,8 +124,9 @@ public class MVRewriteWithSchemaChangeTest extends MvRewriteTestBase {
             waitForSchemaChangeAlterJobFinish();
 
             // check mv invalid
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView mv1 = ((MaterializedView) testDb.getTable("test_cache_mv1"));
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView mv1 = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), "test_cache_mv1"));
             Assert.assertFalse(mv1.isActive());
             try {
                 cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
@@ -272,7 +272,6 @@ public class MVRewriteWithSchemaChangeTest extends MvRewriteTestBase {
             starRocksAssert.dropView("view1");
             dropMv("test", "join_mv_1");
         }
-
 
         {
             starRocksAssert.withMTableNames(cluster, List.of("depts", "emps_par"),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -45,15 +45,15 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteSingleTable_UnionRewrite() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select a, b, d, bitmap_union(to_bitmap(t1.c))" +
-                " from iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " group by a, b, d;");
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select a, b, d, bitmap_union(to_bitmap(t1.c))" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " group by a, b, d;");
 
         testSingleTableWithMVRewrite(mvName);
 
@@ -65,16 +65,16 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteSingleTableWithView() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withView("CREATE VIEW view1 as select a, b, d, bitmap_union(to_bitmap(t1.c))\n" +
-                " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                " group by a, b, d;");
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " group by a, b, d;");
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select * from view1");
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select * from view1");
 
         testSingleTableWithMVRewrite(mvName);
 
@@ -84,24 +84,25 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     }
 
     private void testSingleTableWithMVRewrite(String mvName) throws Exception {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "test_mv1");
         }
@@ -109,86 +110,86 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select a, b, d, count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " where d='2023-08-01'" +
-                    " group by a, b, d;";
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " where d='2023-08-01'" +
+                        " group by a, b, d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         {
             String query = "select a, b, d, count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " where t1.d >= '2023-08-01' \n" +
-                    " group by a, b, d;";
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " where t1.d >= '2023-08-01' \n" +
+                        " group by a, b, d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
 
             PlanTestBase.assertContains(plan, "OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
             PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
-                    "     TABLE: part_tbl1\n" +
-                    "     PREDICATES: 13: d != '2023-08-01', 13: d >= '2023-08-01'");
+                        "     TABLE: part_tbl1\n" +
+                        "     PREDICATES: 13: d != '2023-08-01', 13: d >= '2023-08-01'");
         }
         {
             String query = "select a, b, d, count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " group by a, b, d;";
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " group by a, b, d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
 
             PlanTestBase.assertContains(plan, "OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
             PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
-                    "     TABLE: part_tbl1\n" +
-                    "     PREDICATES: 13: d != '2023-08-01'");
+                        "     TABLE: part_tbl1\n" +
+                        "     PREDICATES: 13: d != '2023-08-01'");
         }
 
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-02') " +
-                "end ('2023-08-03') force with sync mode");
+                    "end ('2023-08-03') force with sync mode");
         partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803"), partitions);
 
         {
             String query = "select a, b, d, count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " where t1.d >= '2023-08-01' \n" +
-                    " group by a, b, d;";
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " where t1.d >= '2023-08-01' \n" +
+                        " group by a, b, d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
 
             PlanTestBase.assertContains(plan, "OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=2/2");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=2/2");
             PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
-                    "     TABLE: part_tbl1\n" +
-                    "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
+                        "     TABLE: part_tbl1\n" +
+                        "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
         }
         {
             String query = "select a, b, d, count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " group by a, b, d;";
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " group by a, b, d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
 
             PlanTestBase.assertContains(plan, "OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=2/2");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=2/2");
             PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
-                    "     TABLE: part_tbl1\n" +
-                    "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
+                        "     TABLE: part_tbl1\n" +
+                        "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
         }
     }
 
@@ -196,67 +197,68 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_FullRefresh() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='20230801';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d >= '20230801'\n" +
-                    "     partitions=3/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d >= '20230801'\n" +
+                        "     partitions=3/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d < '20230802';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d < '20230802';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -266,64 +268,65 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_PartialRefresh() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='20230801';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d < '20230802';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d < '20230802';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -333,67 +336,68 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_LeftJoin_FullRefresh() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='20230801';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d >= '20230801'\n" +
-                    "     partitions=3/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d >= '20230801'\n" +
+                        "     partitions=3/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d < '20230802';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d < '20230802';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -403,89 +407,90 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_LeftJoin_PartialRefresh() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='20230801';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d < '20230802';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d < '20230802';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d < '2023-08-02';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d < '2023-08-02';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         starRocksAssert.dropMaterializedView(mvName);
     }
@@ -494,138 +499,139 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_PartitionPrune1() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d='2023-08-01';";
+                        " where d='2023-08-01';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d in ('2023-08-01');";
+                        " where d in ('2023-08-01');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d in ('2023-08-01', '2023-08-02');";
+                        " where d in ('2023-08-01', '2023-08-02');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02')\n" +
-                    "     partitions=2/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02')\n" +
+                        "     partitions=2/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+                        " where d in ('2023-08-01', '2023-08-02', '2023-08-03');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    "     partitions=3/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        "     partitions=3/3");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d not in ('2023-08-01', '2023-08-02');";
+                        " where d not in ('2023-08-01', '2023-08-02');";
             String plan = getFragmentPlan(query);
             // TODO: no partition prune
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: d NOT IN ('2023-08-01', '2023-08-02')\n" +
-                    "     partitions=3/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 4: d NOT IN ('2023-08-01', '2023-08-02')\n" +
+                        "     partitions=3/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d >= '2023-08-01' and d < '2023-08-02';";
+                        " where d >= '2023-08-01' and d < '2023-08-02';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where cast(d as date) >= '2023-08-01'";
+                        " where cast(d as date) >= '2023-08-01'";
             String plan = getFragmentPlan(query);
             // TODO: no partition prune
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: CAST(4: d AS DATE) >= '2023-08-01'\n" +
-                    "     partitions=3/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: CAST(4: d AS DATE) >= '2023-08-01'\n" +
+                        "     partitions=3/3");
         }
 
         connectContext.getSessionVariable().setRangePrunerPredicateMaxLen(0);
         {
             String query = "select  count(*) from " + mvName +
-                    " where d in ('2023-08-01');";
+                        " where d in ('2023-08-01');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d in ('2023-08-01', '2023-08-02');";
+                        " where d in ('2023-08-01', '2023-08-02');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02')\n" +
-                    "     partitions=2/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02')\n" +
+                        "     partitions=2/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  count(*) from " + mvName +
-                    " where d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+                        " where d in ('2023-08-01', '2023-08-02', '2023-08-03');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    "     partitions=3/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        "     partitions=3/3");
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -635,165 +641,166 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_PartitionPrune2() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d='2023-08-01';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d='2023-08-01';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01');";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02');";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02')\n" +
-                    "     partitions=2/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02')\n" +
+                        "     partitions=2/3");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    "     partitions=3/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        "     partitions=3/3");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d not in ('2023-08-01', '2023-08-02');";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d not in ('2023-08-01', '2023-08-02');";
             String plan = getFragmentPlan(query);
             // TODO: no partition prune
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d != '2023-08-01', 16: d != '2023-08-02'\n" +
-                    "     partitions=3/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d != '2023-08-01', 16: d != '2023-08-02'\n" +
+                        "     partitions=3/3");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d >= '2023-08-01' and t1.d < '2023-08-02';";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d >= '2023-08-01' and t1.d < '2023-08-02';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where cast(t1.d as date) >= '2023-08-01'";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where cast(t1.d as date) >= '2023-08-01'";
             String plan = getFragmentPlan(query);
             // TODO: no partition prune
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: CAST(16: d AS DATE) >= '2023-08-01'\n" +
-                    "     partitions=3/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: CAST(16: d AS DATE) >= '2023-08-01'\n" +
+                        "     partitions=3/3");
         }
 
         connectContext.getSessionVariable().setRangePrunerPredicateMaxLen(0);
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01');";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/3");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02');";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02')\n" +
-                    "     partitions=2/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02')\n" +
+                        "     partitions=2/3");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03');";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    "     partitions=3/3");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        "     partitions=3/3");
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -803,89 +810,90 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_ExtraCompensate() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(b) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.d, t2.b, t3.c;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(b) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null and t2.b in ('xxx') " +
-                    " and t3.c in ('xxx') " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null and t2.b in ('xxx') " +
+                        " and t3.c in ('xxx') " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         starRocksAssert.dropMaterializedView(mvName);
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
@@ -895,50 +903,51 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_LeftJoin_OnPredicates_ExtraCompensate() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(b) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.d, t2.b, t3.c;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(b) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
@@ -946,11 +955,11 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         }
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
             PlanTestBase.assertNotContains(plan, "test_mv1");
@@ -958,45 +967,45 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d in ('2023-08-01', '2023-08-02') " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d in ('2023-08-01', '2023-08-02') " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
             PlanTestBase.assertNotContains(plan, "test_mv1");
         }
 
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-02') " +
-                "end ('2023-08-03') force with sync mode");
+                    "end ('2023-08-03') force with sync mode");
         partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803"), partitions);
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "3:IcebergScanNode\n" +
-                    "     TABLE: part_tbl1\n" +
-                    "     PREDICATES: 19: d >= '2023-08-01'");
+                        "     TABLE: part_tbl1\n" +
+                        "     PREDICATES: 19: d >= '2023-08-01'");
         }
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d in ('2023-08-01', '2023-08-02') " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d in ('2023-08-01', '2023-08-02') " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
@@ -1009,50 +1018,51 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_OnPredicates_ExtraCompensate() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(b) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.d, t2.b, t3.c;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(b) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
@@ -1060,11 +1070,11 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         }
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "test_mv1");
@@ -1072,11 +1082,11 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d in ('2023-08-01', '2023-08-02') " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d in ('2023-08-01', '2023-08-02') " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "test_mv1");
@@ -1089,90 +1099,91 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_LeftJoin_ExtraCompensate() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(b) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.d, t2.b, t3.c;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(b) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null and t2.b in ('xxx') " +
-                    " and t3.c in ('xxx') " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null and t2.b in ('xxx') " +
+                        " and t3.c in ('xxx') " +
+                        " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView(mvName);
@@ -1182,154 +1193,155 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteInnerJoinAggregatePartialRefreshUnion() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select t1.a, t2.b, t1.d, count(t1.c)" +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.a, t2.b, t1.d;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select t1.a, t2.b, t1.d, count(t1.c)" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.a, t2.b, t1.d;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d ='2023-08-01'\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d ='2023-08-01'\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d >= '2023-08-01' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d >= '2023-08-01' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d >= '2023-08-01' and t1.d <= '2023-08-02' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d >= '2023-08-01' and t1.d <= '2023-08-02' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d = '2023-08-01' or t1.d = '2023-08-02' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d = '2023-08-01' or t1.d = '2023-08-02' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             connectContext.getSessionVariable().setRangePrunerPredicateMaxLen(0);
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         starRocksAssert.dropMaterializedView(mvName);
     }
@@ -1338,153 +1350,154 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteLeftJoinAggregatePartialRefreshUnion() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select t1.a, t2.b, t1.d, count(t1.c)" +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.a, t2.b, t1.d;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select t1.a, t2.b, t1.d, count(t1.c)" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.a, t2.b, t1.d;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d ='2023-08-01'\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d ='2023-08-01'\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d >= '2023-08-01' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d >= '2023-08-01' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d >= '2023-08-01' and t1.d <= '2023-08-02' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d >= '2023-08-01' and t1.d <= '2023-08-02' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d = '2023-08-01' or t1.d = '2023-08-02' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d = '2023-08-01' or t1.d = '2023-08-02' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             connectContext.getSessionVariable().setRangePrunerPredicateMaxLen(0);
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         starRocksAssert.dropMaterializedView(mvName);
     }
@@ -1493,36 +1506,37 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteLeftJoinBitmapAggregatePartialRefreshUnion() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select t1.a, t2.b, t1.d, bitmap_union(to_bitmap(t1.c))" +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.a, t2.b, t1.d;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select t1.a, t2.b, t1.d, bitmap_union(to_bitmap(t1.c))" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.a, t2.b, t1.d;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "test_mv1");
         }
@@ -1530,132 +1544,132 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
 
             PlanTestBase.assertContains(plan, "OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
             PlanTestBase.assertContains(plan, "5:IcebergScanNode\n" +
-                    "     TABLE: part_tbl3\n" +
-                    "     PREDICATES: 27: d != '2023-08-01'");
+                        "     TABLE: part_tbl3\n" +
+                        "     PREDICATES: 27: d != '2023-08-01'");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d ='2023-08-01'\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d ='2023-08-01'\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d >= '2023-08-01' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d >= '2023-08-01' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d >= '2023-08-01' and t1.d <= '2023-08-02' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d >= '2023-08-01' and t1.d <= '2023-08-02' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d = '2023-08-01' or t1.d = '2023-08-02' \n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d = '2023-08-01' or t1.d = '2023-08-02' \n" +
+                        " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
-                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
-                    " group by t1.a, t2.b, t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                        " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                        " group by t1.a, t2.b, t1.d;";
             connectContext.getSessionVariable().setRangePrunerPredicateMaxLen(0);
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView(mvName);
@@ -1665,105 +1679,106 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteWithBitmapHash_LeftJoin() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(b) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.d, t2.b, t3.c;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(b) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         {
             String query = "select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         {
             String query = "select  t1.d, t2.b, t3.c, bitmap_union_count(bitmap_hash(t1.a)) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select t1.d, t2.b, t3.c, count(distinct t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(distinct t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         {
             String query = "select  t1.d, count(distinct t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "15:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
         starRocksAssert.dropMaterializedView(mvName);
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
@@ -1773,104 +1788,105 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteWithBitmapHash_InnerJoin() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(b) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.d, t2.b, t3.c;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(b) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         {
             String query = "select  t1.d, t2.b, t3.c, bitmap_union_count(bitmap_hash(t1.a)) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select t1.d, t2.b, t3.c, count(distinct t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         {
             String query = "select  t1.d, t2.b, t3.c, count(distinct t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d, t2.b, t3.c;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d, t2.b, t3.c;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         {
             String query = "select  t1.d, count(distinct t1.a) " +
-                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='2023-08-01' " +
-                    " group by t1.d;";
+                        " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='2023-08-01' " +
+                        " group by t1.d;";
 
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "15:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView(mvName);
@@ -1880,51 +1896,52 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteSingleTableWithDateTruc_Day() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withView("CREATE VIEW view1 as select " +
-                " a, b, " +
-                " date_trunc('day', str2date(d,'%Y-%m-%d')) as dt, " +
-                " bitmap_union(to_bitmap(t1.c))\n" +
-                " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                " group by a, b, dt;");
+                    " a, b, " +
+                    " date_trunc('day', str2date(d,'%Y-%m-%d')) as dt, " +
+                    " bitmap_union(to_bitmap(t1.c))\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " group by a, b, dt;");
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by dt " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select * from view1");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by dt " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select * from view1");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select a, b, date_trunc('day', str2date(d,'%Y-%m-%d')) as dt, " +
-                    " count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " where d='2023-08-01'" +
-                    " group by a, b, dt;";
+                        " count(distinct t1.c)\n" +
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " where d='2023-08-01'" +
+                        " group by a, b, dt;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
         }
 
         // TODO: Support date_trunc('day', str2date(t1.d, ''%Y-%m-%d'')) to str2date(d, '%Y-%m-%d')
         {
             String query = "select a, b, count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " where date_trunc('day', str2date(t1.d, '%Y-%m-%d'))  >= '2023-08-01' \n" +
-                    " group by a, b;";
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " where date_trunc('day', str2date(t1.d, '%Y-%m-%d'))  >= '2023-08-01' \n" +
+                        " group by a, b;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, mvName);
         }
@@ -1938,53 +1955,54 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewriteSingleTableWithDateTruc_Month() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withView("CREATE VIEW view1 as select a, b, " +
-                " date_trunc('month', str2date(d,'%Y-%m-%d')) as dt, " +
-                " bitmap_union(to_bitmap(t1.c))\n" +
-                " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                " group by a, b, d;");
+                    " date_trunc('month', str2date(d,'%Y-%m-%d')) as dt, " +
+                    " bitmap_union(to_bitmap(t1.c))\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " group by a, b, d;");
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by dt " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select * from view1");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by dt " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select * from view1");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
-                "end ('2023-08-02') force with sync mode");
+                    "end ('2023-08-02') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p202308_202309"), partitions);
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select " +
-                    " a, b, date_trunc('month', str2date(d,'%Y-%m-%d')) as dt, " +
-                    " count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " where date_trunc('month', str2date(d,'%Y-%m-%d')) ='2023-08-01'" +
-                    " group by a, b, dt;";
+                        " a, b, date_trunc('month', str2date(d,'%Y-%m-%d')) as dt, " +
+                        " count(distinct t1.c)\n" +
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " where date_trunc('month', str2date(d,'%Y-%m-%d')) ='2023-08-01'" +
+                        " group by a, b, dt;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "UNION");
             UtFrameUtils.matchPlanWithoutId(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 9: dt = '2023-08-01'\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 9: dt = '2023-08-01'\n" +
+                        "     partitions=1/1\n" +
+                        "     rollup: test_mv1");
         }
 
         // TODO: Support date_trunc('day', str2date(t1.d, ''%Y-%m-%d'')) to str2date(d, '%Y-%m-%d')
         {
             String query = "select a, b, d, count(distinct t1.c)\n" +
-                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
-                    " where t1.d >= '2023-08-01' \n" +
-                    " group by a, b, d;";
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                        " where t1.d >= '2023-08-01' \n" +
+                        " group by a, b, d;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, mvName);
         }
@@ -1998,26 +2016,26 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     public void testViewBasedRewrite() throws Exception {
         connectContext.getSessionVariable().setEnableViewBasedMvRewrite(true);
         String view = "create view iceberg_table_view " +
-                " as select t1.a, t2.b, t1.d, count(t1.c) as cnt" +
-                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
-                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.a, t2.b, t1.d;";
+                    " as select t1.a, t2.b, t1.d, count(t1.c) as cnt" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.a, t2.b, t1.d;";
         starRocksAssert.withView(view);
         String mvName = "iceberg_mv_1";
         String mv = "create materialized view iceberg_mv_1 " +
-                "partition by str2date(d,'%Y-%m-%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as " +
-                "select a, b, d, cnt " +
-                "from iceberg_table_view";
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as " +
+                    "select a, b, d, cnt " +
+                    "from iceberg_table_view";
         starRocksAssert.withMaterializedView(mv);
         starRocksAssert.getCtx().executeSql("refresh materialized view iceberg_mv_1" +
-                " partition start('2023-08-01') end('2023-08-02') with sync mode");
+                    " partition start('2023-08-01') end('2023-08-02') with sync mode");
 
         {
             String query = "select a, b, d, cnt from iceberg_table_view";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
@@ -41,7 +41,7 @@ public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
         ConnectorPlanTestBase.mockCatalog(connectContext, MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME);
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
-                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
     }
 
@@ -49,69 +49,70 @@ public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_FullRefresh() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y%m%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'," +
-                "'query_rewrite_consistency' = 'loose'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y%m%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'," +
+                    "'query_rewrite_consistency' = 'loose'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p00010101_20230801", "p20230801_20230802",
-                "p20230802_20230803", "p20230803_99991231"), partitions);
+                    "p20230802_20230803", "p20230803_99991231"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='20230801';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d = '20230801'\n" +
-                    "     partitions=1/4");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d = '20230801'\n" +
+                        "     partitions=1/4");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='20230801';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d >= '20230801'\n" +
-                    "     partitions=3/4\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d >= '20230801'\n" +
+                        "     partitions=3/4\n" +
+                        "     rollup: test_mv1");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d < '20230802';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d < '20230802';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=2/4\n" +
-                    "     rollup: test_mv1");
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=2/4\n" +
+                        "     rollup: test_mv1");
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -121,34 +122,35 @@ public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_InnerJoin_PartialRefresh() throws Exception {
         String mvName = "test_mv2";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y%m%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "\"query_rewrite_consistency\" = \"disable\",\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y%m%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"query_rewrite_consistency\" = \"disable\",\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('20230801') " +
-                "end ('20230802') force with sync mode");
+                    "end ('20230802') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='20230801';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "test_mv2");
         }
@@ -156,74 +158,74 @@ public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
         starRocksAssert.dropMaterializedView(mvName);
     }
 
-
     @Test
     public void testStr2DateMVRefreshRewrite_LeftJoin_FullRefresh() throws Exception {
         String mvName = "test_mv3";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y%m%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "'replication_num' = '1'," +
-                "'query_rewrite_consistency' = 'loose'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y%m%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'," +
+                    "'query_rewrite_consistency' = 'loose'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p00010101_20230801", "p20230801_20230802", "p20230802_20230803",
-                "p20230803_99991231"), partitions);
+                    "p20230803_99991231"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='20230801';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv3\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d = '20230801'\n" +
-                    "     partitions=1/4");
+                        "     TABLE: test_mv3\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d = '20230801'\n" +
+                        "     partitions=1/4");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d>='20230801';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d>='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv3\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 16: d >= '20230801'\n" +
-                    "     partitions=3/4\n" +
-                    "     rollup: test_mv3");
+                        "     TABLE: test_mv3\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 16: d >= '20230801'\n" +
+                        "     partitions=3/4\n" +
+                        "     rollup: test_mv3");
         }
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d < '20230802';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d < '20230802';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: test_mv3\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=2/4\n" +
-                    "     rollup: test_mv3");
+                        "     TABLE: test_mv3\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=2/4\n" +
+                        "     rollup: test_mv3");
         }
 
         starRocksAssert.dropMaterializedView(mvName);
@@ -233,34 +235,35 @@ public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
     public void testStr2DateMVRefreshRewrite_LeftJoin_PartialRefresh() throws Exception {
         String mvName = "test_mv4";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y%m%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "\"query_rewrite_consistency\" = \"disable\",\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                "as select  t1.a, t2.b, t3.c, t1.d " +
-                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                    "partition by str2date(d,'%Y%m%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"query_rewrite_consistency\" = \"disable\",\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(testDb.getFullName(), mvName));
 
         // initial create
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('20230801') " +
-                "end ('20230802') force with sync mode");
+                    "end ('20230802') force with sync mode");
         List<String> partitions =
-                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                        .collect(Collectors.toList());
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
         {
             String query = "select  t1.a, t2.b, t3.c, t1.d " +
-                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
-                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
-                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
-                    " where t1.d='20230801';";
+                        " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                        " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                        " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                        " where t1.d='20230801';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertNotContains(plan, "test_mv4");
         }
@@ -271,24 +274,24 @@ public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
     @Test
     public void testViewBasedMvRewriteOnJdbcTable() throws Exception {
         String view = "create view jdbc_table_view " +
-                " as select t1.a, t2.b, t1.d, count(t1.c) as cnt" +
-                " from  jdbc0.partitioned_db.part_tbl1 as t1 " +
-                " inner join jdbc0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
-                " inner join jdbc0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                " group by t1.a, t2.b, t1.d;";
+                    " as select t1.a, t2.b, t1.d, count(t1.c) as cnt" +
+                    " from  jdbc0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " group by t1.a, t2.b, t1.d;";
         starRocksAssert.withView(view);
         String mvName = "jdbc_view_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
-                "partition by str2date(d,'%Y%m%d') " +
-                "distributed by hash(a) " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "\"query_rewrite_consistency\" = \"loose\",\n" +
-                "'replication_num' = '1'" +
-                ") " +
-                " as select a, b, d, cnt" +
-                " from jdbc_table_view");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    "partition by str2date(d,'%Y%m%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"query_rewrite_consistency\" = \"loose\",\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    " as select a, b, d, cnt" +
+                    " from jdbc_table_view");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " with sync mode");
 
         {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshTest.java
@@ -31,7 +31,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class MvRefreshTest extends MVRefreshTestBase  {
+public class MvRefreshTest extends MVRefreshTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         PseudoCluster.getOrCreateWithRandomPort(true, 1);
@@ -45,143 +45,149 @@ public class MvRefreshTest extends MVRefreshTestBase  {
     @Test
     public void testMvWithComplexNameRefresh() throws Exception {
         createAndRefreshMv("create materialized view `cc`" +
-                " partition by id_date" +
-                " distributed by hash(`t1a`)" +
-                " as" +
-                " select t1a, id_date, t1b from table_with_partition");
+                    " partition by id_date" +
+                    " distributed by hash(`t1a`)" +
+                    " as" +
+                    " select t1a, id_date, t1b from table_with_partition");
 
         createAndRefreshMv("create materialized view `luchen_order_8e2c65ba_1c30`" +
-                " partition by id_date" +
-                " distributed by hash(`t1a`)" +
-                " as" +
-                " select t1a, id_date, t1b from table_with_partition");
+                    " partition by id_date" +
+                    " distributed by hash(`t1a`)" +
+                    " as" +
+                    " select t1a, id_date, t1b from table_with_partition");
     }
 
     @Test
     public void testMVRefreshWithQueryRewrite1() throws Exception {
         createAndRefreshMv("create materialized view `test_mv1` \n" +
-                " partition by id_date\n" +
-                " distributed by hash(`t1a`)\n" +
-                " refresh deferred manual \n" +
-                " as\n" +
-                " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
+                    " partition by id_date\n" +
+                    " distributed by hash(`t1a`)\n" +
+                    " refresh deferred manual \n" +
+                    " as\n" +
+                    " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
         starRocksAssert.withMaterializedView("create materialized view `test_mv2` \n" +
-                        " partition by id_date\n" +
-                        " distributed by hash(`t1a`)\n" +
-                        " refresh deferred manual \n" +
-                        " as\n" +
-                        " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
-                () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    MaterializedView materializedView = ((MaterializedView) testDb.getTable("test_mv2"));
-                    Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                    TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                " partition by id_date\n" +
+                                " distributed by hash(`t1a`)\n" +
+                                " refresh deferred manual \n" +
+                                " as\n" +
+                                " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
+                    () -> {
+                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        MaterializedView materializedView =
+                                    ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                .getTable(testDb.getFullName(), "test_mv2"));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                    // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
-                    // test_mv1.
-                    {
-                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
-                        Assert.assertNotNull("exec plan should not null", execPlan);
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        PlanTestBase.assertContains(plan, "test_mv1");
-                    }
+                        // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
+                        // test_mv1.
+                        {
+                            ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                            Assert.assertNotNull("exec plan should not null", execPlan);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "test_mv1");
+                        }
 
-                    // If the base table has changed and test_mv1 has not been refreshed, test_mv2 refresh should
-                    // not use test_mv1.
-                    {
-                        executeInsertSql(connectContext, "insert into table_with_partition partition(p1991)" +
-                                " values(\"varchar12\", '1991-03-01', 2, 1, 1)");
-                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
-                        Assert.assertNotNull("exec plan should not null", execPlan);
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        PlanTestBase.assertNotContains(plan, "test_mv1");
-                    }
-                });
+                        // If the base table has changed and test_mv1 has not been refreshed, test_mv2 refresh should
+                        // not use test_mv1.
+                        {
+                            executeInsertSql(connectContext, "insert into table_with_partition partition(p1991)" +
+                                        " values(\"varchar12\", '1991-03-01', 2, 1, 1)");
+                            ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                            Assert.assertNotNull("exec plan should not null", execPlan);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertNotContains(plan, "test_mv1");
+                        }
+                    });
         starRocksAssert.dropMaterializedView("test_mv1");
     }
 
     @Test
     public void testMVRefreshWithQueryRewrite2() throws Exception {
         createAndRefreshMv("create materialized view `test_mv1` \n" +
-                " partition by id_date\n" +
-                " distributed by hash(`t1a`)\n" +
-                " refresh deferred manual \n" +
-                " as\n" +
-                " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
+                    " partition by id_date\n" +
+                    " distributed by hash(`t1a`)\n" +
+                    " refresh deferred manual \n" +
+                    " as\n" +
+                    " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
         starRocksAssert.withMaterializedView("create materialized view `test_mv2` \n" +
-                        "partition by id_date\n" +
-                        "distributed by hash(`t1a`)\n" +
-                        "refresh deferred manual \n" +
-                        "PROPERTIES (\n" +
-                        "   'replication_num' = '1', \n" +
-                        "   'session.enable_materialized_view_rewrite' = 'false' \n" +
-                        ")\n" +
-                        " as\n" +
-                        " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
-                () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    MaterializedView materializedView = ((MaterializedView) testDb.getTable("test_mv2"));
-                    Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                    TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                "partition by id_date\n" +
+                                "distributed by hash(`t1a`)\n" +
+                                "refresh deferred manual \n" +
+                                "PROPERTIES (\n" +
+                                "   'replication_num' = '1', \n" +
+                                "   'session.enable_materialized_view_rewrite' = 'false' \n" +
+                                ")\n" +
+                                " as\n" +
+                                " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
+                    () -> {
+                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        MaterializedView materializedView =
+                                    ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                .getTable(testDb.getFullName(), "test_mv2"));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                    // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
-                    // test_mv1.
-                    {
-                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
-                        Assert.assertNotNull("exec plan should not null", execPlan);
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        PlanTestBase.assertNotContains(plan, "test_mv1");
-                    }
-                });
+                        // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
+                        // test_mv1.
+                        {
+                            ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                            Assert.assertNotNull("exec plan should not null", execPlan);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertNotContains(plan, "test_mv1");
+                        }
+                    });
         starRocksAssert.dropMaterializedView("test_mv1");
     }
 
     @Test
     public void testMVRefreshWithQueryRewrite3() throws Exception {
         createAndRefreshMv("create materialized view `test_mv1` \n" +
-                " partition by id_date\n" +
-                " distributed by hash(`t1a`)\n" +
-                " refresh deferred manual \n" +
-                " as\n" +
-                " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
+                    " partition by id_date\n" +
+                    " distributed by hash(`t1a`)\n" +
+                    " refresh deferred manual \n" +
+                    " as\n" +
+                    " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
         Config.enable_mv_refresh_query_rewrite = false;
         starRocksAssert.withMaterializedView("create materialized view `test_mv2` \n" +
-                        "partition by id_date\n" +
-                        "distributed by hash(`t1a`)\n" +
-                        "refresh deferred manual \n" +
-                        "PROPERTIES (\n" +
-                        "   'replication_num' = '1', \n" +
-                        "   'session.enable_materialized_view_rewrite' = 'true', \n" +
-                        "   'session.enable_materialized_view_for_insert' = 'true' \n" +
-                        ")\n" +
-                        " as\n" +
-                        " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
-                () -> {
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    MaterializedView materializedView = ((MaterializedView) testDb.getTable("test_mv2"));
-                    Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                    TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                "partition by id_date\n" +
+                                "distributed by hash(`t1a`)\n" +
+                                "refresh deferred manual \n" +
+                                "PROPERTIES (\n" +
+                                "   'replication_num' = '1', \n" +
+                                "   'session.enable_materialized_view_rewrite' = 'true', \n" +
+                                "   'session.enable_materialized_view_for_insert' = 'true' \n" +
+                                ")\n" +
+                                " as\n" +
+                                " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
+                    () -> {
+                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        MaterializedView materializedView =
+                                    ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                                .getTable(testDb.getFullName(), "test_mv2"));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
 
-                    // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
-                    // test_mv1.
-                    {
-                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
-                        Assert.assertNotNull("exec plan should not null", execPlan);
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        PlanTestBase.assertContains(plan, "test_mv1");
-                    }
+                        // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
+                        // test_mv1.
+                        {
+                            ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                            Assert.assertNotNull("exec plan should not null", execPlan);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertContains(plan, "test_mv1");
+                        }
 
-                    // If the base table has changed and test_mv1 has not been refreshed, test_mv2 refresh should
-                    // not use test_mv1.
-                    {
-                        executeInsertSql(connectContext, "insert into table_with_partition partition(p1991)" +
-                                " values(\"varchar12\", '1991-03-01', 2, 1, 1)");
-                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
-                        Assert.assertNotNull("exec plan should not null", execPlan);
-                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-                        PlanTestBase.assertNotContains(plan, "test_mv1");
-                    }
-                });
+                        // If the base table has changed and test_mv1 has not been refreshed, test_mv2 refresh should
+                        // not use test_mv1.
+                        {
+                            executeInsertSql(connectContext, "insert into table_with_partition partition(p1991)" +
+                                        " values(\"varchar12\", '1991-03-01', 2, 1, 1)");
+                            ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                            Assert.assertNotNull("exec plan should not null", execPlan);
+                            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                            PlanTestBase.assertNotContains(plan, "test_mv1");
+                        }
+                    });
         Config.enable_mv_refresh_query_rewrite = true;
         starRocksAssert.dropMaterializedView("test_mv1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -123,8 +123,8 @@ public class MvRewriteTestBase {
     }
 
     public static Table getTable(String dbName, String mvName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(mvName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName);
         Assert.assertNotNull(table);
         return table;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -100,14 +101,14 @@ public class MvUtilsTest {
         BinaryPredicateOperator binaryPredicate = new BinaryPredicateOperator(
                 BinaryType.EQ, columnRef1, columnRef2);
 
-        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getDb("test");
-        Table table1 = db.getTable("t0");
+        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb("test");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
         LogicalScanOperator scanOperator1 = new LogicalOlapScanOperator(table1);
         BinaryPredicateOperator binaryPredicate2 = new BinaryPredicateOperator(
                 BinaryType.GE, columnRef1, ConstantOperator.createInt(1));
         scanOperator1.setPredicate(binaryPredicate2);
         OptExpression scanExpr = OptExpression.create(scanOperator1);
-        Table table2 = db.getTable("t1");
+        Table table2 = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
         LogicalScanOperator scanOperator2 = new LogicalOlapScanOperator(table2);
         BinaryPredicateOperator binaryPredicate3 = new BinaryPredicateOperator(
                 BinaryType.GE, columnRef2, ConstantOperator.createInt(1));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
@@ -127,8 +127,8 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testGetColumnStatistic(@Mocked CachedStatisticStorage cachedStatisticStorage) {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t0");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
 
         new Expectations() {
             {
@@ -160,8 +160,8 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testGetColumnStatistics(@Mocked CachedStatisticStorage cachedStatisticStorage) {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t0");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
 
         ColumnStatistic columnStatistic1 = ColumnStatistic.builder().setDistinctValuesCount(888).build();
         ColumnStatistic columnStatistic2 = ColumnStatistic.builder().setDistinctValuesCount(999).build();
@@ -367,8 +367,8 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testLoadCacheLoadEmpty(@Mocked CachedStatisticStorage cachedStatisticStorage) {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        Table table = db.getTable("t0");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
 
         new Expectations() {
             {
@@ -388,8 +388,8 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testConvert2ColumnStatistics() {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t0");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
         ColumnBasicStatsCacheLoader cachedStatisticStorage =
                 Deencapsulation.newInstance(ColumnBasicStatsCacheLoader.class);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -99,54 +99,54 @@ public class StatisticsCalculatorTest {
     @Before
     public void before() throws Exception {
         starRocksAssert.withTable("CREATE TABLE `test_all_type` (\n" +
-                "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
-                "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
-                "  `t1c` int(11) NULL COMMENT \"\",\n" +
-                "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
-                "  `t1e` float NULL COMMENT \"\",\n" +
-                "  `t1f` double NULL COMMENT \"\",\n" +
-                "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
-                "  `id_datetime` datetime NULL COMMENT \"\",\n" +
-                "  `id_date` date NULL COMMENT \"\", \n" +
-                "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`t1a`)\n" +
-                "PARTITION BY RANGE (id_date)\n" +
-                "(\n" +
-                "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
-                "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"), \n" +
-                "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")  \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"in_memory\" = \"false\"\n" +
-                ");");
+                    "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
+                    "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
+                    "  `t1c` int(11) NULL COMMENT \"\",\n" +
+                    "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
+                    "  `t1e` float NULL COMMENT \"\",\n" +
+                    "  `t1f` double NULL COMMENT \"\",\n" +
+                    "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
+                    "  `id_datetime` datetime NULL COMMENT \"\",\n" +
+                    "  `id_date` date NULL COMMENT \"\", \n" +
+                    "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`t1a`)\n" +
+                    "PARTITION BY RANGE (id_date)\n" +
+                    "(\n" +
+                    "PARTITION p1 VALUES LESS THAN (\"2014-01-01\"),\n" +
+                    "PARTITION p2 VALUES LESS THAN (\"2014-06-01\"), \n" +
+                    "PARTITION p3 VALUES LESS THAN (\"2014-12-01\")  \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"in_memory\" = \"false\"\n" +
+                    ");");
 
         starRocksAssert.withTable("CREATE TABLE `test_all_type_day_partition` (\n" +
-                "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
-                "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
-                "  `t1c` int(11) NULL COMMENT \"\",\n" +
-                "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
-                "  `t1e` float NULL COMMENT \"\",\n" +
-                "  `t1f` double NULL COMMENT \"\",\n" +
-                "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
-                "  `id_datetime` datetime NULL COMMENT \"\",\n" +
-                "  `id_date` date NULL COMMENT \"\", \n" +
-                "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`t1a`)\n" +
-                "PARTITION BY RANGE (id_date)\n" +
-                "(\n" +
-                "partition p1 values [('2020-04-23'), ('2020-04-24')),\n" +
-                "partition p2 values [('2020-04-24'), ('2020-04-25')),\n" +
-                "partition p3 values [('2020-04-25'), ('2020-04-26')) \n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"in_memory\" = \"false\"\n" +
-                ");");
+                    "  `t1a` varchar(20) NULL COMMENT \"\",\n" +
+                    "  `t1b` smallint(6) NULL COMMENT \"\",\n" +
+                    "  `t1c` int(11) NULL COMMENT \"\",\n" +
+                    "  `t1d` bigint(20) NULL COMMENT \"\",\n" +
+                    "  `t1e` float NULL COMMENT \"\",\n" +
+                    "  `t1f` double NULL COMMENT \"\",\n" +
+                    "  `t1g` bigint(20) NULL COMMENT \"\",\n" +
+                    "  `id_datetime` datetime NULL COMMENT \"\",\n" +
+                    "  `id_date` date NULL COMMENT \"\", \n" +
+                    "  `id_decimal` decimal(10,2) NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`t1a`)\n" +
+                    "PARTITION BY RANGE (id_date)\n" +
+                    "(\n" +
+                    "partition p1 values [('2020-04-23'), ('2020-04-24')),\n" +
+                    "partition p2 values [('2020-04-24'), ('2020-04-25')),\n" +
+                    "partition p3 values [('2020-04-25'), ('2020-04-26')) \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(`t1a`) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"in_memory\" = \"false\"\n" +
+                    ");");
     }
 
     @After
@@ -176,7 +176,7 @@ public class StatisticsCalculatorTest {
         groupExpression.setGroup(new Group(1));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         Assert.assertEquals(50, expressionContext.getStatistics().getOutputRowCount(), 0.001);
 
@@ -186,11 +186,11 @@ public class StatisticsCalculatorTest {
         groupExpression.setGroup(new Group(1));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         Assert.assertEquals(
-                50 * 50 * Math.pow(StatisticsEstimateCoefficient.UNKNOWN_GROUP_BY_CORRELATION_COEFFICIENT, 2),
-                expressionContext.getStatistics().getOutputRowCount(), 0.001);
+                    50 * 50 * Math.pow(StatisticsEstimateCoefficient.UNKNOWN_GROUP_BY_CORRELATION_COEFFICIENT, 2),
+                    expressionContext.getStatistics().getOutputRowCount(), 0.001);
     }
 
     @Test
@@ -220,13 +220,13 @@ public class StatisticsCalculatorTest {
         childGroup2.setStatistics(childBuilder2.build());
         // construct group expression
         LogicalUnionOperator unionOperator = new LogicalUnionOperator(Lists.newArrayList(v5, v6),
-                Lists.newArrayList(Lists.newArrayList(v1, v2), Lists.newArrayList(v3, v4)), true);
+                    Lists.newArrayList(Lists.newArrayList(v1, v2), Lists.newArrayList(v3, v4)), true);
         GroupExpression groupExpression =
-                new GroupExpression(unionOperator, Lists.newArrayList(childGroup1, childGroup2));
+                    new GroupExpression(unionOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
 
         ColumnStatistic columnStatisticV5 = expressionContext.getStatistics().getColumnStatistic(v5);
@@ -239,10 +239,10 @@ public class StatisticsCalculatorTest {
     @Test
     public void testLogicalOlapTableScan() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table = (OlapTable) globalStateMgr.getDb("statistics_test").getTable("test_all_type");
+        OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("statistics_test").getTable("test_all_type");
         Collection<Partition> partitions = table.getPartitions();
         List<Long> partitionIds =
-                partitions.stream().mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
+                    partitions.stream().mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
         for (Partition partition : partitions) {
             partition.getBaseIndex().setRowCount(1000);
         }
@@ -257,32 +257,32 @@ public class StatisticsCalculatorTest {
             columnToRef.put(column, ref);
 
             LogicalOlapScanOperator olapScanOperator = new LogicalOlapScanOperator(table,
-                    refToColumn, columnToRef,
-                    null, -1, null,
-                    ((OlapTable) table).getBaseIndexId(),
-                    partitionIds,
-                    null,
-                    false,
-                    Lists.newArrayList(),
-                    Lists.newArrayList(),
-                    Lists.newArrayList(),
-                    false);
+                        refToColumn, columnToRef,
+                        null, -1, null,
+                        ((OlapTable) table).getBaseIndexId(),
+                        partitionIds,
+                        null,
+                        false,
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        Lists.newArrayList(),
+                        false);
 
             GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
             groupExpression.setGroup(new Group(0));
             ExpressionContext expressionContext = new ExpressionContext(groupExpression);
             Statistics.Builder builder = Statistics.builder();
             olapScanOperator.getOutputColumns().forEach(col ->
-                    builder.addColumnStatistic(col,
-                            new ColumnStatistic(-100, 100, 0.0, 5.0, 10))
+                        builder.addColumnStatistic(col,
+                                    new ColumnStatistic(-100, 100, 0.0, 5.0, 10))
             );
             expressionContext.setStatistics(builder.build());
             StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                    columnRefFactory, optimizerContext);
+                        columnRefFactory, optimizerContext);
             statisticsCalculator.estimatorStats();
             Assert.assertEquals(1000 * partitions.size(), expressionContext.getStatistics().getOutputRowCount(), 0.001);
             Assert.assertEquals(ref.getType().getTypeSize() * 1000 * partitions.size(),
-                    expressionContext.getStatistics().getComputeSize(), 0.001);
+                        expressionContext.getStatistics().getComputeSize(), 0.001);
         }
     }
 
@@ -306,9 +306,9 @@ public class StatisticsCalculatorTest {
         }
 
         BinaryPredicateOperator predicateOperator = new BinaryPredicateOperator(BinaryType.LT,
-                partitionColumn, ConstantOperator.createInt(50));
+                    partitionColumn, ConstantOperator.createInt(50));
         LogicalIcebergScanOperator icebergScanOperator = new LogicalIcebergScanOperator(icebergTable, refToColumn,
-                columnToRef, -1, predicateOperator, TableVersionRange.empty());
+                    columnToRef, -1, predicateOperator, TableVersionRange.empty());
 
         GroupExpression groupExpression = new GroupExpression(icebergScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
@@ -317,22 +317,22 @@ public class StatisticsCalculatorTest {
         new MockUp<MetadataMgr>() {
             @Mock
             public Statistics getTableStatisticsFromInternalStatistics(Table table, Map<ColumnRefOperator,
-                    Column> columns) {
+                        Column> columns) {
                 Statistics.Builder builder = Statistics.builder();
                 icebergScanOperator.getOutputColumns().forEach(col ->
-                        builder.addColumnStatistic(col,
-                                new ColumnStatistic(0, 100, 0.0, 5.0, 100))
+                            builder.addColumnStatistic(col,
+                                        new ColumnStatistic(0, 100, 0.0, 5.0, 100))
                 );
                 builder.setOutputRowCount(100);
                 return builder.build();
             }
         };
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         Assert.assertEquals(50, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         Assert.assertEquals(50, expressionContext.getStatistics().
-                getColumnStatistic(partitionColumn).getMaxValue(), 0.001);
+                    getColumnStatistic(partitionColumn).getMaxValue(), 0.001);
         Assert.assertTrue(optimizerContext.isObtainedFromInternalStatistics());
         optimizerContext.setObtainedFromInternalStatistics(false);
     }
@@ -341,7 +341,7 @@ public class StatisticsCalculatorTest {
     public void testLogicalOlapTableEmptyPartition(@Mocked CachedStatisticStorage cachedStatisticStorage) {
         ColumnRefOperator idDate = columnRefFactory.create("id_date", Type.DATE, true);
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        Table table = globalStateMgr.getDb("statistics_test").getTable("test_all_type");
+        Table table = globalStateMgr.getLocalMetastore().getDb("statistics_test").getTable("test_all_type");
 
         List<Partition> partitions = new ArrayList<>(((OlapTable) table).getPartitions());
 
@@ -353,41 +353,41 @@ public class StatisticsCalculatorTest {
         partition2.setVisibleVersion(2, System.currentTimeMillis());
         partition3.setVisibleVersion(2, System.currentTimeMillis());
         List<Long> partitionIds = partitions.stream().filter(partition -> !(partition.getName().equalsIgnoreCase("p1"))).
-                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
 
         new Expectations() {
             {
                 cachedStatisticStorage.getColumnStatistics(table, Lists.newArrayList("id_date"));
                 result = new ColumnStatistic(0, Utils.getLongFromDateTime(LocalDateTime.of(2014, 12, 01, 0, 0, 0)),
-                        0, 0, 30);
+                            0, 0, 30);
                 minTimes = 0;
 
                 cachedStatisticStorage.getColumnStatistic(table, "id_date");
                 result = new ColumnStatistic(0, Utils.getLongFromDateTime(LocalDateTime.of(2014, 12, 01, 0, 0, 0)),
-                        0, 0, 30);
+                            0, 0, 30);
                 minTimes = 0;
             }
         };
 
         LogicalOlapScanOperator olapScanOperator =
-                new LogicalOlapScanOperator(table,
-                        ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
-                        ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate),
-                        null, -1, null,
-                        ((OlapTable) table).getBaseIndexId(),
-                        partitionIds,
-                        null,
-                        false,
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        false);
+                    new LogicalOlapScanOperator(table,
+                                ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
+                                ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate),
+                                null, -1, null,
+                                ((OlapTable) table).getBaseIndexId(),
+                                partitionIds,
+                                null,
+                                false,
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         ColumnStatistic columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
         Assert.assertEquals(30, columnStatistic.getDistinctValuesCount(), 0.001);
@@ -396,23 +396,23 @@ public class StatisticsCalculatorTest {
 
     @Test
     public void testLogicalOlapTableScanPartitionPrune1(@Mocked CachedStatisticStorage cachedStatisticStorage)
-            throws Exception {
+                throws Exception {
         FeConstants.runningUnitTest = true;
         ColumnRefOperator idDate = columnRefFactory.create("id_date", Type.DATE, true);
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        Table table = globalStateMgr.getDb("statistics_test").getTable("test_all_type");
+        Table table = globalStateMgr.getLocalMetastore().getDb("statistics_test").getTable("test_all_type");
 
         new Expectations() {
             {
                 cachedStatisticStorage.getColumnStatistics(table, Lists.newArrayList("id_date"));
                 result = new ColumnStatistic(0, Utils.getLongFromDateTime(LocalDateTime.of(2014, 12, 01, 0, 0, 0)),
-                        0, 0, 30);
+                            0, 0, 30);
                 minTimes = 0;
 
                 cachedStatisticStorage.getColumnStatistic(table, "id_date");
                 result = new ColumnStatistic(0, Utils.getLongFromDateTime(LocalDateTime.of(2014, 12, 01, 0, 0, 0)),
-                        0, 0, 30);
+                            0, 0, 30);
                 minTimes = 0;
             }
         };
@@ -420,95 +420,96 @@ public class StatisticsCalculatorTest {
         Collection<Partition> partitions = ((OlapTable) table).getPartitions();
         // select partition p1
         List<Long> partitionIds = partitions.stream().filter(partition -> partition.getName().equalsIgnoreCase("p1")).
-                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
         for (Partition partition : partitions) {
             partition.getBaseIndex().setRowCount(1000);
         }
 
         LogicalOlapScanOperator olapScanOperator =
-                new LogicalOlapScanOperator(table,
-                        ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
-                        ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate),
-                        null, -1,
-                        new BinaryPredicateOperator(BinaryType.EQ,
-                                idDate, ConstantOperator.createDate(LocalDateTime.of(2013, 12, 30, 0, 0, 0))),
-                        ((OlapTable) table).getBaseIndexId(),
-                        partitionIds,
-                        null,
-                        false,
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        false);
+                    new LogicalOlapScanOperator(table,
+                                ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
+                                ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate),
+                                null, -1,
+                                new BinaryPredicateOperator(BinaryType.EQ,
+                                            idDate, ConstantOperator.createDate(LocalDateTime.of(2013, 12, 30, 0, 0, 0))),
+                                ((OlapTable) table).getBaseIndexId(),
+                                partitionIds,
+                                null,
+                                false,
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         // partition column count distinct values is 30 in table level, after partition prune,
         // the column statistic distinct values is 10, so the estimate row count is 1000 * (1/10)
         Assert.assertEquals(100, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         ColumnStatistic columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
         Assert.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2013, 12, 30, 0, 0, 0)),
-                columnStatistic.getMaxValue(), 0.001);
+                    columnStatistic.getMaxValue(), 0.001);
 
         // select partition p2, p3
         partitionIds.clear();
         partitionIds = partitions.stream().filter(partition -> !(partition.getName().equalsIgnoreCase("p1"))).
-                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
         olapScanOperator =
-                new LogicalOlapScanOperator(table,
-                        ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
-                        ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate),
-                        null, -1, null, ((OlapTable) table).getBaseIndexId(),
-                        partitionIds,
-                        null,
-                        false,
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        false);
+                    new LogicalOlapScanOperator(table,
+                                ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
+                                ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate),
+                                null, -1, null, ((OlapTable) table).getBaseIndexId(),
+                                partitionIds,
+                                null,
+                                false,
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                false);
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryType.GE,
-                idDate, ConstantOperator.createDate(LocalDateTime.of(2014, 5, 1, 0, 0, 0))));
+                    idDate, ConstantOperator.createDate(LocalDateTime.of(2014, 5, 1, 0, 0, 0))));
 
         groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
         columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
 
         Assert.assertEquals(1281.4371, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         Assert.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2014, 5, 1, 0, 0, 0)),
-                columnStatistic.getMinValue(), 0.001);
+                    columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2014, 12, 1, 0, 0, 0)),
-                columnStatistic.getMaxValue(), 0.001);
+                    columnStatistic.getMaxValue(), 0.001);
         Assert.assertEquals(20, columnStatistic.getDistinctValuesCount(), 0.001);
         FeConstants.runningUnitTest = false;
     }
 
     @Test
     public void testLogicalOlapTableScanPartitionPrune2(@Mocked CachedStatisticStorage cachedStatisticStorage)
-            throws Exception {
+                throws Exception {
         FeConstants.runningUnitTest = true;
         ColumnRefOperator idDate = columnRefFactory.create("id_date", Type.DATE, true);
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table = (OlapTable) globalStateMgr.getDb("statistics_test").getTable("test_all_type_day_partition");
+        OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("statistics_test")
+                    .getTable("test_all_type_day_partition");
 
         new Expectations() {
             {
                 cachedStatisticStorage.getColumnStatistics(table, Lists.newArrayList("id_date"));
                 result = new ColumnStatistic(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 23, 0, 0, 0)),
-                        Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 25, 0, 0, 0)), 0, 0, 3);
+                            Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 25, 0, 0, 0)), 0, 0, 3);
                 minTimes = 0;
 
                 cachedStatisticStorage.getColumnStatistic(table, "id_date");
                 result = new ColumnStatistic(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 23, 0, 0, 0)),
-                        Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 25, 0, 0, 0)), 0, 0, 3);
+                            Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 25, 0, 0, 0)), 0, 0, 3);
                 minTimes = 0;
             }
         };
@@ -516,57 +517,57 @@ public class StatisticsCalculatorTest {
         Collection<Partition> partitions = table.getPartitions();
         // select partition p2
         List<Long> partitionIds = partitions.stream().filter(partition -> partition.getName().equalsIgnoreCase("p2")).
-                mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
+                    mapToLong(partition -> partition.getId()).boxed().collect(Collectors.toList());
         for (Partition partition : partitions) {
             partition.getBaseIndex().setRowCount(1000);
         }
 
         LogicalOlapScanOperator olapScanOperator =
-                new LogicalOlapScanOperator(table,
-                        ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
-                        ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate), null, -1, null,
-                        ((OlapTable) table).getBaseIndexId(),
-                        partitionIds,
-                        null,
-                        false,
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        false);
+                    new LogicalOlapScanOperator(table,
+                                ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
+                                ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate), null, -1, null,
+                                ((OlapTable) table).getBaseIndexId(),
+                                partitionIds,
+                                null,
+                                false,
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         statisticsCalculator.estimatorStats();
 
         Assert.assertEquals(1000, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         ColumnStatistic columnStatistic = expressionContext.getStatistics().getColumnStatistic(idDate);
         Assert.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 24, 0, 0, 0)),
-                columnStatistic.getMinValue(), 0.001);
+                    columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 25, 0, 0, 0)),
-                columnStatistic.getMaxValue(), 0.001);
+                    columnStatistic.getMaxValue(), 0.001);
         Assert.assertEquals(1, columnStatistic.getDistinctValuesCount(), 0.001);
 
         // select partition p2, p3
         partitionIds.clear();
         partitionIds = partitions.stream().filter(partition -> !(partition.getName().equalsIgnoreCase("p1"))).
-                mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+                    mapToLong(Partition::getId).boxed().collect(Collectors.toList());
         olapScanOperator =
-                new LogicalOlapScanOperator(table,
-                        ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
-                        ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate), null, -1, null,
-                        ((OlapTable) table).getBaseIndexId(),
-                        partitionIds,
-                        null,
-                        false,
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        Lists.newArrayList(),
-                        false);
+                    new LogicalOlapScanOperator(table,
+                                ImmutableMap.of(idDate, new Column("id_date", Type.DATE, true)),
+                                ImmutableMap.of(new Column("id_date", Type.DATE, true), idDate), null, -1, null,
+                                ((OlapTable) table).getBaseIndexId(),
+                                partitionIds,
+                                null,
+                                false,
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                Lists.newArrayList(),
+                                false);
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryType.GE,
-                idDate, ConstantOperator.createDate(LocalDateTime.of(2020, 04, 24, 0, 0, 0))));
+                    idDate, ConstantOperator.createDate(LocalDateTime.of(2020, 04, 24, 0, 0, 0))));
 
         groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
@@ -577,9 +578,9 @@ public class StatisticsCalculatorTest {
         // has two partitions
         Assert.assertEquals(2000, expressionContext.getStatistics().getOutputRowCount(), 0.001);
         Assert.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 24, 0, 0, 0)),
-                columnStatistic.getMinValue(), 0.001);
+                    columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(Utils.getLongFromDateTime(LocalDateTime.of(2020, 4, 26, 0, 0, 0)),
-                columnStatistic.getMaxValue(), 0.001);
+                    columnStatistic.getMaxValue(), 0.001);
         Assert.assertEquals(2, columnStatistic.getDistinctValuesCount(), 0.001);
         FeConstants.runningUnitTest = false;
     }
@@ -622,21 +623,21 @@ public class StatisticsCalculatorTest {
         columnRefFactory.updateColumnToRelationIds(v6.getId(), 4);
         // on predicate : t0.v1 = t1.v3 and t0.v2 = t1.v4
         BinaryPredicateOperator eqOnPredicate1 =
-                new BinaryPredicateOperator(BinaryType.EQ, v1, v3);
+                    new BinaryPredicateOperator(BinaryType.EQ, v1, v3);
         BinaryPredicateOperator eqOnPredicate2 =
-                new BinaryPredicateOperator(BinaryType.EQ, v2, v4);
+                    new BinaryPredicateOperator(BinaryType.EQ, v2, v4);
         BinaryPredicateOperator eqOnPredicate3 =
-                new BinaryPredicateOperator(BinaryType.EQ, v5, v6);
+                    new BinaryPredicateOperator(BinaryType.EQ, v5, v6);
         // construct group expression
         LogicalJoinOperator joinOperator =
-                new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
-                        CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, eqOnPredicate2));
+                    new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
+                                CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, eqOnPredicate2));
         GroupExpression groupExpression =
-                new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
+                    new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         ExpressionContext expressionContext = new ExpressionContext(groupExpression);
         StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         // use middle ground method to estimate
         ConnectContext.get().getSessionVariable().setUseCorrelatedJoinEstimate(false);
         statisticsCalculator.estimatorStats();
@@ -657,13 +658,13 @@ public class StatisticsCalculatorTest {
         // on predicate : t0.v1 = t1.v3 and t0.v2 = t2.v4 and t3.v5 = t4.v6
         // construct group expression
         joinOperator = new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
-                CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, new CompoundPredicateOperator(
-                CompoundPredicateOperator.CompoundType.AND, eqOnPredicate2, eqOnPredicate3)));
+                    CompoundPredicateOperator.CompoundType.AND, eqOnPredicate1, new CompoundPredicateOperator(
+                    CompoundPredicateOperator.CompoundType.AND, eqOnPredicate2, eqOnPredicate3)));
         groupExpression = new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         // use middle ground method to estimate
         ConnectContext.get().getSessionVariable().setUseCorrelatedJoinEstimate(false);
         statisticsCalculator.estimatorStats();
@@ -671,18 +672,18 @@ public class StatisticsCalculatorTest {
 
         // on predicate : t0.v1 = t1.v3 + t1.v4 and t0.v2 = t1.v3 + t1.v4
         BinaryPredicateOperator eqOnPredicateWithAdd1 =
-                new BinaryPredicateOperator(BinaryType.EQ, v1,
-                        new CallOperator("add", Type.BIGINT, Lists.newArrayList(v3, v4)));
+                    new BinaryPredicateOperator(BinaryType.EQ, v1,
+                                new CallOperator("add", Type.BIGINT, Lists.newArrayList(v3, v4)));
         BinaryPredicateOperator eqOnPredicateWithAdd2 =
-                new BinaryPredicateOperator(BinaryType.EQ, v2,
-                        new CallOperator("add", Type.BIGINT, Lists.newArrayList(v3, v4)));
+                    new BinaryPredicateOperator(BinaryType.EQ, v2,
+                                new CallOperator("add", Type.BIGINT, Lists.newArrayList(v3, v4)));
         joinOperator = new LogicalJoinOperator(JoinOperator.INNER_JOIN, new CompoundPredicateOperator(
-                CompoundPredicateOperator.CompoundType.AND, eqOnPredicateWithAdd1, eqOnPredicateWithAdd2));
+                    CompoundPredicateOperator.CompoundType.AND, eqOnPredicateWithAdd1, eqOnPredicateWithAdd2));
         groupExpression = new GroupExpression(joinOperator, Lists.newArrayList(childGroup1, childGroup2));
         groupExpression.setGroup(new Group(2));
         expressionContext = new ExpressionContext(groupExpression);
         statisticsCalculator = new StatisticsCalculator(expressionContext,
-                columnRefFactory, optimizerContext);
+                    columnRefFactory, optimizerContext);
         // use middle ground method to estimate
         ConnectContext.get().getSessionVariable().setUseCorrelatedJoinEstimate(false);
         statisticsCalculator.estimatorStats();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -42,10 +42,10 @@ public class CTEPlanTest extends PlanTestBase {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         globalStateMgr.setStatisticStorage(new TestStorage());
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 20000000);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 2000000);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
@@ -111,45 +111,45 @@ public class DistributedEnvPlanTestBase extends PlanTestBase {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         int scale = 100;
         connectContext.getGlobalStateMgr().setStatisticStorage(new MockTpchStatisticStorage(connectContext, scale));
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("region");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("region");
         setTableStatistics(t0, 5);
 
-        OlapTable t5 = (OlapTable) globalStateMgr.getDb("test").getTable("nation");
+        OlapTable t5 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("nation");
         setTableStatistics(t5, 25);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("supplier");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("supplier");
         setTableStatistics(t1, 10000 * scale);
 
-        OlapTable t4 = (OlapTable) globalStateMgr.getDb("test").getTable("customer");
+        OlapTable t4 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("customer");
         setTableStatistics(t4, 150000 * scale);
 
-        OlapTable t6 = (OlapTable) globalStateMgr.getDb("test").getTable("part");
+        OlapTable t6 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("part");
         setTableStatistics(t6, 200000 * scale);
 
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("partsupp");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("partsupp");
         setTableStatistics(t2, 800000 * scale);
 
-        OlapTable t3 = (OlapTable) globalStateMgr.getDb("test").getTable("orders");
+        OlapTable t3 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("orders");
         setTableStatistics(t3, 1500000 * scale);
 
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
 
-        OlapTable t8 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem_partition");
+        OlapTable t8 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem_partition");
         setTableStatistics(t8, 6000000 * scale);
 
-        OlapTable testAllType = (OlapTable) globalStateMgr.getDb("test").getTable("test_all_type");
+        OlapTable testAllType = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("test_all_type");
         setTableStatistics(testAllType, 6000000);
 
         OlapTable lineorderNewL =
-                (OlapTable) globalStateMgr.getDb("test").getTable("lineorder_new_l");
+                (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineorder_new_l");
         setTableStatistics(lineorderNewL, 1200018434);
 
-        OlapTable datesN = (OlapTable) globalStateMgr.getDb("test").getTable("dates_n");
+        OlapTable datesN = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("dates_n");
         setTableStatistics(datesN, 2556);
 
         OlapTable skewTable =
-                (OlapTable) globalStateMgr.getDb("test").getTable("skew_table");
+                (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("skew_table");
         setTableStatistics(skewTable, 10000000);
 
         UtFrameUtils.addMockBackend(10002);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -949,7 +949,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     @Test
     public void testCastDatePredicate() throws Exception {
         OlapTable lineitem =
-                (OlapTable) connectContext.getGlobalStateMgr().getDb("test").getTable("lineitem");
+                (OlapTable) connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test").getTable("lineitem");
 
         MockTpchStatisticStorage mock = new MockTpchStatisticStorage(connectContext, 100);
         connectContext.getGlobalStateMgr().setStatisticStorage(mock);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvTPCDSPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvTPCDSPlanTest.java
@@ -30,19 +30,19 @@ public class DistributedEnvTPCDSPlanTest extends TPCDSPlanTestBase {
         TPCDSPlanTest.beforeClass();
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         OlapTable customerAddress =
-                (OlapTable) globalStateMgr.getDb("test").getTable("customer_address");
+                (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("customer_address");
         setTableStatistics(customerAddress, 1000000);
 
-        OlapTable customer = (OlapTable) globalStateMgr.getDb("test").getTable("customer");
+        OlapTable customer = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("customer");
         setTableStatistics(customer, 2000000);
 
-        OlapTable storeSales = (OlapTable) globalStateMgr.getDb("test").getTable("store_sales");
+        OlapTable storeSales = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("store_sales");
         setTableStatistics(storeSales, 287997024);
 
-        OlapTable dateDim = (OlapTable) globalStateMgr.getDb("test").getTable("date_dim");
+        OlapTable dateDim = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("date_dim");
         setTableStatistics(dateDim, 73048);
 
-        OlapTable item = (OlapTable) globalStateMgr.getDb("test").getTable("item");
+        OlapTable item = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("item");
         setTableStatistics(item, 203999);
 
         UtFrameUtils.addMockBackend(10002);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -236,8 +236,8 @@ public class ExternalTableTest extends PlanTestBase {
     @Test
     public void testJoinWithMysqlTable() throws Exception {
         // set data size and row count for the olap table
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable tbl = (OlapTable) db.getTable("jointest");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "jointest");
         for (Partition partition : tbl.getPartitions()) {
             partition.updateVisibleVersion(2);
             for (MaterializedIndex mIndex : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -30,7 +30,7 @@ public class GroupingSetsTest extends PlanTestBase {
         PlanTestBase.beforeClass();
         Config.alter_scheduler_interval_millisecond = 1;
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, NUM_TABLE0_ROWS);
         FeConstants.runningUnitTest = true;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -1125,8 +1125,8 @@ public class JoinTest extends PlanTestBase {
     @Test
     public void testJoinReorderTakeEffect() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        Database db = globalStateMgr.getDb("test");
-        Table table = db.getTable("join2");
+        Database db = globalStateMgr.getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "join2");
         OlapTable olapTable1 = (OlapTable) table;
         try {
             setTableStatistics(olapTable1, 2);
@@ -1149,7 +1149,7 @@ public class JoinTest extends PlanTestBase {
     public void testJoinReorderWithWithClause() throws Exception {
         connectContext.setDatabase("test");
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        Table table = globalStateMgr.getDb("test").getTable("join2");
+        Table table = globalStateMgr.getLocalMetastore().getDb("test").getTable("join2");
         OlapTable olapTable1 = (OlapTable) table;
         try {
             setTableStatistics(olapTable1, 2);
@@ -1652,7 +1652,7 @@ public class JoinTest extends PlanTestBase {
     @Test
     public void testJoinReorderWithReanalyze() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        Table table = globalStateMgr.getDb("test").getTable("join2");
+        Table table = globalStateMgr.getLocalMetastore().getDb("test").getTable("join2");
         OlapTable olapTable1 = (OlapTable) table;
         try {
             setTableStatistics(olapTable1, 2);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -787,7 +787,7 @@ public class LimitTest extends PlanTestBase {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
 
         // We need to let some tablets have data, some tablets don't data
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         MaterializedIndex index = t0.getPartitions().stream().findFirst().get().getBaseIndex();
         LocalTablet tablets = (LocalTablet) index.getTablets().get(0);
         Replica replica = tablets.getSingleReplica();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
@@ -58,16 +58,16 @@ public class MockTpchStatisticStorage implements StatisticStorage {
 
     private void mockTpchTableStats(ConnectContext connectContext, int scale) {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        Database database = globalStateMgr.getDb("test");
+        Database database = globalStateMgr.getLocalMetastore().getDb("test");
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("region");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("region");
         rowCountStats.put(t0.getId(), Optional.of(5L));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t0.getId(), null,
-                        StatsConstants.AnalyzeType.FULL,
-                        LocalDateTime.of(2020, 1, 1, 1, 1, 1),
-                        Maps.newHashMap()));
+                StatsConstants.AnalyzeType.FULL,
+                LocalDateTime.of(2020, 1, 1, 1, 1, 1),
+                Maps.newHashMap()));
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("nation");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("nation");
         rowCountStats.put(t1.getId(), Optional.of(
                 25L));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t1.getId(), null,
@@ -75,7 +75,7 @@ public class MockTpchStatisticStorage implements StatisticStorage {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("supplier");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("supplier");
         rowCountStats.put(t2.getId(), Optional.of(
                 10000L * scale));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t2.getId(), null,
@@ -83,7 +83,7 @@ public class MockTpchStatisticStorage implements StatisticStorage {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        OlapTable t3 = (OlapTable) globalStateMgr.getDb("test").getTable("customer");
+        OlapTable t3 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("customer");
         rowCountStats.put(t3.getId(), Optional.of(
                 150000L * scale));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t3.getId(), null,
@@ -91,7 +91,7 @@ public class MockTpchStatisticStorage implements StatisticStorage {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        OlapTable t4 = (OlapTable) globalStateMgr.getDb("test").getTable("part");
+        OlapTable t4 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("part");
         rowCountStats.put(t4.getId(), Optional.of(
                 200000L * scale));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t4.getId(), null,
@@ -99,7 +99,7 @@ public class MockTpchStatisticStorage implements StatisticStorage {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        OlapTable t5 = (OlapTable) globalStateMgr.getDb("test").getTable("partsupp");
+        OlapTable t5 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("partsupp");
         rowCountStats.put(t5.getId(), Optional.of(
                 800000L * scale));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t5.getId(), null,
@@ -107,7 +107,7 @@ public class MockTpchStatisticStorage implements StatisticStorage {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        OlapTable t6 = (OlapTable) globalStateMgr.getDb("test").getTable("orders");
+        OlapTable t6 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("orders");
         rowCountStats.put(t6.getId(), Optional.of(
                 1500000L * scale));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t6.getId(), null,
@@ -115,7 +115,7 @@ public class MockTpchStatisticStorage implements StatisticStorage {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem");
         rowCountStats.put(t7.getId(), Optional.of(
                 6000000L * scale));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(database.getId(), t7.getId(), null,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -34,15 +34,15 @@ public class MultiJoinReorderTest extends PlanTestBase {
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 1);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 10);
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("t2");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t2");
         setTableStatistics(t2, 100000);
 
-        OlapTable t3 = (OlapTable) globalStateMgr.getDb("test").getTable("t3");
+        OlapTable t3 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t3");
         setTableStatistics(t3, 1000000000);
         connectContext.getSessionVariable().setMaxTransformReorderJoins(2);
         FeConstants.runningUnitTest = true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -64,16 +64,16 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         Config.alter_scheduler_interval_millisecond = 1;
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("test_all_type");
+        OlapTable table2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("test_all_type");
         setTableStatistics(table2, NUM_TABLE2_ROWS);
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, NUM_TABLE0_ROWS);
 
-        OlapTable colocateT0 = (OlapTable) globalStateMgr.getDb("test").getTable("colocate_t0");
+        OlapTable colocateT0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("colocate_t0");
         setTableStatistics(colocateT0, NUM_TABLE0_ROWS);
 
-        OlapTable lineitem = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem");
+        OlapTable lineitem = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem");
         setTableStatistics(lineitem, NUM_TABLE0_ROWS * NUM_TABLE0_ROWS);
 
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
@@ -181,9 +181,9 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     public void testCrossJoinBroadCast() throws Exception {
         // check cross join generate plan without exception
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("test_all_type");
+        OlapTable table2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("test_all_type");
         setTableStatistics(table2, 20000000);
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 20000000);
 
         String sql = "select t1a,v1 from test_all_type, t0";
@@ -424,9 +424,9 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table1 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable table1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(table1, 10000);
-        OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("test_all_type");
+        OlapTable table2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("test_all_type");
         setTableStatistics(table2, 5000);
         String sql = "SELECT v2,t1d from t0 join test_all_type on t0.v2 = test_all_type.t1d ;";
         String plan = getFragmentPlan(sql);
@@ -469,7 +469,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testBroadcastInnerJoinWithCommutativity() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(table, 1000);
         String sql = "SELECT * from t0 join test_all_type on t0.v1 = test_all_type.t1d ;";
         String plan = getFragmentPlan(sql);
@@ -731,9 +731,9 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testThriftWaitingNodeIds() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 10000000);
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 10000);
 
         String sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5 and t0.v1 = 1 and t1.v5 = 2";
@@ -746,11 +746,11 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     public void testIntersectReorder() throws Exception {
         // check cross join generate plan without exception
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 1000);
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 100);
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("t2");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t2");
         setTableStatistics(t2, 1);
 
         String sql = "select v1 from t0 intersect select v7 from t2 intersect select v4 from t1";
@@ -774,10 +774,10 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testNotPushDownRuntimeFilterToSortNode() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 10);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 1000000000L);
 
         String sql = "select t0.v1 from (select v4 from t1 order by v4 limit 1000000000) as t1x " +
@@ -809,10 +809,10 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         connectContext.getSessionVariable().setGlobalRuntimeFilterBuildMaxSize(0);
         connectContext.getSessionVariable().setGlobalRuntimeFilterProbeMinSize(0);
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 10000000L);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 1000000000L);
 
         String sql = "select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 and t0.v3 = t1.v6";
@@ -835,13 +835,13 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         connectContext.getSessionVariable().setGlobalRuntimeFilterBuildMaxSize(0);
         connectContext.getSessionVariable().setGlobalRuntimeFilterProbeMinSize(0);
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 10000000L);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 10000000L);
 
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("t2");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t2");
         setTableStatistics(t2, 10000000L);
 
         String sql = "select * from (select t1.v5 as v5, t0.v3 as v3 from t0 join[shuffle] t1 on t0.v2 = " +
@@ -878,11 +878,11 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     public void testPushDownRuntimeFilterAcrossSetOperationNode() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 1000);
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 100);
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("t2");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t2");
         List<OlapTable> tables = new ArrayList<>(Arrays.asList(t0, t1, t2));
         List<String> tabletIdsStrList = new ArrayList<>();
         tables.forEach(olapTable -> tabletIdsStrList.add(Joiner.on(",")
@@ -1051,8 +1051,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         connectContext.getSessionVariable().setEnablePipelineEngine(true);
         connectContext.getSessionVariable().setCboCTERuseRatio(0);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("t2");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t2");
         List<OlapTable> tables = new ArrayList<>(Arrays.asList(t1, t2));
         List<String> tabletIdsStrList = new ArrayList<>();
         tables.forEach(olapTable -> tabletIdsStrList.add(Joiner.on(",")
@@ -1119,8 +1119,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testOverflowFilterOnColocateJoin() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("colocate1");
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("colocate2");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("colocate1");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("colocate2");
 
         StatisticStorage ss = globalStateMgr.getCurrentState().getStatisticStorage();
         new Expectations(ss) {
@@ -1150,8 +1150,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testPruneShuffleColumns() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
 
         StatisticStorage ss = globalStateMgr.getCurrentState().getStatisticStorage();
         new Expectations(ss) {
@@ -1227,7 +1227,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testToDateToDays() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("test_all_type");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("test_all_type");
         StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
         new Expectations(ss) {
             {
@@ -1249,8 +1249,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testMultiJoinColumnPruneShuffleColumnsAndGRF() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
 
         StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
         new Expectations(ss) {
@@ -1973,7 +1973,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Ignore
     public void testDeepTreePredicate() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("test_dict");
+        OlapTable table2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("test_dict");
         setTableStatistics(table2, 20000000);
 
         String sql = getSQLFile("optimized-plan/large_predicate");
@@ -1987,12 +1987,12 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testJoinUnreorder() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(t0, 10000000);
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
         setTableStatistics(t1, 10000);
 
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("t2");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t2");
         setTableStatistics(t1, 10);
 
         String sql = "Select * " +
@@ -2034,7 +2034,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testPruneLimit() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem_partition");
+        OlapTable table2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem_partition");
         setTableStatistics(table2, 10);
 
         new MockUp<LocalTablet>() {
@@ -2054,7 +2054,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     @Test
     public void testPruneInvalidPredicate() throws Exception {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem_partition");
+        OlapTable table2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem_partition");
         setTableStatistics(table2, 10);
 
         new MockUp<LocalTablet>() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -967,7 +967,7 @@ public class PlanTestBase extends PlanTestNoneDBBase {
     public static void cleanupEphemeralMVs(StarRocksAssert starRocksAssert, long startTime) throws Exception {
         String currentDb = starRocksAssert.getCtx().getDatabase();
         if (StringUtils.isNotEmpty(currentDb)) {
-            Database testDb = GlobalStateMgr.getCurrentState().getDb(currentDb);
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(currentDb);
             for (MaterializedView mv : ListUtils.emptyIfNull(testDb.getMaterializedViews())) {
                 if (startTime > 0 && mv.getCreateTime() > startTime) {
                     starRocksAssert.dropMaterializedView(mv.getName());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -806,7 +806,7 @@ public class PlanTestNoneDBBase {
 
     public Table getTable(String t) {
         GlobalStateMgr globalStateMgr = starRocksAssert.getCtx().getGlobalStateMgr();
-        return globalStateMgr.getDb("test").getTable(t);
+        return globalStateMgr.getLocalMetastore().getDb("test").getTable(t);
     }
 
     public OlapTable getOlapTable(String t) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -42,28 +42,28 @@ public class SkewJoinTest extends PlanTestBase {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("region");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("region");
         setTableStatistics(t0, 5);
 
-        OlapTable t5 = (OlapTable) globalStateMgr.getDb("test").getTable("nation");
+        OlapTable t5 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("nation");
         setTableStatistics(t5, 25);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("supplier");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("supplier");
         setTableStatistics(t1, 10000 * scale);
 
-        OlapTable t4 = (OlapTable) globalStateMgr.getDb("test").getTable("customer");
+        OlapTable t4 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("customer");
         setTableStatistics(t4, 150000 * scale);
 
-        OlapTable t6 = (OlapTable) globalStateMgr.getDb("test").getTable("part");
+        OlapTable t6 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("part");
         setTableStatistics(t6, 200000 * scale);
 
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("partsupp");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("partsupp");
         setTableStatistics(t2, 800000 * scale);
 
-        OlapTable t3 = (OlapTable) globalStateMgr.getDb("test").getTable("orders");
+        OlapTable t3 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("orders");
         setTableStatistics(t3, 1500000 * scale);
 
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
 
         starRocksAssert.withTable("create table struct_tbl(c0 INT, " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
@@ -43,7 +43,7 @@ public class TPCHPlanTest extends PlanTestBase {
     @Test
     public void testJoin() {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        OlapTable table1 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        OlapTable table1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
         setTableStatistics(table1, 10000);
         runFileUnitTest("optimized-plan/join");
         setTableStatistics(table1, 0);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
@@ -45,28 +45,28 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
         connectContext.getGlobalStateMgr().setStatisticStorage(new MockHistogramStatisticStorage(scale));
         connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("region");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("region");
         setTableStatistics(t0, 5);
 
-        OlapTable t5 = (OlapTable) globalStateMgr.getDb("test").getTable("nation");
+        OlapTable t5 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("nation");
         setTableStatistics(t5, 25);
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("supplier");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("supplier");
         setTableStatistics(t1, 10000 * scale);
 
-        OlapTable t4 = (OlapTable) globalStateMgr.getDb("test").getTable("customer");
+        OlapTable t4 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("customer");
         setTableStatistics(t4, 150000 * scale);
 
-        OlapTable t6 = (OlapTable) globalStateMgr.getDb("test").getTable("part");
+        OlapTable t6 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("part");
         setTableStatistics(t6, 200000 * scale);
 
-        OlapTable t2 = (OlapTable) globalStateMgr.getDb("test").getTable("partsupp");
+        OlapTable t2 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("partsupp");
         setTableStatistics(t2, 800000 * scale);
 
-        OlapTable t3 = (OlapTable) globalStateMgr.getDb("test").getTable("orders");
+        OlapTable t3 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("orders");
         setTableStatistics(t3, 1500000 * scale);
 
-        OlapTable t7 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem");
+        OlapTable t7 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/CacheLoaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/CacheLoaderTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.Bucket;
 import com.starrocks.sql.optimizer.statistics.ColumnBasicStatsCacheLoader;
 import com.starrocks.sql.optimizer.statistics.ColumnHistogramStatsCacheLoader;
@@ -62,7 +63,7 @@ public class CacheLoaderTest {
 
     @Test
     public void testCovertBasicStatistics() {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
         OlapTable table = (OlapTable) db.getTable("t0");
         ColumnBasicStatsCacheLoader basicStatsCacheLoader
                 = Deencapsulation.newInstance(ColumnBasicStatsCacheLoader.class);
@@ -103,8 +104,8 @@ public class CacheLoaderTest {
 
     @Test
     public void testCovertHistogramStatistics() {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t0");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
         ColumnHistogramStatsCacheLoader columnHistogramStatsCacheLoader
                 = Deencapsulation.newInstance(ColumnHistogramStatsCacheLoader.class);
 
@@ -146,8 +147,8 @@ public class CacheLoaderTest {
 
     @Test
     public void testCovertHistogramStatisticsDate() {
-        Database db = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) db.getTable("t0");
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
         ColumnHistogramStatsCacheLoader columnHistogramStatsCacheLoader
                 = Deencapsulation.newInstance(ColumnHistogramStatsCacheLoader.class);
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -32,8 +32,8 @@ public class StatisticExecutorTest extends PlanTestBase {
     @Test
     public void testEmpty() throws Exception {
         StatisticExecutor statisticExecutor = new StatisticExecutor();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable olapTable = (OlapTable) db.getTable("t0");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
 
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(db.getId(), olapTable.getId(), null,
                 StatsConstants.AnalyzeType.FULL,
@@ -48,7 +48,7 @@ public class StatisticExecutorTest extends PlanTestBase {
     @Test
     public void testDroppedDB() throws Exception {
         StatisticExecutor statisticExecutor = new StatisticExecutor();
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(db.getId(), 1000, null,
                 StatsConstants.AnalyzeType.FULL,

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -95,7 +95,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0_stats");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0_stats");
         t0StatsTableId = t0.getId();
         Partition partition = new ArrayList<>(t0.getPartitions()).get(0);
         partition.updateVisibleVersion(2, t0UpdateTime
@@ -114,7 +114,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable t1 = (OlapTable) globalStateMgr.getDb("test").getTable("t1_stats");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1_stats");
         new ArrayList<>(t1.getPartitions()).get(0).updateVisibleVersion(2);
         setTableStatistics(t1, 20000000);
 
@@ -142,7 +142,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "\"replication_num\" = \"1\",\n" +
                 "\"in_memory\" = \"false\"\n" +
                 ");");
-        OlapTable t0p = (OlapTable) globalStateMgr.getDb("test").getTable("t0_stats_partition");
+        OlapTable t0p = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0_stats_partition");
         new ArrayList<>(t0p.getPartitions()).get(0).updateVisibleVersion(2);
         setTableStatistics(t0p, 20000000);
 
@@ -160,7 +160,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable tps = (OlapTable) globalStateMgr.getDb("stats").getTable("tprimary_stats");
+        OlapTable tps = (OlapTable) globalStateMgr.getLocalMetastore().getDb("stats").getTable("tprimary_stats");
         new ArrayList<>(tps.getPartitions()).get(0).updateVisibleVersion(2);
         setTableStatistics(tps, 20000000);
 
@@ -176,7 +176,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable tus = (OlapTable) globalStateMgr.getDb("stats").getTable("tunique_stats");
+        OlapTable tus = (OlapTable) globalStateMgr.getLocalMetastore().getDb("stats").getTable("tunique_stats");
         new ArrayList<>(tus.getPartitions()).get(0).updateVisibleVersion(2);
         setTableStatistics(tps, 20000000);
 
@@ -191,7 +191,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable tcount = (OlapTable) globalStateMgr.getDb("stats").getTable("tcount");
+        OlapTable tcount = (OlapTable) globalStateMgr.getLocalMetastore().getDb("stats").getTable("tcount");
         new ArrayList<>(tcount.getPartitions()).get(0).updateVisibleVersion(2);
         setTableStatistics(tcount, 20000000);
 
@@ -206,7 +206,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "    \"replication_num\" = \"1\"\n" +
                 ");";
         starRocksAssert.withTable(createStructTableSql);
-        OlapTable structTable = (OlapTable) globalStateMgr.getDb("stats").getTable("struct_a");
+        OlapTable structTable = (OlapTable) globalStateMgr.getLocalMetastore().getDb("stats").getTable("struct_a");
         new ArrayList<>(structTable.getPartitions()).get(0).updateVisibleVersion(2);
         setTableStatistics(structTable, 20000000);
     }
@@ -239,7 +239,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeDB() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         List<StatisticsCollectJob> jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
                 new NativeAnalyzeJob(db.getId(), StatsConstants.DEFAULT_ALL_ID, null, null,
                         StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
@@ -258,7 +258,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeTable() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         List<StatisticsCollectJob> jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
                 new NativeAnalyzeJob(testDb.getId(), t0StatsTableId, null, null,
                         StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
@@ -271,8 +271,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assert.assertEquals("t0_stats", fullStatisticsCollectJob.getTable().getName());
         Assert.assertEquals("[v1, v2, v3, v4, v5]", fullStatisticsCollectJob.getColumnNames().toString());
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("stats");
-        Table table = db.getTable("tprimary_stats");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("stats");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tprimary_stats");
         jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
                 new NativeAnalyzeJob(db.getId(), table.getId(), null, null,
                         StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
@@ -285,7 +285,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assert.assertEquals("tprimary_stats", fullStatisticsCollectJob.getTable().getName());
         Assert.assertEquals("[pk, v1, v2]", fullStatisticsCollectJob.getColumnNames().toString());
 
-        table = db.getTable("tunique_stats");
+        table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tunique_stats");
         jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
                 new NativeAnalyzeJob(db.getId(), table.getId(), null, null,
                         StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
@@ -301,8 +301,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeStructSubFiled() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("stats");
-        Table table = db.getTable("struct_a");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("stats");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "struct_a");
         List<StatisticsCollectJob> jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
                 new NativeAnalyzeJob(db.getId(), table.getId(), ImmutableList.of("b.a", "b.c", "d.c.a"),
                         ImmutableList.of(Type.INT, Type.INT, Type.INT),
@@ -319,7 +319,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeColumn() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         List<StatisticsCollectJob> jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
                 new NativeAnalyzeJob(db.getId(), t0StatsTableId, Lists.newArrayList("v2"),
                         Lists.newArrayList(Type.BIGINT),
@@ -335,7 +335,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeColumnSample() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         List<StatisticsCollectJob> jobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
                 new NativeAnalyzeJob(db.getId(), t0StatsTableId, Lists.newArrayList("v2"),
                         Lists.newArrayList(Type.BIGINT),
@@ -351,8 +351,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeColumnSample2() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable olapTable = (OlapTable) db.getTable("t0_stats");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
 
         BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), olapTable.getId(), null,
                 StatsConstants.AnalyzeType.SAMPLE,
@@ -396,8 +397,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeHistogram() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        OlapTable olapTable = (OlapTable) db.getTable("t0_stats");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
         long dbid = db.getId();
 
         Map<String, String> properties = new HashMap<>();
@@ -461,7 +463,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testNativeAnalyzeJob() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         NativeAnalyzeJob nativeAnalyzeJob = new NativeAnalyzeJob(testDb.getId(), t0StatsTableId, null, null,
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
@@ -486,7 +488,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         new MockUp<FullStatisticsCollectJob>() {
             @Mock
-            public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {}
+            public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+            }
         };
 
         nativeAnalyzeJob.run(statsConnectCtx, statisticExecutor);
@@ -499,8 +502,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("stats");
-        Table table = db.getTable("tprimary_stats");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("stats");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tprimary_stats");
         nativeAnalyzeJob = new NativeAnalyzeJob(db.getId(), table.getId(), null, null,
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
                 Maps.newHashMap(),
@@ -557,7 +560,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         new MockUp<ExternalFullStatisticsCollectJob>() {
             @Mock
-            public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {}
+            public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+            }
         };
 
         externalAnalyzeJob.run(statsConnectCtx, statisticExecutor);
@@ -869,7 +873,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     @Test
     public void testFullStatisticsBuildCollectSQLList() {
         OlapTable t0p = (OlapTable) connectContext.getGlobalStateMgr()
-                .getDb("test").getTable("t0_stats_partition");
+                .getLocalMetastore().getDb("test").getTable("t0_stats_partition");
         int i = 1;
         for (Partition p : t0p.getAllPartitions()) {
             p.updateVisibleVersion(2);
@@ -877,8 +881,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             i++;
         }
 
-        Database database = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) database.getTable("t0_stats_partition");
+        Database database = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(database.getFullName(), "t0_stats_partition");
         List<Long> partitionIdList =
                 table.getAllPartitions().stream().map(Partition::getId).collect(Collectors.toList());
 
@@ -919,12 +924,12 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("hive0",
-                database,
-                table, null,
-                Lists.newArrayList("c1", "c2", "c3", "par_col"),
-                StatsConstants.AnalyzeType.FULL,
-                StatsConstants.ScheduleType.ONCE,
-                Maps.newHashMap());
+                        database,
+                        table, null,
+                        Lists.newArrayList("c1", "c2", "c3", "par_col"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
         List<List<String>> collectSqlList = collectJob.buildCollectSQLList(1);
         Assert.assertEquals(12, collectSqlList.size());
 
@@ -1191,9 +1196,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     @Test
     public void testExcludeStatistics() {
         OlapTable table = (OlapTable) connectContext.getGlobalStateMgr()
-                .getDb("test").getTable("t0_stats_partition");
+                .getLocalMetastore().getDb("test").getTable("t0_stats_partition");
 
-        Database database = connectContext.getGlobalStateMgr().getDb("test");
+        Database database = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
 
         NativeAnalyzeJob job = new NativeAnalyzeJob(StatsConstants.DEFAULT_ALL_ID, StatsConstants.DEFAULT_ALL_ID,
                 null, null,
@@ -1244,8 +1249,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testCount() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("stats");
-        OlapTable olapTable = (OlapTable) db.getTable("tcount");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("stats");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tcount");
         long dbid = db.getId();
 
         SampleStatisticsCollectJob sampleStatisticsCollectJob = new SampleStatisticsCollectJob(
@@ -1268,7 +1274,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testAnalyzeBeforeUpdate() {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         NativeAnalyzeJob job = new NativeAnalyzeJob(db.getId(), t0StatsTableId, null, null,
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
                 Maps.newHashMap(),
@@ -1319,7 +1325,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         BasicStatsMeta execMeta1 = new BasicStatsMeta(db.getId(), t0StatsTableId, null,
                 StatsConstants.AnalyzeType.FULL,
                 now.minusSeconds(Config.statistic_auto_collect_large_table_interval).minusHours(1),
@@ -1383,7 +1389,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         BasicStatsMeta execMeta1 = new BasicStatsMeta(db.getId(), t0StatsTableId, null,
                 StatsConstants.AnalyzeType.FULL,
                 now.minusSeconds(Config.statistic_auto_collect_large_table_interval).minusHours(1),
@@ -1443,7 +1449,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             }
         };
 
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         BasicStatsMeta execMeta = new BasicStatsMeta(db.getId(), t0StatsTableId, null,
                 StatsConstants.AnalyzeType.FULL,
                 now.minusSeconds(Config.statistic_auto_collect_large_table_interval).minusHours(1),

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -71,7 +71,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0_stats");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0_stats");
         Partition partition = new ArrayList<>(t0.getPartitions()).get(0);
         partition.updateVisibleVersion(2, LocalDateTime.of(2022, 1, 1, 1, 1, 1)
                 .atZone(Clock.systemDefaultZone().getZone()).toEpochSecond() * 1000);
@@ -87,8 +87,9 @@ public class StatisticsExecutorTest extends PlanTestBase {
             }
         };
 
-        Database database = connectContext.getGlobalStateMgr().getDb("test");
-        OlapTable table = (OlapTable) database.getTable("t0_stats");
+        Database database = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t0_stats");
         List<Long> partitionIdList =
                 table.getAllPartitions().stream().map(Partition::getId).collect(Collectors.toList());
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -121,14 +121,14 @@ public class StatisticsSQLTest extends PlanTestBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
-        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("stat0");
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("stat0");
         t0StatsTableId = t0.getId();
     }
 
     @Test
     public void testSampleStatisticsSQL() throws Exception {
-        Table t0 = GlobalStateMgr.getCurrentState().getDb("test").getTable("stat0");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("stat0");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> columnNames = Lists.newArrayList("v3", "j1", "s1");
         List<Type> columnTypes = Lists.newArrayList(Type.BIGINT, Type.JSON, Type.STRING);
@@ -159,8 +159,8 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testFullStatisticsSQL() throws Exception {
-        Table t0 = GlobalStateMgr.getCurrentState().getDb("test").getTable("stat0");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("stat0");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         List<Long> pids = t0.getPartitions().stream().map(Partition::getId).collect(Collectors.toList());
 
         List<String> columnNames = Lists.newArrayList("j1", "s1");
@@ -183,8 +183,8 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testFullStatisticsSQLWithStruct() throws Exception {
-        Table t0 = GlobalStateMgr.getCurrentState().getDb("test").getTable("struct_a");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("struct_a");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         List<Long> pids = t0.getPartitions().stream().map(Partition::getId).collect(Collectors.toList());
 
         List<String> columnNames = Lists.newArrayList("b.a", "b.c", "d.c.a");
@@ -207,8 +207,8 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testHistogramStatisticsSQLWithStruct() throws Exception {
-        Table t0 = GlobalStateMgr.getCurrentState().getDb("test").getTable("struct_a");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("struct_a");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         List<String> columnNames = Lists.newArrayList("b.a", "b.c", "d.c.a");
         HistogramStatisticsCollectJob histogramStatisticsCollectJob = new HistogramStatisticsCollectJob(
@@ -269,8 +269,8 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testEscapeFullSQL() throws Exception {
-        Table t0 = GlobalStateMgr.getCurrentState().getDb("test").getTable("escape0['abc']");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("escape0['abc']");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         List<Long> pids = t0.getPartitions().stream().map(Partition::getId).collect(Collectors.toList());
 
         List<String> columnNames = t0.getColumns().stream().map(Column::getName).collect(Collectors.toList());
@@ -293,8 +293,8 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testEscapeSampleSQL() throws Exception {
-        Table t0 = GlobalStateMgr.getCurrentState().getDb("test").getTable("escape0['abc']");
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("escape0['abc']");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         for (Column column : t0.getColumns()) {
             if (!column.getType().canStatistic()) {
@@ -414,7 +414,7 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testQuota() {
-        Table t0 = GlobalStateMgr.getCurrentState().getDb("test").getTable("complex_table");
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("complex_table");
         assertContains(StatisticUtils.quoting(t0, "v2.a2.b2['+']"), "`v2.a2.b2['+']`");
         assertContains(StatisticUtils.quoting(t0, "struct_a.c3.d3"), "`struct_a.c3.d3`");
         assertContains(StatisticUtils.quoting(t0, "struct_a.c3.d3.struct_b"), "`struct_a.c3.d3`.`struct_b`");

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -315,7 +315,7 @@ public class SystemInfoServiceTest {
 
         Assert.assertEquals(10L, version.get());
     }
-    
+
     @Test
     public void testGetHostAndPort() {
         String ipv4 = "192.168.1.2:9050";

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -116,14 +116,14 @@ public class GlobalTransactionMgrTest {
     private static GlobalStateMgr slaveGlobalStateMgr;
 
     private TransactionState.TxnCoordinator transactionSource =
-            new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "localfe");
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "localfe");
 
     private TransactionState.TxnCoordinator transactionSourceBe =
-            new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "localbe");
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "localbe");
 
     @Before
     public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException, NoSuchMethodException, SecurityException {
+                InvocationTargetException, NoSuchMethodException, SecurityException {
         fakeEditLog = new FakeEditLog();
         fakeGlobalStateMgr = new FakeGlobalStateMgr();
         fakeTransactionIDGenerator = new FakeTransactionIDGenerator();
@@ -143,15 +143,15 @@ public class GlobalTransactionMgrTest {
 
     @Test
     public void testBeginTransaction() throws LabelAlreadyUsedException, AnalysisException,
-            RunningTxnExceedException, DuplicatedRequestException {
+                RunningTxnExceedException, DuplicatedRequestException {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         long transactionId = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         TransactionState transactionState =
-                masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId);
+                    masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId);
         assertNotNull(transactionState);
         assertEquals(transactionId, transactionState.getTransactionId());
         assertEquals(TransactionStatus.PREPARE, transactionState.getTransactionStatus());
@@ -161,20 +161,21 @@ public class GlobalTransactionMgrTest {
 
     @Test
     public void testBeginTransactionWithSameLabel() throws LabelAlreadyUsedException, AnalysisException,
-            RunningTxnExceedException, DuplicatedRequestException {
+                RunningTxnExceedException, DuplicatedRequestException {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         long transactionId = 0;
         try {
             transactionId = masterTransMgr
-                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                            GlobalStateMgrTestUtil.testTxnLable1,
-                            transactionSource,
-                            LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                        .beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                                    Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                    GlobalStateMgrTestUtil.testTxnLable1,
+                                    transactionSource,
+                                    LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         } catch (AnalysisException | LabelAlreadyUsedException e) {
             e.printStackTrace();
         }
         TransactionState transactionState =
-                masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId);
+                    masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId);
         assertNotNull(transactionState);
         assertEquals(transactionId, transactionState.getTransactionId());
         assertEquals(TransactionStatus.PREPARE, transactionState.getTransactionStatus());
@@ -183,10 +184,11 @@ public class GlobalTransactionMgrTest {
 
         try {
             transactionId = masterTransMgr
-                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                            GlobalStateMgrTestUtil.testTxnLable1,
-                            transactionSource,
-                            LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                        .beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                                    Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                    GlobalStateMgrTestUtil.testTxnLable1,
+                                    transactionSource,
+                                    LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         } catch (Exception e) {
             // TODO: handle exception
         }
@@ -197,36 +199,36 @@ public class GlobalTransactionMgrTest {
     public void testCommitTransaction1() throws UserException {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         long transactionId = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
         TabletCommitInfo tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId1);
+                    GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo2 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId2);
+                    GlobalStateMgrTestUtil.testBackendId2);
         TabletCommitInfo tabletCommitInfo3 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId3);
+                    GlobalStateMgrTestUtil.testBackendId3);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
-                Lists.newArrayList(), null);
+                    Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         // check status is committed
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
         // check replica version
-        Partition testPartition =
-                masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1).getTable(GlobalStateMgrTestUtil.testTableId1)
-                        .getPartition(GlobalStateMgrTestUtil.testPartition1);
+        Partition testPartition = masterGlobalStateMgr.getLocalMetastore()
+                    .getTable(GlobalStateMgrTestUtil.testDbId1, GlobalStateMgrTestUtil.testTableId1)
+                    .getPartition(GlobalStateMgrTestUtil.testPartition1);
         // check partition version
         assertEquals(GlobalStateMgrTestUtil.testStartVersion, testPartition.getVisibleVersion());
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 2, testPartition.getNextVersion());
         // check partition next version
         LocalTablet tablet = (LocalTablet) testPartition.getIndex(GlobalStateMgrTestUtil.testIndexId1)
-                .getTablet(GlobalStateMgrTestUtil.testTabletId1);
+                    .getTablet(GlobalStateMgrTestUtil.testTabletId1);
         for (Replica replica : tablet.getImmutableReplicas()) {
             assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica.getVersion());
         }
@@ -242,20 +244,20 @@ public class GlobalTransactionMgrTest {
         TransactionState transactionState = null;
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         long transactionId = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction with 1,2 success
         TabletCommitInfo tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId1);
+                    GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo2 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId2);
+                    GlobalStateMgrTestUtil.testBackendId2);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
-                Lists.newArrayList(), null);
+                    Lists.newArrayList(), null);
 
         // follower globalStateMgr replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -266,19 +268,19 @@ public class GlobalTransactionMgrTest {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         // commit another transaction with 1,3 success
         long transactionId2 = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable2,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable2,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo3 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId3);
+                    GlobalStateMgrTestUtil.testBackendId3);
         transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
             masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
-                    Lists.newArrayList(), null);
+                        Lists.newArrayList(), null);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId2);
@@ -287,14 +289,15 @@ public class GlobalTransactionMgrTest {
         }
         // check replica version
         Partition testPartition =
-                masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1).getTable(GlobalStateMgrTestUtil.testTableId1)
-                        .getPartition(GlobalStateMgrTestUtil.testPartition1);
+                    masterGlobalStateMgr.getLocalMetastore()
+                                .getTable(GlobalStateMgrTestUtil.testDbId1, GlobalStateMgrTestUtil.testTableId1)
+                                .getPartition(GlobalStateMgrTestUtil.testPartition1);
         // check partition version
         assertEquals(GlobalStateMgrTestUtil.testStartVersion, testPartition.getVisibleVersion());
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 2, testPartition.getNextVersion());
         // check partition next version
         LocalTablet tablet = (LocalTablet) testPartition.getIndex(GlobalStateMgrTestUtil.testIndexId1)
-                .getTablet(GlobalStateMgrTestUtil.testTabletId1);
+                    .getTablet(GlobalStateMgrTestUtil.testTabletId1);
         for (Replica replica : tablet.getImmutableReplicas()) {
             assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica.getVersion());
         }
@@ -310,19 +313,20 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
-                Lists.newArrayList(), null);
+                    Lists.newArrayList(), null);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
         // check replica version
-        testPartition = masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1).getTable(GlobalStateMgrTestUtil.testTableId1)
-                .getPartition(GlobalStateMgrTestUtil.testPartition1);
+        testPartition = masterGlobalStateMgr.getLocalMetastore()
+                    .getTable(GlobalStateMgrTestUtil.testDbId1, GlobalStateMgrTestUtil.testTableId1)
+                    .getPartition(GlobalStateMgrTestUtil.testPartition1);
         // check partition version
         assertEquals(GlobalStateMgrTestUtil.testStartVersion, testPartition.getVisibleVersion());
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 3, testPartition.getNextVersion());
         // check partition next version
         tablet = (LocalTablet) testPartition.getIndex(GlobalStateMgrTestUtil.testIndexId1)
-                .getTablet(GlobalStateMgrTestUtil.testTabletId1);
+                    .getTablet(GlobalStateMgrTestUtil.testTabletId1);
         for (Replica replica : tablet.getImmutableReplicas()) {
             assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica.getVersion());
         }
@@ -353,35 +357,35 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testCommitRoutineLoadTransaction(@Injectable TabletCommitInfo tabletCommitInfo,
                                                  @Mocked EditLog editLog)
-            throws UserException {
+                throws UserException {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
 
         TabletCommitInfo tabletCommitInfo1 =
-                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1);
+                    new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo2 =
-                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId2);
+                    new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId2);
         TabletCommitInfo tabletCommitInfo3 =
-                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId3);
+                    new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId3);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
 
         KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L, "host:port",
-                "topic");
+                    "topic");
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList =
-                Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
+                    Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
         Map<Integer, Long> partitionIdToOffset = Maps.newHashMap();
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
-                new KafkaTaskInfo(UUID.randomUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
-                        partitionIdToOffset, Config.routine_load_task_timeout_second);
+                    new KafkaTaskInfo(UUID.randomUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
+                                partitionIdToOffset, Config.routine_load_task_timeout_second);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         TransactionState transactionState = new TransactionState(1L, Lists.newArrayList(1L), 1L, "label", null,
-                LoadJobSourceType.ROUTINE_LOAD_TASK, new TxnCoordinator(TxnSourceType.BE, "be1"),
-                routineLoadJob.getId(),
-                Config.stream_load_default_timeout_second);
+                    LoadJobSourceType.ROUTINE_LOAD_TASK, new TxnCoordinator(TxnSourceType.BE, "be1"),
+                    routineLoadJob.getId(),
+                    Config.stream_load_default_timeout_second);
         transactionState.setTransactionStatus(TransactionStatus.PREPARE);
         masterTransMgr.getCallbackFactory().addCallback(routineLoadJob);
         // Deencapsulation.setField(transactionState, "txnStateChangeListener", routineLoadJob);
@@ -429,9 +433,9 @@ public class GlobalTransactionMgrTest {
         routineLoadManager.addRoutineLoadJob(routineLoadJob, "db");
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),
-                "idToRunningTransactionState", idToTransactionState);
+                    "idToRunningTransactionState", idToTransactionState);
         masterTransMgr.commitTransaction(1L, 1L, transTablets, Lists.newArrayList(),
-                txnCommitAttachment);
+                    txnCommitAttachment);
 
         Assert.assertEquals(Long.valueOf(101), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
         Assert.assertEquals(Long.valueOf(1), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
@@ -448,31 +452,31 @@ public class GlobalTransactionMgrTest {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
 
         TabletCommitInfo tabletCommitInfo1 =
-                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1);
+                    new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo2 =
-                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId2);
+                    new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId2);
         TabletCommitInfo tabletCommitInfo3 =
-                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId3);
+                    new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId3);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
 
         KafkaRoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "test", 1L, 1L, "host:port", "topic");
+                    new KafkaRoutineLoadJob(1L, "test", 1L, 1L, "host:port", "topic");
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList =
-                Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
+                    Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
         Map<Integer, Long> partitionIdToOffset = Maps.newHashMap();
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
-                new KafkaTaskInfo(UUID.randomUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
-                        partitionIdToOffset, Config.routine_load_task_timeout_second);
+                    new KafkaTaskInfo(UUID.randomUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
+                                partitionIdToOffset, Config.routine_load_task_timeout_second);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         TransactionState transactionState = new TransactionState(1L, Lists.newArrayList(1L), 1L, "label", null,
-                LoadJobSourceType.ROUTINE_LOAD_TASK, new TxnCoordinator(TxnSourceType.BE, "be1"),
-                routineLoadJob.getId(),
-                Config.stream_load_default_timeout_second);
+                    LoadJobSourceType.ROUTINE_LOAD_TASK, new TxnCoordinator(TxnSourceType.BE, "be1"),
+                    routineLoadJob.getId(),
+                    Config.stream_load_default_timeout_second);
         transactionState.setTransactionStatus(TransactionStatus.PREPARE);
         masterTransMgr.getCallbackFactory().addCallback(routineLoadJob);
         Map<Long, TransactionState> idToTransactionState = Maps.newHashMap();
@@ -519,14 +523,14 @@ public class GlobalTransactionMgrTest {
         routineLoadManager.addRoutineLoadJob(routineLoadJob, "db");
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),
-                "idToRunningTransactionState", idToTransactionState);
+                    "idToRunningTransactionState", idToTransactionState);
         masterTransMgr.commitTransaction(1L, 1L, transTablets, Lists.newArrayList(),
-                txnCommitAttachment);
+                    txnCommitAttachment);
 
         Assert.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
         Assert.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
         Assert.assertEquals(Long.valueOf(111L),
-                ((KafkaProgress) routineLoadJob.getProgress()).getOffsetByPartition(1));
+                    ((KafkaProgress) routineLoadJob.getProgress()).getOffsetByPartition(1));
         // todo(ml): change to assert queue
         // Assert.assertEquals(0, routineLoadManager.getNeedScheduleTasksQueue().size());
         Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
@@ -535,23 +539,23 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testFinishTransaction() throws UserException {
         long transactionId = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
         TabletCommitInfo tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId1);
+                    GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo2 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId2);
+                    GlobalStateMgrTestUtil.testBackendId2);
         TabletCommitInfo tabletCommitInfo3 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId3);
+                    GlobalStateMgrTestUtil.testBackendId3);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
-                Lists.newArrayList(), null);
+                    Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         slaveTransMgr.replayUpsertTransactionState(transactionState);
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -562,14 +566,15 @@ public class GlobalTransactionMgrTest {
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         // check replica version
         Partition testPartition =
-                masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1).getTable(GlobalStateMgrTestUtil.testTableId1)
-                        .getPartition(GlobalStateMgrTestUtil.testPartition1);
+                    masterGlobalStateMgr.getLocalMetastore()
+                                .getTable(GlobalStateMgrTestUtil.testDbId1, GlobalStateMgrTestUtil.testTableId1)
+                                .getPartition(GlobalStateMgrTestUtil.testPartition1);
         // check partition version
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 1, testPartition.getVisibleVersion());
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 2, testPartition.getNextVersion());
         // check partition next version
         LocalTablet tablet = (LocalTablet) testPartition.getIndex(GlobalStateMgrTestUtil.testIndexId1)
-                .getTablet(GlobalStateMgrTestUtil.testTabletId1);
+                    .getTablet(GlobalStateMgrTestUtil.testTabletId1);
         for (Replica replica : tablet.getImmutableReplicas()) {
             if (replica.getId() == GlobalStateMgrTestUtil.testReplicaId1) {
                 assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica.getVersion());
@@ -587,26 +592,27 @@ public class GlobalTransactionMgrTest {
     public void testFinishTransactionWithOneFailed() throws UserException {
         TransactionState transactionState = null;
         Partition testPartition =
-                masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1).getTable(GlobalStateMgrTestUtil.testTableId1)
-                        .getPartition(GlobalStateMgrTestUtil.testPartition1);
+                    masterGlobalStateMgr.getLocalMetastore()
+                                .getTable(GlobalStateMgrTestUtil.testDbId1, GlobalStateMgrTestUtil.testTableId1)
+                                .getPartition(GlobalStateMgrTestUtil.testPartition1);
         LocalTablet tablet = (LocalTablet) testPartition.getIndex(GlobalStateMgrTestUtil.testIndexId1)
-                .getTablet(GlobalStateMgrTestUtil.testTabletId1);
+                    .getTablet(GlobalStateMgrTestUtil.testTabletId1);
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         long transactionId = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction with 1,2 success
         TabletCommitInfo tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId1);
+                    GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo2 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId2);
+                    GlobalStateMgrTestUtil.testBackendId2);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
-                Lists.newArrayList(), null);
+                    Lists.newArrayList(), null);
 
         // follower globalStateMgr replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -654,19 +660,19 @@ public class GlobalTransactionMgrTest {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
         // commit another transaction with 1,3 success
         long transactionId2 = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable2,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable2,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo3 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId3);
+                    GlobalStateMgrTestUtil.testBackendId3);
         transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
             masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
-                    Lists.newArrayList(), null);
+                        Lists.newArrayList(), null);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId2);
@@ -683,13 +689,14 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
-                Lists.newArrayList(), null);
+                    Lists.newArrayList(), null);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
         // check replica version
-        testPartition = masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1).getTable(GlobalStateMgrTestUtil.testTableId1)
-                .getPartition(GlobalStateMgrTestUtil.testPartition1);
+        testPartition = masterGlobalStateMgr.getLocalMetastore()
+                    .getTable(GlobalStateMgrTestUtil.testDbId1, GlobalStateMgrTestUtil.testTableId1)
+                    .getPartition(GlobalStateMgrTestUtil.testPartition1);
         // check partition version
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 1, testPartition.getVisibleVersion());
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 3, testPartition.getNextVersion());
@@ -734,8 +741,8 @@ public class GlobalTransactionMgrTest {
 
         // 1. replay a normal finished transaction
         TransactionState state =
-                new TransactionState(dbId, new ArrayList<>(), 1, "label_a", null, LoadJobSourceType.BACKEND_STREAMING,
-                        transactionSource, -1, -1);
+                    new TransactionState(dbId, new ArrayList<>(), 1, "label_a", null, LoadJobSourceType.BACKEND_STREAMING,
+                                transactionSource, -1, -1);
         state.setTransactionStatus(TransactionStatus.ABORTED);
         state.setReason("fake reason");
         state.setFinishTime(System.currentTimeMillis() - 2000);
@@ -744,8 +751,8 @@ public class GlobalTransactionMgrTest {
 
         // 2. replay a expired transaction
         TransactionState state2 =
-                new TransactionState(dbId, new ArrayList<>(), 2, "label_b", null, LoadJobSourceType.BACKEND_STREAMING,
-                        transactionSource, -1, -1);
+                    new TransactionState(dbId, new ArrayList<>(), 2, "label_b", null, LoadJobSourceType.BACKEND_STREAMING,
+                                transactionSource, -1, -1);
         state2.setTransactionStatus(TransactionStatus.ABORTED);
         state2.setReason("fake reason");
         state2.setFinishTime(System.currentTimeMillis());
@@ -755,8 +762,8 @@ public class GlobalTransactionMgrTest {
         Thread.sleep(2000);
         // 3. replay a valid transaction, let state expire
         TransactionState state3 =
-                new TransactionState(dbId, new ArrayList<>(), 3, "label_c", null, LoadJobSourceType.BACKEND_STREAMING,
-                        transactionSource, -1, -1);
+                    new TransactionState(dbId, new ArrayList<>(), 3, "label_c", null, LoadJobSourceType.BACKEND_STREAMING,
+                                transactionSource, -1, -1);
         state3.setTransactionStatus(TransactionStatus.ABORTED);
         state3.setReason("fake reason");
         state3.setFinishTime(System.currentTimeMillis());
@@ -788,29 +795,30 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testPrepareTransaction() throws UserException {
         long transactionId = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
         TabletCommitInfo tabletCommitInfo1 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId1);
+                    GlobalStateMgrTestUtil.testBackendId1);
         TabletCommitInfo tabletCommitInfo2 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId2);
+                    GlobalStateMgrTestUtil.testBackendId2);
         TabletCommitInfo tabletCommitInfo3 = new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1,
-                GlobalStateMgrTestUtil.testBackendId3);
+                    GlobalStateMgrTestUtil.testBackendId3);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
         masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
-                Lists.newArrayList(), null);
+                    Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         assertEquals(TransactionStatus.PREPARED, transactionState.getTransactionStatus());
 
         try {
-            masterTransMgr.commitPreparedTransaction(masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1), transactionId,
-                    (long) 1000);
+            masterTransMgr.commitPreparedTransaction(
+                        masterGlobalStateMgr.getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDbId1), transactionId,
+                        (long) 1000);
             Assert.fail("should throw publish timeout exception");
         } catch (UserException e) {
         }
@@ -825,14 +833,15 @@ public class GlobalTransactionMgrTest {
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         // check replica version
         Partition testPartition =
-                masterGlobalStateMgr.getDb(GlobalStateMgrTestUtil.testDbId1).getTable(GlobalStateMgrTestUtil.testTableId1)
-                        .getPartition(GlobalStateMgrTestUtil.testPartition1);
+                    masterGlobalStateMgr.getLocalMetastore()
+                                .getTable(GlobalStateMgrTestUtil.testDbId1, GlobalStateMgrTestUtil.testTableId1)
+                                .getPartition(GlobalStateMgrTestUtil.testPartition1);
         // check partition version
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 1, testPartition.getVisibleVersion());
         assertEquals(GlobalStateMgrTestUtil.testStartVersion + 2, testPartition.getNextVersion());
         // check partition next version
         LocalTablet tablet = (LocalTablet) testPartition.getIndex(GlobalStateMgrTestUtil.testIndexId1)
-                .getTablet(GlobalStateMgrTestUtil.testTabletId1);
+                    .getTablet(GlobalStateMgrTestUtil.testTabletId1);
         for (Replica replica : tablet.getImmutableReplicas()) {
             if (replica.getId() == GlobalStateMgrTestUtil.testReplicaId1) {
                 assertEquals(GlobalStateMgrTestUtil.testStartVersion, replica.getVersion());
@@ -849,10 +858,10 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testSaveLoadJsonFormatImage() throws Exception {
         long transactionId = masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSource,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSource,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
 
         UtFrameUtils.PseudoImage pseudoImage = new UtFrameUtils.PseudoImage();
         masterTransMgr.saveTransactionStateV2(pseudoImage.getImageWriter());
@@ -868,7 +877,7 @@ public class GlobalTransactionMgrTest {
 
     @Test
     public void testRetryCommitOnRateLimitExceededTimeout()
-            throws UserException {
+                throws UserException {
         Database db = new Database(10, "db0");
         GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
         DatabaseTransactionMgr dbTransactionMgr = spy(new DatabaseTransactionMgr(10L, GlobalStateMgr.getCurrentState()));
@@ -878,15 +887,15 @@ public class GlobalTransactionMgrTest {
         doReturn(transactionState).when(globalTransactionMgr).getTransactionState(db.getId(), 1001);
         doReturn(dbTransactionMgr).when(globalTransactionMgr).getDatabaseTransactionMgr(db.getId());
         doThrow(new CommitRateExceededException(1001, now + 60 * 1000L))
-                .when(dbTransactionMgr)
-                .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
+                    .when(dbTransactionMgr)
+                    .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
         Assert.assertThrows(CommitRateExceededException.class, () -> globalTransactionMgr.commitAndPublishTransaction(db, 1001,
-                Collections.emptyList(), Collections.emptyList(), 10, null));
+                    Collections.emptyList(), Collections.emptyList(), 10, null));
     }
 
     @Test
     public void testPublishVersionTimeout()
-            throws UserException, LockTimeoutException {
+                throws UserException, LockTimeoutException {
         Database db = new Database(10, "db0");
         GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
         DatabaseTransactionMgr dbTransactionMgr = spy(new DatabaseTransactionMgr(10L, GlobalStateMgr.getCurrentState()));
@@ -896,52 +905,52 @@ public class GlobalTransactionMgrTest {
         doReturn(dbTransactionMgr).when(globalTransactionMgr).getDatabaseTransactionMgr(db.getId());
         doReturn(transactionState).when(globalTransactionMgr).getTransactionState(db.getId(), 1001);
         doReturn(new VisibleStateWaiter(new TransactionState()))
-                .when(dbTransactionMgr)
-                .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
+                    .when(dbTransactionMgr)
+                    .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
         Assert.assertFalse(globalTransactionMgr.commitAndPublishTransaction(db, 1001,
-                Collections.emptyList(), Collections.emptyList(), 2, null));
+                    Collections.emptyList(), Collections.emptyList(), 2, null));
     }
 
     @Test
     public void testRetryCommitOnRateLimitExceededThrowUnexpectedException()
-            throws UserException {
+                throws UserException {
         Database db = new Database(10, "db0");
         GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
         DatabaseTransactionMgr dbTransactionMgr = spy(new DatabaseTransactionMgr(10L, GlobalStateMgr.getCurrentState()));
 
         doReturn(dbTransactionMgr).when(globalTransactionMgr).getDatabaseTransactionMgr(db.getId());
         doThrow(NullPointerException.class)
-                .when(dbTransactionMgr)
-                .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
+                    .when(dbTransactionMgr)
+                    .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
         Assert.assertThrows(UserException.class, () -> globalTransactionMgr.commitAndPublishTransaction(db, 1001,
-                Collections.emptyList(), Collections.emptyList(), 10, null));
+                    Collections.emptyList(), Collections.emptyList(), 10, null));
     }
 
     @Test
     public void testRetryCommitOnRateLimitExceededThrowLockTimeoutException()
-            throws UserException, LockTimeoutException {
+                throws UserException, LockTimeoutException {
         Database db = new Database(10L, "db0");
         GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
         TransactionState transactionState = new TransactionState();
         doReturn(transactionState)
-                .when(globalTransactionMgr)
-                .getTransactionState(10L, 1001L);
+                    .when(globalTransactionMgr)
+                    .getTransactionState(10L, 1001L);
 
         doThrow(LockTimeoutException.class)
-                .when(globalTransactionMgr)
-                .retryCommitOnRateLimitExceeded(db, 1001L, Collections.emptyList(), Collections.emptyList(), null, 10L);
+                    .when(globalTransactionMgr)
+                    .retryCommitOnRateLimitExceeded(db, 1001L, Collections.emptyList(), Collections.emptyList(), null, 10L);
         Assert.assertThrows(LockTimeoutException.class, () -> globalTransactionMgr.commitAndPublishTransaction(db, 1001L,
-                Collections.emptyList(), Collections.emptyList(), 10L, null));
+                    Collections.emptyList(), Collections.emptyList(), 10L, null));
     }
 
     @Test
     public void testGetTransactionNumByCoordinateBe() throws LabelAlreadyUsedException, AnalysisException,
-            RunningTxnExceedException, DuplicatedRequestException {
+                RunningTxnExceedException, DuplicatedRequestException {
         masterTransMgr
-                .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
-                        GlobalStateMgrTestUtil.testTxnLable1,
-                        transactionSourceBe,
-                        LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                    .beginTransaction(GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                                GlobalStateMgrTestUtil.testTxnLable1,
+                                transactionSourceBe,
+                                LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         long res = masterTransMgr.getTransactionNumByCoordinateBe("localbe");
         assertEquals(1, res);
     }
@@ -993,16 +1002,16 @@ public class GlobalTransactionMgrTest {
         Database db = new Database(10L, "db0");
         GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
         doThrow(LockTimeoutException.class)
-                .when(globalTransactionMgr)
-                .commitAndPublishTransaction(db, 1001L, Collections.emptyList(), Collections.emptyList(), 10L, null);
+                    .when(globalTransactionMgr)
+                    .commitAndPublishTransaction(db, 1001L, Collections.emptyList(), Collections.emptyList(), 10L, null);
         Assert.assertThrows(ErrorReportException.class, () -> globalTransactionMgr.commitAndPublishTransaction(db, 1001L,
-                Collections.emptyList(), Collections.emptyList(), 10L));
+                    Collections.emptyList(), Collections.emptyList(), 10L));
     }
 
     @Test
     public void testCheckValidTimeoutSecond() {
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "Invalid timeout: '1'. Expected values should be between 2 and 3 seconds",
-                () -> GlobalTransactionMgr.checkValidTimeoutSecond(1, 3, 2));
+                    "Invalid timeout: '1'. Expected values should be between 2 and 3 seconds",
+                    () -> GlobalTransactionMgr.checkValidTimeoutSecond(1, 3, 2));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -225,7 +226,7 @@ public class LakePublishBatchTest {
         globalTransactionMgr.commitTransaction(db.getId(), transactionId6, transTablets,
                 Lists.newArrayList(), null);
 
-        new MockUp<GlobalStateMgr>() {
+        new MockUp<LocalMetastore>() {
             @Mock
             public Database getDb(long dbId) {
                 return null;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -90,8 +90,8 @@ public class LakePublishBatchTest {
 
     @Test
     public void testNormal() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        Table table = db.getTable(TABLE);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
         List<TabletCommitInfo> transTablets1 = Lists.newArrayList();
         List<TabletCommitInfo> transTablets2 = Lists.newArrayList();
 
@@ -159,8 +159,8 @@ public class LakePublishBatchTest {
 
     @Test
     public void testPublishTransactionState() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        Table table = db.getTable(TABLE);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
 
         for (Partition partition : table.getPartitions()) {
@@ -192,8 +192,8 @@ public class LakePublishBatchTest {
 
     @Test
     public void testPublishDbDroped() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        Table table = db.getTable(TABLE);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getBaseIndex();
@@ -248,8 +248,8 @@ public class LakePublishBatchTest {
 
     @Test
     public void testPublishTableDropped() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        Table table = db.getTable(TABLE);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getBaseIndex();
@@ -304,8 +304,8 @@ public class LakePublishBatchTest {
 
     @Test
     public void testTransformBatchToSingle() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb(DB);
-        Table table = db.getTable(TABLE);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
         List<TabletCommitInfo> transTablets1 = Lists.newArrayList();
         List<TabletCommitInfo> transTablets2 = Lists.newArrayList();
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -172,7 +172,7 @@ public class StarRocksAssert {
 
     public StarRocksAssert withDatabase(String dbName) throws Exception {
         DropDbStmt dropDbStmt =
-                (DropDbStmt) UtFrameUtils.parseStmtWithNewParser("drop database if exists `" + dbName + "`;", ctx);
+                    (DropDbStmt) UtFrameUtils.parseStmtWithNewParser("drop database if exists `" + dbName + "`;", ctx);
         try {
             GlobalStateMgr.getCurrentState().getMetadata().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
         } catch (MetaNotFoundException e) {
@@ -182,7 +182,7 @@ public class StarRocksAssert {
         }
 
         CreateDbStmt createDbStmt =
-                (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database `" + dbName + "`;", ctx);
+                    (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database `" + dbName + "`;", ctx);
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
         return this;
     }
@@ -190,8 +190,8 @@ public class StarRocksAssert {
     public StarRocksAssert createDatabaseIfNotExists(String dbName) throws Exception {
         try {
             CreateDbStmt createDbStmt =
-                    (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database if not exists `"
-                            + dbName + "`;", ctx);
+                        (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser("create database if not exists `"
+                                    + dbName + "`;", ctx);
             GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
         } catch (AlreadyExistsException e) {
             // ignore
@@ -201,15 +201,15 @@ public class StarRocksAssert {
 
     public StarRocksAssert withRole(String roleName) throws Exception {
         CreateRoleStmt createRoleStmt =
-                (CreateRoleStmt) UtFrameUtils.parseStmtWithNewParser("create role " + roleName + ";", ctx);
+                    (CreateRoleStmt) UtFrameUtils.parseStmtWithNewParser("create role " + roleName + ";", ctx);
         GlobalStateMgr.getCurrentState().getAuthorizationMgr().createRole(createRoleStmt);
         return this;
     }
 
     public StarRocksAssert withUser(String user) throws Exception {
         CreateUserStmt createUserStmt =
-                (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(
-                        "create user " + user + " identified by '';", ctx);
+                    (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(
+                                "create user " + user + " identified by '';", ctx);
         GlobalStateMgr.getCurrentState().getAuthenticationMgr().createUser(createUserStmt);
         return this;
     }
@@ -221,7 +221,7 @@ public class StarRocksAssert {
     }
 
     public boolean databaseExist(String dbName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb("" + dbName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("" + dbName);
         return db != null;
     }
 
@@ -326,7 +326,7 @@ public class StarRocksAssert {
                 }
                 retryTime++;
                 System.out.println(operationMsg + " failed with " + retryTime + " time retry, msg: " +
-                        e.getMessage() + ", " + Arrays.toString(e.getStackTrace()));
+                            e.getMessage() + ", " + Arrays.toString(e.getStackTrace()));
                 Thread.sleep(500);
             }
         }
@@ -337,7 +337,7 @@ public class StarRocksAssert {
             CreateTableStmt createTableStmtCopied = createTableStmt;
             if (retryTime > 0) {
                 createTableStmtCopied = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
-                        createTableStmt.getOrigStmt().originStmt, ctx);
+                            createTableStmt.getOrigStmt().originStmt, ctx);
             }
             GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmtCopied);
         }, "Create Table", 3);
@@ -348,7 +348,7 @@ public class StarRocksAssert {
             DropTableStmt dropTableStmtCopied = dropTableStmt;
             if (retryTime > 0) {
                 dropTableStmtCopied = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(
-                        dropTableStmt.getOrigStmt().originStmt, ctx);
+                            dropTableStmt.getOrigStmt().originStmt, ctx);
             }
             GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmtCopied);
         }, "Drop Table", 3);
@@ -369,7 +369,7 @@ public class StarRocksAssert {
 
     public StarRocksAssert withTemporaryTable(String sql) throws Exception {
         CreateTemporaryTableStmt createTableStmt =
-                (CreateTemporaryTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                    (CreateTemporaryTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         createTableStmt.setSessionId(ctx.getSessionId());
         utCreateTableWithRetry(createTableStmt, ctx);
         return this;
@@ -378,7 +378,7 @@ public class StarRocksAssert {
     public StarRocksAssert withTemporaryTableLike(String dstTable, String srcTable) throws Exception {
         String sql = "create temporary table " + dstTable + " like " + srcTable;
         CreateTemporaryTableLikeStmt createTemporaryTableLikeStmt =
-                (CreateTemporaryTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                    (CreateTemporaryTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         createTemporaryTableLikeStmt.setSessionId(ctx.getSessionId());
         utCreateTableWithRetry(createTemporaryTableLikeStmt.getCreateTableStmt(), ctx);
         return this;
@@ -390,7 +390,7 @@ public class StarRocksAssert {
     }
 
     public StarRocksAssert withMTable(String mTable,
-                                       ExceptionRunnable action) {
+                                      ExceptionRunnable action) {
         return withMTableNames(null, ImmutableList.of(mTable), action);
     }
 
@@ -401,9 +401,10 @@ public class StarRocksAssert {
 
     /**
      * Create tables by using MTables and do insert datas and later actions.
+     *
      * @param cluster pseudo cluster
      * @param mTables mtables to be used for creating tables
-     * @param action action after creating base tables
+     * @param action  action after creating base tables
      * @return return this
      */
     public StarRocksAssert withMTables(PseudoCluster cluster,
@@ -420,7 +421,7 @@ public class StarRocksAssert {
                 String sql = mTable.getCreateTableSql();
                 System.out.println(sql);
                 CreateTableStmt createTableStmt =
-                        (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                            (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
                 utCreateTableWithRetry(createTableStmt, ctx);
                 names.add(Pair.create(dbName, mTable.getTableName()));
 
@@ -455,17 +456,18 @@ public class StarRocksAssert {
 
     /**
      * With input base table's create table sqls and actions.
-     * @param sqls the base table's create table sqls
+     *
+     * @param sqls   the base table's create table sqls
      * @param action action after creating base tables
      * @return return this
      */
     public StarRocksAssert withTables(List<String> sqls,
-                                       ExceptionRunnable action) {
+                                      ExceptionRunnable action) {
         Set<String> tables = Sets.newHashSet();
         try {
             for (String sql : sqls) {
                 CreateTableStmt createTableStmt =
-                        (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                            (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
                 utCreateTableWithRetry(createTableStmt, ctx);
                 tables.add(createTableStmt.getTableName());
             }
@@ -474,7 +476,7 @@ public class StarRocksAssert {
             }
         } catch (Exception e) {
             e.printStackTrace();
-            Assert.fail("Do action failed:" +  e.getMessage());
+            Assert.fail("Do action failed:" + e.getMessage());
         } finally {
             if (action != null) {
                 for (String table : tables) {
@@ -505,7 +507,7 @@ public class StarRocksAssert {
                 MTable mTable = MSchema.getTable(table);
                 String sql = mTable.getCreateTableSql();
                 CreateTableStmt createTableStmt =
-                        (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                            (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
                 utCreateTableWithRetry(createTableStmt, ctx);
 
                 if (cluster != null) {
@@ -569,12 +571,16 @@ public class StarRocksAssert {
     }
 
     public Table getTable(String dbName, String tableName) {
-        return ctx.getGlobalStateMgr().mayGetDb(dbName).map(db -> db.getTable(tableName)).orElse(null);
+        return ctx.getGlobalStateMgr().getLocalMetastore().mayGetDb(dbName)
+                    .map(db -> GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName))
+                    .orElse(null);
     }
 
     public MaterializedView getMv(String dbName, String tableName) {
-        return (MaterializedView) ctx.getGlobalStateMgr().mayGetDb(dbName).map(db -> db.getTable(tableName))
-                .orElse(null);
+        return (MaterializedView) ctx.getGlobalStateMgr().getLocalMetastore()
+                    .mayGetDb(dbName)
+                    .map(db -> GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName))
+                    .orElse(null);
     }
 
     public StarRocksAssert withSingleReplicaTable(String sql) throws Exception {
@@ -609,9 +615,9 @@ public class StarRocksAssert {
     }
 
     public void withAsyncMv(
-            CreateMaterializedViewStatement createMaterializedViewStatement,
-            boolean isOnlySingleReplica,
-            boolean isRefresh) throws Exception {
+                CreateMaterializedViewStatement createMaterializedViewStatement,
+                boolean isOnlySingleReplica,
+                boolean isRefresh) throws Exception {
         if (isOnlySingleReplica) {
             createMaterializedViewStatement.getProperties().put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "1");
         }
@@ -623,8 +629,9 @@ public class StarRocksAssert {
                     if (stmt instanceof InsertStmt) {
                         InsertStmt insertStmt = (InsertStmt) stmt;
                         TableName tableName = insertStmt.getTableName();
-                        Database testDb = GlobalStateMgr.getCurrentState().getDb(stmt.getTableName().getDb());
-                        OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(stmt.getTableName().getDb());
+                        OlapTable tbl = ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(testDb.getFullName(), tableName.getTbl()));
                         for (Partition partition : tbl.getPartitions()) {
                             if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
                                 long version = partition.getVisibleVersion() + 1;
@@ -643,8 +650,8 @@ public class StarRocksAssert {
                 }
             };
             String refreshSql = String.format("refresh materialized view `%s`.`%s` with sync mode;",
-                    createMaterializedViewStatement.getTableName().getDb(),
-                    createMaterializedViewStatement.getTableName().getTbl());
+                        createMaterializedViewStatement.getTableName().getDb(),
+                        createMaterializedViewStatement.getTableName().getTbl());
             ctx.executeSql(refreshSql);
         }
     }
@@ -671,21 +678,21 @@ public class StarRocksAssert {
 
     public StarRocksAssert dropView(String viewName) throws Exception {
         DropTableStmt dropViewStmt =
-                (DropTableStmt) UtFrameUtils.parseStmtWithNewParser("drop view " + viewName + ";", ctx);
+                    (DropTableStmt) UtFrameUtils.parseStmtWithNewParser("drop view " + viewName + ";", ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropViewStmt);
         return this;
     }
 
     public StarRocksAssert dropCatalog(String catalogName) throws Exception {
         DropCatalogStmt dropCatalogStmt =
-                (DropCatalogStmt) UtFrameUtils.parseStmtWithNewParser("drop catalog " + catalogName + ";", ctx);
+                    (DropCatalogStmt) UtFrameUtils.parseStmtWithNewParser("drop catalog " + catalogName + ";", ctx);
         GlobalStateMgr.getCurrentState().getCatalogMgr().dropCatalog(dropCatalogStmt);
         return this;
     }
 
     public StarRocksAssert dropDatabase(String dbName) throws Exception {
         DropDbStmt dropDbStmt =
-                (DropDbStmt) UtFrameUtils.parseStmtWithNewParser("drop database " + dbName + ";", ctx);
+                    (DropDbStmt) UtFrameUtils.parseStmtWithNewParser("drop database " + dbName + ";", ctx);
         GlobalStateMgr.getCurrentState().getMetadata().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
         return this;
     }
@@ -721,22 +728,22 @@ public class StarRocksAssert {
 
     public StarRocksAssert dropTable(String tableName) throws Exception {
         DropTableStmt dropTableStmt =
-                (DropTableStmt) UtFrameUtils.parseStmtWithNewParser("drop table " + tableName + ";", ctx);
+                    (DropTableStmt) UtFrameUtils.parseStmtWithNewParser("drop table " + tableName + ";", ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);
         return this;
     }
 
     public StarRocksAssert dropTemporaryTable(String tableName, boolean ifExists) throws Exception {
         DropTemporaryTableStmt dropTemporaryTableStmt = (DropTemporaryTableStmt)
-                UtFrameUtils.parseStmtWithNewParser("drop temporary table " + (ifExists ? "if exists " : "")
-                        + tableName + ";", ctx);
+                    UtFrameUtils.parseStmtWithNewParser("drop temporary table " + (ifExists ? "if exists " : "")
+                                + tableName + ";", ctx);
         GlobalStateMgr.getCurrentState().getMetadataMgr().dropTemporaryTable(dropTemporaryTableStmt);
         return this;
     }
 
     public StarRocksAssert dropMaterializedView(String materializedViewName) throws Exception {
         DropMaterializedViewStmt dropMaterializedViewStmt = (DropMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser("drop materialized view if exists " + materializedViewName + ";", ctx);
+                    parseStmtWithNewParser("drop materialized view if exists " + materializedViewName + ";", ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropMaterializedView(dropMaterializedViewStmt);
         return this;
     }
@@ -840,8 +847,8 @@ public class StarRocksAssert {
     }
 
     public void assertMVWithoutComplexExpression(String dbName, String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        Table table = db.getTable(tableName);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         if (!(table instanceof OlapTable)) {
             return;
         }
@@ -899,8 +906,8 @@ public class StarRocksAssert {
             RefreshMaterializedViewStatement refreshMaterializedViewStatement = (RefreshMaterializedViewStatement) stmt;
 
             TableName mvName = refreshMaterializedViewStatement.getMvName();
-            Database db = GlobalStateMgr.getCurrentState().getDb(mvName.getDb());
-            Table table = db.getTable(mvName.getTbl());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvName.getDb());
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName.getTbl());
             Assert.assertNotNull(table);
             Assert.assertTrue(table instanceof MaterializedView);
             MaterializedView mv = (MaterializedView) table;
@@ -922,6 +929,7 @@ public class StarRocksAssert {
 
     /**
      * Wait the input mv refresh task finished.
+     *
      * @param mvId: mv id
      * @return true if the mv refresh task finished, otherwise false.
      */
@@ -944,7 +952,8 @@ public class StarRocksAssert {
 
     /**
      * Refresh materialized view asynchronously.
-     * @param ctx connnect context
+     *
+     * @param ctx    connnect context
      * @param mvName mv's name
      */
     public StarRocksAssert refreshMV(ConnectContext ctx, String mvName) throws Exception {
@@ -952,8 +961,8 @@ public class StarRocksAssert {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         RefreshMaterializedViewStatement refreshMaterializedViewStatement = (RefreshMaterializedViewStatement) stmt;
         TableName tableName = refreshMaterializedViewStatement.getMvName();
-        Database db = GlobalStateMgr.getCurrentState().getDb(tableName.getDb());
-        Table table = db.getTable(tableName.getTbl());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tableName.getDb());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName.getTbl());
         Assert.assertNotNull(table);
         Assert.assertTrue(table instanceof MaterializedView);
         ctx.executeSql(sql);
@@ -964,8 +973,8 @@ public class StarRocksAssert {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         RefreshMaterializedViewStatement refreshMaterializedViewStatement = (RefreshMaterializedViewStatement) stmt;
         TableName mvName = refreshMaterializedViewStatement.getMvName();
-        Database db = GlobalStateMgr.getCurrentState().getDb(mvName.getDb());
-        Table table = db.getTable(mvName.getTbl());
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvName.getDb());
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), mvName.getTbl());
         Assert.assertNotNull(table);
         Assert.assertTrue(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;
@@ -988,7 +997,7 @@ public class StarRocksAssert {
     }
 
     public void updateTablePartitionVersion(String dbName, String tableName, long version) {
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb(dbName).getTable(tableName);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName).getTable(tableName);
         for (PhysicalPartition partition : table.getPhysicalPartitions()) {
             partition.setVisibleVersion(version, System.currentTimeMillis());
             MaterializedIndex baseIndex = partition.getBaseIndex();
@@ -1049,8 +1058,8 @@ public class StarRocksAssert {
         ShowResultSet res = ShowExecutor.execute((ShowStmt) stmt, ctx);
         String header = res.getMetaData().getColumns().stream().map(Column::getName).collect(Collectors.joining("|"));
         String body = res.getResultRows().stream()
-                .map(row -> String.join("|", row))
-                .collect(Collectors.joining("\n"));
+                    .map(row -> String.join("|", row))
+                    .collect(Collectors.joining("\n"));
         return header + "\n" + body;
     }
 
@@ -1076,8 +1085,9 @@ public class StarRocksAssert {
             if (alterJobV2.getJobState().isFinalState()) {
                 continue;
             }
-            Database database = GlobalStateMgr.getCurrentState().getDb(alterJobV2.getDbId());
-            Table table = database.getTable(alterJobV2.getTableId());
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(alterJobV2.getDbId());
+            Table table =
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), alterJobV2.getTableId());
             Preconditions.checkState(table instanceof OlapTable);
             OlapTable olapTable = (OlapTable) table;
             int retry = 0;
@@ -1168,7 +1178,7 @@ public class StarRocksAssert {
                 explainQuery();
             } catch (AnalysisException | StarRocksPlannerException analysisException) {
                 Assert.assertTrue(analysisException.getMessage(),
-                        Stream.of(keywords).allMatch(analysisException.getMessage()::contains));
+                            Stream.of(keywords).allMatch(analysisException.getMessage()::contains));
                 return;
             } catch (Exception ex) {
                 Assert.fail();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -176,26 +176,26 @@ public class UtFrameUtils {
     private static final AtomicBoolean CREATED_MIN_CLUSTER = new AtomicBoolean(false);
 
     public static final String CREATE_STATISTICS_TABLE_STMT = "CREATE TABLE `table_statistic_v1` (\n" +
-            "  `table_id` bigint(20) NOT NULL COMMENT \"\",\n" +
-            "  `column_name` varchar(65530) NOT NULL COMMENT \"\",\n" +
-            "  `db_id` bigint(20) NOT NULL COMMENT \"\",\n" +
-            "  `table_name` varchar(65530) NOT NULL COMMENT \"\",\n" +
-            "  `db_name` varchar(65530) NOT NULL COMMENT \"\",\n" +
-            "  `row_count` bigint(20) NOT NULL COMMENT \"\",\n" +
-            "  `data_size` bigint(20) NOT NULL COMMENT \"\",\n" +
-            "  `distinct_count` bigint(20) NOT NULL COMMENT \"\",\n" +
-            "  `null_count` bigint(20) NOT NULL COMMENT \"\",\n" +
-            "  `max` varchar(65530) NOT NULL COMMENT \"\",\n" +
-            "  `min` varchar(65530) NOT NULL COMMENT \"\",\n" +
-            "  `update_time` datetime NOT NULL COMMENT \"\"\n" +
-            ") ENGINE=OLAP\n" +
-            "UNIQUE KEY(`table_id`, `column_name`, `db_id`)\n" +
-            "COMMENT \"OLAP\"\n" +
-            "DISTRIBUTED BY HASH(`table_id`, `column_name`, `db_id`) BUCKETS 10\n" +
-            "PROPERTIES (\n" +
-            "\"replication_num\" = \"1\",\n" +
-            "\"in_memory\" = \"false\"\n" +
-            ");";
+                "  `table_id` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "  `column_name` varchar(65530) NOT NULL COMMENT \"\",\n" +
+                "  `db_id` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "  `table_name` varchar(65530) NOT NULL COMMENT \"\",\n" +
+                "  `db_name` varchar(65530) NOT NULL COMMENT \"\",\n" +
+                "  `row_count` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "  `data_size` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "  `distinct_count` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "  `null_count` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "  `max` varchar(65530) NOT NULL COMMENT \"\",\n" +
+                "  `min` varchar(65530) NOT NULL COMMENT \"\",\n" +
+                "  `update_time` datetime NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "UNIQUE KEY(`table_id`, `column_name`, `db_id`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`table_id`, `column_name`, `db_id`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");";
 
     // Help to create a mocked ConnectContext.
     public static ConnectContext createDefaultCtx() {
@@ -212,11 +212,11 @@ public class UtFrameUtils {
 
     // Parse an origin stmt . Return a StatementBase instance.
     public static StatementBase parseStmtWithNewParser(String originStmt, ConnectContext ctx)
-            throws Exception {
+                throws Exception {
         StatementBase statementBase;
         try {
             statementBase =
-                    com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
+                        com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
         } catch (ParsingException | SemanticException e) {
             System.err.println("parse failed: " + e.getMessage());
@@ -231,11 +231,11 @@ public class UtFrameUtils {
     }
 
     public static StatementBase parseStmtWithNewParserNotIncludeAnalyzer(String originStmt, ConnectContext ctx)
-            throws Exception {
+                throws Exception {
         StatementBase statementBase;
         try {
             statementBase =
-                    com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
+                        com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
         } catch (ParsingException e) {
             if (e.getMessage() == null) {
                 throw e;
@@ -302,7 +302,7 @@ public class UtFrameUtils {
             // sleep to wait first heartbeat
             int retry = 0;
             while (GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(10001).getBePort() == -1 &&
-                    retry++ < 600) {
+                        retry++ < 600) {
                 Thread.sleep(100);
             }
             CREATED_MIN_CLUSTER.set(true);
@@ -362,7 +362,7 @@ public class UtFrameUtils {
             int starletPort = backend.getStarletPort();
             String workerAddress = backend.getHost() + ":" + starletPort;
             GlobalStateMgr.getCurrentState().getStarOSAgent().addWorker(be.getId(), workerAddress,
-                    StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                        StarOSAgent.DEFAULT_WORKER_GROUP_ID);
         }
         return be;
     }
@@ -380,7 +380,7 @@ public class UtFrameUtils {
             int starletPort = backend.getStarletPort();
             String workerAddress = backend.getHost() + ":" + starletPort;
             GlobalStateMgr.getCurrentState().getStarOSAgent().addWorker(cn.getId(), workerAddress,
-                    StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                        StarOSAgent.DEFAULT_WORKER_GROUP_ID);
         }
         return cn;
     }
@@ -452,7 +452,7 @@ public class UtFrameUtils {
         }
 
         Assert.assertEquals("Some fragments do not belong to the fragment tree",
-                plan.getFragments().size(), visitedFragments.size());
+                    plan.getFragments().size(), visitedFragments.size());
     }
 
     /*
@@ -460,11 +460,11 @@ public class UtFrameUtils {
      */
     public static Pair<CreateMaterializedViewStatement, ExecPlan> planMVMaintenance(ConnectContext connectContext,
                                                                                     String sql)
-            throws DdlException, CloneNotSupportedException {
+                throws DdlException, CloneNotSupportedException {
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
 
         List<StatementBase> statements =
-                com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode());
+                    com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode());
         connectContext.getDumpInfo().setOriginStmt(sql);
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
         StatementBase statementBase = statements.get(0);
@@ -532,7 +532,7 @@ public class UtFrameUtils {
     public static String getFragmentPlan(ConnectContext connectContext, String sql, String traceModule) {
         try {
             Pair<String, Pair<ExecPlan, String>> result =
-                    UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);
+                        UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);
             Pair<ExecPlan, String> execPlanWithQuery = result.second;
             String traceLog = execPlanWithQuery.second;
             if (!Strings.isNullOrEmpty(traceLog)) {
@@ -546,7 +546,7 @@ public class UtFrameUtils {
     }
 
     public static Pair<String, Pair<ExecPlan, String>> getFragmentPlanWithTrace(
-            ConnectContext connectContext, String sql, String module) throws Exception {
+                ConnectContext connectContext, String sql, String module) throws Exception {
         if (Strings.isNullOrEmpty(module)) {
             Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
             Pair<ExecPlan, String> planAndTrace = Pair.create(planPair.second, "");
@@ -573,34 +573,34 @@ public class UtFrameUtils {
     }
 
     public static Pair<String, ExecPlan> getPlanAndFragment(ConnectContext connectContext, String originStmt)
-            throws Exception {
+                throws Exception {
         return buildPlan(connectContext, originStmt,
-                (context, statementBase, execPlan) -> new Pair<>(printPhysicalPlan(execPlan.getPhysicalPlan()),
-                        execPlan));
+                    (context, statementBase, execPlan) -> new Pair<>(printPhysicalPlan(execPlan.getPhysicalPlan()),
+                                execPlan));
     }
 
     public static DefaultCoordinator startScheduling(ConnectContext connectContext, String originStmt) throws Exception {
         return buildPlan(connectContext, originStmt,
-                (context, statementBase, execPlan) -> {
-                    DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
+                    (context, statementBase, execPlan) -> {
+                        DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
 
-                    scheduler.startScheduling();
+                        scheduler.startScheduling();
 
-                    return scheduler;
-                });
+                        return scheduler;
+                    });
     }
 
     public static Pair<String, DefaultCoordinator> getPlanAndStartScheduling(ConnectContext connectContext, String originStmt)
-            throws Exception {
+                throws Exception {
         return buildPlan(connectContext, originStmt,
-                (context, statementBase, execPlan) -> {
-                    DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
+                    (context, statementBase, execPlan) -> {
+                        DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
 
-                    scheduler.startSchedulingWithoutDeploy();
-                    String plan = scheduler.getSchedulerExplain();
+                        scheduler.startSchedulingWithoutDeploy();
+                        String plan = scheduler.getSchedulerExplain();
 
-                    return Pair.create(plan, scheduler);
-                });
+                        return Pair.create(plan, scheduler);
+                    });
     }
 
     public static DefaultCoordinator getScheduler(ConnectContext connectContext, String originStmt) throws Exception {
@@ -613,14 +613,14 @@ public class UtFrameUtils {
         if (statementBase instanceof DmlStmt) {
             if (statementBase instanceof InsertStmt) {
                 scheduler = new DefaultCoordinator.Factory().createInsertScheduler(context,
-                        execPlan.getFragments(), execPlan.getScanNodes(),
-                        execPlan.getDescTbl().toThrift());
+                            execPlan.getFragments(), execPlan.getScanNodes(),
+                            execPlan.getDescTbl().toThrift());
             } else {
                 throw new RuntimeException("can only handle insert DML");
             }
         } else {
             scheduler = new DefaultCoordinator.Factory().createQueryScheduler(context,
-                    execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
+                        execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
         }
 
         return scheduler;
@@ -635,12 +635,12 @@ public class UtFrameUtils {
     }
 
     private static void testView(ConnectContext connectContext, String originStmt, StatementBase statementBase)
-            throws Exception {
+                throws Exception {
         if (!FeConstants.unitTestView) {
             return;
         }
         if (statementBase instanceof QueryStatement && !connectContext.getDatabase().isEmpty() &&
-                !statementBase.isExplain()) {
+                    !statementBase.isExplain()) {
             String viewName = "view" + INDEX.getAndIncrement();
             String createView = "create view " + viewName + " as " + originStmt;
             CreateViewStmt createTableStmt;
@@ -648,12 +648,12 @@ public class UtFrameUtils {
                 createTableStmt = (CreateViewStmt) UtFrameUtils.parseStmtWithNewParser(createView, connectContext);
                 try {
                     StatementBase viewStatement =
-                            SqlParser.parse(createTableStmt.getInlineViewDef(),
-                                    connectContext.getSessionVariable().getSqlMode()).get(0);
+                                SqlParser.parse(createTableStmt.getInlineViewDef(),
+                                            connectContext.getSessionVariable().getSqlMode()).get(0);
                     com.starrocks.sql.analyzer.Analyzer.analyze(viewStatement, connectContext);
                 } catch (Exception e) {
                     System.out.println("invalid view def: " + createTableStmt.getInlineViewDef()
-                            + "\nError msg:" + e.getMessage());
+                                + "\nError msg:" + e.getMessage());
                     throw e;
                 }
             } catch (SemanticException | AnalysisException e) {
@@ -675,8 +675,8 @@ public class UtFrameUtils {
 
     public static String getStmtDigest(ConnectContext connectContext, String originStmt) throws Exception {
         StatementBase statementBase =
-                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable())
-                        .get(0);
+                    com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable())
+                                .get(0);
         Preconditions.checkState(statementBase instanceof QueryStatement);
         return ConnectProcessor.computeStatementDigest(statementBase);
     }
@@ -686,7 +686,7 @@ public class UtFrameUtils {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         if (!starRocksAssert.databaseExist("_statistics_")) {
             starRocksAssert.withDatabaseWithoutAnalyze(StatsConstants.STATISTICS_DB_NAME)
-                    .useDatabase(StatsConstants.STATISTICS_DB_NAME);
+                        .useDatabase(StatsConstants.STATISTICS_DB_NAME);
             starRocksAssert.withTable(CREATE_STATISTICS_TABLE_STMT);
         }
         // prepare dump mock environment
@@ -702,11 +702,11 @@ public class UtFrameUtils {
         // mock replay external table info
         if (!replayDumpInfo.getHmsTableMap().isEmpty()) {
             ReplayMetadataMgr replayMetadataMgr = new ReplayMetadataMgr(
-                    GlobalStateMgr.getCurrentState().getLocalMetastore(),
-                    GlobalStateMgr.getCurrentState().getConnectorMgr(),
-                    GlobalStateMgr.getCurrentState().getResourceMgr(),
-                    replayDumpInfo.getHmsTableMap(),
-                    replayDumpInfo.getTableStatisticsMap());
+                        GlobalStateMgr.getCurrentState().getLocalMetastore(),
+                        GlobalStateMgr.getCurrentState().getConnectorMgr(),
+                        GlobalStateMgr.getCurrentState().getResourceMgr(),
+                        replayDumpInfo.getHmsTableMap(),
+                        replayDumpInfo.getTableStatisticsMap());
             GlobalStateMgr.getCurrentState().setMetadataMgr(replayMetadataMgr);
         }
 
@@ -727,7 +727,7 @@ public class UtFrameUtils {
         }
 
         Set<String> dbSet = replayDumpInfo.getCreateTableStmtMap().keySet().stream().map(key -> key.split("\\.")[0])
-                .collect(Collectors.toSet());
+                    .collect(Collectors.toSet());
         dbSet.forEach(db -> {
             if (starRocksAssert.databaseExist(db)) {
                 try {
@@ -765,7 +765,7 @@ public class UtFrameUtils {
             String dropView = String.format("drop view if exists `%s`.`%s`;", dbName, viewName);
             connectContext.executeSql(dropView);
             String createView = String.format("create view `%s`.`%s` as %s",
-                    dbName, viewName, replayDumpInfo.getCreateViewStmtMap().get(normalizedViewName));
+                        dbName, viewName, replayDumpInfo.getCreateViewStmtMap().get(normalizedViewName));
             starRocksAssert.withView(createView);
         }
         // create materialized views
@@ -794,8 +794,8 @@ public class UtFrameUtils {
         // mock table row count
         for (Map.Entry<String, Map<String, Long>> entry : replayDumpInfo.getPartitionRowCountMap().entrySet()) {
             String dbName = entry.getKey().split("\\.")[0];
-            OlapTable replayTable = (OlapTable) GlobalStateMgr.getCurrentState().getDb("" + dbName)
-                    .getTable(entry.getKey().split("\\.")[1]);
+            OlapTable replayTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("" + dbName)
+                        .getTable(entry.getKey().split("\\.")[1]);
 
             for (Map.Entry<String, Long> partitionEntry : entry.getValue().entrySet()) {
                 setPartitionStatistics(replayTable, partitionEntry.getKey(), partitionEntry.getValue());
@@ -803,14 +803,14 @@ public class UtFrameUtils {
         }
         // mock table column statistics
         for (Map.Entry<String, Map<String, ColumnStatistic>> entry : replayDumpInfo.getTableStatisticsMap()
-                .entrySet()) {
+                    .entrySet()) {
             String dbName = entry.getKey().split("\\.")[0];
-            Table replayTable = GlobalStateMgr.getCurrentState().getDb("" + dbName)
-                    .getTable(entry.getKey().split("\\.")[1]);
+            Table replayTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("" + dbName)
+                        .getTable(entry.getKey().split("\\.")[1]);
             for (Map.Entry<String, ColumnStatistic> columnStatisticEntry : entry.getValue().entrySet()) {
                 GlobalStateMgr.getCurrentState().getStatisticStorage()
-                        .addColumnStatistic(replayTable, columnStatisticEntry.getKey(),
-                                columnStatisticEntry.getValue());
+                            .addColumnStatistic(replayTable, columnStatisticEntry.getKey(),
+                                        columnStatisticEntry.getValue());
             }
         }
         return replaySql;
@@ -834,7 +834,7 @@ public class UtFrameUtils {
         LogicalPlan logicalPlan;
         try (Timer t = Tracers.watchScope("Transformer")) {
             logicalPlan = new RelationTransformer(columnRefFactory, connectContext)
-                    .transform((statement).getQueryRelation());
+                        .transform((statement).getQueryRelation());
 
         }
         return logicalPlan;
@@ -853,11 +853,11 @@ public class UtFrameUtils {
                 optimizer = new Optimizer();
             }
             optimizedPlan = optimizer.optimize(
-                    connectContext,
-                    logicalPlan.getRoot(),
-                    new PhysicalPropertySet(),
-                    new ColumnRefSet(logicalPlan.getOutputColumn()),
-                    columnRefFactory);
+                        connectContext,
+                        logicalPlan.getRoot(),
+                        new PhysicalPropertySet(),
+                        new ColumnRefSet(logicalPlan.getOutputColumn()),
+                        columnRefFactory);
         }
         return optimizedPlan;
     }
@@ -869,7 +869,7 @@ public class UtFrameUtils {
     }
 
     private static Pair<String, ExecPlan> getQueryExecPlan(QueryStatement statement, ConnectContext connectContext)
-            throws Exception {
+                throws Exception {
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
         try {
             if (statement.isExistQueryScopeHint()) {
@@ -883,9 +883,9 @@ public class UtFrameUtils {
             ExecPlan execPlan;
             try (Timer t = Tracers.watchScope("Builder")) {
                 execPlan = PlanFragmentBuilder
-                        .createPhysicalPlan(optimizedPlan, connectContext,
-                                logicalPlan.getOutputColumn(), columnRefFactory, new ArrayList<>(),
-                                TResultSinkType.MYSQL_PROTOCAL, true);
+                            .createPhysicalPlan(optimizedPlan, connectContext,
+                                        logicalPlan.getOutputColumn(), columnRefFactory, new ArrayList<>(),
+                                        TResultSinkType.MYSQL_PROTOCAL, true);
             }
             return new Pair<>(LogicalPlanPrinter.print(optimizedPlan), execPlan);
         } finally {
@@ -932,7 +932,7 @@ public class UtFrameUtils {
     }
 
     public static ExecPlan getPlanFragmentFromQueryDump(ConnectContext connectContext, QueryDumpInfo dumpInfo)
-            throws Exception {
+                throws Exception {
         String q = initMockEnv(connectContext, dumpInfo);
         try {
             return UtFrameUtils.getPlanAndFragment(connectContext, q).second;
@@ -950,7 +950,7 @@ public class UtFrameUtils {
             StatementBase statementBase;
             try (Timer st = Tracers.watchScope("Parse")) {
                 statementBase = com.starrocks.sql.parser.SqlParser.parse(replaySql,
-                        connectContext.getSessionVariable()).get(0);
+                            connectContext.getSessionVariable()).get(0);
                 if (statementBase instanceof QueryStatement) {
                     replaceTableCatalogName(statementBase);
                 }
@@ -983,7 +983,7 @@ public class UtFrameUtils {
             if (tableRelation.getName().getCatalog() != null) {
                 String catalogName = tableRelation.getName().getCatalog();
                 tableRelation.getName().setCatalog(
-                        CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName(catalogName, "hive"));
+                            CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName(catalogName, "hive"));
             }
         }
     }
@@ -1088,13 +1088,13 @@ public class UtFrameUtils {
 
         public SRMetaBlockReader getMetaBlockReader() throws IOException {
             JsonReader jsonReader = new JsonReader(new InputStreamReader(new ByteArrayInputStream(buffer.getData(),
-                    0, buffer.getLength())));
+                        0, buffer.getLength())));
             return new SRMetaBlockReaderV2(jsonReader);
         }
 
         public JsonReader getJsonReader() throws IOException {
             return new JsonReader(new InputStreamReader(new ByteArrayInputStream(buffer.getData(),
-                    0, buffer.getLength())));
+                        0, buffer.getLength())));
         }
     }
 
@@ -1104,10 +1104,10 @@ public class UtFrameUtils {
     public static class PseudoJournalReplayer {
         // master journal queue
         private static BlockingQueue<JournalTask> masterJournalQueue =
-                new ArrayBlockingQueue<>(Config.metadata_journal_queue_size);
+                    new ArrayBlockingQueue<>(Config.metadata_journal_queue_size);
         // follower journal queue
         private static BlockingQueue<JournalTask> followerJournalQueue =
-                new ArrayBlockingQueue<>(Config.metadata_journal_queue_size);
+                    new ArrayBlockingQueue<>(Config.metadata_journal_queue_size);
         // constantly move master journal to follower and mark succeed
         private static Thread fakeJournalWriter = null;
 
@@ -1151,7 +1151,7 @@ public class UtFrameUtils {
                 }
                 DataOutputBuffer buffer = followerJournalQueue.take().getBuffer();
                 DataInputStream dis =
-                        new DataInputStream(new ByteArrayInputStream(buffer.getData(), 0, buffer.getLength()));
+                            new DataInputStream(new ByteArrayInputStream(buffer.getData(), 0, buffer.getLength()));
                 try {
                     JournalEntity je = new JournalEntity();
                     je.readFields(dis);
@@ -1172,7 +1172,7 @@ public class UtFrameUtils {
                 DataOutputBuffer buffer = followerJournalQueue.take().getBuffer();
                 JournalEntity je = new JournalEntity();
                 try (DataInputStream dis = new DataInputStream(
-                        new ByteArrayInputStream(buffer.getData(), 0, buffer.getLength()))) {
+                            new ByteArrayInputStream(buffer.getData(), 0, buffer.getLength()))) {
                     je.readFields(dis);
                     GlobalStateMgr.getCurrentState().getEditLog().loadJournal(GlobalStateMgr.getCurrentState(), je);
                     // System.out.println("replayed journal type: " + je.getOpCode());
@@ -1213,11 +1213,11 @@ public class UtFrameUtils {
 
     public static boolean matchPlanWithoutId(String expect, String actual) {
         String trimedExpect = expect.replaceAll("\\d+:\\s*", "")
-                .replaceAll("\\[\\d+,", "[")
-                .replaceAll("<slot \\d+>", "<slot>");
+                    .replaceAll("\\[\\d+,", "[")
+                    .replaceAll("<slot \\d+>", "<slot>");
         String trimedActual = actual.replaceAll("\\d+:\\s*", "")
-                .replaceAll("\\[\\d+,", "[")
-                .replaceAll("<slot \\d+>", "<slot>");
+                    .replaceAll("\\[\\d+,", "[")
+                    .replaceAll("<slot \\d+>", "<slot>");
         boolean ret = trimedActual.contains(trimedExpect);
         if (!ret) {
             System.out.println("trimedExpect:");
@@ -1338,8 +1338,9 @@ public class UtFrameUtils {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                    OlapTable tbl = ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(testDb.getFullName(), tableName.getTbl()));
                     if (tbl != null) {
                         for (Long partitionId : insertStmt.getTargetPartitionIds()) {
                             Partition partition = tbl.getPartition(partitionId);
@@ -1349,8 +1350,9 @@ public class UtFrameUtils {
                 } else if (stmt instanceof DeleteStmt) {
                     DeleteStmt delete = (DeleteStmt) stmt;
                     TableName tableName = delete.getTableName();
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                    OlapTable tbl = ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(testDb.getFullName(), tableName.getTbl()));
                     tbl.setHasDelete();
                 }
             }
@@ -1367,7 +1369,7 @@ public class UtFrameUtils {
                 }
                 for (Map.Entry<String, String> entry : hint.getValue().entrySet()) {
                     VariableMgr.setSystemVariable(clonedSessionVariable,
-                            new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true);
+                                new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true);
                 }
             } else if (hint instanceof UserVariableHint) {
                 UserVariableHint userVariableHint = (UserVariableHint) hint;


### PR DESCRIPTION
## Why I'm doing:
In the current code, if you want to get a Table Object, there are at least 5 ways (GlobalStateMgr, LocalMetastore, Database, MetaUtils, MetadataMgr). This makes code maintenance very difficult. We cannot simply replace the underlying logic of getting Table Objects because there are too many inconsistent codes.

The biggest benefit of this reconstruction is that we can gradually separate the metadata storage and logic.
## What I'm doing:
Unify the getTable logic into two interfaces.

- LocalMetastore: responsible for the logic of getting Table inside the SR Native storage engine

- MetadataMgr: responsible for the logic of getting Table when SR is an Olap Query Engine

MetadataMgr is the upper-level logic of LocalMetastore in terms of code layering. LocalMetastore is just one of the many Connectors supported by SR Query Engine. When querying SR native table, MetadataMgr calls the getTable interface of LocalMetastore

**Although this PR modifies a lot of code, it only changes the calling interface without any logic modification.
Reviewer only needs to review the two files LocalMetasotre/GlobalStateMgr**

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
