### PR TITLE
[Enhancement] add metrics for analysis error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -56,9 +56,6 @@ public class MetricCalculator extends TimerTask {
     private long lastQueryErrCounter = -1;
     private long lastQueryEventTime = -1;
 
-    private long lastQueryAnalysisErrCounter = -1;
-    private long lastQueryInternalErrCounter = -1;
-
     @Override
     public void run() {
         update();
@@ -71,8 +68,6 @@ public class MetricCalculator extends TimerTask {
             lastQueryCounter = MetricRepo.COUNTER_QUERY_ALL.getValue();
             lastRequestCounter = MetricRepo.COUNTER_REQUEST_ALL.getValue();
             lastQueryErrCounter = MetricRepo.COUNTER_QUERY_ERR.getValue();
-            lastQueryAnalysisErrCounter = MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.getValue();
-            lastQueryInternalErrCounter = MetricRepo.COUNTER_QUERY_INTERNAL_ERR.getValue();
             lastQueryEventTime = System.currentTimeMillis() * 1000000;
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -56,6 +56,9 @@ public class MetricCalculator extends TimerTask {
     private long lastQueryErrCounter = -1;
     private long lastQueryEventTime = -1;
 
+    private long lastQueryAnalysisErrCounter = -1;
+    private long lastQueryInternalErrCounter = -1;
+
     @Override
     public void run() {
         update();
@@ -68,6 +71,8 @@ public class MetricCalculator extends TimerTask {
             lastQueryCounter = MetricRepo.COUNTER_QUERY_ALL.getValue();
             lastRequestCounter = MetricRepo.COUNTER_REQUEST_ALL.getValue();
             lastQueryErrCounter = MetricRepo.COUNTER_QUERY_ERR.getValue();
+            lastQueryAnalysisErrCounter = MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.getValue();
+            lastQueryInternalErrCounter = MetricRepo.COUNTER_QUERY_INTERNAL_ERR.getValue();
             lastQueryEventTime = System.currentTimeMillis() * 1000000;
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -112,8 +112,8 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_QUERY_QUEUE_SLOT_PENDING;
     public static LongCounterMetric COUNTER_QUERY_QUEUE_SLOT_RUNNING;
 
-    public static LongCounterMetric COUNT_QUERY_ANALYSIS_ERR;
-    public static LongCounterMetric COUNT_QUERY_INTERNAL_ERR;
+    public static LongCounterMetric COUNTER_QUERY_ANALYSIS_ERR;
+    public static LongCounterMetric COUNTER_QUERY_INTERNAL_ERR;
 
     public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING =
             new MetricWithLabelGroup<>("category",
@@ -460,10 +460,10 @@ public final class MetricRepo {
         COUNTER_SHORTCIRCUIT_RPC = new LongCounterMetric("shortcircuit_rpc", MetricUnit.REQUESTS, "total shortcircuit rpc");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_RPC);
 
-        COUNT_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS, "total analysis error query");
-        STARROCKS_METRIC_REGISTER.addMetric(COUNT_QUERY_ANALYSIS_ERR);
-        COUNT_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS, "total internal error query");
-        STARROCKS_METRIC_REGISTER.addMetric(COUNT_QUERY_INTERNAL_ERR);
+        COUNTER_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS, "total analysis error query");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_ANALYSIS_ERR);
+        COUNTER_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS, "total internal error query");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_INTERNAL_ERR);
 
         COUNTER_TXN_REJECT =
                 new LongCounterMetric("txn_reject", MetricUnit.REQUESTS, "counter of rejected transactions");

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -460,9 +460,11 @@ public final class MetricRepo {
         COUNTER_SHORTCIRCUIT_RPC = new LongCounterMetric("shortcircuit_rpc", MetricUnit.REQUESTS, "total shortcircuit rpc");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_RPC);
 
-        COUNTER_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS, "total analysis error query");
+        COUNTER_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS,
+                                                           "total analysis error query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_ANALYSIS_ERR);
-        COUNTER_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS, "total internal error query");
+        COUNTER_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS, 
+                                                           "total internal error query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_INTERNAL_ERR);
 
         COUNTER_TXN_REJECT =

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -112,6 +112,9 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_QUERY_QUEUE_SLOT_PENDING;
     public static LongCounterMetric COUNTER_QUERY_QUEUE_SLOT_RUNNING;
 
+    public static LongCounterMetric COUNT_QUERY_ANALYSIS_ERR;
+    public static LongCounterMetric COUNT_QUERY_INTERNAL_ERR;
+
     public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING =
             new MetricWithLabelGroup<>("category",
                     () -> new LongCounterMetric("query_queue_v2_category_pending_slots", MetricUnit.REQUESTS,
@@ -456,6 +459,11 @@ public final class MetricRepo {
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_QUERY);
         COUNTER_SHORTCIRCUIT_RPC = new LongCounterMetric("shortcircuit_rpc", MetricUnit.REQUESTS, "total shortcircuit rpc");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_RPC);
+
+        COUNT_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS, "total analysis error query");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNT_QUERY_ANALYSIS_ERR);
+        COUNT_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS, "total internal error query");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNT_QUERY_INTERNAL_ERR);
 
         COUNTER_TXN_REJECT =
                 new LongCounterMetric("txn_reject", MetricUnit.REQUESTS, "counter of rejected transactions");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -216,6 +216,12 @@ public class ConnectProcessor {
                 MetricRepo.COUNTER_QUERY_ERR.increase(1L);
                 ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
                 ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
+                //represent analysis err
+                if (ctx.getState().getStateType() == QueryState.ErrType.ANALYSIS_ERR){
+                    MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.increase(1L);
+                } else {
+                    MetricRepo.COUNTER_QUERY_INTERNAL_ERR.increase(1L);
+                }
             } else {
                 // ok query
                 MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -217,7 +217,7 @@ public class ConnectProcessor {
                 ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
                 ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
                 //represent analysis err
-                if (ctx.getState().getStateType() == QueryState.ErrType.ANALYSIS_ERR) {
+                if (ctx.getState().getErrType() == QueryState.ErrType.ANALYSIS_ERR) {
                     MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.increase(1L);
                 } else {
                     MetricRepo.COUNTER_QUERY_INTERNAL_ERR.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -217,7 +217,7 @@ public class ConnectProcessor {
                 ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
                 ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
                 //represent analysis err
-                if (ctx.getState().getStateType() == QueryState.ErrType.ANALYSIS_ERR){
+                if (ctx.getState().getStateType() == QueryState.ErrType.ANALYSIS_ERR) {
                     MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.increase(1L);
                 } else {
                     MetricRepo.COUNTER_QUERY_INTERNAL_ERR.increase(1L);


### PR DESCRIPTION
## Why I'm doing:
Currently query_err has no way to distinguish between analysis errors and starrocks internal errors.

## What I'm doing:
Add metrics for analysis errors and starrocks internal errors.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
