### PR TITLE
[BugFix] Fix reuse block container in SpillBlockOutputStream

### DIFF
--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -124,6 +124,6 @@ public:
     // acquire a block from BlockManager, return error if BlockManager can't allocate one.
     virtual StatusOr<BlockPtr> acquire_block(const AcquireBlockOptions& opts) = 0;
     // return Block to BlockManager
-    virtual Status release_block(const BlockPtr& block) = 0;
+    virtual Status release_block(BlockPtr block) = 0;
 };
 } // namespace starrocks::spill

--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -107,6 +107,7 @@ Status BlockSpillOutputDataStream::flush() {
 
     // release block if not exclusive
     RETURN_IF_ERROR(_block_manager->release_block(std::move(_cur_block)));
+    DCHECK(_cur_block == nullptr);
 
     return Status::OK();
 }

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -212,7 +212,7 @@ StatusOr<BlockPtr> FileBlockManager::acquire_block(const AcquireBlockOptions& op
     return res;
 }
 
-Status FileBlockManager::release_block(const BlockPtr& block) {
+Status FileBlockManager::release_block(BlockPtr block) {
     auto file_block = down_cast<FileBlock*>(block.get());
     auto container = file_block->container();
     TRACE_SPILL_LOG << "release block: " << block->debug_string();

--- a/be/src/exec/spill/file_block_manager.h
+++ b/be/src/exec/spill/file_block_manager.h
@@ -39,7 +39,7 @@ public:
     Status open() override;
     void close() override;
     StatusOr<BlockPtr> acquire_block(const AcquireBlockOptions& opts) override;
-    Status release_block(const BlockPtr& block) override;
+    Status release_block(BlockPtr block) override;
 
 private:
     StatusOr<FileBlockContainerPtr> get_or_create_container(const DirPtr& dir, const TUniqueId& fragment_instance_id,

--- a/be/src/exec/spill/hybird_block_manager.cpp
+++ b/be/src/exec/spill/hybird_block_manager.cpp
@@ -54,10 +54,10 @@ StatusOr<BlockPtr> HyBirdBlockManager::acquire_block(const AcquireBlockOptions& 
     return remote_block;
 }
 
-Status HyBirdBlockManager::release_block(const BlockPtr& block) {
+Status HyBirdBlockManager::release_block(BlockPtr block) {
     if (block->is_remote()) {
-        return _remote_block_manager->release_block(block);
+        return _remote_block_manager->release_block(std::move(block));
     }
-    return _local_block_manager->release_block(block);
+    return _local_block_manager->release_block(std::move(block));
 }
 } // namespace starrocks::spill

--- a/be/src/exec/spill/hybird_block_manager.h
+++ b/be/src/exec/spill/hybird_block_manager.h
@@ -30,7 +30,7 @@ public:
     Status open() override;
     void close() override;
     StatusOr<BlockPtr> acquire_block(const AcquireBlockOptions& opts) override;
-    Status release_block(const BlockPtr& block) override;
+    Status release_block(BlockPtr block) override;
 
 private:
     std::unique_ptr<BlockManager> _local_block_manager;

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -259,7 +259,7 @@ StatusOr<BlockPtr> LogBlockManager::acquire_block(const AcquireBlockOptions& opt
     return res;
 }
 
-Status LogBlockManager::release_block(const BlockPtr& block) {
+Status LogBlockManager::release_block(BlockPtr block) {
     auto log_block = down_cast<LogBlock*>(block.get());
     auto container = log_block->container();
     TRACE_SPILL_LOG << "release block: " << block->debug_string();

--- a/be/src/exec/spill/log_block_manager.h
+++ b/be/src/exec/spill/log_block_manager.h
@@ -52,7 +52,7 @@ public:
     void close() override;
 
     StatusOr<BlockPtr> acquire_block(const AcquireBlockOptions& opts) override;
-    Status release_block(const BlockPtr& block) override;
+    Status release_block(BlockPtr block) override;
 
 #ifdef BE_TEST
     void set_dir_manager(DirManager* dir_mgr) { _dir_mgr = dir_mgr; }


### PR DESCRIPTION


## Why I'm doing:
call std::move(BlockPtr) release(const BlockPtr&) won't reset _cur_block. it will cause reuse the container in block

## What I'm doing:

Fixes 
```
@ 0xffffa79b25d4 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x825d3)
@ 0x94841f8 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
@ 0xffffa8e24850 ([vdso]+0x84f)
@ 0x55802ec starrocks::spill::LogBlockContainer::append_data(std::vector<starrocks::Slice, std::allocatorstarrocks::Slice > const&, unsigned long)
@ 0x5585554 starrocks::spill::LogBlock::append(std::vector<starrocks::Slice, std::allocatorstarrocks::Slice > const&)
@ 0x56f5938 starrocks::spill::BlockSpillOutputDataStream::append(starrocks::RuntimeState*, std::vector<starrocks::Slice, std::allocatorstarrocks::Slice > const&, unsigned long, unsigned long)
@ 0x56ebc0c starrocks::spill::ColumnarSerde::serialize(starrocks::RuntimeState*, starrocks::spill::SerdeContext&, std::shared_ptrstarrocks::Chunk const&, std::shared_ptrstarrocks::spill::SpillOutputDataStream const&, bool)
@ 0x56c6dc8 starrocks::spill::UnorderedMemTable::finalize(starrocks::workgroup::YieldContext&, std::shared_ptrstarrocks::spill::SpillOutputDataStream const&)
@ 0x56bd814 starrocks::spill::PartitionedSpillerWriter::spill_partition(starrocks::workgroup::YieldContext&, starrocks::spill::SerdeContext&, starrocks::spill::SpilledPartition*)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
