### PR TITLE
[Enhancement] Support Generated Column rewrite from subquery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -232,7 +232,7 @@ public class QueryAnalyzer {
                     if (queryRelation instanceof SelectRelation) {
                         SelectRelation childSelectRelation = (SelectRelation) queryRelation;
                         if (childSelectRelation.getGeneratedExprToColumnRef() == null ||
-                            childSelectRelation.getGeneratedExprToColumnRef().isEmpty()) {
+                                childSelectRelation.getGeneratedExprToColumnRef().isEmpty()) {
                             return null;
                         }
                         // 1. get all available generated column from subquery

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -227,9 +227,94 @@ public class QueryAnalyzer {
                 }
 
                 @Override
+                public Void visitSubquery(SubqueryRelation subquery, Void context) {
+                    QueryRelation queryRelation = subquery.getQueryStatement().getQueryRelation();
+                    if (queryRelation instanceof SelectRelation) {
+                        SelectRelation childSelectRelation = (SelectRelation) queryRelation;
+                        if (childSelectRelation.getGeneratedExprToColumnRef() == null ||
+                            childSelectRelation.getGeneratedExprToColumnRef().isEmpty()) {
+                            return null;
+                        }
+                        // 1. get all available generated column from subquery
+                        // available means that:
+                        // a. generated column output from subquery directly.
+                        // b. all reference column of generated column output from subquery directly.
+                        List<SlotRef> outputSlotRef = childSelectRelation.getOutputExpression()
+                                                      .stream().filter(e -> e instanceof SlotRef)
+                                                      .map(e -> (SlotRef) e).collect(Collectors.toList());
+                        boolean hasStar = childSelectRelation.getSelectList()
+                                                    .getItems().stream().anyMatch(SelectListItem::isStar);
+
+                        for (Map.Entry<Expr, SlotRef> entry : childSelectRelation.getGeneratedExprToColumnRef().entrySet()) {
+                            List<SlotRef> allRefColumns = Lists.newArrayList();
+                            entry.getKey().collect(SlotRef.class, allRefColumns);
+                            allRefColumns.add(entry.getValue());
+                            if (hasStar || outputSlotRef.containsAll(allRefColumns)) {
+                                generatedExprToColumnRef.put(entry.getKey().clone(), (SlotRef) entry.getValue().clone());
+                            }
+                        }
+
+                        // 2. rewrite(rename slotRef) generated column expression(unAnalyzed) using alias in current scope
+                        Map<String, String> slotRefToAlias = new HashMap<>();
+                        for (SelectListItem item : childSelectRelation.getSelectList().getItems()) {
+                            if (item.isStar()) {
+                                slotRefToAlias.clear();
+                                break;
+                            }
+
+                            if (!(item.getExpr() instanceof SlotRef) || (item.getAlias() == null || item.getAlias().isEmpty())) {
+                                continue;
+                            }
+
+                            slotRefToAlias.put(((SlotRef) item.getExpr()).toSql(), item.getAlias());
+                        }
+                        List<SlotRef> allRefSlotRefs = new ArrayList<>();
+                        for (Map.Entry<Expr, SlotRef> entry : generatedExprToColumnRef.entrySet()) {
+                            List<SlotRef> refColumns = Lists.newArrayList();
+                            entry.getKey().collect(SlotRef.class, refColumns);
+
+                            allRefSlotRefs.addAll(refColumns);
+                            allRefSlotRefs.add(entry.getValue());
+                        }
+                        for (SlotRef slotRef : allRefSlotRefs) {
+                            if (!slotRefToAlias.isEmpty()) {
+                                String alias = slotRefToAlias.get(slotRef.toSql());
+                                if (alias != null) {
+                                    slotRef.setColumnName(alias);
+                                }
+                            }
+                            slotRef.setTblName(null);
+                        }
+
+                        // 3. analyze generated column expression based on current scope
+                        for (Map.Entry<Expr, SlotRef> entry : generatedExprToColumnRef.entrySet()) {
+                            entry.getKey().reset();
+                            entry.getValue().reset();
+                            
+                            try {
+                                ExpressionAnalyzer.analyzeExpression(entry.getKey(), new AnalyzeState(), sourceScope, session);
+                                ExpressionAnalyzer.analyzeExpression(entry.getValue(), new AnalyzeState(), sourceScope, session);
+                            } catch (Exception ignore) {
+                                // ignore generated column rewrite if hit any exception
+                                generatedExprToColumnRef.clear();
+                            }
+                        }
+                    }
+                    return null;
+                }
+
+                // Do not support rewrite like JOIN wiht {left: Subquery, right: Relation}
+                @Override
                 public Void visitJoin(JoinRelation joinRelation, Void context) {
-                    visit(joinRelation.getLeft());
-                    visit(joinRelation.getRight());
+                    Relation leftRelation = joinRelation.getLeft();
+                    Relation rightRelation = joinRelation.getRight();
+                    if (leftRelation instanceof TableRelation && rightRelation instanceof TableRelation) {
+                        TableRelation leftTableRelation = (TableRelation) leftRelation;
+                        TableRelation rightTableRelation = (TableRelation) rightRelation;
+
+                        generatedExprToColumnRef.putAll(leftTableRelation.getGeneratedExprToColumnRef());
+                        generatedExprToColumnRef.putAll(rightTableRelation.getGeneratedExprToColumnRef());
+                    }
                     return null;
                 }
             }.visit(resolvedRelation);
@@ -510,17 +595,17 @@ public class QueryAnalyzer {
             Scope scope = new Scope(RelationId.of(node), new RelationFields(fields.build()));
             node.setScope(scope);
 
-            Map<Expr, SlotRef> generatedExprToColumnRef = new HashMap<>();
+            Map<Expr, SlotRef> getGeneratedExprToColumnRef = new HashMap<>();
             for (Column column : table.getBaseSchema()) {
-                Expr materializedExpression = column.getGeneratedColumnExpr(table.getIdToColumn());
-                if (materializedExpression != null) {
-                    ExpressionAnalyzer.analyzeExpression(materializedExpression, new AnalyzeState(), scope, session);
+                Expr generatedColumnExpression = column.getGeneratedColumnExpr(table.getIdToColumn());
+                if (generatedColumnExpression != null) {
                     SlotRef slotRef = new SlotRef(null, column.getName());
+                    ExpressionAnalyzer.analyzeExpression(generatedColumnExpression, new AnalyzeState(), scope, session);
                     ExpressionAnalyzer.analyzeExpression(slotRef, new AnalyzeState(), scope, session);
-                    generatedExprToColumnRef.put(materializedExpression, slotRef);
+                    getGeneratedExprToColumnRef.put(generatedColumnExpression, slotRef);
                 }
             }
-            node.setGeneratedExprToColumnRef(generatedExprToColumnRef);
+            node.setGeneratedExprToColumnRef(getGeneratedExprToColumnRef);
 
             return scope;
         }

--- a/test/sql/test_materialized_column/R/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/R/test_generated_column_rewrite
@@ -35,3 +35,93 @@ PLAN FRAGMENT 0
 DROP DATABASE test_generated_column_rewrite;
 -- result:
 -- !result
+-- name: test_generated_column_subquery_rewrite
+CREATE TABLE `t_generated_column_subquery_rewrite_1` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t_generated_column_subquery_rewrite_2` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_generated_column_subquery_rewrite_1 VALUES (1);
+-- result:
+-- !result
+INSERT INTO t_generated_column_subquery_rewrite_2 VALUES (1);
+-- result:
+-- !result
+INSERT INTO t_generated_column_subquery_rewrite_2 VALUES (2);
+-- result:
+-- !result
+function: assert_explain_not_contains('SELECT CONCAT(CAST(id AS STRING), "_abc") FROM t_generated_column_subquery_rewrite_1', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_subquery_rewrite_1 where id = 1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_subquery_rewrite_1 where id = 1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'abc')
+-- result:
+None
+-- !result
+function: assert_explain_contains('SELECT COUNT(*) FROM (SELECT col AS id FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'abc')
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_subquery_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_subquery_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_subquery_rewrite_1 t1, t_generated_column_subquery_rewrite_2 t2 WHERE t1.id = t2.id) result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "abc")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_subquery_rewrite_1 t1, t_generated_column_subquery_rewrite_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc")) result where CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "abc")
+-- result:
+None
+-- !result

--- a/test/sql/test_materialized_column/T/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/T/test_generated_column_rewrite
@@ -8,3 +8,51 @@ insert into t1 values(1);
 [UC]explain select v from (select id + 1 as v from t) t2;
 
 DROP DATABASE test_generated_column_rewrite;
+
+-- name: test_generated_column_subquery_rewrite
+CREATE TABLE `t_generated_column_subquery_rewrite_1` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t_generated_column_subquery_rewrite_2` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_generated_column_subquery_rewrite_1 VALUES (1);
+INSERT INTO t_generated_column_subquery_rewrite_2 VALUES (1);
+INSERT INTO t_generated_column_subquery_rewrite_2 VALUES (2);
+
+function: assert_explain_not_contains('SELECT CONCAT(CAST(id AS STRING), "_abc") FROM t_generated_column_subquery_rewrite_1', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_subquery_rewrite_1 where id = 1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_subquery_rewrite_1 where id = 1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'abc')
+function: assert_explain_contains('SELECT COUNT(*) FROM (SELECT col AS id FROM t_generated_column_subquery_rewrite_1) t_generated_column_subquery_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'abc')
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_subquery_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_subquery_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_subquery_rewrite_1 t1, t_generated_column_subquery_rewrite_2 t2 WHERE t1.id = t2.id) result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "abc")
+function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_subquery_rewrite_1 t1, t_generated_column_subquery_rewrite_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc")) result where CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "abc")


### PR DESCRIPTION
This pr introduce a new rewrite rule for Generated Column. The Generated Column expression can be rewrite from the result of subquery if and only if:
1. The generated column is outputed directly from the subquery.
2. All ref columns of the expression are outputed directly from the subquery.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
