### PR TITLE
[Enhancement] don't print error if the configvar name appears to be an ENV var name

### DIFF
--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -153,7 +153,12 @@ inline bool parse_key_value_pairs(std::istream& input) {
 
         auto op_field = Field::get(kv.first);
         if (!op_field.has_value()) {
-            std::cerr << fmt::format("Ignored unknown config: {}\n", kv.first);
+            // A valid env var name should be: [A-Z_][A-Z0-9_]*
+            static const std::string ENV_CHARSET("ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_");
+            if (kv.first.find_first_not_of(ENV_CHARSET) != std::string::npos) {
+                // only report error when the var name appears not to be valid, not strict here.
+                std::cerr << fmt::format("Ignored unknown config: {}\n", kv.first);
+            }
             continue;
         }
         auto field = op_field.value();


### PR DESCRIPTION
* suppress errors such as `Ignored unknown config: JAVA_OPTS`

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
