### PR TITLE
[BugFix] Fix text based mv rewrite compare bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ColumnPrivilege.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ColumnPrivilege.java
@@ -15,7 +15,6 @@
 package com.starrocks.privilege;
 
 import com.google.common.collect.Maps;
-import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.InternalCatalog;
@@ -40,11 +39,11 @@ import com.starrocks.sql.optimizer.OptimizerConfig;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
-import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
+import com.starrocks.sql.optimizer.transformer.MVTransformerContext;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 
@@ -105,9 +104,8 @@ public class ColumnPrivilege {
              */
             ColumnRefFactory columnRefFactory = new ColumnRefFactory();
             LogicalPlan logicalPlan;
-            Map<Operator, ParseNode> optToAstMap = StatementPlanner.makeOptToAstMap(context.getSessionVariable());
-
-            TransformerContext transformerContext = new TransformerContext(columnRefFactory, context, optToAstMap);
+            MVTransformerContext mvTransformerContext = StatementPlanner.makeMVTransformerContext(context.getSessionVariable());
+            TransformerContext transformerContext = new TransformerContext(columnRefFactory, context, mvTransformerContext);
             logicalPlan = new RelationTransformer(transformerContext).transformWithSelectLimit(stmt.getQueryRelation());
 
             OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -305,6 +305,8 @@ public class MvRewritePreprocessor {
                 sessionVariable.isEnableSyncMaterializedViewRewrite());
         logMVPrepare(connectContext, "  enable_view_based_mv_rewrite: {}",
                 sessionVariable.isEnableViewBasedMvRewrite());
+        logMVPrepare(connectContext, "  enable_materialized_view_text_match_rewrite: {}",
+                sessionVariable.isEnableMaterializedViewTextMatchRewrite());
 
         // limit
         logMVPrepare(connectContext, "---------------------------------");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -18,7 +18,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.JoinOperator;
-import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.profile.Timer;
@@ -111,6 +110,7 @@ import com.starrocks.sql.optimizer.task.RewriteAtMostOnceTask;
 import com.starrocks.sql.optimizer.task.RewriteDownTopTask;
 import com.starrocks.sql.optimizer.task.RewriteTreeTask;
 import com.starrocks.sql.optimizer.task.TaskContext;
+import com.starrocks.sql.optimizer.transformer.MVTransformerContext;
 import com.starrocks.sql.optimizer.validate.MVRewriteValidator;
 import com.starrocks.sql.optimizer.validate.OptExpressionValidator;
 import com.starrocks.sql.optimizer.validate.PlanValidator;
@@ -119,7 +119,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -172,7 +171,7 @@ public class Optimizer {
 
     public OptExpression optimize(ConnectContext connectContext,
                                   OptExpression logicOperatorTree,
-                                  Map<Operator, ParseNode> optToAstMap,
+                                  MVTransformerContext mvTransformerContext,
                                   StatementBase stmt,
                                   PhysicalPropertySet requiredProperty,
                                   ColumnRefSet requiredColumns,
@@ -184,7 +183,7 @@ public class Optimizer {
             // prepare for mv rewrite
             prepareMvRewrite(connectContext, logicOperatorTree, columnRefFactory, requiredColumns);
             try (Timer ignored = Tracers.watchScope("MVTextRewrite")) {
-                logicOperatorTree = new TextMatchBasedRewriteRule(connectContext, stmt, optToAstMap)
+                logicOperatorTree = new TextMatchBasedRewriteRule(connectContext, stmt, mvTransformerContext)
                         .transform(logicOperatorTree, context).get(0);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -55,6 +55,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.optimizer.transformer.MVTransformerContext;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,7 +83,7 @@ public class TextMatchBasedRewriteRule extends Rule {
     );
     private final ConnectContext connectContext;
     private final StatementBase stmt;
-    private final Map<Operator, ParseNode> optToAstMap;
+    private final MVTransformerContext mvTransformerContext;
 
     // To avoid text match costing too much time, use parameters below to limit it.
     // limit for sub-query text match(default 4), no match when it <= 0
@@ -94,12 +95,12 @@ public class TextMatchBasedRewriteRule extends Rule {
 
     public TextMatchBasedRewriteRule(ConnectContext connectContext,
                                      StatementBase stmt,
-                                     Map<Operator, ParseNode> optToAstMap) {
+                                     MVTransformerContext mvTransformerContext) {
         super(RuleType.TF_MV_TEXT_MATCH_REWRITE_RULE, Pattern.create(OperatorType.PATTERN));
 
         this.connectContext = connectContext;
         this.stmt = stmt;
-        this.optToAstMap = optToAstMap;
+        this.mvTransformerContext = mvTransformerContext;
         this.mvSubQueryTextMatchMaxCount =
                 connectContext.getSessionVariable().getMaterializedViewSubQueryTextMatchMaxCount();
         this.mvRewriteRelatedMVsLimit =
@@ -141,11 +142,11 @@ public class TextMatchBasedRewriteRule extends Rule {
             return rewritten;
         }
         // try to rewrite sub-query again if exact-match failed.
-        if (optToAstMap == null || optToAstMap.isEmpty()) {
+        if (mvTransformerContext == null || mvTransformerContext.isOpASTEmpty()) {
             logMVRewrite(context, this, "OptToAstMap is empty, no try to rewrite sub-query again");
             return null;
         }
-        return input.getOp().accept(new TextBasedRewriteVisitor(context, optToAstMap), input, connectContext);
+        return input.getOp().accept(new TextBasedRewriteVisitor(context, mvTransformerContext), input, connectContext);
     }
 
     private boolean isSupportForTextBasedRewrite(OptExpression input) {
@@ -368,11 +369,11 @@ public class TextMatchBasedRewriteRule extends Rule {
 
     class TextBasedRewriteVisitor extends OptExpressionVisitor<OptExpression, ConnectContext> {
         private final OptimizerContext optimizerContext;
-        private final Map<Operator, ParseNode> optToAstMap;
+        private final MVTransformerContext mvTransformerContext;
         public TextBasedRewriteVisitor(OptimizerContext optimizerContext,
-                                       Map<Operator, ParseNode> optToAstMap) {
+                                       MVTransformerContext mvTransformerContext) {
             this.optimizerContext = optimizerContext;
-            this.optToAstMap = optToAstMap;
+            this.mvTransformerContext = mvTransformerContext;
         }
 
         private List<OptExpression> visitChildren(OptExpression optExpression, ConnectContext connectContext) {
@@ -405,10 +406,10 @@ public class TextMatchBasedRewriteRule extends Rule {
 
         private OptExpression doRewrite(OptExpression input) {
             Operator op = input.getOp();
-            if (!optToAstMap.containsKey(op)) {
+            if (!mvTransformerContext.hasOpAST(op)) {
                 return null;
             }
-            ParseNode parseNode = optToAstMap.get(op);
+            ParseNode parseNode = mvTransformerContext.getOpAST(op);
             OptExpression rewritten = rewriteByTextMatch(input, optimizerContext,
                     new CachingMvPlanContextBuilder.AstKey(parseNode));
             if (rewritten != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/MVTransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/MVTransformerContext.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.transformer;
+
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.util.Box;
+
+import java.util.Map;
+
+public class MVTransformerContext {
+    // Map from operator to AST tree which is used for text based mv rewrite
+    // Use Box to ensure the identity of the operator because the operator may be different even
+    // if `Operator`'s equals method is true.
+    private final Map<Box<Operator>, ParseNode> opToASTMap = Maps.newHashMap();
+
+    public MVTransformerContext() {
+    }
+
+    /**
+     * Register the AST tree for the given operator in transformer stage
+     * @param op input operator
+     * @param ast AST tree of this operator
+     */
+    public void registerOpAST(Operator op, ParseNode ast) {
+        if (op == null) {
+            return;
+        }
+        opToASTMap.put(Box.of(op), ast);
+    }
+
+    /**
+     * Check whether the AST tree for the given operator is registered in transformer stage
+     */
+    public boolean hasOpAST(Operator op) {
+        return opToASTMap.containsKey(Box.of(op));
+    }
+
+    /**
+     * Check whether the operator to AST tree map is empty or not.
+     */
+    public boolean isOpASTEmpty() {
+        return opToASTMap.isEmpty();
+    }
+
+    /**
+     * Get the AST tree for the given operator in transformer stage
+     */
+    public ParseNode getOpAST(Operator op) {
+        return opToASTMap.get(Box.of(op));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -25,7 +25,6 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.OrderByElement;
-import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
@@ -41,7 +40,6 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.AggType;
-import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
@@ -69,18 +67,18 @@ public class QueryTransformer {
     private final List<ColumnRefOperator> correlation = new ArrayList<>();
     private final CTETransformerContext cteContext;
     private final boolean inlineView;
-    private final Map<Operator, ParseNode> optToAstMap;
+    private final MVTransformerContext mvTransformerContext;
     public static final String GROUPING_ID = "GROUPING_ID";
     public static final String GROUPING = "GROUPING";
 
     public QueryTransformer(ColumnRefFactory columnRefFactory, ConnectContext session,
                             CTETransformerContext cteContext, boolean inlineView,
-                            Map<Operator, ParseNode> optToAstMap) {
+                            MVTransformerContext mvTransformerContext) {
         this.columnRefFactory = columnRefFactory;
         this.session = session;
         this.cteContext = cteContext;
         this.inlineView = inlineView;
-        this.optToAstMap = optToAstMap;
+        this.mvTransformerContext = mvTransformerContext;
     }
 
     public LogicalPlan plan(SelectRelation queryBlock, ExpressionMapping outer) {
@@ -165,7 +163,7 @@ public class QueryTransformer {
     private OptExprBuilder planFrom(Relation node, CTETransformerContext cteContext) {
         TransformerContext transformerContext = new TransformerContext(
                 columnRefFactory, session, new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())),
-                cteContext, inlineView, optToAstMap);
+                cteContext, inlineView, mvTransformerContext);
         return new RelationTransformer(transformerContext).visit(node).getRootBuilder();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -26,7 +26,6 @@ import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.OrderByElement;
-import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.catalog.Column;
@@ -167,7 +166,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
     private final List<ColumnRefOperator> correlation = new ArrayList<>();
     private final boolean inlineView;
     private final boolean enableViewBasedMvRewrite;
-    private final Map<Operator, ParseNode> optToAstMap;
+    private final MVTransformerContext mvTransformerContext;
 
     public RelationTransformer(ColumnRefFactory columnRefFactory, ConnectContext session) {
         this(columnRefFactory, session,
@@ -187,7 +186,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
         this.cteContext = context.getCteContext();
         this.inlineView = context.isInlineView();
         this.enableViewBasedMvRewrite = context.isEnableViewBasedMvRewrite();
-        this.optToAstMap = context.getOptToAstMap();
+        this.mvTransformerContext = context.getMVTransformerContext();
     }
 
     // transform relation to plan with session variable sql_select_limit
@@ -275,7 +274,8 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
 
     @Override
     public LogicalPlan visitSelect(SelectRelation node, ExpressionMapping context) {
-        QueryTransformer queryTransformer = new QueryTransformer(columnRefFactory, session, cteContext, inlineView, optToAstMap);
+        QueryTransformer queryTransformer = new QueryTransformer(columnRefFactory, session, cteContext,
+                inlineView, mvTransformerContext);
         LogicalPlan logicalPlan = queryTransformer.plan(node, outer);
         return logicalPlan;
     }
@@ -753,8 +753,9 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
 
         // store opt expression to ast map if sub-query's type is supported.
         OperatorType operatorType = subQueryOptExpression.getOp().getOpType();
-        if (optToAstMap != null && TextMatchBasedRewriteRule.SUPPORTED_REWRITE_OPERATOR_TYPES.contains(operatorType)) {
-            optToAstMap.put(subQueryOptExpression.getOp(), node.getQueryStatement());
+        if (this.mvTransformerContext != null
+                && TextMatchBasedRewriteRule.SUPPORTED_REWRITE_OPERATOR_TYPES.contains(operatorType)) {
+            this.mvTransformerContext.registerOpAST(subQueryOptExpression.getOp(), node.getQueryStatement());
         }
 
         return new LogicalPlan(builder, logicalPlan.getOutputColumn(), logicalPlan.getCorrelation());
@@ -1014,7 +1015,8 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
         // aggregate
         List<Expr> groupKeys = node.getGroupByKeys();
         List<FunctionCallExpr> aggFunctions = node.getRewrittenAggFunctions();
-        QueryTransformer queryTransformer = new QueryTransformer(columnRefFactory, session, cteContext, inlineView, optToAstMap);
+        QueryTransformer queryTransformer = new QueryTransformer(columnRefFactory, session, cteContext,
+                inlineView, mvTransformerContext);
         OptExprBuilder builder = queryTransformer.aggregate(
                 queryPlan.getRootBuilder(), groupKeys, aggFunctions, null, ImmutableList.of());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/TransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/TransformerContext.java
@@ -14,15 +14,11 @@
 
 package com.starrocks.sql.optimizer.transformer;
 
-import com.starrocks.analysis.ParseNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
-import com.starrocks.sql.optimizer.operator.Operator;
-
-import java.util.Map;
 
 public class TransformerContext {
     private final ColumnRefFactory columnRefFactory;
@@ -35,25 +31,25 @@ public class TransformerContext {
     private final boolean inlineView;
     private final boolean enableViewBasedMvRewrite;
 
-    private final Map<Operator, ParseNode> optToAstMap;
+    private final MVTransformerContext mvTransformerContext;
 
     public TransformerContext(
             ColumnRefFactory columnRefFactory,
             ConnectContext session,
-            Map<Operator, ParseNode> optToAstMap) {
+            MVTransformerContext mvTransformerContext) {
         this(columnRefFactory, session,
                 new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())),
-                new CTETransformerContext(session.getSessionVariable().getCboCTEMaxLimit()), true, optToAstMap);
+                new CTETransformerContext(session.getSessionVariable().getCboCTEMaxLimit()), true, mvTransformerContext);
     }
 
     public TransformerContext(
             ColumnRefFactory columnRefFactory,
             ConnectContext session,
             boolean inlineView,
-            Map<Operator, ParseNode> optToAstMap) {
+            MVTransformerContext mvTransformerContext) {
         this(columnRefFactory, session,
                 new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())),
-                new CTETransformerContext(session.getSessionVariable().getCboCTEMaxLimit()), inlineView, optToAstMap);
+                new CTETransformerContext(session.getSessionVariable().getCboCTEMaxLimit()), inlineView, mvTransformerContext);
     }
 
     public TransformerContext(
@@ -61,8 +57,8 @@ public class TransformerContext {
             ConnectContext session,
             ExpressionMapping outer,
             CTETransformerContext cteContext,
-            Map<Operator, ParseNode> optToAstMap) {
-        this(columnRefFactory, session, outer, cteContext, true, optToAstMap);
+            MVTransformerContext mvTransformerContext) {
+        this(columnRefFactory, session, outer, cteContext, true, mvTransformerContext);
     }
 
     public TransformerContext(
@@ -71,14 +67,14 @@ public class TransformerContext {
             ExpressionMapping outer,
             CTETransformerContext cteContext,
             boolean inlineView,
-            Map<Operator, ParseNode> optToAstMap) {
+            MVTransformerContext mvTransformerContext) {
         this.columnRefFactory = columnRefFactory;
         this.session = session;
         this.outer = outer;
         this.cteContext = cteContext;
         this.inlineView = inlineView;
         this.enableViewBasedMvRewrite = session.getSessionVariable().isEnableViewBasedMvRewrite();
-        this.optToAstMap = optToAstMap;
+        this.mvTransformerContext = mvTransformerContext;
     }
 
     public ColumnRefFactory getColumnRefFactory() {
@@ -105,7 +101,7 @@ public class TransformerContext {
         return enableViewBasedMvRewrite;
     }
 
-    public Map<Operator, ParseNode> getOptToAstMap() {
-        return optToAstMap;
+    public MVTransformerContext getMVTransformerContext() {
+        return mvTransformerContext;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -331,4 +331,16 @@ public class MaterializedViewTestBase extends PlanTestBase {
         Map.Entry<Table, Column> e = result.entrySet().iterator().next();
         return Pair.create(e.getKey(), e.getValue());
     }
+
+    public String getQueryPlan(String query) {
+        try {
+            Pair<ExecPlan, String> planAndTrace =
+                    UtFrameUtils.getFragmentPlanWithTrace(connectContext, query, traceLogModule).second;
+            return planAndTrace.first.getExplainString(TExplainLevel.NORMAL);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        return null;
+    }
 }
+

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
@@ -17,6 +17,7 @@ package com.starrocks.planner;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -355,5 +356,21 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
                 sql(query).nonMatch("mv0");
             }
         });
+    }
+
+    @Test
+    public void testTextMatchRewriteWithSubQueryFilter() {
+        starRocksAssert.withMaterializedView("create materialized view mv0" +
+                " distributed by  random" +
+                " as select user_id, time, bitmap_union(to_bitmap(tag_id)) as a from user_tags group by user_id,time;",
+                () -> {
+                    String query = "select * from (select user_id, time, bitmap_union(to_bitmap(tag_id)) as a from user_tags group by " +
+                            " user_id,time) s where user_id != 'xxxx'";
+                    String plan = getQueryPlan(query);
+                    PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                            "     TABLE: mv0\n" +
+                            "     PREAGGREGATION: ON\n" +
+                            "     PREDICATES: CAST(6: user_id AS VARCHAR(1048576)) != 'xxxx'");
+                });
     }
 }

--- a/test/sql/test_materialized_view/R/test_materialized_view_text_based_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_text_based_rewrite
@@ -83,14 +83,10 @@ select * from (select user_id + 1, time, sum(tag_id) from user_tags group by use
 -- !result
 select * from (select user_id + 1, time, sum(tag_id) from user_tags group by user_id + 1, time) as t where time='2023-4-13';
 -- result:
-2	2023-04-11	1
-3	2023-04-12	5
 4	2023-04-13	6
 -- !result
 select * from (select user_id + 1, time, sum(tag_id) from user_tags group by user_id + 1, time) as t where time>='2023-4-13' order by time;
 -- result:
-2	2023-04-11	1
-3	2023-04-12	5
 4	2023-04-13	6
 -- !result
 drop materialized view mv1;


### PR DESCRIPTION
## Why I'm doing:
- After text based mv rewrite, query's result may be wrong because of missing `where` exprs.


eg:
```
create materialized view mv0
distributed by  random
as select user_id, time, bitmap_union(to_bitmap(tag_id)) as a from user_tags group by user_id,time;
```

`mv0` can rewrite query `select * from (select user_id, time, bitmap_union(to_bitmap(tag_id)) as a from user_tags group by user_id,time)x where user_id = 'a'` but may lose `where user_id = 'a'`` predicate.

The root cause : `Operator`'s `hashCode` and `equals` methods are not satisfied and maybe equal even if they are not the same. 
```
    @Override
    public boolean equals(Object o) {
        if (this == o) {
            return true;
        }
        if (o == null || getClass() != o.getClass()) {
            return false;
        }
        Operator operator = (Operator) o;
        return limit == operator.limit && opType == operator.opType &&
                Objects.equals(predicate, operator.predicate) &&
                Objects.equals(projection, operator.projection) &&
                Objects.equals(salt, operator.salt);
    }

    @Override
    public int hashCode() {
        return Objects.hash(opType.ordinal(), limit, predicate, projection, salt);
    }
```

## What I'm doing:
- Use Box<T> to identify the same Operator object rather than `Operator` directly.
- Introduce `MVTransformerContext` class to wrapper the relation of Operator to AST Tree.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
