### PR TITLE
[WIP][BugFix] Type json is not comparable

### DIFF
--- a/be/src/types/logical_type_infra.h
+++ b/be/src/types/logical_type_infra.h
@@ -54,6 +54,17 @@ namespace starrocks {
     M(TYPE_VARBINARY)                \
     M(TYPE_BOOLEAN)
 
+#define APPLY_FOR_ALL_COMPARABLE_SCALAR_TYPE(M) \
+    APPLY_FOR_ALL_NUMBER_TYPE(M)                \
+    M(TYPE_DECIMALV2)                           \
+    M(TYPE_VARCHAR)                             \
+    M(TYPE_CHAR)                                \
+    M(TYPE_DATE)                                \
+    M(TYPE_DATETIME)                            \
+    M(TYPE_TIME)                                \
+    M(TYPE_VARBINARY)                           \
+    M(TYPE_BOOLEAN)
+
 #define APPLY_FOR_COMPLEX_TYPE(M) \
     M(TYPE_STRUCT)                \
     M(TYPE_MAP)                   \
@@ -200,7 +211,7 @@ Ret type_dispatch_predicate(LogicalType ltype, bool assert, Functor fun, Args...
 template <class Functor, class Ret, class... Args>
 auto type_dispatch_filter(LogicalType ltype, Ret default_value, Functor fun, Args... args) {
     switch (ltype) {
-        APPLY_FOR_ALL_SCALAR_TYPE(_TYPE_DISPATCH_CASE)
+        APPLY_FOR_ALL_COMPARABLE_SCALAR_TYPE(_TYPE_DISPATCH_CASE)
     default:
         return default_value;
     }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -389,6 +389,7 @@ set(EXEC_FILES
         ./serde/protobuf_serde_test.cpp
         ./types/bitmap_value_test.cpp
         ./types/type_checker_test.cpp
+        ./types/logical_type_infra_test.cpp
         ./simd/batch_run_counter_test.cpp
         ./simd/simd_test.cpp
         ./simd/simd_selector_test.cpp

--- a/be/test/types/logical_type_infra_test.cpp
+++ b/be/test/types/logical_type_infra_test.cpp
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/logical_type_infra.h"
+
+#include <gtest/gtest.h>
+
+#include "common/object_pool.h"
+#include "exprs/runtime_filter.h"
+
+namespace starrocks {
+class LogicalTypeInfraTest : public ::testing::Test {
+protected:
+    struct FilterBuilder {
+        template <LogicalType lt>
+        JoinRuntimeFilter* operator()() {
+            return new RuntimeBloomFilter<lt>();
+        }
+    };
+};
+
+TEST_F(LogicalTypeInfraTest, test_type_dispatch_filter) {
+    ObjectPool pool;
+
+    auto* filter = type_dispatch_filter(TYPE_VARCHAR, (JoinRuntimeFilter*)nullptr, FilterBuilder());
+    ASSERT_TRUE(filter != nullptr);
+
+    filter = type_dispatch_filter(TYPE_JSON, (JoinRuntimeFilter*)nullptr, FilterBuilder());
+    ASSERT_TRUE(filter == nullptr);
+}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Type json is not comparable.

```
struct FilterZoneMapWithMinMaxOp {
    template <LogicalType ltype>
    bool operator()(const JoinRuntimeFilter* expr, const Column* min_column, const Column* max_column) {
        using CppType = RunTimeCppType<ltype>;
        auto* filter = (RuntimeBloomFilter<ltype>*)(expr);
        const CppType* min_value = ColumnHelper::unpack_cpp_data_one_value<ltype>(min_column);
        const CppType* max_value = ColumnHelper::unpack_cpp_data_one_value<ltype>(max_column);
        return filter->filter_zonemap_with_min_max(min_value, max_value);
    }
};
```

using CppType = RunTimeCppType<TYPE_JSON>; // CppType is `JsonValue*`

Compare using `JsonValue*` is unreasonable.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
